### PR TITLE
修复角色 AI 一键帮写未刷新 LLM 配置

### DIFF
--- a/config/character_manager.py
+++ b/config/character_manager.py
@@ -20,11 +20,15 @@ class CharacterManager:
     
     # 私有属性，用于缓存 LLM Manager 实例
     _llm_manager: Optional[Any] = None 
+    # 记录当前缓存的 LLM adapter 参数；设置页改模型或 API 后用它判断是否需要重建。
+    _llm_config_signature: Optional[Tuple[Tuple[str, str], ...]] = None
     _config_manager: ConfigManager
     
     def __init__(self):
         """初始化 CharacterManager，获取 ConfigManager 单例。"""
         self._config_manager = ConfigManager()
+        self._llm_manager = None
+        self._llm_config_signature = None
 
     def _get_characters(self) -> List[Character]:
         """获取当前的 Character 列表"""
@@ -94,22 +98,31 @@ class CharacterManager:
             
             if not llm_provider or not api_key or not llm_model:
                 return "LLM 配置不完整，请先设定大语言模型供应商、模型和 API Key。", setting
-                
-            if self._llm_manager is None:
-                # 假设 LLMAdapterFactory 和 LLMManager 已定义
-                from llm.llm_manager import LLMAdapterFactory, LLMManager 
+
+            from llm.llm_manager import LLMAdapterFactory, LLMManager
+
+            llm_factory_kwargs = self._config_manager.merged_llm_factory_kwargs(
+                llm_provider,
+                {
+                    "llm_provider": llm_provider,
+                    "api_key": api_key,
+                    "base_url": llm_base_url,
+                    "model": llm_model,
+                },
+            )
+            # 用最终传给 adapter 的参数做签名，覆盖 provider 默认值和用户在设置页的覆盖项。
+            # 这样角色页复用 CharacterManager 时，也能感知模型、API Key、Base URL 等变更。
+            llm_config_signature = tuple(
+                sorted((str(k), repr(v)) for k, v in llm_factory_kwargs.items())
+            )
+
+            # 配置没变就复用已有 LLMManager；配置变了才重建 adapter，避免继续请求旧模型。
+            if self._llm_manager is None or self._llm_config_signature != llm_config_signature:
                 llm_adapter = LLMAdapterFactory.create_adapter(
-                    **self._config_manager.merged_llm_factory_kwargs(
-                        llm_provider,
-                        {
-                            "llm_provider": llm_provider,
-                            "api_key": api_key,
-                            "base_url": llm_base_url,
-                            "model": llm_model,
-                        },
-                    )
+                    **llm_factory_kwargs
                 )
                 self._llm_manager = LLMManager(adapter=llm_adapter, user_template=template)
+                self._llm_config_signature = llm_config_signature
                 
             self._llm_manager.set_user_template(template)
             

--- a/test/unit/managers/test_character_manager.py
+++ b/test/unit/managers/test_character_manager.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+import llm.llm_manager as llm_manager_module
+from config.character_manager import CharacterManager
+from test.conftest import make_character
+
+
+class _FakeConfigManager:
+    def __init__(self):
+        self.model = "model-a"
+        self.character = make_character(name="Alice", character_setting="old")
+        self.config = SimpleNamespace(characters=[self.character])
+        self.saved = 0
+
+    def get_llm_api_config(self):
+        return "Deepseek", self.model, "https://example.test/v1", "sk-test"
+
+    def merged_llm_factory_kwargs(self, _provider, base_kwargs):
+        return dict(base_kwargs)
+
+    def get_character_by_name(self, name):
+        return self.character if name == self.character.name else None
+
+    def save_characters_config(self):
+        self.saved += 1
+
+
+class _FakeAdapter:
+    def __init__(self, model):
+        self.model = model
+
+
+class _FakeLLMManager:
+    def __init__(self, adapter, user_template=""):
+        self.adapter = adapter
+        self.user_template = user_template
+
+    def set_user_template(self, template):
+        self.user_template = template
+
+    def chat(self, *_args, **_kwargs):
+        return f"generated:{self.adapter.model}"
+
+
+def test_character_ai_writer_rebuilds_llm_when_model_config_changes(monkeypatch):
+    created_models = []
+
+    def fake_create_adapter(**kwargs):
+        created_models.append(kwargs["model"])
+        return _FakeAdapter(kwargs["model"])
+
+    monkeypatch.setattr(
+        llm_manager_module.LLMAdapterFactory,
+        "create_adapter",
+        fake_create_adapter,
+    )
+    monkeypatch.setattr(llm_manager_module, "LLMManager", _FakeLLMManager)
+
+    config = _FakeConfigManager()
+    manager = CharacterManager()
+    manager._config_manager = config
+
+    # 模拟设置页已切换模型，但角色页仍复用同一个 CharacterManager 实例。
+    status, setting = manager.generate_character_setting("Alice", "seed")
+    assert status == "输出成功"
+    assert setting == "generated:model-a"
+
+    config.model = "model-b"
+    status, setting = manager.generate_character_setting("Alice", "seed")
+    assert status == "输出成功"
+    assert setting == "generated:model-b"
+
+    # 第三次配置不变时应该继续复用，防止把缓存修复成每次都重建。
+    status, setting = manager.generate_character_setting("Alice", "seed")
+    assert status == "输出成功"
+    assert setting == "generated:model-b"
+
+    assert created_models == ["model-a", "model-b"]
+    assert config.saved == 3


### PR DESCRIPTION
## 问题

角色配置页的「AI 一键帮写」会缓存第一次创建的 LLMManager。用户在 API 设置中修改模型 ID、API Key、Base URL 或 provider 额外配置后，后续 AI 帮写仍可能复用旧 adapter，导致请求继续使用旧配置。

## 修复

为 CharacterManager 增加 LLM 配置签名。每次调用角色 AI 帮写前，都会基于最终传给 LLMAdapterFactory 的参数生成签名：

- 配置未变化：复用已有 LLMManager
- 配置已变化：重建 LLM adapter 和 LLMManager

这样可以让角色页在设置变更后自动使用最新 LLM 配置。

## 验证

- 新增回归测试，覆盖从 model-a 切换到 model-b 后应重建 adapter 的场景
- 覆盖配置未变化时继续复用缓存的场景
- 本地通过 py_compile 语法检查
