### PR TITLE
Decouple DAG nodes and workflow from core logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ runtime/
 /dist
 /logs
 /temp_export_*
+/.pytest_cache
+/.tmp_pytest_*
 /ui/settings_ui/__pycache__
 /ui/settings_ui/.gitignore
 /ui/settings_ui/images

--- a/assets/system/workflow/headless.yaml
+++ b/assets/system/workflow/headless.yaml
@@ -1,0 +1,32 @@
+nodes:
+  - name: llm_worker
+    type: core.runtime.workers.LLMWorker
+  - name: tts_worker
+    type: core.runtime.workers.TTSWorker
+  - name: headless_sink
+    type: core.runtime.workers.HeadlessSinkNode
+edges:
+  - src: llm_worker
+    src_port: llm_output
+    dst: tts_worker
+    dst_port: llm_output
+  - src: tts_worker
+    src_port: tts_output
+    dst: headless_sink
+    dst_port: tts_output
+exports:
+  chat.input:
+    node: llm_worker
+    port: user_input
+    direction: input
+  chat.tts_input:
+    node: tts_worker
+    port: llm_output
+    direction: input
+  chat.audio_output:
+    node: headless_sink
+    port: tts_output
+    direction: input
+  chat.ui_worker:
+    node: headless_sink
+    direction: node

--- a/core/handlers/tts_message_handler.py
+++ b/core/handlers/tts_message_handler.py
@@ -224,7 +224,6 @@ class DefaultCharacterTtsHandler(MessageHandler):
                             is_final_segment=_is_last,
                             timeout=None if _is_first else 0,
                         ))
-                    rt.tts_queue.task_done()
                     return  # already emitted per-sentence, skip final tts_emit_to_ui_queue
             finally:
                 _hide_tts_busy()

--- a/core/handlers/ui_message_handler.py
+++ b/core/handlers/ui_message_handler.py
@@ -256,7 +256,6 @@ class CharacterDialogUiHandler(UIOutputMessageHandler):
                 audio_played,
             )
             ui.post_llm_reply_finished()
-        rt.audio_path_queue.task_done()
 
     def post_process(self, out: TTSOutputMessage) -> None:
         if not out.is_final_segment:

--- a/core/plugins/plugin_host.py
+++ b/core/plugins/plugin_host.py
@@ -65,6 +65,7 @@ def get_plugin_dag_node_factories() -> list[tuple[Callable[[], list], bool]]:
 
 
 def get_plugin_dag_yaml_paths() -> list[str]:
+    """Return plugin-registered workflow YAML paths (reserved — not yet wired into UX)."""
     return list(_plugin_dag_yaml_paths)
 
 

--- a/core/plugins/plugin_host.py
+++ b/core/plugins/plugin_host.py
@@ -44,6 +44,8 @@ _loaded: bool = False
 _plugin_manager: PluginManager | None = None
 _plugin_tts_handlers: List["MessageHandler"] = []
 _plugin_ui_handlers: List["UIOutputMessageHandler"] = []
+_plugin_dag_node_factories: list[tuple[Callable[[], list], bool]] = []
+_plugin_dag_yaml_paths: list[str] = []
 
 
 def get_plugin_manager() -> PluginManager | None:
@@ -58,13 +60,21 @@ def get_plugin_ui_handlers() -> List["UIOutputMessageHandler"]:
     return list(_plugin_ui_handlers)
 
 
+def get_plugin_dag_node_factories() -> list[tuple[Callable[[], list], bool]]:
+    return list(_plugin_dag_node_factories)
+
+
+def get_plugin_dag_yaml_paths() -> list[str]:
+    return list(_plugin_dag_yaml_paths)
+
+
 def ensure_plugins_loaded(config: ConfigManager | None = None) -> PluginManager | None:
     """
     Load ``data/config/plugins.yaml`` if present, instantiate plugins, merge LLM/TTS/ASR/T2I
     provider tables into the respective factories, register tools on the global ToolManager, and cache message handlers
     for :mod:`core.handlers.handler_registry`.
     """
-    global _loaded, _plugin_manager, _plugin_tts_handlers, _plugin_ui_handlers
+    global _loaded, _plugin_manager, _plugin_tts_handlers, _plugin_ui_handlers, _plugin_dag_node_factories, _plugin_dag_yaml_paths
     if _loaded:
         return _plugin_manager
 
@@ -123,6 +133,16 @@ def ensure_plugins_loaded(config: ConfigManager | None = None) -> PluginManager 
         logger.exception("collect_message_handlers failed")
         _plugin_tts_handlers = []
         _plugin_ui_handlers = []
+    try:
+        _plugin_dag_node_factories = mgr.collect_dag_node_factories()
+    except Exception:
+        logger.exception("collect_dag_node_factories failed")
+        _plugin_dag_node_factories = []
+    try:
+        _plugin_dag_yaml_paths = mgr.collect_dag_yaml_paths()
+    except Exception:
+        logger.exception("collect_dag_yaml_paths failed")
+        _plugin_dag_yaml_paths = []
 
     _plugin_manager = mgr
     _loaded = True

--- a/core/runtime/app_runtime.py
+++ b/core/runtime/app_runtime.py
@@ -61,9 +61,7 @@ def tts_emit_to_ui_queue(
     is_system_message: bool = False,
     effect: str = "",
 ) -> None:
-    """
-    与 TTSWorker.put_data 相同：将一条 TTS 结果送入 UI 队列，并对 LLM 侧 tts_queue 执行 task_done。
-    """
+    """Emit one TTS result to the UI queue."""
     from sdk.messages import TTSOutputMessage
 
     rt = get_app_runtime()
@@ -77,9 +75,3 @@ def tts_emit_to_ui_queue(
         effect=effect,
     )
     rt.audio_path_queue.put(out)
-    rt.tts_queue.task_done()
-
-
-def tts_item_done_only() -> None:
-    """仅消费 LLM->TTS 队列的一条任务（不产出 UI 包），如思维链丢弃。"""
-    get_app_runtime().tts_queue.task_done()

--- a/core/runtime/ui_update_manager.py
+++ b/core/runtime/ui_update_manager.py
@@ -47,6 +47,19 @@ def get_character_by_name(name: str):
     return _config_manager.get_character_by_name(name)
 
 
+def _format_dialog_html(name: str, speech: str, color: str, is_system: bool) -> str:
+    separator = "\uff1a"
+    if is_system:
+        return (
+            f"<p style='line-height: 135%; letter-spacing: 2px; color:{color};'>"
+            f"<b>{name}</b>{separator}{speech}</p>"
+        )
+    return (
+        f"<p style='line-height: 135%; letter-spacing: 2px;'>"
+        f"<b style='color:{color};'>{name}</b>{separator}{speech}</p>"
+    )
+
+
 class HeadlessUIUpdateManager:
     """Console/no-op UI facade for workflows that run without a desktop window."""
 
@@ -91,10 +104,10 @@ class HeadlessUIUpdateManager:
         pass
 
     def update_dialog(self, name: str, speech: str, color: str, is_system: bool = True) -> None:
-        line = f"{name}: {speech}" if name else str(speech or "")
-        if line.strip():
-            self.chat_history.append(line)
-            print(line)
+        formatted = _format_dialog_html(name, speech, color, is_system)
+        if str(speech or "").strip() or str(name or "").strip():
+            self.chat_history.append(formatted)
+            print(f"{name}: {speech}" if name else str(speech or ""))
 
     def update_sprite(self, character_name: str, sprite_id: int) -> None:
         pass

--- a/core/runtime/ui_update_manager.py
+++ b/core/runtime/ui_update_manager.py
@@ -13,7 +13,23 @@ from typing import Any, Dict, List, MutableSequence, Optional
 import cv2
 import numpy as np
 import pygame
-from PySide6.QtCore import QObject, Signal
+
+try:
+    from PySide6.QtCore import QObject, Signal
+except ImportError:
+    class QObject:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class _NoopSignal:
+        def connect(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def emit(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    def Signal(*args: Any, **kwargs: Any) -> _NoopSignal:
+        return _NoopSignal()
 
 from config.config_manager import ConfigManager
 
@@ -29,6 +45,67 @@ _config_manager = ConfigManager()
 
 def get_character_by_name(name: str):
     return _config_manager.get_character_by_name(name)
+
+
+class HeadlessUIUpdateManager:
+    """Console/no-op UI facade for workflows that run without a desktop window."""
+
+    def __init__(self, chat_history: Optional[MutableSequence[str]] = None) -> None:
+        self.chat_history: MutableSequence[str] = (
+            chat_history if chat_history is not None else []
+        )
+        self.current_bgm_path: Optional[str] = None
+        self.bg_group: List = []
+
+    def post_notification(self, text: str) -> None:
+        if text:
+            print(text)
+
+    def post_busy_bar(self, text: str, timeout: float = 0.0) -> None:
+        if text:
+            print(text)
+
+    def hide_busy_bar(self) -> None:
+        pass
+
+    def post_options(self, option_list: List[str]) -> None:
+        if option_list:
+            print(" / ".join(str(x) for x in option_list))
+
+    def post_numeric_value(self, text: str) -> None:
+        if text:
+            print(text)
+
+    def post_background(self, path: str) -> None:
+        if path:
+            print(f"background: {path}")
+
+    def post_cg(self, path: str) -> None:
+        if path:
+            print(f"cg: {path}")
+
+    def post_llm_reply_finished(self) -> None:
+        pass
+
+    def post_pause_asr(self) -> None:
+        pass
+
+    def update_dialog(self, name: str, speech: str, color: str, is_system: bool = True) -> None:
+        line = f"{name}: {speech}" if name else str(speech or "")
+        if line.strip():
+            self.chat_history.append(line)
+            print(line)
+
+    def update_sprite(self, character_name: str, sprite_id: int) -> None:
+        pass
+
+    def switch_bgm(self, new_bgm_path: str) -> None:
+        self.current_bgm_path = new_bgm_path or None
+        if new_bgm_path:
+            print(f"bgm: {new_bgm_path}")
+
+    def resolve_effect(self, *args: Any, **kwargs: Any) -> None:
+        pass
 
 
 class UIUpdateManager(QObject):

--- a/core/runtime/workers.py
+++ b/core/runtime/workers.py
@@ -359,3 +359,60 @@ class UIWorker(QThreadDagNode):
         self.task_done_requested.set()
         self.audio_path_queue.put(None)
         super().stop()
+
+
+class HeadlessSinkNode(QThreadDagNode):
+    """Consumes TTS output messages silently; no audio, no UI, no pygame.
+
+    Intended as the terminal node in ``headless.yaml`` so that
+    ``--headless`` mode avoids dragging in UIWorker / pygame audio channels.
+    """
+
+    PORT_TTS_OUTPUT = "tts_output"
+
+    def __init__(
+        self,
+        input_queue: Queue[TTSOutputMessage] | None = None,
+        parent=None,
+        *,
+        name: str = "headless_sink",
+    ):
+        super().__init__(name, parent=parent)
+        self.audio_path_queue = input_queue
+        if input_queue is not None:
+            self.bind_input(self.PORT_TTS_OUTPUT, input_queue)
+
+    def inputs(self) -> dict[str, Port]:
+        return {self.PORT_TTS_OUTPUT: Port(self.PORT_TTS_OUTPUT)}
+
+    def outputs(self) -> dict[str, Port]:
+        return {}
+
+    def _init_app(self):
+        if getattr(self, "_app_inited", False):
+            return
+        self.audio_path_queue = self.inq(self.PORT_TTS_OUTPUT)
+        self._app_inited = True
+
+    def run(self):
+        self._init_app()
+        while self.running:
+            item: Optional[TTSOutputMessage] = None
+            got_item = False
+            try:
+                item = self.audio_path_queue.get()
+                got_item = True
+                if item is None:
+                    break
+                if getattr(item, "text", ""):
+                    print(f"[headless] {item.name}: {item.text}")
+            except Exception:
+                pass
+            finally:
+                if got_item:
+                    self.audio_path_queue.task_done()
+
+    def stop(self):
+        self.running = False
+        self.audio_path_queue.put(None)
+        super().stop()

--- a/core/runtime/workers.py
+++ b/core/runtime/workers.py
@@ -1,13 +1,16 @@
 import re
 import traceback
-from queue import Queue
 from pathlib import Path
 from typing import Optional
 
 from i18n import tr
 from sdk.logging.timing import tracker
 
+from queue import Queue
+
 from PySide6.QtCore import QThread
+
+from sdk.graph import DagNode, Port
 
 # 假设以下依赖文件已在项目路径中
 from llm.llm_manager import STREAM_REASONING_DELTA_KEY
@@ -26,29 +29,28 @@ from sdk.messages import UserInputMessage, LLMDialogMessage, TTSOutputMessage
 from core.runtime.app_runtime import get_app_runtime, try_get_app_runtime, tts_emit_to_ui_queue
 from core.messaging.stream_parser import LlmResponseStreamParser
 from core.handlers.handler_registry import default_tts_handler_chain, default_ui_output_handler_chain
-# --- 抽象 Worker 接口定义 ---
 
-class BaseWorker(QThread):
-    """
-    Worker 抽象基类，定义了统一 QThread 基础。
-    """
+# --- QThread + DagNode 基类 ---
 
-    def __init__(self, *args, **kwargs):
-        # 确保 QThread 初始化
-        QThread.__init__(self, *args, **kwargs)
+class QThreadDagNode(DagNode, QThread):
+    """每个 DagNode 自带一个 QThread 运行循环。"""
+
+    def __init__(self, name: str, parent=None) -> None:
+        DagNode.__init__(self, name)
+        QThread.__init__(self, parent)
         self.running = True
 
-    def run(self):
-        """Worker 线程的主执行逻辑"""
-        pass
+    def start(self) -> None:
+        if self.isRunning():
+            return
+        self.running = True
+        QThread.start(self)
 
-    def stop(self):
-        """停止 Worker 线程并等待结束（最多 3 秒）。"""
+    def stop(self) -> None:
+        """停止线程并等待退出（最多 3 秒）。"""
         self.running = False
         if not self.wait(3000):
-            print(f"警告: {type(self).__name__} 线程未在 3 秒内退出，强制终止")
-            self.terminate()
-            self.wait()
+            print(f"警告: {type(self).__name__} 线程未在 3 秒内退出，请检查阻塞中的外部调用")
 
 def getCharacter(name: str):
     rt = try_get_app_runtime()
@@ -66,48 +68,66 @@ def _busy_preview_reasoning(raw: str, max_len: int = 200) -> str:
     return s
 
 
-class LLMWorker(BaseWorker):
+class LLMWorker(QThreadDagNode):
+    PORT_USER_INPUT = "user_input"
+    PORT_LLM_OUTPUT = "llm_output"
+
     def __init__(
         self,
-        input_queue: Queue[UserInputMessage],
-        output_queue: Queue[LLMDialogMessage],
+        input_queue: Queue[UserInputMessage] | None = None,
+        output_queue: Queue[LLMDialogMessage] | None = None,
         parent=None,
+        *,
+        name: str = "llm_worker",
     ):
-        super().__init__(parent)
+        super().__init__(name, parent=parent)
+        self._app_inited = False
+        self.user_input_queue = input_queue
+        self.tts_queue = output_queue
+        if input_queue is not None:
+            self.bind_input(self.PORT_USER_INPUT, input_queue)
+        if output_queue is not None:
+            self.bind_output(self.PORT_LLM_OUTPUT, output_queue)
+
+    def _init_app(self):
+        if self._app_inited:
+            return
         rt = get_app_runtime()
         self.ui_update_manager = rt.ui_update_manager
         self.llm_manager = rt.llm_manager
-        self.user_input_queue = input_queue
-        self.tts_queue = output_queue
+        self.user_input_queue = self.inq(self.PORT_USER_INPUT)
+        self.tts_queue = self.outq(self.PORT_LLM_OUTPUT)
         self.tool_manager = ToolManager()
+        self._app_inited = True
+
+    def inputs(self) -> dict[str, Port]:
+        return {self.PORT_USER_INPUT: Port(self.PORT_USER_INPUT)}
+
+    def outputs(self) -> dict[str, Port]:
+        return {self.PORT_LLM_OUTPUT: Port(self.PORT_LLM_OUTPUT)}
 
     def run(self):
+        self._init_app()
         while self.running:
             try:
-                # 从用户输入队列中获取任务，阻塞等待
-                # 期望获取的是 UserInputMessage 实例
                 message: UserInputMessage = self.user_input_queue.get()
                 if message is None:
                     break
-                
+
                 print(f"LLMWorker: 开始处理消息: {message.text}")
                 tracker.start_cross("e2e")
                 self.ui_update_manager.post_notification("发送成功，正在等待回复中...")
 
-                # 将用户消息添加到历史 (以 UI 格式和 LLM 格式分别处理)
                 formatted_user_message = f"<p style='line-height: 135%; letter-spacing: 2px; color:white;'><b style='color:white;'>你</b>: {message.text}</p>"
                 self.ui_update_manager.chat_history.append(formatted_user_message)
 
-                # 统一获取响应流
                 is_streaming = get_app_runtime().config.config.api_config.is_streaming
                 with tracker.track("LLM chat total"):
                     raw_response = self.llm_manager.chat(message.text, stream=is_streaming)
 
-                # 如果不是流式，将其包装成一个列表，使下文的 for 循环可以统一处理
                 if is_streaming:
                     response_stream = raw_response
                 else:
-                    # 包装成可迭代对象，模拟流式的一个 chunk
                     response_stream = [raw_response]
 
                 parser = LlmResponseStreamParser()
@@ -137,7 +157,6 @@ class LLMWorker(BaseWorker):
                     elif parser.unparsed_remainder:
                         _msg += "\n" + tr("desktop.llm_parse_remainder", text=parser.unparsed_remainder)
                     self.ui_update_manager.post_busy_bar(_msg, 0.0)
-                    # 直接投 UI 消息，不调 tts_queue.task_done（因为没 put 过 TTS 任务）
                     from sdk.messages import TTSOutputMessage
                     get_app_runtime().audio_path_queue.put(TTSOutputMessage(
                         audio_path="", name="system", asset_id="-1",
@@ -152,7 +171,6 @@ class LLMWorker(BaseWorker):
             except Exception as e:
                 print(f"LLMWorker: 任务处理失败: {e}")
                 traceback.print_exc()
-                # 异常时也直接投 UI 消息，不走 tts_queue.task_done
                 try:
                     from sdk.messages import TTSOutputMessage
                     _err = tr("desktop.llm_parse_empty") + f"\n{e}"
@@ -163,29 +181,43 @@ class LLMWorker(BaseWorker):
                 except Exception:
                     pass
                 self.user_input_queue.task_done()
-                
+
     def stop(self):
-        """停止 Worker 线程并等待结束。"""
         self.running = False
-        self.user_input_queue.put(None)  # 解锁 get() 阻塞
-        if not self.wait(3000):
-            print(f"警告: LLMWorker 线程未在 3 秒内退出，强制终止")
-            self.terminate()
-            self.wait()
+        self.user_input_queue.put(None)
+        super().stop()
 
 
-class TTSWorker(BaseWorker):
+class TTSWorker(QThreadDagNode):
+    PORT_LLM_OUTPUT = "llm_output"
+    PORT_TTS_OUTPUT = "tts_output"
+
     def __init__(
         self,
-        input_queue: Queue[LLMDialogMessage],
-        output_queue: Queue[TTSOutputMessage],
+        input_queue: Queue[LLMDialogMessage] | None = None,
+        output_queue: Queue[TTSOutputMessage] | None = None,
         parent=None,
+        *,
+        name: str = "tts_worker",
     ):
-        super().__init__(parent)
+        super().__init__(name, parent=parent)
+        self._app_inited = False
         self.tts_queue = input_queue
         self.audio_path_queue = output_queue
+        self.tts_message_dispatcher = None
+        if input_queue is not None:
+            self.bind_input(self.PORT_LLM_OUTPUT, input_queue)
+        if output_queue is not None:
+            self.bind_output(self.PORT_TTS_OUTPUT, output_queue)
+
+    def _init_app(self):
+        if self._app_inited:
+            return
+        self.tts_queue = self.inq(self.PORT_LLM_OUTPUT)
+        self.audio_path_queue = self.outq(self.PORT_TTS_OUTPUT)
         self.tts_message_dispatcher = default_tts_handler_chain()
         self.tts_message_dispatcher.init_handlers()
+        self._app_inited = True
 
     def put_data(self, character_name: str, speech: str, sprite: str, audio_path, is_system_message: bool = False, effect: str = ""):
         """与 handler 中 tts_emit_to_ui_queue 一致，供本 worker 异常路径使用。"""
@@ -194,7 +226,14 @@ class TTSWorker(BaseWorker):
             is_system_message=is_system_message, effect=effect,
         )
 
+    def inputs(self) -> dict[str, Port]:
+        return {self.PORT_LLM_OUTPUT: Port(self.PORT_LLM_OUTPUT)}
+
+    def outputs(self) -> dict[str, Port]:
+        return {self.PORT_TTS_OUTPUT: Port(self.PORT_TTS_OUTPUT)}
+
     def run(self):
+        self._init_app()
         while self.running:
             item: Optional[LLMDialogMessage] = None
             try:
@@ -217,62 +256,72 @@ class TTSWorker(BaseWorker):
                     )
 
     def stop(self):
-        """停止 Worker 线程并等待结束。"""
         self.running = False
         self.tts_queue.put(None)
-        if not self.wait(3000):
-            print(f"警告: TTSWorker 线程未在 3 秒内退出，强制终止")
-            self.terminate()
-            self.wait()
+        super().stop()
 
-class UIWorker(QThread):
-    def __init__(self, input_queue: Queue[TTSOutputMessage], parent=None):
-        super().__init__(parent)
-        rt = get_app_runtime()
-        self.ui_update_manager = rt.ui_update_manager
+class UIWorker(QThreadDagNode):
+    PORT_TTS_OUTPUT = "tts_output"
+    DIALOG_CHANNEL_ID = 7
+
+    def __init__(
+        self,
+        input_queue: Queue[TTSOutputMessage] | None = None,
+        parent=None,
+        *,
+        name: str = "ui_worker",
+    ):
+        super().__init__(name, parent=parent)
+        self._app_inited = False
         self.audio_path_queue = input_queue
-        self.running = True
-        self.task_done_requested = threading.Event() # 使用 Event 对象作为跳过标志
+        self.task_done_requested = threading.Event()
         self.current_audio_path = None
         self.DIALOG_CHANNEL_ID = 7
         self.ui_out_dispatcher = default_ui_output_handler_chain()
+        if input_queue is not None:
+            self.bind_input(self.PORT_TTS_OUTPUT, input_queue)
 
-        self.init_channel()
+    def _init_app(self):
+        if self._app_inited:
+            return
+        rt = get_app_runtime()
+        self.ui_update_manager = rt.ui_update_manager
+        self.audio_path_queue = self.inq(self.PORT_TTS_OUTPUT)
+        self._init_channel()
         br = get_app_runtime().ui_playback
         br.task_done_requested = self.task_done_requested
         br.dialog_channel = self.dialog_channel
         self.ui_out_dispatcher.init_handlers()
+        self._app_inited = True
 
-    def init_channel(self):
-        # --- 新增 Mixer 初始化和通道获取 ---
+    def inputs(self) -> dict[str, Port]:
+        return {self.PORT_TTS_OUTPUT: Port(self.PORT_TTS_OUTPUT)}
+
+    def outputs(self) -> dict[str, Port]:
+        return {}
+
+    def _init_channel(self):
         try:
             pygame.mixer.init()
-            # 确保有足够的通道，此处至少需要 DIALOG_CHANNEL_ID + 1 个
             if pygame.mixer.get_num_channels() < self.DIALOG_CHANNEL_ID + 1:
                 pygame.mixer.set_num_channels(self.DIALOG_CHANNEL_ID + 1)
-            
-            # 获取对话专用通道
             self.dialog_channel: pygame.mixer.Channel = pygame.mixer.Channel(self.DIALOG_CHANNEL_ID)
             print(f"UIWorker: 对话播放通道初始化成功，使用通道 {self.DIALOG_CHANNEL_ID}")
-
         except Exception as e:
             print(f"UIWorker: Pygame Mixer 初始化或通道获取失败: {e}")
-            self.dialog_channel = None # 如果失败，则禁用音频播放
-        # --- 结束新增 ---
+            self.dialog_channel = None
 
     def skip_speech(self):
-        """跳过当前对话"""
         if self.audio_path_queue.empty():
             return
         if self.dialog_channel and self.dialog_channel.get_busy():
             self.dialog_channel.stop()
-
         self.current_audio_path = None
         get_app_runtime().ui_playback.current_audio_path = None
-
         self.task_done_requested.set()
 
     def run(self):
+        self._init_app()
         while self.running:
             try:
                 self.task_done_requested.clear()
@@ -294,11 +343,7 @@ class UIWorker(QThread):
                 self.audio_path_queue.task_done()
 
     def stop(self):
-        """停止 UIWorker 线程并等待结束。"""
         self.running = False
         self.task_done_requested.set()
         self.audio_path_queue.put(None)
-        if not self.wait(3000):
-            print(f"警告: UIWorker 线程未在 3 秒内退出，强制终止")
-            self.terminate()
-            self.wait()
+        super().stop()

--- a/core/runtime/workers.py
+++ b/core/runtime/workers.py
@@ -109,8 +109,10 @@ class LLMWorker(QThreadDagNode):
     def run(self):
         self._init_app()
         while self.running:
+            got_item = False
             try:
                 message: UserInputMessage = self.user_input_queue.get()
+                got_item = True
                 if message is None:
                     break
 
@@ -166,8 +168,6 @@ class LLMWorker(QThreadDagNode):
                     _warn = tr("desktop.llm_parse_partial", n=parser.parse_failures)
                     print(f"LLMWorker: {_warn}")
 
-                self.user_input_queue.task_done()
-
             except Exception as e:
                 print(f"LLMWorker: 任务处理失败: {e}")
                 traceback.print_exc()
@@ -180,7 +180,9 @@ class LLMWorker(QThreadDagNode):
                     ))
                 except Exception:
                     pass
-                self.user_input_queue.task_done()
+            finally:
+                if got_item:
+                    self.user_input_queue.task_done()
 
     def stop(self):
         self.running = False
@@ -236,8 +238,10 @@ class TTSWorker(QThreadDagNode):
         self._init_app()
         while self.running:
             item: Optional[LLMDialogMessage] = None
+            got_item = False
             try:
                 item = self.tts_queue.get()
+                got_item = True
                 if item is None:
                     break
                 with tracker.track("TTS dispatch"):
@@ -254,6 +258,9 @@ class TTSWorker(QThreadDagNode):
                         is_system_message=False,
                         effect=item.effect,
                     )
+            finally:
+                if got_item:
+                    self.tts_queue.task_done()
 
     def stop(self):
         self.running = False
@@ -323,9 +330,12 @@ class UIWorker(QThreadDagNode):
     def run(self):
         self._init_app()
         while self.running:
+            output_data: Optional[TTSOutputMessage] = None
+            got_item = False
             try:
                 self.task_done_requested.clear()
-                output_data: TTSOutputMessage = self.audio_path_queue.get()
+                output_data = self.audio_path_queue.get()
+                got_item = True
                 if output_data is None:
                     break
                 self.ui_out_dispatcher.dispatch(output_data)
@@ -340,7 +350,9 @@ class UIWorker(QThreadDagNode):
                     _text = getattr(output_data, "text", "") or ""
                     wait = max(len(_text) / 10, 0.3) if _text else 0.3
                     self.task_done_requested.wait(timeout=wait)
-                self.audio_path_queue.task_done()
+            finally:
+                if got_item:
+                    self.audio_path_queue.task_done()
 
     def stop(self):
         self.running = False

--- a/core/runtime/workflow.py
+++ b/core/runtime/workflow.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from queue import Queue
+from typing import Any
+
+from sdk.graph import Dag
+
+DEFAULT_WORKFLOW_PATH = "assets/system/workflow/default.yaml"
+
+
+@dataclass
+class RuntimeWorkflow:
+    """Runtime DAG plus named exports declared by the workflow."""
+
+    dag: Dag
+    exports: dict[str, Any]
+    workflow_path: str
+
+    def start(self) -> None:
+        self.dag.start()
+
+    def stop(self) -> None:
+        self.dag.stop()
+
+    def get_export(self, name: str) -> Any | None:
+        return self.exports.get(name)
+
+    def require_export(self, name: str) -> Any:
+        value = self.get_export(name)
+        if value is None:
+            raise RuntimeError(f"Workflow export not found: {name}")
+        return value
+
+
+@dataclass
+class ChatWorkflowHandles:
+    """Optional handles used by the desktop chat surface."""
+
+    input_queue: Any | None = None
+    tts_queue: Any | None = None
+    audio_queue: Any | None = None
+    ui_worker: Any | None = None
+
+
+def _resolve_exports(dag: Dag) -> dict[str, Any]:
+    exports: dict[str, Any] = {}
+    for name in dag.export_specs():
+        exports[name] = dag.resolve_export(name)
+    return exports
+
+
+def build_runtime_workflow(
+    *,
+    workflow_path: str | None = None,
+    queue_factory: Callable[[], Any] = Queue,
+) -> RuntimeWorkflow:
+    """Build the host runtime DAG and resolve its named exports."""
+
+    dag = Dag(queue_factory=queue_factory)
+    selected_workflow = (workflow_path or "").strip()
+
+    selected_workflow = selected_workflow or DEFAULT_WORKFLOW_PATH
+    dag.load_yaml(selected_workflow)
+
+    dag.build()
+
+    return RuntimeWorkflow(
+        dag=dag,
+        exports=_resolve_exports(dag),
+        workflow_path=selected_workflow,
+    )
+
+
+def get_chat_workflow_handles(workflow: RuntimeWorkflow) -> ChatWorkflowHandles:
+    return ChatWorkflowHandles(
+        input_queue=workflow.get_export("chat.input"),
+        tts_queue=workflow.get_export("chat.tts_input"),
+        audio_queue=workflow.get_export("chat.audio_output"),
+        ui_worker=workflow.get_export("chat.ui_worker"),
+    )

--- a/core/sprite/chat_ui_service.py
+++ b/core/sprite/chat_ui_service.py
@@ -22,7 +22,7 @@ from sdk.chat_ui_context import ChatUIContext, set_chat_ui_context
 def install_chat_ui_context(
     window: Any,
     *,
-    emit_user_text: Callable[[str], None],
+    emit_user_text: Callable[[str], None] | None,
 ) -> ChatUIContext:
     """Create context from window factories, register globals, apply desktop plugin widgets."""
     state_proxy = window._make_state_proxy()
@@ -50,7 +50,7 @@ def wire_chat_ui_bridge(
     *,
     window: Any,
     app: Any,
-    emit_user_text: Callable[[str], None],
+    emit_user_text: Callable[[str], None] | None,
     chat_history: list,
     history_file: str,
     llm_manager: LLMManager,
@@ -68,6 +68,9 @@ def wire_chat_ui_bridge(
 
     def on_message_submitted(message: str) -> None:
         print(_tr("main.print_submitted", message=message))
+        if emit_user_text is None:
+            ctx.set_notification_hint(_tr("main.notify_chat"))
+            return
         emit_user_text(message)
         ctx.set_notification_hint(_tr("main.notify_submitted"))
 
@@ -78,7 +81,7 @@ def wire_chat_ui_bridge(
         llm_manager._strip_orphaned_tool_calls()
         pop_last_assistant_turn(chat_history, messages)
         last_msg = getattr(window, "_last_user_message", "")
-        if last_msg:
+        if last_msg and emit_user_text is not None:
             emit_user_text(last_msg)
         ctx.set_notification_hint(_tr("main.notify_reroll"))
 
@@ -107,14 +110,16 @@ def wire_chat_ui_bridge(
         app.quit()
 
     ctx.on_close_window(_on_chat_ui_close)
-    ctx.on_clear_chat_history(
-        lambda: clear_chat_history(
-            history_file=history_file,
-            ui_queue=audio_path_queue,
-            llm_manager=llm_manager,
+    if audio_path_queue is not None:
+        ctx.on_clear_chat_history(
+            lambda: clear_chat_history(
+                history_file=history_file,
+                ui_queue=audio_path_queue,
+                llm_manager=llm_manager,
+            )
         )
-    )
-    ctx.on_skip_speech_signal(lambda: ui_worker.skip_speech())
+    if ui_worker is not None and hasattr(ui_worker, "skip_speech"):
+        ctx.on_skip_speech_signal(lambda: ui_worker.skip_speech())
     ctx.on_copy_chat_history_to_clipboard(copy_chat_history_to_clipboard)
     ctx.on_revert_chat_history(
         lambda index: revert_chat_history(

--- a/core/sprite/sprite_cli.py
+++ b/core/sprite/sprite_cli.py
@@ -23,6 +23,17 @@ def build_sprite_arg_parser(tr_i18n: Callable[..., str]) -> argparse.ArgumentPar
     parser.add_argument("--bg", type=str, default="")
     parser.add_argument("--t2i", type=str, default="ComfyUI")
     parser.add_argument(
+        "--workflow",
+        type=str,
+        default="",
+        help="Path to the workflow YAML to run. Defaults to the built-in desktop workflow.",
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run the selected workflow without creating the desktop UI.",
+    )
+    parser.add_argument(
         "--room_id",
         type=str,
         default="",

--- a/core/sprite/sprite_cli.py
+++ b/core/sprite/sprite_cli.py
@@ -31,7 +31,12 @@ def build_sprite_arg_parser(tr_i18n: Callable[..., str]) -> argparse.ArgumentPar
     parser.add_argument(
         "--headless",
         action="store_true",
-        help="Run the selected workflow without creating the desktop UI.",
+        help=(
+            "Run without the desktop window. "
+            "Defaults to assets/system/workflow/headless.yaml "
+            "(LLM→TTS→headless sink; no pygame audio). "
+            "Override with --workflow to supply a custom workflow."
+        ),
     )
     parser.add_argument(
         "--room_id",

--- a/docs/PLUGIN_DEVELOPER_GUIDE.md
+++ b/docs/PLUGIN_DEVELOPER_GUIDE.md
@@ -31,7 +31,7 @@ You need a **full restart** after changing `plugins.yaml` (unlike MCP save-and-a
 | `register_settings_ui`          | Extra Settings sidebar page                                |
 | `register_tools_tab`            | Extra tab under **Settings → Tools**                       |
 | `register_chat_ui_widget`       | Chat window widget + placement hint                        |
-| `register_dag_yaml`             | Selectable workflow YAML path                              |
+| `register_dag_yaml`             | Workflow YAML path (reserved — not yet wired into UX)      |
 | `register_dag_node`             | DAG node candidates for plugin tooling                     |
 
 
@@ -67,7 +67,10 @@ The host runs exactly one workflow at a time:
 
 - If the user passes `--workflow path/to/workflow.yaml`, only that YAML is loaded.
 - If no workflow is selected, the host loads `assets/system/workflow/default.yaml`.
+  In headless mode (``--headless``) the default is `assets/system/workflow/headless.yaml`,
+  which omits UIWorker and avoids pygame/Qt window dependencies.
 - Plugin workflow YAML files are selectable candidates; they are not merged into the default workflow automatically.
+  (Workflow selection UX is not yet wired — ``register_dag_yaml`` paths are reserved for future use.)
 
 A workflow YAML has three top-level sections:
 
@@ -75,10 +78,12 @@ A workflow YAML has three top-level sections:
 nodes:
   - name: rule
     type: plugins.my_plugin.workflow.RuleNode
-    accepted: "yes"
+    params:
+      accepted: "yes"
   - name: router
     type: plugins.my_plugin.workflow.RouterNode
-    rule_node: rule
+    params:
+      rule_node: rule
 edges:
   - src: router
     src_port: accepted
@@ -91,7 +96,8 @@ exports:
     direction: input
 ```
 
-- `nodes` instantiate classes by dotted import path. Any keys other than `name` and `type` are passed to the node constructor.
+- `nodes` instantiate classes by dotted import path. The ``params`` dict under each node
+  maps directly to the node class constructor kwargs.
 - `edges` connect an output port to an input port with a shared queue.
 - `exports` expose queues or node handles to the host.
 

--- a/docs/PLUGIN_DEVELOPER_GUIDE.md
+++ b/docs/PLUGIN_DEVELOPER_GUIDE.md
@@ -31,6 +31,8 @@ You need a **full restart** after changing `plugins.yaml` (unlike MCP save-and-a
 | `register_settings_ui`          | Extra Settings sidebar page                                |
 | `register_tools_tab`            | Extra tab under **Settings → Tools**                       |
 | `register_chat_ui_widget`       | Chat window widget + placement hint                        |
+| `register_dag_yaml`             | Selectable workflow YAML path                              |
+| `register_dag_node`             | DAG node candidates for plugin tooling                     |
 
 
 **Host-only** (do **not** call from plugins): `set_settings_ui_plugin_context`, `clear_settings_ui_plugin_context`. The host wraps `initialize` so `SettingsUIContribution` / `ToolsTabContribution` pick up `plugin_id` / `plugin_version` when you leave those fields `None`.
@@ -57,6 +59,78 @@ You need a **full restart** after changing `plugins.yaml` (unlike MCP save-and-a
 
 
 Prefer these over raw Qt signals on internal windows.
+
+### Runtime workflows
+
+Runtime workflows are declared as YAML and loaded through `core.runtime.workflow`.
+The host runs exactly one workflow at a time:
+
+- If the user passes `--workflow path/to/workflow.yaml`, only that YAML is loaded.
+- If no workflow is selected, the host loads `assets/system/workflow/default.yaml`.
+- Plugin workflow YAML files are selectable candidates; they are not merged into the default workflow automatically.
+
+A workflow YAML has three top-level sections:
+
+```yaml
+nodes:
+  - name: rule
+    type: plugins.my_plugin.workflow.RuleNode
+    accepted: "yes"
+  - name: router
+    type: plugins.my_plugin.workflow.RouterNode
+    rule_node: rule
+edges:
+  - src: router
+    src_port: accepted
+    dst: sink
+    dst_port: in
+exports:
+  chat.input:
+    node: router
+    port: in
+    direction: input
+```
+
+- `nodes` instantiate classes by dotted import path. Any keys other than `name` and `type` are passed to the node constructor.
+- `edges` connect an output port to an input port with a shared queue.
+- `exports` expose queues or node handles to the host.
+
+`DagNode` is passive by default. Its sync lifecycle hooks (`start` / `stop`) and async lifecycle hooks (`astart` / `astop`) do nothing unless your subclass overrides them. Queue-driven nodes should own their execution loop in lifecycle hooks. Passive helper nodes should expose normal Python methods and be called by another node or by the host.
+
+To reference another node from YAML, pass its name as a constructor parameter and resolve it in `configure(nodes)`:
+
+```python
+from sdk.graph import DagNode, Port
+
+
+class RuleNode(DagNode):
+    def inputs(self):
+        return {}
+
+    def outputs(self):
+        return {}
+
+    def accepts(self, value: str) -> bool:
+        return value == "yes"
+
+
+class RouterNode(DagNode):
+    def __init__(self, name: str, rule_node: str):
+        super().__init__(name)
+        self.rule_node_name = rule_node
+        self.rule = None
+
+    def inputs(self):
+        return {"in": Port("in")}
+
+    def outputs(self):
+        return {"accepted": Port("accepted"), "rejected": Port("rejected")}
+
+    def configure(self, nodes):
+        self.rule = nodes[self.rule_node_name]
+```
+
+Important boundary: `edges` only wire queues. A passive node is not executed just because it appears in YAML. Something must call its methods, or it must implement its own lifecycle.
 
 ### Adapter classes: schemas and “extra” kwargs
 

--- a/main.py
+++ b/main.py
@@ -28,14 +28,9 @@ import llm.tools.file_tools
 from llm.template_generator import is_transparent_background
 from llm.llm_manager import LLMManager, LLMAdapterFactory
 from llm.text_processor import TextProcessor
-from core.runtime.workers import LLMWorker, TTSWorker, UIWorker
 from core.runtime.app_runtime import AppRuntime, set_app_runtime
-from core.runtime.ui_update_manager import UIUpdateManager, connect_to_desktop_window
-from PySide6.QtWidgets import QApplication
-from PySide6.QtGui import QIcon
+from core.runtime.workflow import build_runtime_workflow, get_chat_workflow_handles
 from tts.tts_manager import TTSManager, TTSAdapterFactory
-from ui.chat_ui.chat_ui import ChatUIWindow
-from ui.chat_ui.qss_fusion import ensure_fusion_style
 from config.config_manager import ConfigManager
 from t2i.t2i_manager import T2IAdapterFactory, T2IManager
 import pygame
@@ -65,6 +60,17 @@ except ImportError as e:
 
 voice_lang = "ja"
 cc = OpenCC("t2s")  # 繁体到简体转换器
+
+
+def _shutdown_plugins() -> None:
+    try:
+        from core.plugins.plugin_host import get_plugin_manager
+
+        mgr = get_plugin_manager()
+        if mgr is not None:
+            mgr.shutdown_all()
+    except Exception:
+        pass
 
 
 def main():
@@ -182,13 +188,8 @@ def main():
     image_queue = Queue()
     emotion_queue = Queue()
 
-    # 初始化 Pygame
-    pygame.mixer.init()
-
-    # 创建三个消息队列
-    user_input_queue = Queue()
-    tts_queue = Queue()
-    audio_path_queue = Queue()
+    if not args.headless:
+        pygame.mixer.init()
 
     text_processor = TextProcessor()
 
@@ -219,8 +220,60 @@ def main():
         )
     except Exception:
         pass
-    
+
+    workflow = build_runtime_workflow(
+        workflow_path=args.workflow or None,
+        queue_factory=Queue,
+    )
+    chat_handles = get_chat_workflow_handles(workflow)
+    user_input_queue = chat_handles.input_queue
+    audio_path_queue = chat_handles.audio_queue
+    tts_queue = chat_handles.tts_queue
+    _um = chat_handles.ui_worker
+
+    if args.headless:
+        from core.runtime.ui_update_manager import HeadlessUIUpdateManager
+
+        ui_updates = HeadlessUIUpdateManager(chat_history=chat_history)
+        set_app_runtime(
+            AppRuntime(
+                config=config,
+                ui_update_manager=ui_updates,
+                llm_manager=llm_manager,
+                tts_manager=tts_manager,
+                t2i_manager=t2i_manager,
+                bgm_list=bgm_list,
+                user_input_queue=user_input_queue,
+                tts_queue=tts_queue,
+                audio_path_queue=audio_path_queue,
+                text_processor=text_processor,
+                opencc=cc,
+            )
+        )
+        workflow.start()
+        print(f"Workflow started: {args.workflow or 'default'}")
+        try:
+            import time
+
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            workflow.stop()
+            _shutdown_plugins()
+            if tts_manager:
+                tts_manager.shutdown()
+            save_chat_history(args.history, llm_manager.get_messages())
+        return
+
     # Init UI and connect to runtime
+    from core.runtime.ui_update_manager import UIUpdateManager, connect_to_desktop_window
+    from PySide6.QtGui import QIcon
+    from PySide6.QtWidgets import QApplication
+    from ui.chat_ui.chat_ui import ChatUIWindow
+    from ui.chat_ui.qss_fusion import ensure_fusion_style
+
     app = QApplication([])
     ensure_fusion_style(app)
     ui_updates = UIUpdateManager(chat_history=chat_history, bg_group=bg_group or [])
@@ -249,15 +302,7 @@ def main():
         )
     )
 
-    # 创建并启动 Worker 线程（队列显式连接流水线，其馀从 app_runtime 注入）
-    ui_worker = UIWorker(audio_path_queue)
-    ui_worker.start()
-
-    tts_worker = TTSWorker(tts_queue, audio_path_queue)
-    tts_worker.start()
-
-    llm_worker = LLMWorker(user_input_queue, tts_queue)
-    llm_worker.start()
+    workflow.start()
 
     init_sprite_path = args.init_sprite_path
     print(init_sprite_path)
@@ -281,7 +326,10 @@ def main():
             window.setDisplayWords(_welcome_html)
     window.setNotification(tr_i18n("main.notify_chat"))
 
-    emit_user_text = wire_user_input_plugins(user_input_queue)
+    if user_input_queue is not None:
+        emit_user_text = wire_user_input_plugins(user_input_queue)
+    else:
+        emit_user_text = None
 
     # Update system_config with current session's bg/bgm so restore doesn't use stale values
     sc = config.config.system_config.model_copy(deep=True)
@@ -296,13 +344,14 @@ def main():
 
     chat_ui_ctx = install_chat_ui_context(window, emit_user_text=emit_user_text)
 
-    restore_session_ui(
-        messages,
-        audio_path_queue=audio_path_queue,
-        window=window,
-        config=config,
-        tr_i18n=tr_i18n,
-    )
+    if audio_path_queue is not None:
+        restore_session_ui(
+            messages,
+            audio_path_queue=audio_path_queue,
+            window=window,
+            config=config,
+            tr_i18n=tr_i18n,
+        )
 
     wire_chat_ui_bridge(
         chat_ui_ctx,
@@ -314,17 +363,18 @@ def main():
         llm_manager=llm_manager,
         audio_path_queue=audio_path_queue,
         tts_manager=tts_manager,
-        ui_worker=ui_worker,
+        ui_worker=_um,
         tr_i18n=tr_i18n,
     )
 
     if args.room_id:
         print(tr_i18n("main.print_bili_start", id=args.room_id))
-        try:
-            start_bilibili_service(args.room_id, user_input_queue=user_input_queue)
-        except ImportError as e:
-            # print(tr_i18n("main.print_bili_import", e=str(e)))
-            pass
+        if user_input_queue is not None:
+            try:
+                start_bilibili_service(args.room_id, user_input_queue=user_input_queue)
+            except ImportError as e:
+                # print(tr_i18n("main.print_bili_import", e=str(e)))
+                pass
 
     # 确保在程序退出时停止所有线程
     try:
@@ -334,26 +384,10 @@ def main():
         print(tr_i18n("main.print_icon_fail", e=str(e)))
 
     # 关闭顺序：插件 → TTS 服务器 → Worker 线程 → 保存数据
-    try:
-        from core.plugins.plugin_host import get_plugin_manager
-
-        mgr = get_plugin_manager()
-
-        def _shutdown_plugins() -> None:
-            if mgr is not None:
-                try:
-                    mgr.shutdown_all()
-                except Exception:
-                    pass
-
-        app.aboutToQuit.connect(_shutdown_plugins)
-    except Exception:
-        pass
+    app.aboutToQuit.connect(workflow.stop)
+    app.aboutToQuit.connect(_shutdown_plugins)
     app.aboutToQuit.connect(lambda: tts_manager and tts_manager.shutdown())
     app.aboutToQuit.connect(lambda: save_chat_history(args.history, llm_manager.get_messages()))
-    app.aboutToQuit.connect(llm_worker.stop)
-    app.aboutToQuit.connect(tts_worker.stop)
-    app.aboutToQuit.connect(ui_worker.stop)
     app.aboutToQuit.connect(
         lambda: save_bg(
             bg_path=window.current_background_path,

--- a/main.py
+++ b/main.py
@@ -221,8 +221,13 @@ def main():
     except Exception:
         pass
 
+    if args.headless and not (args.workflow or "").strip():
+        headless_workflow = "assets/system/workflow/headless.yaml"
+    else:
+        headless_workflow = None
+
     workflow = build_runtime_workflow(
-        workflow_path=args.workflow or None,
+        workflow_path=args.workflow or headless_workflow,
         queue_factory=Queue,
     )
     chat_handles = get_chat_workflow_handles(workflow)

--- a/sdk/graph.py
+++ b/sdk/graph.py
@@ -278,9 +278,10 @@ class DagBuilder:
         import yaml
 
         text = path_or_text
-        p = Path(path_or_text)
-        if p.is_file():
-            text = p.read_text(encoding="utf-8")
+        if "\n" not in path_or_text and "\r" not in path_or_text:
+            p = Path(path_or_text)
+            if p.is_file():
+                text = p.read_text(encoding="utf-8")
         data = yaml.safe_load(text)
         if not isinstance(data, dict):
             raise ValueError("YAML must be a dict with 'nodes' and 'edges'")

--- a/sdk/graph.py
+++ b/sdk/graph.py
@@ -1,13 +1,15 @@
-"""
-DAG 流水线抽象 —— 插件可用 ``DagNode`` 注册自定义处理节点，宿主用 ``DagBuilder`` 组装。
+"""Queue-based DAG primitives for host and plugin workflows.
 
-无 PySide6 / queue.Queue 等依赖，只定义接口。
+Nodes declare ports. The builder binds queues to edges and exports. Nodes are
+passive by default: ``start`` / ``stop`` and ``astart`` / ``astop`` are no-ops
+unless a subclass chooses to own execution.
 """
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -17,37 +19,25 @@ except ImportError:
     from typing_extensions import Self
 
 
-# ── Port ────────────────────────────────────────────────────────────────
-
 @dataclass
 class Port:
-    """DAG 节点的输入/输出端口。
-
-    不绑定具体队列类型；宿主在 ``DagBuilder.build()`` 时注入实际 ``Queue``。
-    """
-
     name: str
 
 
 @dataclass
 class Edge:
-    """一条有向边：src_node.outputs[src_port] → dst_node.inputs[dst_port]"""
-
     src_node: str
     src_port: str
     dst_node: str
     dst_port: str
 
 
-# ── DagNode ──────────────────────────────────────────────────────────────
-
 class DagNode:
-    """DAG 中的一个处理节点。
+    """Base DAG node.
 
-    子类实现 ``inputs`` / ``outputs`` 声明端口，
-    实现 ``start`` / ``stop`` 管理生命周期。
-    宿主在 ``DagBuilder.build()`` 时通过
-    ``bind_input`` / ``bind_output`` 注入实际 ``Queue``。
+    Passive nodes only declare ports and expose methods for other nodes or the
+    host to call. Active nodes can override sync ``start`` / ``stop`` or async
+    ``astart`` / ``astop``.
     """
 
     def __init__(self, name: str) -> None:
@@ -59,21 +49,31 @@ class DagNode:
     def name(self) -> str:
         return self._name
 
-    # ── 子类实现 ──────────────────────────────────────────────────────
-
     def inputs(self) -> dict[str, Port]:
-        """声明输入端口（子类必须覆写）。"""
         raise NotImplementedError(f"{type(self).__name__}.inputs()")
 
     def outputs(self) -> dict[str, Port]:
-        """声明输出端口（子类必须覆写）。"""
         raise NotImplementedError(f"{type(self).__name__}.outputs()")
 
-    def stop(self) -> None:
-        """停止节点并等待退出（子类必须覆写）。"""
-        raise NotImplementedError(f"{type(self).__name__}.stop()")
+    def configure(self, nodes: dict[str, "DagNode"]) -> None:
+        """Resolve references to other workflow nodes after YAML load."""
+        pass
 
-    # ── 宿主调用 ──────────────────────────────────────────────────────
+    def start(self) -> None:
+        """Start node work if it owns execution. Passive nodes do nothing."""
+        pass
+
+    def stop(self) -> None:
+        """Stop node work if it owns execution. Passive nodes do nothing."""
+        pass
+
+    async def astart(self) -> None:
+        """Async start hook. By default it delegates to ``start``."""
+        self.start()
+
+    async def astop(self) -> None:
+        """Async stop hook. By default it delegates to ``stop``."""
+        self.stop()
 
     def bind_input(self, port_name: str, queue: Any) -> None:
         self._bound_inputs[port_name] = queue
@@ -82,7 +82,6 @@ class DagNode:
         self._bound_outputs[port_name] = queue
 
     def inq(self, port_name: str) -> Any:
-        """获取已绑定的输入队列。"""
         q = self._bound_inputs.get(port_name)
         if q is None:
             raise RuntimeError(
@@ -91,7 +90,6 @@ class DagNode:
         return q
 
     def outq(self, port_name: str) -> Any:
-        """获取已绑定的输出队列。"""
         q = self._bound_outputs.get(port_name)
         if q is None:
             raise RuntimeError(
@@ -100,24 +98,15 @@ class DagNode:
         return q
 
 
-# ── EdgeSpec ────────────────────────────────────────────────────────────
-
-
 @dataclass
 class EdgeSpec:
-    """插件声明的一条连线（不依赖宿主的实际节点名是否存在）。"""
-
     src: str
     src_port: str
     dst: str
     dst_port: str
 
 
-# ── DagBuilder ───────────────────────────────────────────────────────────
-
 class DagBuilder:
-    """声明式构建 DAG。"""
-
     def __init__(self) -> None:
         self._nodes: dict[str, DagNode] = {}
         self._edges: list[Edge] = []
@@ -126,7 +115,6 @@ class DagBuilder:
         self._exports: dict[str, dict[str, Any]] = {}
 
     def set_queue_factory(self, factory: Callable[[], Any]) -> Self:
-        """设置 Queue 工厂（宿主传入 ``Queue`` 即可）。"""
         self._queue_factory = factory
         return self
 
@@ -136,60 +124,49 @@ class DagBuilder:
         self._nodes[node.name] = node
         return self
 
-    def connect(
-        self, src: str, src_port: str, dst: str, dst_port: str
-    ) -> Self:
-        """连接两个节点的端口（节点必须已添加）。"""
+    def connect(self, src: str, src_port: str, dst: str, dst_port: str) -> Self:
         if src not in self._nodes:
             raise ValueError(f"Unknown source node: {src}")
         if dst not in self._nodes:
             raise ValueError(f"Unknown destination node: {dst}")
-        
+
         src_ports = self._nodes[src].outputs()
         dst_ports = self._nodes[dst].inputs()
         if src_port not in src_ports:
-            raise ValueError(
-                f"Node '{src}' has no output port '{src_port}'"
-            )
+            raise ValueError(f"Node '{src}' has no output port '{src_port}'")
         if dst_port not in dst_ports:
-            raise ValueError(
-                f"Node '{dst}' has no input port '{dst_port}'"
-            )
+            raise ValueError(f"Node '{dst}' has no input port '{dst_port}'")
         self._edges.append(
             Edge(src_node=src, src_port=src_port, dst_node=dst, dst_port=dst_port)
         )
         return self
 
     def add_edges(self, specs: list[EdgeSpec]) -> Self:
-        """延迟连线：记录连线意图，build() 时再校验并落实。"""
         self._pending_edges.extend(specs)
         return self
 
     def build(self) -> list[DagNode]:
-        """构建 DAG：落实延迟连线、创建队列、绑定端口、返回节点列表。
-
-        ``set_queue_factory`` 必须先调用。
-        """
         if self._queue_factory is None:
             raise RuntimeError("queue_factory not set")
 
-        # 落实延迟连线（插件注册的 EdgeSpec）。复用 connect()，确保端口也被校验。
+        for node in self._nodes.values():
+            node.configure(self._nodes)
+
         pending_edges = self._pending_edges
         self._pending_edges = []
         for spec in pending_edges:
             self.connect(spec.src, spec.src_port, spec.dst, spec.dst_port)
 
-        _queues: dict[tuple[str, str], Any] = {}
+        queues: dict[tuple[str, str], Any] = {}
         for e in self._edges:
             key = (e.src_node, e.src_port)
-            q = _queues.get(key)
+            q = queues.get(key)
             if q is None:
                 q = self._queue_factory()
-                _queues[key] = q
+                queues[key] = q
             self._nodes[e.src_node].bind_output(e.src_port, q)
             self._nodes[e.dst_node].bind_input(e.dst_port, q)
 
-        # 为没有 incoming edge 的输入端口创建独立队列（管线起点 / 外部馈入）
         for node in self._nodes.values():
             for port_name in node.inputs():
                 if port_name not in node._bound_inputs:
@@ -198,7 +175,6 @@ class DagBuilder:
                 if port_name not in node._bound_outputs:
                     node.bind_output(port_name, self._queue_factory())
 
-        # 只返回有连线的节点（注册但未连线的节点不启动，避免空转线程）
         connected: set[str] = set()
         for e in self._edges:
             connected.add(e.src_node)
@@ -209,10 +185,7 @@ class DagBuilder:
                 connected.add(node_name)
         return [n for n in self._nodes.values() if n.name in connected]
 
-    # ── 序列化 ────────────────────────────────────────────────────────
-
     def to_dict(self) -> dict:
-        """导出 DAG 结构为 dict（不含队列绑定，仅元数据）。"""
         return {
             "nodes": [
                 {
@@ -224,8 +197,12 @@ class DagBuilder:
                 for n in self._nodes.values()
             ],
             "edges": [
-                {"src": e.src_node, "src_port": e.src_port,
-                 "dst": e.dst_node, "dst_port": e.dst_port}
+                {
+                    "src": e.src_node,
+                    "src_port": e.src_port,
+                    "dst": e.dst_node,
+                    "dst_port": e.dst_port,
+                }
                 for e in self._edges
             ],
             "exports": dict(self._exports),
@@ -233,18 +210,37 @@ class DagBuilder:
 
     @staticmethod
     def _import_class(dotted: str) -> type:
-        """从 ``package.module.ClassName`` 字符串导入类。"""
-        import importlib
-
         parts = dotted.rsplit(".", 1)
         if len(parts) != 2:
             raise ValueError(f"Cannot parse dotted class name: {dotted}")
         mod, cls_name = parts
-        m = importlib.import_module(mod)
-        return getattr(m, cls_name)
+        module = importlib.import_module(mod)
+        return getattr(module, cls_name)
+
+    @staticmethod
+    def _make_node(node_cls: type, name: str, params: dict[str, Any]) -> DagNode:
+        attempts = (
+            lambda: node_cls(name=name, **params),
+            lambda: node_cls(name, **params),
+            lambda: node_cls(**params),
+            lambda: node_cls(name=name),
+            lambda: node_cls(name),
+            lambda: node_cls(),
+        )
+        last_error: TypeError | None = None
+        for attempt in attempts:
+            try:
+                node = attempt()
+            except TypeError as exc:
+                last_error = exc
+                continue
+            if isinstance(node, DagNode):
+                return node
+            raise TypeError(f"{node_cls!r} did not create a DagNode")
+        assert last_error is not None
+        raise last_error
 
     def to_yaml(self, path: str | None = None) -> str:
-        """导出 DAG 为 YAML 字符串；若提供 ``path`` 则写入文件。"""
         import yaml
 
         out = yaml.dump(self.to_dict(), allow_unicode=True, sort_keys=False)
@@ -253,7 +249,6 @@ class DagBuilder:
         return out
 
     def load_dict(self, data: dict) -> None:
-        """从 dict 加载节点和边到当前 builder（用于组装多方工作流）。"""
         for nd in data.get("nodes") or []:
             dotted = nd.get("type", "")
             try:
@@ -261,13 +256,11 @@ class DagBuilder:
             except Exception as e:
                 raise ValueError(f"Cannot import {dotted}: {e}") from e
             node_name = nd["name"]
+            params = {k: v for k, v in nd.items() if k not in {"name", "type"}}
             try:
-                node = node_cls(name=node_name)
-            except TypeError:
-                try:
-                    node = node_cls(node_name)
-                except TypeError:
-                    node = node_cls()
+                node = self._make_node(node_cls, node_name, params)
+            except Exception as e:
+                raise ValueError(f"Cannot instantiate {dotted}: {e}") from e
             self.add_node(node)
 
         for e in data.get("edges") or []:
@@ -282,7 +275,6 @@ class DagBuilder:
             self._exports[name] = dict(spec)
 
     def load_yaml(self, path_or_text: str) -> None:
-        """从 YAML 文件路径或 YAML 字符串加载节点和边到当前 builder。"""
         import yaml
 
         text = path_or_text
@@ -296,7 +288,6 @@ class DagBuilder:
 
     @classmethod
     def from_dict(cls, data: dict, *, queue_factory=None) -> "DagBuilder":
-        """从 dict 创建新 builder 并加载（用于测试/独立场景）。"""
         builder = cls()
         if queue_factory:
             builder.set_queue_factory(queue_factory)
@@ -305,7 +296,6 @@ class DagBuilder:
 
     @classmethod
     def from_yaml(cls, path_or_text: str, *, queue_factory=None) -> "DagBuilder":
-        """从 YAML 文件路径或 YAML 字符串创建新 builder 并加载。"""
         builder = cls()
         if queue_factory:
             builder.set_queue_factory(queue_factory)
@@ -313,30 +303,13 @@ class DagBuilder:
         return builder
 
 
-# ── Dag ─────────────────────────────────────────────────────────────────
-
 class Dag:
-    """DAG 全生命周期管理：构建、启动、关闭。
-
-    用法::
-
-        dag = Dag(queue_factory=Queue)
-        dag.load_yaml("workflow/default.yaml")
-        dag.add_node(my_node)
-        dag.load_yaml("plugin/workflow.yaml")
-        dag.start()
-        # … 运行 …
-        dag.stop()
-    """
-
     def __init__(self, *, queue_factory=None):
         self._builder = DagBuilder()
         if queue_factory:
             self._builder.set_queue_factory(queue_factory)
         self._nodes: list[DagNode] = []
         self._started = False
-
-    # ── 构建 ──────────────────────────────────────────────────────────
 
     def load_yaml(self, path_or_text: str) -> "Dag":
         self._builder.load_yaml(path_or_text)
@@ -346,15 +319,11 @@ class Dag:
         self._builder.add_node(node)
         return self
 
-    # ── 生命周期 ──────────────────────────────────────────────────────
-
     def build(self) -> list[DagNode]:
-        """构造 DAG：创建队列、绑定端口（必须在 start 之前调用）。"""
         self._nodes = self._builder.build()
         return self._nodes
 
     def start(self) -> None:
-        """启动所有节点线程（必须在 build 之后调用）。"""
         for node in self._nodes:
             node.start()
         self._started = True
@@ -367,19 +336,30 @@ class Dag:
                 pass
         self._started = False
 
+    async def astart(self) -> None:
+        for node in self._nodes:
+            await node.astart()
+        self._started = True
+
+    async def astop(self) -> None:
+        for node in self._nodes:
+            try:
+                await node.astop()
+            except Exception:
+                pass
+        self._started = False
+
     def inq(self, node_name: str, port_name: str) -> Any:
-        """获取指定节点输入端口绑定的队列（供外部馈入数据）。"""
         return self.get_node(node_name).inq(port_name)
 
     def outq(self, node_name: str, port_name: str) -> Any:
-        """获取指定节点输出端口绑定的队列。"""
         return self.get_node(node_name).outq(port_name)
 
     def get_node(self, node_name: str) -> DagNode:
-        n = self._builder._nodes.get(node_name)
-        if n is None:
+        node = self._builder._nodes.get(node_name)
+        if node is None:
             raise KeyError(f"Node '{node_name}' not found")
-        return n
+        return node
 
     def export_specs(self) -> dict[str, dict[str, Any]]:
         return dict(self._builder._exports)

--- a/sdk/graph.py
+++ b/sdk/graph.py
@@ -59,6 +59,23 @@ class DagNode:
         """Resolve references to other workflow nodes after YAML load."""
         pass
 
+    def to_config(self) -> dict[str, Any]:
+        """Return constructor kwargs needed to recreate this node.
+
+        Subclasses with extra constructor parameters MUST override this
+        so that YAML round-trip (save/load) preserves their state.
+        """
+        return {}
+
+    @classmethod
+    def from_config(cls, name: str, params: dict[str, Any]) -> "DagNode":
+        """Create a node from a serialized config dict.
+
+        By default this calls ``cls(name=name, **params)``.  Subclasses
+        may override when argument mapping is non-trivial.
+        """
+        return cls(name=name, **params)
+
     def start(self) -> None:
         """Start node work if it owns execution. Passive nodes do nothing."""
         pass
@@ -191,6 +208,7 @@ class DagBuilder:
                 {
                     "name": n.name,
                     "type": type(n).__module__ + "." + type(n).__qualname__,
+                    "params": n.to_config(),
                     "inputs": list(n.inputs().keys()),
                     "outputs": list(n.outputs().keys()),
                 }
@@ -219,13 +237,12 @@ class DagBuilder:
 
     @staticmethod
     def _make_node(node_cls: type, name: str, params: dict[str, Any]) -> DagNode:
+        if hasattr(node_cls, "from_config") and node_cls.from_config is not DagNode.from_config:
+            return node_cls.from_config(name, params)
         attempts = (
             lambda: node_cls(name=name, **params),
             lambda: node_cls(name, **params),
             lambda: node_cls(**params),
-            lambda: node_cls(name=name),
-            lambda: node_cls(name),
-            lambda: node_cls(),
         )
         last_error: TypeError | None = None
         for attempt in attempts:
@@ -256,7 +273,7 @@ class DagBuilder:
             except Exception as e:
                 raise ValueError(f"Cannot import {dotted}: {e}") from e
             node_name = nd["name"]
-            params = {k: v for k, v in nd.items() if k not in {"name", "type"}}
+            params = nd.get("params", {})
             try:
                 node = self._make_node(node_cls, node_name, params)
             except Exception as e:

--- a/sdk/graph.py
+++ b/sdk/graph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -170,10 +171,73 @@ class DagBuilder:
         for node in self._nodes.values():
             node.configure(self._nodes)
 
+    def _validate_topology(self) -> None:
+        """Reject cycles, fan-out, and fan-in before binding queues."""
+
+        # --- cycle detection (DFS) ---
+        adjacency: dict[str, list[str]] = defaultdict(list)
+        for e in self._edges:
+            adjacency[e.src_node].append(e.dst_node)
+
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color: dict[str, int] = {name: WHITE for name in self._nodes}
+
+        def _dfs(node: str, path: list[str]) -> None:
+            color[node] = GRAY
+            path.append(node)
+            for neighbor in adjacency.get(node, []):
+                if color[neighbor] == GRAY:
+                    cycle = path[path.index(neighbor):] + [neighbor]
+                    raise ValueError(
+                        f"Cycle detected in workflow DAG: "
+                        + " → ".join(cycle)
+                    )
+                if color[neighbor] == WHITE:
+                    _dfs(neighbor, path)
+            path.pop()
+            color[node] = BLACK
+
+        for node_name in self._nodes:
+            if color[node_name] == WHITE:
+                _dfs(node_name, [])
+
+        # --- fan-out check: one output port → at most one downstream ---
+        out_fan: dict[tuple[str, str], list[str]] = defaultdict(list)
+        for e in self._edges:
+            key = (e.src_node, e.src_port)
+            out_fan[key].append(f"{e.dst_node}.{e.dst_port}")
+        for (src, port), targets in out_fan.items():
+            if len(targets) > 1:
+                raise ValueError(
+                    f"Fan-out not supported: output {src}.{port} "
+                    f"is connected to multiple downstream ports: {', '.join(targets)}"
+                )
+
+        # --- fan-in check: one input port ← at most one upstream ---
+        in_fan: dict[tuple[str, str], list[str]] = defaultdict(list)
+        for e in self._edges:
+            key = (e.dst_node, e.dst_port)
+            in_fan[key].append(f"{e.src_node}.{e.src_port}")
+        for (dst, port), sources in in_fan.items():
+            if len(sources) > 1:
+                raise ValueError(
+                    f"Fan-in not supported: input {dst}.{port} "
+                    f"is fed by multiple upstream ports: {', '.join(sources)}"
+                )
+
+    def build(self) -> list[DagNode]:
+        if self._queue_factory is None:
+            raise RuntimeError("queue_factory not set")
+
+        for node in self._nodes.values():
+            node.configure(self._nodes)
+
         pending_edges = self._pending_edges
         self._pending_edges = []
         for spec in pending_edges:
             self.connect(spec.src, spec.src_port, spec.dst, spec.dst_port)
+
+        self._validate_topology()
 
         queues: dict[tuple[str, str], Any] = {}
         for e in self._edges:

--- a/sdk/graph.py
+++ b/sdk/graph.py
@@ -8,6 +8,7 @@ unless a subclass chooses to own execution.
 from __future__ import annotations
 
 import importlib
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -239,23 +240,26 @@ class DagBuilder:
     def _make_node(node_cls: type, name: str, params: dict[str, Any]) -> DagNode:
         if hasattr(node_cls, "from_config") and node_cls.from_config is not DagNode.from_config:
             return node_cls.from_config(name, params)
-        attempts = (
-            lambda: node_cls(name=name, **params),
-            lambda: node_cls(name, **params),
-            lambda: node_cls(**params),
+
+        sig = inspect.signature(node_cls.__init__)
+        param_names = {
+            p.name
+            for p in sig.parameters.values()
+            if p.kind
+            not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        }
+        has_var_kwargs = any(
+            p.kind == p.VAR_KEYWORD for p in sig.parameters.values()
         )
-        last_error: TypeError | None = None
-        for attempt in attempts:
-            try:
-                node = attempt()
-            except TypeError as exc:
-                last_error = exc
-                continue
-            if isinstance(node, DagNode):
-                return node
+
+        if "name" in param_names or has_var_kwargs:
+            node = node_cls(name=name, **params)
+        else:
+            node = node_cls(**params)
+
+        if not isinstance(node, DagNode):
             raise TypeError(f"{node_cls!r} did not create a DagNode")
-        assert last_error is not None
-        raise last_error
+        return node
 
     def to_yaml(self, path: str | None = None) -> str:
         import yaml

--- a/sdk/manager.py
+++ b/sdk/manager.py
@@ -250,6 +250,18 @@ class PluginManager:
             return []
         return self._capabilities.chat_ui_contributions
 
+    def collect_dag_node_factories(self) -> list[tuple[Callable[[], list], bool]]:
+        self._ensure_plugins_initialized()
+        if self._capabilities is None:
+            return []
+        return self._capabilities.dag_node_factories
+
+    def collect_dag_yaml_paths(self) -> list[str]:
+        self._ensure_plugins_initialized()
+        if self._capabilities is None:
+            return []
+        return self._capabilities.dag_yaml_paths
+
     def iter_plugin_ids(self) -> Iterator[str]:
         self._ensure_plugins_instantiated()
         return (p.plugin_id for p in self._instances)

--- a/sdk/register.py
+++ b/sdk/register.py
@@ -216,10 +216,14 @@ class PluginCapabilityRegistry:
         self._dag_node_factories.append((factory, skip_default))
 
     def register_dag_yaml(self, path: str) -> None:
-        """Register a selectable workflow YAML path.
+        """Register a workflow YAML path (reserved for future workflow selection UX).
 
-        The host records the path as a candidate. It is only loaded when the
-        user selects it, not merged into the default workflow automatically.
+        .. note::
+            This API is **reserved** and not yet active.  Plugin-registered
+            workflow YAML paths are collected but are not consumed by the
+            runtime builder, CLI, or Settings UI yet.  Plugins that call this
+            method today will have their paths stored, but users have no
+            mechanism to select them at runtime.
         """
         self._dag_yaml_paths.append(path)
 

--- a/sdk/register.py
+++ b/sdk/register.py
@@ -128,6 +128,8 @@ class PluginCapabilityRegistry:
         self._settings_ui_plugin_ctx: tuple[str, str] | None = None
         self._tools_tab_contributions: list[ToolsTabContribution] = []
         self._chat_ui_contributions: list[ChatUIContribution] = []
+        self._dag_node_factories: list[tuple[Callable[[], list], bool]] = []
+        self._dag_yaml_paths: list[str] = []
 
     def register_llm_adapter(self, provider: str, adapter_cls: Type[LLMAdapter]) -> None:
         self._llm_adapters[provider] = adapter_cls
@@ -198,6 +200,29 @@ class PluginCapabilityRegistry:
     def register_chat_ui_widget(self, contribution: ChatUIContribution) -> None:
         self._chat_ui_contributions.append(contribution)
 
+    def register_dag_node(
+        self,
+        factory: Callable[[], list],
+        *,
+        skip_default: bool = False,
+    ) -> None:
+        """Register DAG node candidates for plugin tooling.
+
+        Runtime workflow execution no longer auto-merges registered nodes.
+        Users select exactly one workflow YAML, and that YAML references node
+        classes directly by dotted import path. ``skip_default`` is kept for
+        compatibility and is not used by the runtime builder.
+        """
+        self._dag_node_factories.append((factory, skip_default))
+
+    def register_dag_yaml(self, path: str) -> None:
+        """Register a selectable workflow YAML path.
+
+        The host records the path as a candidate. It is only loaded when the
+        user selects it, not merged into the default workflow automatically.
+        """
+        self._dag_yaml_paths.append(path)
+
     @property
     def llm_adapters(self) -> dict[str, Type[LLMAdapter]]:
         return dict(self._llm_adapters)
@@ -235,6 +260,14 @@ class PluginCapabilityRegistry:
     @property
     def chat_ui_contributions(self) -> list[ChatUIContribution]:
         return sorted(self._chat_ui_contributions, key=lambda c: c.order)
+
+    @property
+    def dag_node_factories(self) -> list[tuple[Callable[[], list], bool]]:
+        return list(self._dag_node_factories)
+
+    @property
+    def dag_yaml_paths(self) -> list[str]:
+        return list(self._dag_yaml_paths)
 
     def apply_llm_tools(self, tool_manager: ToolManager) -> None:
         for registrar in self._llm_tool_registrars:

--- a/test/integration/test_workers.py
+++ b/test/integration/test_workers.py
@@ -65,6 +65,15 @@ def _make_runtime_for_workers(mock_llm_adapter=None, **overrides):
     return rt
 
 
+def _wait_for_unfinished_tasks(q: Queue, expected: int = 0, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if q.unfinished_tasks == expected:
+            return True
+        time.sleep(0.01)
+    return q.unfinished_tasks == expected
+
+
 # ---------------------------------------------------------------------------
 # LLMWorker
 # ---------------------------------------------------------------------------
@@ -239,9 +248,78 @@ class TestTTSWorker:
         assert isinstance(out, TTSOutputMessage)
         assert out.name == "NARR"
         assert out.is_system_message is True
+        assert _wait_for_unfinished_tasks(rt.tts_queue)
 
         worker.stop()
         worker.wait(3000)
+
+    def test_worker_marks_tts_task_done_on_dispatch_error(self, qtbot):
+        mock_llm = MockLLMAdapter(responses=[""])
+        rt = _make_runtime_for_workers(mock_llm_adapter=mock_llm)
+        set_app_runtime(rt)
+
+        worker = TTSWorker(
+            input_queue=rt.tts_queue,
+            output_queue=rt.audio_path_queue,
+        )
+        worker.tts_message_dispatcher = MagicMock()
+        worker.tts_message_dispatcher.dispatch.side_effect = RuntimeError("boom")
+        worker.start()
+
+        rt.tts_queue.put(LLMDialogMessage(name="TestChar", text="Failure path", asset_id="-1"))
+
+        assert _wait_for_unfinished_tasks(rt.tts_queue)
+        worker.stop()
+        worker.wait(3000)
+
+
+class TestUIWorker:
+    def test_worker_marks_audio_task_done_after_dispatch(self, qtbot):
+        mock_llm = MockLLMAdapter(responses=[""])
+        rt = _make_runtime_for_workers(mock_llm_adapter=mock_llm)
+        set_app_runtime(rt)
+
+        worker = UIWorker(rt.audio_path_queue)
+        worker.ui_out_dispatcher = MagicMock()
+
+        out = TTSOutputMessage(
+            audio_path="",
+            name="NARR",
+            text="Displayed",
+            asset_id="-1",
+            is_system_message=True,
+        )
+        rt.audio_path_queue.put(out)
+        rt.audio_path_queue.put(None)
+
+        worker.run()
+
+        worker.ui_out_dispatcher.dispatch.assert_called_once_with(out)
+        assert rt.audio_path_queue.unfinished_tasks == 0
+
+    def test_worker_marks_audio_task_done_on_dispatch_error(self, qtbot):
+        mock_llm = MockLLMAdapter(responses=[""])
+        rt = _make_runtime_for_workers(mock_llm_adapter=mock_llm)
+        set_app_runtime(rt)
+
+        worker = UIWorker(rt.audio_path_queue)
+        worker.ui_out_dispatcher = MagicMock()
+        worker.ui_out_dispatcher.dispatch.side_effect = RuntimeError("boom")
+
+        out = TTSOutputMessage(
+            audio_path="",
+            name="NARR",
+            text="",
+            asset_id="-1",
+            is_system_message=True,
+        )
+        rt.audio_path_queue.put(out)
+        rt.audio_path_queue.put(None)
+
+        worker.run()
+
+        worker.ui_out_dispatcher.dispatch.assert_called_once_with(out)
+        assert rt.audio_path_queue.unfinished_tasks == 0
 
 
 # ---------------------------------------------------------------------------

--- a/test/unit/test_workers_behavior.py
+++ b/test/unit/test_workers_behavior.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 
-from core.runtime.app_runtime import AppRuntime, set_app_runtime
+from core.runtime.app_runtime import AppRuntime, get_app_runtime, set_app_runtime
 from core.runtime.workers import LLMWorker, TTSWorker, UIWorker
 from sdk.messages import LLMDialogMessage, TTSOutputMessage, UserInputMessage
 
@@ -46,7 +46,22 @@ class FakeEvent:
         return self._set
 
 
-def _set_runtime(*, tts_queue=None, audio_path_queue=None, ui_manager=None) -> AppRuntime:
+@pytest.fixture(autouse=True)
+def _isolate_app_runtime() -> None:
+    """Save/restore the module-level app runtime so tests don't leak."""
+    from core.runtime import app_runtime as _mod
+
+    saved = getattr(_mod, "_runtime", None)
+    _mod._runtime = None
+    yield
+    _mod._runtime = saved
+
+
+def _make_app_runtime(
+    tts_queue: Queue | None = None,
+    audio_path_queue: Queue | None = None,
+    ui_manager: MagicMock | None = None,
+) -> AppRuntime:
     runtime = AppRuntime(
         config=MagicMock(),
         ui_update_manager=ui_manager or MagicMock(chat_history=[]),
@@ -65,6 +80,7 @@ def _set_runtime(*, tts_queue=None, audio_path_queue=None, ui_manager=None) -> A
 
 
 def test_workers_keep_original_queue_attributes_and_bind_ports() -> None:
+    _make_app_runtime()
     user_input_queue = Queue()
     tts_queue = Queue()
     audio_path_queue = Queue()
@@ -87,13 +103,15 @@ def test_workers_keep_original_queue_attributes_and_bind_ports() -> None:
     assert ui_worker.inq(UIWorker.PORT_TTS_OUTPUT) is audio_path_queue
 
 
-def test_llm_worker_run_uses_original_queues_and_marks_input_done(monkeypatch) -> None:
+def test_llm_worker_run_uses_original_queues_and_marks_input_done(
+    monkeypatch,
+) -> None:
     user_input_queue = CountingQueue()
     tts_queue = CountingQueue()
     user_input_queue.put(UserInputMessage(text="hello"))
     user_input_queue.put(None)
 
-    runtime = _set_runtime()
+    runtime = _make_app_runtime()
     runtime.config.config.api_config.is_streaming = False
     runtime.llm_manager.chat.return_value = (
         '{"character_name":"Alice","speech":"Hi","sprite":"0"}'
@@ -115,12 +133,14 @@ def test_llm_worker_run_uses_original_queues_and_marks_input_done(monkeypatch) -
     runtime.llm_manager.chat.assert_called_once_with("hello", stream=False)
 
 
-def test_tts_worker_exception_path_uses_original_put_data_fallback(monkeypatch) -> None:
+def test_tts_worker_exception_path_uses_original_put_data_fallback(
+    monkeypatch,
+) -> None:
     tts_queue = CountingQueue()
     audio_path_queue = CountingQueue()
     tts_queue.put(LLMDialogMessage(name="Alice", text="broken", asset_id="2", effect="shake"))
     tts_queue.put(None)
-    _set_runtime(tts_queue=tts_queue, audio_path_queue=audio_path_queue)
+    _make_app_runtime(tts_queue=tts_queue, audio_path_queue=audio_path_queue)
 
     worker = TTSWorker(tts_queue, audio_path_queue)
     monkeypatch.setattr(worker, "_init_app", lambda: None)
@@ -142,7 +162,7 @@ def test_tts_worker_exception_path_uses_original_put_data_fallback(monkeypatch) 
 
 def test_ui_worker_skip_speech_is_noop_when_queue_empty() -> None:
     audio_path_queue = Queue()
-    _set_runtime(audio_path_queue=audio_path_queue)
+    _make_app_runtime(audio_path_queue=audio_path_queue)
     worker = UIWorker(audio_path_queue)
     worker.task_done_requested = FakeEvent()
     worker.current_audio_path = "current.wav"
@@ -155,7 +175,9 @@ def test_ui_worker_skip_speech_is_noop_when_queue_empty() -> None:
     assert worker.task_done_requested.set_calls == 0
 
 
-def test_ui_worker_exception_branch_keeps_original_wait_and_task_done(monkeypatch) -> None:
+def test_ui_worker_exception_branch_keeps_original_wait_and_task_done(
+    monkeypatch,
+) -> None:
     audio_path_queue = CountingQueue()
     audio_path_queue.put(
         TTSOutputMessage(
@@ -168,7 +190,7 @@ def test_ui_worker_exception_branch_keeps_original_wait_and_task_done(monkeypatc
     )
     audio_path_queue.put(None)
     ui_manager = MagicMock()
-    _set_runtime(audio_path_queue=audio_path_queue, ui_manager=ui_manager)
+    _make_app_runtime(audio_path_queue=audio_path_queue, ui_manager=ui_manager)
 
     worker = UIWorker(audio_path_queue)
     fake_event = FakeEvent()

--- a/test/unit/test_workers_behavior.py
+++ b/test/unit/test_workers_behavior.py
@@ -1,61 +1,11 @@
 from __future__ import annotations
 
-import sys
-import types
 from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
-
-class _FakeQThread:
-    def __init__(self, parent=None) -> None:
-        self.parent = parent
-        self._is_running = False
-
-    def start(self) -> None:
-        self._is_running = True
-
-    def isRunning(self) -> bool:
-        return self._is_running
-
-    def wait(self, timeout: int | None = None) -> bool:
-        self._is_running = False
-        return True
-
-
-if "PySide6.QtCore" not in sys.modules:
-    pyside6 = types.ModuleType("PySide6")
-    qtcore = types.ModuleType("PySide6.QtCore")
-    qtcore.QThread = _FakeQThread
-    pyside6.QtCore = qtcore
-    sys.modules["PySide6"] = pyside6
-    sys.modules["PySide6.QtCore"] = qtcore
-
-if "pygame" not in sys.modules:
-    pygame = types.ModuleType("pygame")
-    pygame.mixer = SimpleNamespace()
-    sys.modules["pygame"] = pygame
-
-llm_manager = types.ModuleType("llm.llm_manager")
-llm_manager.STREAM_REASONING_DELTA_KEY = "reasoning_delta"
-sys.modules.setdefault("llm.llm_manager", llm_manager)
-
-tool_manager = types.ModuleType("llm.tools.tool_manager")
-tool_manager.ToolManager = MagicMock
-sys.modules.setdefault("llm.tools.tool_manager", tool_manager)
-
-handler_registry = types.ModuleType("core.handlers.handler_registry")
-handler_registry.default_tts_handler_chain = lambda: SimpleNamespace(
-    init_handlers=lambda: None,
-    dispatch=lambda item: None,
-)
-handler_registry.default_ui_output_handler_chain = lambda: SimpleNamespace(
-    init_handlers=lambda: None,
-    dispatch=lambda item: None,
-)
-sys.modules.setdefault("core.handlers.handler_registry", handler_registry)
 
 from core.runtime.app_runtime import AppRuntime, set_app_runtime
 from core.runtime.workers import LLMWorker, TTSWorker, UIWorker
@@ -160,7 +110,8 @@ def test_llm_worker_run_uses_original_queues_and_marks_input_done(monkeypatch) -
     assert isinstance(output, LLMDialogMessage)
     assert output.name == "Alice"
     assert output.text == "Hi"
-    assert user_input_queue.task_done_calls == 1
+    assert user_input_queue.task_done_calls == 2
+    assert user_input_queue.unfinished_tasks == 0
     runtime.llm_manager.chat.assert_called_once_with("hello", stream=False)
 
 
@@ -185,7 +136,8 @@ def test_tts_worker_exception_path_uses_original_put_data_fallback(monkeypatch) 
     assert output.text == "broken"
     assert output.asset_id == "2"
     assert output.effect == "shake"
-    assert tts_queue.task_done_calls == 1
+    assert tts_queue.task_done_calls == 2
+    assert tts_queue.unfinished_tasks == 0
 
 
 def test_ui_worker_skip_speech_is_noop_when_queue_empty() -> None:
@@ -231,4 +183,5 @@ def test_ui_worker_exception_branch_keeps_original_wait_and_task_done(monkeypatc
 
     ui_manager.post_notification.assert_called_once()
     assert fake_event.wait_calls == [1.0]
-    assert audio_path_queue.task_done_calls == 1
+    assert audio_path_queue.task_done_calls == 2
+    assert audio_path_queue.unfinished_tasks == 0

--- a/test/unit/test_workers_behavior.py
+++ b/test/unit/test_workers_behavior.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import sys
+import types
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeQThread:
+    def __init__(self, parent=None) -> None:
+        self.parent = parent
+        self._is_running = False
+
+    def start(self) -> None:
+        self._is_running = True
+
+    def isRunning(self) -> bool:
+        return self._is_running
+
+    def wait(self, timeout: int | None = None) -> bool:
+        self._is_running = False
+        return True
+
+
+if "PySide6.QtCore" not in sys.modules:
+    pyside6 = types.ModuleType("PySide6")
+    qtcore = types.ModuleType("PySide6.QtCore")
+    qtcore.QThread = _FakeQThread
+    pyside6.QtCore = qtcore
+    sys.modules["PySide6"] = pyside6
+    sys.modules["PySide6.QtCore"] = qtcore
+
+if "pygame" not in sys.modules:
+    pygame = types.ModuleType("pygame")
+    pygame.mixer = SimpleNamespace()
+    sys.modules["pygame"] = pygame
+
+llm_manager = types.ModuleType("llm.llm_manager")
+llm_manager.STREAM_REASONING_DELTA_KEY = "reasoning_delta"
+sys.modules.setdefault("llm.llm_manager", llm_manager)
+
+tool_manager = types.ModuleType("llm.tools.tool_manager")
+tool_manager.ToolManager = MagicMock
+sys.modules.setdefault("llm.tools.tool_manager", tool_manager)
+
+handler_registry = types.ModuleType("core.handlers.handler_registry")
+handler_registry.default_tts_handler_chain = lambda: SimpleNamespace(
+    init_handlers=lambda: None,
+    dispatch=lambda item: None,
+)
+handler_registry.default_ui_output_handler_chain = lambda: SimpleNamespace(
+    init_handlers=lambda: None,
+    dispatch=lambda item: None,
+)
+sys.modules.setdefault("core.handlers.handler_registry", handler_registry)
+
+from core.runtime.app_runtime import AppRuntime, set_app_runtime
+from core.runtime.workers import LLMWorker, TTSWorker, UIWorker
+from sdk.messages import LLMDialogMessage, TTSOutputMessage, UserInputMessage
+
+
+pytestmark = pytest.mark.unit
+
+
+class CountingQueue(Queue):
+    def __init__(self) -> None:
+        super().__init__()
+        self.task_done_calls = 0
+
+    def task_done(self) -> None:
+        self.task_done_calls += 1
+        super().task_done()
+
+
+class FakeEvent:
+    def __init__(self) -> None:
+        self.set_calls = 0
+        self.wait_calls: list[float | None] = []
+        self._set = False
+
+    def set(self) -> None:
+        self.set_calls += 1
+        self._set = True
+
+    def clear(self) -> None:
+        self._set = False
+
+    def is_set(self) -> bool:
+        return self._set
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self.wait_calls.append(timeout)
+        return self._set
+
+
+def _set_runtime(*, tts_queue=None, audio_path_queue=None, ui_manager=None) -> AppRuntime:
+    runtime = AppRuntime(
+        config=MagicMock(),
+        ui_update_manager=ui_manager or MagicMock(chat_history=[]),
+        llm_manager=MagicMock(),
+        tts_manager=None,
+        t2i_manager=None,
+        bgm_list=[],
+        user_input_queue=Queue(),
+        tts_queue=tts_queue or CountingQueue(),
+        audio_path_queue=audio_path_queue or CountingQueue(),
+        text_processor=MagicMock(),
+        opencc=SimpleNamespace(convert=lambda value: f"converted:{value}"),
+    )
+    set_app_runtime(runtime)
+    return runtime
+
+
+def test_workers_keep_original_queue_attributes_and_bind_ports() -> None:
+    user_input_queue = Queue()
+    tts_queue = Queue()
+    audio_path_queue = Queue()
+
+    llm_worker = LLMWorker(user_input_queue, tts_queue)
+    tts_worker = TTSWorker(tts_queue, audio_path_queue)
+    ui_worker = UIWorker(audio_path_queue)
+
+    assert llm_worker.user_input_queue is user_input_queue
+    assert llm_worker.tts_queue is tts_queue
+    assert llm_worker.inq(LLMWorker.PORT_USER_INPUT) is user_input_queue
+    assert llm_worker.outq(LLMWorker.PORT_LLM_OUTPUT) is tts_queue
+
+    assert tts_worker.tts_queue is tts_queue
+    assert tts_worker.audio_path_queue is audio_path_queue
+    assert tts_worker.inq(TTSWorker.PORT_LLM_OUTPUT) is tts_queue
+    assert tts_worker.outq(TTSWorker.PORT_TTS_OUTPUT) is audio_path_queue
+
+    assert ui_worker.audio_path_queue is audio_path_queue
+    assert ui_worker.inq(UIWorker.PORT_TTS_OUTPUT) is audio_path_queue
+
+
+def test_llm_worker_run_uses_original_queues_and_marks_input_done(monkeypatch) -> None:
+    user_input_queue = CountingQueue()
+    tts_queue = CountingQueue()
+    user_input_queue.put(UserInputMessage(text="hello"))
+    user_input_queue.put(None)
+
+    runtime = _set_runtime()
+    runtime.config.config.api_config.is_streaming = False
+    runtime.llm_manager.chat.return_value = (
+        '{"character_name":"Alice","speech":"Hi","sprite":"0"}'
+    )
+
+    worker = LLMWorker(user_input_queue, tts_queue)
+    monkeypatch.setattr(worker, "_init_app", lambda: None)
+    worker.ui_update_manager = runtime.ui_update_manager
+    worker.llm_manager = runtime.llm_manager
+
+    worker.run()
+
+    output = tts_queue.get_nowait()
+    assert isinstance(output, LLMDialogMessage)
+    assert output.name == "Alice"
+    assert output.text == "Hi"
+    assert user_input_queue.task_done_calls == 1
+    runtime.llm_manager.chat.assert_called_once_with("hello", stream=False)
+
+
+def test_tts_worker_exception_path_uses_original_put_data_fallback(monkeypatch) -> None:
+    tts_queue = CountingQueue()
+    audio_path_queue = CountingQueue()
+    tts_queue.put(LLMDialogMessage(name="Alice", text="broken", asset_id="2", effect="shake"))
+    tts_queue.put(None)
+    _set_runtime(tts_queue=tts_queue, audio_path_queue=audio_path_queue)
+
+    worker = TTSWorker(tts_queue, audio_path_queue)
+    monkeypatch.setattr(worker, "_init_app", lambda: None)
+    worker.tts_message_dispatcher = SimpleNamespace(
+        dispatch=MagicMock(side_effect=RuntimeError("tts failed"))
+    )
+
+    worker.run()
+
+    output = audio_path_queue.get_nowait()
+    assert isinstance(output, TTSOutputMessage)
+    assert output.name == "converted:Alice"
+    assert output.text == "broken"
+    assert output.asset_id == "2"
+    assert output.effect == "shake"
+    assert tts_queue.task_done_calls == 1
+
+
+def test_ui_worker_skip_speech_is_noop_when_queue_empty() -> None:
+    audio_path_queue = Queue()
+    _set_runtime(audio_path_queue=audio_path_queue)
+    worker = UIWorker(audio_path_queue)
+    worker.task_done_requested = FakeEvent()
+    worker.current_audio_path = "current.wav"
+    worker.dialog_channel = MagicMock()
+
+    worker.skip_speech()
+
+    worker.dialog_channel.stop.assert_not_called()
+    assert worker.current_audio_path == "current.wav"
+    assert worker.task_done_requested.set_calls == 0
+
+
+def test_ui_worker_exception_branch_keeps_original_wait_and_task_done(monkeypatch) -> None:
+    audio_path_queue = CountingQueue()
+    audio_path_queue.put(
+        TTSOutputMessage(
+            audio_path="",
+            name="Alice",
+            text="1234567890",
+            asset_id="-1",
+            effect="",
+        )
+    )
+    audio_path_queue.put(None)
+    ui_manager = MagicMock()
+    _set_runtime(audio_path_queue=audio_path_queue, ui_manager=ui_manager)
+
+    worker = UIWorker(audio_path_queue)
+    fake_event = FakeEvent()
+    monkeypatch.setattr(worker, "_init_app", lambda: None)
+    worker.task_done_requested = fake_event
+    worker.ui_update_manager = ui_manager
+    worker.ui_out_dispatcher = SimpleNamespace(
+        dispatch=MagicMock(side_effect=RuntimeError("ui failed"))
+    )
+
+    worker.run()
+
+    ui_manager.post_notification.assert_called_once()
+    assert fake_event.wait_calls == [1.0]
+    assert audio_path_queue.task_done_calls == 1

--- a/test/unit/tools/test_dag_graph.py
+++ b/test/unit/tools/test_dag_graph.py
@@ -488,6 +488,115 @@ exports:
         with pytest.raises(TypeError, match="internal bug: boom"):
             DagBuilder._make_node(BuggyNode, "bomb", {"fail_on": "boom"})
 
+class TestTopologyValidation:
+    def test_cycle_detection_two_nodes(self):
+        """x -> y -> x cycle is rejected at build time."""
+        a = EchoNode("x")
+        b = EchoNode("y")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a).add_node(b)
+        builder.connect("x", "out", "y", "in")
+        builder.connect("y", "out", "x", "in")
+
+        with pytest.raises(ValueError, match="Cycle detected"):
+            builder.build()
+
+    def test_cycle_detection_three_nodes(self):
+        """A -> B -> C -> A cycle is rejected."""
+        a = EchoNode("A")
+        b = EchoNode("B")
+        c = EchoNode("C")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a).add_node(b).add_node(c)
+        builder.connect("A", "out", "B", "in")
+        builder.connect("B", "out", "C", "in")
+        builder.connect("C", "out", "A", "in")
+
+        with pytest.raises(ValueError, match="Cycle detected"):
+            builder.build()
+
+    def test_self_loop_rejected(self):
+        """Node connecting to itself is a cycle."""
+        a = EchoNode("x")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a)
+        builder.connect("x", "out", "x", "in")
+
+        with pytest.raises(ValueError, match="Cycle detected"):
+            builder.build()
+
+    def test_fan_out_rejected(self):
+        """One output to multiple downstream inputs is rejected."""
+        a = EchoNode("src")
+        b = SinkNode("dst1")
+        c = SinkNode("dst2")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a).add_node(b).add_node(c)
+        builder.connect("src", "out", "dst1", "in")
+        builder.connect("src", "out", "dst2", "in")
+
+        with pytest.raises(ValueError, match="Fan-out not supported"):
+            builder.build()
+
+    def test_fan_in_rejected(self):
+        """Multiple upstream outputs to one input is rejected."""
+        a = EchoNode("src1")
+        b = EchoNode("src2")
+        c = SinkNode("dst")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a).add_node(b).add_node(c)
+        builder.connect("src1", "out", "dst", "in")
+        builder.connect("src2", "out", "dst", "in")
+
+        with pytest.raises(ValueError, match="Fan-in not supported"):
+            builder.build()
+
+    def test_valid_chain_still_passes(self):
+        """A clean linear chain still builds successfully."""
+        a = EchoNode("A")
+        b = EchoNode("B")
+        c = SinkNode("C")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a).add_node(b).add_node(c)
+        builder.connect("A", "out", "B", "in")
+        builder.connect("B", "out", "C", "in")
+        builder.build()  # must not raise
+
+    def test_diamond_topology_rejected(self):
+        """A -> B, A -> C is fan-out and should be rejected."""
+        a = EchoNode("A")
+        b = EchoNode("B")
+        c = SinkNode("C")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a).add_node(b).add_node(c)
+        builder.connect("A", "out", "B", "in")
+        builder.connect("A", "out", "C", "in")
+
+        with pytest.raises(ValueError, match="Fan-out not supported"):
+            builder.build()
+
+    def test_merge_topology_rejected(self):
+        """A -> C, B -> C is fan-in and should be rejected."""
+        a = EchoNode("A")
+        b = EchoNode("B")
+        c = SinkNode("C")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(a).add_node(b).add_node(c)
+        builder.connect("A", "out", "C", "in")
+        builder.connect("B", "out", "C", "in")
+
+        with pytest.raises(ValueError, match="Fan-in not supported"):
+            builder.build()
+
+
 class TestRuntimeWorkflow:
     def test_build_runtime_workflow_uses_only_selected_yaml(self, tmp_path):
         first = tmp_path / "first.yaml"

--- a/test/unit/tools/test_dag_graph.py
+++ b/test/unit/tools/test_dag_graph.py
@@ -1,5 +1,6 @@
 """End-to-end DAG graph test: build, bind ports, pump messages, YAML round-trip."""
 
+import asyncio
 import tempfile
 import threading
 import time
@@ -8,7 +9,13 @@ from queue import Queue
 
 import pytest
 
-from sdk.graph import DagBuilder, DagNode, EdgeSpec, Port
+from core.runtime.workflow import build_runtime_workflow
+from sdk.graph import (
+    DagBuilder,
+    DagNode,
+    EdgeSpec,
+    Port,
+)
 
 
 class EchoNode(DagNode):
@@ -78,6 +85,72 @@ class SinkNode(DagNode):
             self._thread.join(timeout=3)
 
 
+class PassiveNoPortsNode(DagNode):
+    def inputs(self):
+        return {}
+
+    def outputs(self):
+        return {}
+
+
+class RuleNode(PassiveNoPortsNode):
+    def __init__(self, name: str, accepted: str = "yes"):
+        super().__init__(name)
+        self.accepted = accepted
+
+    def accepts(self, value: str) -> bool:
+        return value == self.accepted
+
+
+class RuleRouterNode(DagNode):
+    def __init__(self, name: str, rule_node: str):
+        super().__init__(name)
+        self.rule_node_name = rule_node
+        self.rule: RuleNode | None = None
+
+    def inputs(self):
+        return {"in": Port("in")}
+
+    def outputs(self):
+        return {"accepted": Port("accepted"), "rejected": Port("rejected")}
+
+    def configure(self, nodes):
+        rule = nodes.get(self.rule_node_name)
+        if not isinstance(rule, RuleNode):
+            raise ValueError(f"Unknown rule node: {self.rule_node_name}")
+        self.rule = rule
+
+    def start(self):
+        item = self.inq("in").get()
+        assert self.rule is not None
+        if self.rule.accepts(item):
+            self.outq("accepted").put(item)
+        else:
+            self.outq("rejected").put(item)
+        self.inq("in").task_done()
+
+
+class AsyncLifecycleNode(PassiveNoPortsNode):
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.events: list[str] = []
+
+    async def astart(self):
+        await asyncio.sleep(0)
+        self.events.append("start")
+
+    async def astop(self):
+        await asyncio.sleep(0)
+        self.events.append("stop")
+
+
+class StopOrderNode(PassiveNoPortsNode):
+    events: list[str] = []
+
+    def stop(self):
+        self.events.append(self.name)
+
+
 class TestDagBuilder:
     def test_two_node_pipeline(self):
         """A -> B: message flows through."""
@@ -117,6 +190,61 @@ class TestDagBuilder:
         builder.add_node(a)
         nodes = builder.build()
         assert nodes == []
+
+    def test_passive_node_lifecycle_is_noop(self):
+        """Passive nodes can participate as exports without owning a thread."""
+        node = PassiveNoPortsNode("passive")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(node)
+        builder._exports["passive"] = {"node": "passive", "direction": "node"}
+        nodes = builder.build()
+
+        assert nodes == [node]
+        node.start()
+        node.stop()
+
+    def test_async_lifecycle_hooks(self):
+        node = AsyncLifecycleNode("async_node")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(node)
+        builder._exports["async_node"] = {"node": "async_node", "direction": "node"}
+        nodes = builder.build()
+
+        from sdk.graph import Dag
+
+        dag = Dag(queue_factory=Queue)
+        dag.add_node(node)
+        dag._builder._exports["async_node"] = {"node": "async_node", "direction": "node"}
+        dag.build()
+        asyncio.run(dag.astart())
+        asyncio.run(dag.astop())
+
+        assert nodes == [node]
+        assert node.events == ["start", "stop"]
+
+    def test_stop_order_matches_start_order(self):
+        StopOrderNode.events = []
+        src = StopOrderNode("src")
+        dst = StopOrderNode("dst")
+
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(src).add_node(dst)
+        builder._exports["src"] = {"node": "src", "direction": "node"}
+        builder._exports["dst"] = {"node": "dst", "direction": "node"}
+
+        from sdk.graph import Dag
+
+        dag = Dag(queue_factory=Queue)
+        dag.add_node(src).add_node(dst)
+        dag._builder._exports["src"] = {"node": "src", "direction": "node"}
+        dag._builder._exports["dst"] = {"node": "dst", "direction": "node"}
+        dag.build()
+        dag.stop()
+
+        assert StopOrderNode.events == ["src", "dst"]
 
     def test_external_edges(self):
         """Plugin-provided EdgeSpecs are resolved at build time."""
@@ -261,3 +389,76 @@ exports:
         assert [node.name for node in nodes] == ["src"]
         assert dag.resolve_export("chat.input") is dag.inq("src", "in")
         assert dag.resolve_export("chat.node").name == "src"
+
+    def test_yaml_node_reference_via_configure(self):
+        dag_yaml = """
+nodes:
+  - name: rule
+    type: test.unit.tools.test_dag_graph.RuleNode
+    accepted: "yes"
+  - name: router
+    type: test.unit.tools.test_dag_graph.RuleRouterNode
+    rule_node: rule
+edges: []
+exports:
+  input:
+    node: router
+    port: in
+    direction: input
+  accepted:
+    node: router
+    port: accepted
+    direction: output
+"""
+        from sdk.graph import Dag
+
+        dag = Dag(queue_factory=Queue)
+        dag.load_yaml(dag_yaml)
+        nodes = dag.build()
+
+        dag.resolve_export("input").put("yes")
+        dag.start()
+
+        assert [node.name for node in nodes] == ["router"]
+        assert dag.resolve_export("accepted").get(timeout=0.2) == "yes"
+
+class TestRuntimeWorkflow:
+    def test_build_runtime_workflow_uses_only_selected_yaml(self, tmp_path):
+        first = tmp_path / "first.yaml"
+        second = tmp_path / "second.yaml"
+        first.write_text(
+            """
+nodes:
+  - name: first
+    type: test.unit.tools.test_dag_graph.EchoNode
+edges: []
+exports:
+  selected:
+    node: first
+    direction: node
+""",
+            encoding="utf-8",
+        )
+        second.write_text(
+            """
+nodes:
+  - name: second
+    type: test.unit.tools.test_dag_graph.EchoNode
+edges: []
+exports:
+  selected:
+    node: second
+    direction: node
+""",
+            encoding="utf-8",
+        )
+
+        workflow = build_runtime_workflow(
+            workflow_path=str(second),
+            queue_factory=Queue,
+        )
+
+        assert workflow.workflow_path == str(second)
+        assert workflow.require_export("selected").name == "second"
+        with pytest.raises(KeyError):
+            workflow.dag.get_node("first")

--- a/test/unit/tools/test_dag_graph.py
+++ b/test/unit/tools/test_dag_graph.py
@@ -6,6 +6,7 @@ import threading
 import time
 from pathlib import Path
 from queue import Queue
+from typing import Any
 
 import pytest
 
@@ -101,6 +102,13 @@ class RuleNode(PassiveNoPortsNode):
     def accepts(self, value: str) -> bool:
         return value == self.accepted
 
+    def to_config(self):
+        return {"accepted": self.accepted}
+
+    @classmethod
+    def from_config(cls, name: str, params: dict[str, Any]) -> "RuleNode":
+        return cls(name=name, **params)
+
 
 class RuleRouterNode(DagNode):
     def __init__(self, name: str, rule_node: str):
@@ -113,6 +121,13 @@ class RuleRouterNode(DagNode):
 
     def outputs(self):
         return {"accepted": Port("accepted"), "rejected": Port("rejected")}
+
+    def to_config(self):
+        return {"rule_node": self.rule_node_name}
+
+    @classmethod
+    def from_config(cls, name: str, params: dict[str, Any]) -> "RuleRouterNode":
+        return cls(name=name, **params)
 
     def configure(self, nodes):
         rule = nodes.get(self.rule_node_name)
@@ -311,7 +326,7 @@ class TestDagBuilder:
 
 class TestDagSerialization:
     def test_to_dict_round_trip(self):
-        """to_dict produces valid structure that from_dict can reload."""
+        """to_dict produces valid structure with params field."""
         a = EchoNode("A")
         b = SinkNode("B")
         builder = DagBuilder()
@@ -327,6 +342,9 @@ class TestDagSerialization:
         assert len(data["edges"]) == 1
         assert data["edges"][0]["src"] == "A"
         assert data["edges"][0]["src_port"] == "out"
+        for node in data["nodes"]:
+            assert "params" in node
+            assert isinstance(node["params"], dict)
 
     def test_to_yaml_writes_file(self, tmp_path):
         """to_yaml writes a YAML file with full dotted type paths."""
@@ -395,10 +413,12 @@ exports:
 nodes:
   - name: rule
     type: test.unit.tools.test_dag_graph.RuleNode
-    accepted: "yes"
+    params:
+      accepted: "yes"
   - name: router
     type: test.unit.tools.test_dag_graph.RuleRouterNode
-    rule_node: rule
+    params:
+      rule_node: rule
 edges: []
 exports:
   input:
@@ -421,6 +441,32 @@ exports:
 
         assert [node.name for node in nodes] == ["router"]
         assert dag.resolve_export("accepted").get(timeout=0.2) == "yes"
+
+    def test_params_round_trip_via_to_dict(self):
+        """to_dict preserves constructor params, from_dict restores them."""
+        rule = RuleNode("rule", accepted="no")
+        router = RuleRouterNode("router", rule_node="rule")
+        builder = DagBuilder()
+        builder.set_queue_factory(Queue)
+        builder.add_node(rule).add_node(router)
+        builder._exports["router_in"] = {"node": "router", "port": "in", "direction": "input"}
+        builder._exports["rule_node_ref"] = {"node": "rule", "direction": "node"}
+        builder.build()
+
+        data = builder.to_dict()
+        rule_data = next(n for n in data["nodes"] if n["name"] == "rule")
+        router_data = next(n for n in data["nodes"] if n["name"] == "router")
+
+        assert rule_data["params"] == {"accepted": "no"}
+        assert router_data["params"] == {"rule_node": "rule"}
+
+        builder2 = DagBuilder.from_dict(data, queue_factory=Queue)
+        rule2 = builder2._nodes["rule"]
+        router2 = builder2._nodes["router"]
+        assert isinstance(rule2, RuleNode)
+        assert isinstance(router2, RuleRouterNode)
+        assert rule2.accepted == "no"
+        assert router2.rule_node_name == "rule"
 
 class TestRuntimeWorkflow:
     def test_build_runtime_workflow_uses_only_selected_yaml(self, tmp_path):

--- a/test/unit/tools/test_dag_graph.py
+++ b/test/unit/tools/test_dag_graph.py
@@ -468,6 +468,26 @@ exports:
         assert rule2.accepted == "no"
         assert router2.rule_node_name == "rule"
 
+    def test_make_node_propagates_internal_typeerror(self):
+        """Constructor-internal TypeError must surface, not be silently retried."""
+
+        class BuggyNode(DagNode):
+            def __init__(self, name: str, fail_on: str = ""):
+                super().__init__(name)
+                if fail_on:
+                    raise TypeError(f"internal bug: {fail_on}")
+
+            def inputs(self):
+                return {}
+
+            def outputs(self):
+                return {}
+
+        from sdk.graph import DagBuilder
+
+        with pytest.raises(TypeError, match="internal bug: boom"):
+            DagBuilder._make_node(BuggyNode, "bomb", {"fail_on": "boom"})
+
 class TestRuntimeWorkflow:
     def test_build_runtime_workflow_uses_only_selected_yaml(self, tmp_path):
         first = tmp_path / "first.yaml"

--- a/tools/file_util.py
+++ b/tools/file_util.py
@@ -117,13 +117,16 @@ def export_character(character_configs: list[CharacterConfig], output_path: str)
         
         folder_path = Path(output_path).parent.resolve()
         
-        system = platform.system()
-        if system == 'Windows':
-            os.startfile(folder_path)
-        elif system == 'Darwin':  # macOS
-            subprocess.Popen(['open', folder_path])
-        elif system == 'Linux':
-            subprocess.Popen(['xdg-open', folder_path])
+        try:
+            system = platform.system()
+            if system == 'Windows':
+                os.startfile(folder_path)
+            elif system == 'Darwin':  # macOS
+                subprocess.Popen(['open', folder_path])
+            elif system == 'Linux':
+                subprocess.Popen(['xdg-open', folder_path])
+        except Exception as e:
+            print(f"Failed to open export folder {folder_path}: {e}")
 
         print(f"人物成功导出到: {output_path}")
 

--- a/ui/chat_ui/chat_ui.py
+++ b/ui/chat_ui/chat_ui.py
@@ -6,7 +6,7 @@ import numpy as np
 import threading
 import yaml
 import time
-from PySide6.QtCore import QByteArray, QEvent, QPoint, QRect, Qt, Signal, QSize, QUrl
+from PySide6.QtCore import QByteArray, QEvent, QPoint, QRect, Qt, Signal, QSize, QUrl, QTimer
 from PySide6.QtGui import (
     QCursor,
     QFont,
@@ -106,6 +106,7 @@ class ChatUIWindow(DesktopToolbarMixin, DesktopMenuMixin, QWidget):
         # 对话/选项区：小于启动时透明窗初始宽度则横向上与容器同宽（无左右留白）
         self._overlay_min_ref_width = max(1, int(self.original_width))
         self.current_background_path = None
+        self._close_started = False
         # 全尺寸图，供 resize 时重缩放，使底栏 input 与整窗共用同一底图
         self._background_source_pixmap = None
         self._last_user_message = ""
@@ -1439,15 +1440,28 @@ class ChatUIWindow(DesktopToolbarMixin, DesktopMenuMixin, QWidget):
         super().mouseReleaseEvent(event)
 
     def closeEvent(self, event):
-        """关闭窗口时停止线程"""
+        if self._close_started:
+            event.accept()
+            return
+        self._close_started = True
         if self._resizing:
             self._end_resize()
         self._persist_chat_window_geometry()
-        self.mic_button.close()
+        self.setEnabled(False)
+        self.hide()
+        event.accept()
+        QTimer.singleShot(0, self._finish_close)
+        return
+
+    def _finish_close(self):
+        try:
+            self.mic_button.close()
+        except Exception:
+            _logger.exception("mic close cleanup")
         if self.display_thread:
             self.display_thread.stop()
-            self.display_thread.wait()
-        super().closeEvent(event)
+            if not self.display_thread.wait(1000):
+                _logger.warning("display thread did not stop within 1s")
         self.close_window.emit()
         from ui.chat_ui.signal_bridge import detach_chat_ui_window
 


### PR DESCRIPTION
Summary

This PR refactors the runtime chat pipeline into a configurable workflow/DAG while preserving the existing worker behavior and chat history semantics.

Changes

- Added DAG nodes and workflow.
- Added runtime workflow support based on YAML-defined DAGs.
- Updated runtime startup to load exactly one selected workflow per run.
- Converted LLMWorker, TTSWorker, and UIWorker into DAG nodes while preserving their original queue-based behavior.
- Improved worker shutdown to use sentinel-based graceful stop instead of force termination.