### PR TITLE
test(frontend): add feature unit tests

### DIFF
--- a/frontend/src/test/features/api-settings/AdapterExtraForm.test.tsx
+++ b/frontend/src/test/features/api-settings/AdapterExtraForm.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AdapterExtraForm } from "../../../features/api-settings/AdapterExtraForm";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+function renderForm(overrides: Partial<Parameters<typeof AdapterExtraForm>[0]> = {}) {
+  const props: Parameters<typeof AdapterExtraForm>[0] = {
+    onChange: vi.fn(),
+    schema: {
+      reasoning_effort: { choices: ["low", "medium", "high"], default: "medium", label: "Reasoning effort" },
+      temperature: { default: 0.6, label: "Temperature", max: 2, min: 0, step: 0.1, type: "float" },
+      thinking_enabled: { default: true, label: "Thinking", type: "bool" },
+    },
+    values: { reasoning_effort: "medium", temperature: 0.6, thinking_enabled: true },
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <AdapterExtraForm {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("AdapterExtraForm", () => {
+  it("routes schema field changes through the changed adapter key", () => {
+    const { props } = renderForm();
+
+    fireEvent.change(screen.getByLabelText("Temperature"), { target: { value: "0.9" } });
+    expect(props.onChange).toHaveBeenCalledWith("temperature", 0.9);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "high" }));
+    expect(props.onChange).toHaveBeenCalledWith("reasoning_effort", "high");
+  });
+
+  it("disables thinking controls when the selected model cannot use them", () => {
+    renderForm({ modelUnsupportedThinking: true });
+
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
+});

--- a/frontend/src/test/features/api-settings/ApiLanguageSection.test.tsx
+++ b/frontend/src/test/features/api-settings/ApiLanguageSection.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiLanguageSection } from "../../../features/api-settings/ApiLanguageSection";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+import type { SystemConfig } from "../../../entities/config/types";
+
+function systemConfig(overrides: Partial<SystemConfig> = {}): SystemConfig {
+  return {
+    ui_language: "en",
+    ...overrides,
+  } as SystemConfig;
+}
+
+function renderSection(overrides: Partial<Parameters<typeof ApiLanguageSection>[0]> = {}) {
+  const props: Parameters<typeof ApiLanguageSection>[0] = {
+    disabled: false,
+    onChange: vi.fn(),
+    systemDraft: systemConfig(),
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <ApiLanguageSection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("ApiLanguageSection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-color-scheme");
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: false }),
+    });
+  });
+
+  it("normalizes language selection before notifying the parent draft", () => {
+    const { props } = renderSection();
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "Japanese" }));
+
+    expect(props.onChange).toHaveBeenCalledWith("ja");
+  });
+
+  it("persists color scheme changes outside the API draft", () => {
+    renderSection();
+
+    expect(document.documentElement).toHaveAttribute("data-color-scheme", "light");
+
+    fireEvent.click(screen.getByLabelText("Dark mode"));
+
+    expect(document.documentElement).toHaveAttribute("data-color-scheme", "dark");
+    expect(localStorage.getItem("shinsekai-color-scheme")).toBe("dark");
+  });
+});

--- a/frontend/src/test/features/api-settings/AsrSettingsSection.test.tsx
+++ b/frontend/src/test/features/api-settings/AsrSettingsSection.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AsrSettingsSection } from "../../../features/api-settings/AsrSettingsSection";
+import { VOSK_MODEL_PATH } from "../../../features/api-settings/apiSettingsUtils";
+import type { ApiConfig, SystemConfig } from "../../../entities/config/types";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+const mocks = {
+  openExternal: vi.fn(),
+};
+
+vi.mock("../../../entities/files/repository", () => ({
+  openExternal: (url: string) => mocks.openExternal(url),
+}));
+
+function apiConfig(overrides: Partial<ApiConfig> = {}): ApiConfig {
+  return {
+    asr_extra_configs: {},
+    llm_api_key: {},
+    llm_model: {},
+    ...overrides,
+  } as ApiConfig;
+}
+
+function systemConfig(overrides: Partial<SystemConfig> = {}): SystemConfig {
+  return {
+    asr_language: "",
+    asr_provider: "vosk",
+    asr_whisper_compute_type: "",
+    asr_whisper_device: "auto",
+    asr_whisper_model_size: "small",
+    ...overrides,
+  } as SystemConfig;
+}
+
+function renderSection(overrides: Partial<Parameters<typeof AsrSettingsSection>[0]> = {}) {
+  const props: Parameters<typeof AsrSettingsSection>[0] = {
+    activeAsrProvider: "vosk",
+    activeAsrSchema: {},
+    asrComputeSelectOptions: [
+      { label: "Auto", value: "" },
+      { label: "float16", value: "float16" },
+    ],
+    asrProviderSelectOptions: [
+      { label: "Vosk", value: "vosk" },
+      { label: "Faster Whisper", value: "faster_whisper" },
+    ],
+    currentAsrCompute: "",
+    customWhisperModel: false,
+    disabled: false,
+    draft: apiConfig(),
+    onAsrExtraChange: vi.fn(),
+    onSystemPatch: vi.fn(),
+    showWhisperFields: false,
+    systemDraft: systemConfig(),
+    voskModelPath: VOSK_MODEL_PATH,
+    whisperPresetValue: "small",
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <AsrSettingsSection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("AsrSettingsSection", () => {
+  it("renders Vosk model controls and opens official model resources", () => {
+    const { props } = renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: "Vosk models" }));
+    expect(mocks.openExternal).toHaveBeenCalledWith(expect.stringContaining("alphacephei"));
+
+    fireEvent.change(screen.getByDisplayValue(VOSK_MODEL_PATH), { target: { value: "D:/models/vosk" } });
+    expect(props.onAsrExtraChange).toHaveBeenCalledWith("vosk", "model_path", "D:/models/vosk");
+  });
+
+  it("routes Whisper provider, language, model, device, and compute changes", () => {
+    const { props } = renderSection({
+      activeAsrProvider: "faster_whisper",
+      currentAsrCompute: "",
+      showWhisperFields: true,
+      systemDraft: systemConfig({ asr_provider: "faster_whisper" }),
+      whisperPresetValue: "small",
+    });
+
+    const combos = screen.getAllByRole("combobox");
+    fireEvent.click(combos[0]);
+    fireEvent.click(screen.getByRole("option", { name: "Vosk" }));
+    expect(props.onSystemPatch).toHaveBeenCalledWith({ asr_provider: "vosk" });
+
+    fireEvent.click(combos[1]);
+    fireEvent.click(screen.getByRole("option", { name: "English" }));
+    expect(props.onSystemPatch).toHaveBeenCalledWith({ asr_language: "en" });
+
+    fireEvent.click(combos[2]);
+    fireEvent.click(screen.getByRole("option", { name: "large-v3" }));
+    expect(props.onSystemPatch).toHaveBeenCalledWith({ asr_whisper_model_size: "large-v3" });
+
+    fireEvent.click(combos[3]);
+    fireEvent.click(screen.getByRole("option", { name: "CPU" }));
+    expect(props.onSystemPatch).toHaveBeenCalledWith({ asr_whisper_device: "cpu" });
+
+    fireEvent.click(combos[4]);
+    fireEvent.click(screen.getByRole("option", { name: "float16" }));
+    expect(props.onSystemPatch).toHaveBeenCalledWith({ asr_whisper_compute_type: "float16" });
+  });
+});

--- a/frontend/src/test/features/api-settings/EditableModelSelect.test.tsx
+++ b/frontend/src/test/features/api-settings/EditableModelSelect.test.tsx
@@ -92,6 +92,32 @@ describe("EditableModelSelect", () => {
 
     expect(screen.getByRole("button", { name: "Model ID" })).toBeDisabled();
   });
+
+  it("accepts an exact option with Enter and disables the text input when requested", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <EditableModelSelect
+        disabled={false}
+        id="model"
+        onChange={onChange}
+        options={options}
+        placeholder="Model ID"
+        value="deepseek-chat"
+      />,
+    );
+
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith("deepseek-chat");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    rerender(
+      <EditableModelSelect disabled id="model" onChange={onChange} options={[]} placeholder="Model ID" value="" />,
+    );
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
 });
 
 describe("ModelCapabilityBadge", () => {

--- a/frontend/src/test/features/api-settings/LlmConnectionSection.test.tsx
+++ b/frontend/src/test/features/api-settings/LlmConnectionSection.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { LlmConnectionSection } from "../../../features/api-settings/LlmConnectionSection";
+import type { ApiConfig } from "../../../entities/config/types";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+function apiConfig(overrides: Partial<ApiConfig> = {}): ApiConfig {
+  return {
+    asr_extra_configs: {},
+    gpt_sovits_api_path: "",
+    gpt_sovits_url: "",
+    is_streaming: true,
+    llm_api_key: { Deepseek: "secret" },
+    llm_base_url: "https://api.deepseek.com",
+    llm_extra_configs: {},
+    llm_model: { Deepseek: "deepseek-chat" },
+    llm_provider: "Deepseek",
+    t2i_extra_configs: {},
+    tts_extra_configs: {},
+    ...overrides,
+  } as ApiConfig;
+}
+
+function renderSection(overrides: Partial<Parameters<typeof LlmConnectionSection>[0]> = {}) {
+  const props: Parameters<typeof LlmConnectionSection>[0] = {
+    activeApiKey: "secret",
+    activeModel: "deepseek-chat",
+    availableModelOptions: [
+      { id: "deepseek-chat", tags: ["text"] },
+      { id: "deepseek-reasoner", tags: ["text"] },
+    ],
+    disabled: false,
+    draft: apiConfig(),
+    fetchModelsPending: false,
+    llmExtraSchema: {},
+    llmProviderSelectOptions: [
+      { label: "Deepseek", value: "Deepseek" },
+      { label: "OpenAI", value: "OpenAI" },
+    ],
+    modelCandidateListId: "llm-model",
+    modelUnsupportedThinking: false,
+    onAdapterExtraChange: vi.fn(),
+    onDraftPatch: vi.fn(),
+    onFetchModels: vi.fn(),
+    onProviderChange: vi.fn(),
+    onProviderMapChange: vi.fn(),
+    selectedOption: { id: "deepseek-chat", tags: ["text"] },
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <LlmConnectionSection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("LlmConnectionSection", () => {
+  it("routes provider, connection, and model changes through public callbacks", () => {
+    const { props } = renderSection();
+
+    fireEvent.click(screen.getAllByRole("combobox")[0]);
+    fireEvent.click(screen.getByRole("option", { name: "OpenAI" }));
+    expect(props.onProviderChange).toHaveBeenCalledWith("OpenAI");
+
+    fireEvent.change(screen.getByDisplayValue("https://api.deepseek.com"), {
+      target: { value: "https://api.example.com/v1" },
+    });
+    expect(props.onDraftPatch).toHaveBeenCalledWith({ llm_base_url: "https://api.example.com/v1" });
+
+    fireEvent.change(screen.getByDisplayValue("secret"), { target: { value: "new-secret" } });
+    expect(props.onProviderMapChange).toHaveBeenCalledWith("llm_api_key", "new-secret");
+
+    fireEvent.focus(screen.getByDisplayValue("deepseek-chat"));
+    fireEvent.click(screen.getByRole("option", { name: /deepseek-reasoner/ }));
+    expect(props.onProviderMapChange).toHaveBeenCalledWith("llm_model", "deepseek-reasoner");
+
+    fireEvent.click(screen.getByRole("button", { name: "Fetch available models" }));
+    expect(props.onFetchModels).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays selected model capability badges and streams toggle changes", () => {
+    const { props } = renderSection();
+
+    expect(screen.getAllByText("Text").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(props.onDraftPatch).toHaveBeenCalledWith({ is_streaming: false });
+  });
+});

--- a/frontend/src/test/features/api-settings/TtsBundleSection.test.tsx
+++ b/frontend/src/test/features/api-settings/TtsBundleSection.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TtsBundleSection } from "../../../features/api-settings/TtsBundleSection";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+import type { TaskSnapshot, TtsBundleDownloadResult } from "../../../shared/platform/types";
+
+function task(): TaskSnapshot<TtsBundleDownloadResult> {
+  return {
+    createdAt: 0,
+    id: "download-1",
+    kind: "tts-bundle",
+    logs: ["Downloading"],
+    message: "Downloading",
+    phase: "download",
+    status: "running",
+    title: "TTS bundle",
+    updatedAt: 0,
+  };
+}
+
+function renderSection(overrides: Partial<Parameters<typeof TtsBundleSection>[0]> = {}) {
+  const props: Parameters<typeof TtsBundleSection>[0] = {
+    canCancelDownload: false,
+    cancelPending: false,
+    dialogOpen: false,
+    downloadPending: false,
+    error: null,
+    kind: "genie",
+    onCancelDownload: vi.fn(),
+    onCloseDialog: vi.fn(),
+    onKindChange: vi.fn(),
+    onOpenDialog: vi.fn(),
+    onStartDownload: vi.fn(),
+    recommendation: {
+      gpus: [{ device: "RTX 4090", vendor: "NVIDIA", vram_gb: 24 }],
+      kind: "gptso",
+      platform: "Windows",
+    },
+    recommendationError: false,
+    recommendationLoading: false,
+    savePending: false,
+    task: null,
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <TtsBundleSection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("TtsBundleSection", () => {
+  it("opens the download dialog from the section action", () => {
+    const { props } = renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose package" }));
+    expect(props.onOpenDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders recommendation, task progress, and dialog actions", () => {
+    const { props } = renderSection({
+      canCancelDownload: true,
+      dialogOpen: true,
+      error: "Download failed",
+      task: task(),
+    });
+    const dialog = screen.getByRole("dialog", { name: "Download TTS package" });
+
+    expect(within(dialog).getByText("Windows")).toBeInTheDocument();
+    expect(within(dialog).getByText("NVIDIA RTX 4090 / 24 GB")).toBeInTheDocument();
+    expect(within(dialog).getAllByText("GPT-SoVITS v2pro").length).toBeGreaterThan(0);
+    expect(within(dialog).getByRole("alert")).toHaveTextContent("Download failed");
+    expect(within(dialog).getByText("Downloading")).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("combobox"));
+    fireEvent.click(within(dialog).getByRole("option", { name: "GPT-SoVITS v2pro for RTX 50" }));
+    expect(props.onKindChange).toHaveBeenCalledWith("gptso50");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel download" }));
+    expect(props.onCancelDownload).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Start download" }));
+    expect(props.onStartDownload).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(within(dialog).getAllByRole("button", { name: "Close" })[0]);
+    expect(props.onCloseDialog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/features/api-settings/apiSettingsUtils.test.ts
+++ b/frontend/src/test/features/api-settings/apiSettingsUtils.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  containsPathQuotes,
+  isTaskRunning,
+  mergeModelOptions,
+  normalizeApiAsrForSave,
+  normalizeAsrProvider,
+  normalizeSystemAsrForSave,
+  resolveAsrWhisperPresetValue,
+  updateAsrExtraConfig,
+  VOSK_MODEL_PATH,
+  withCurrentOption,
+} from "../../../features/api-settings/apiSettingsUtils";
+import type { ApiConfig, SystemConfig } from "../../../entities/config/types";
+import type { TaskSnapshot } from "../../../shared/platform/types";
+
+function apiConfig(overrides: Partial<ApiConfig> = {}): ApiConfig {
+  return {
+    asr_extra_configs: {},
+    llm_api_key: {},
+    llm_base_url: "",
+    llm_model: {},
+    llm_provider: "Deepseek",
+    ...overrides,
+  } as ApiConfig;
+}
+
+function systemConfig(overrides: Partial<SystemConfig> = {}): SystemConfig {
+  return {
+    asr_provider: "vosk",
+    asr_whisper_compute_type: "",
+    asr_whisper_device: "auto",
+    asr_whisper_model_size: "small",
+    ...overrides,
+  } as SystemConfig;
+}
+
+function task(status: TaskSnapshot["status"]): TaskSnapshot {
+  return {
+    createdAt: 0,
+    id: status,
+    kind: "test",
+    logs: [],
+    message: "",
+    phase: "",
+    status,
+    title: "",
+    updatedAt: 0,
+  };
+}
+
+describe("API settings utilities", () => {
+  it("normalizes ASR provider aliases and save payloads", () => {
+    expect(normalizeAsrProvider("faster-whisper")).toBe("faster_whisper");
+    expect(normalizeAsrProvider("RealtimeSTT")).toBe("realtime_stt");
+    expect(normalizeAsrProvider("")).toBe("vosk");
+
+    expect(
+      normalizeSystemAsrForSave(
+        systemConfig({
+          asr_provider: "RealtimeSTT",
+          asr_whisper_compute_type: " float16 ",
+          asr_whisper_device: " CUDA ",
+          asr_whisper_model_size: "",
+        }),
+      ),
+    ).toMatchObject({
+      asr_provider: "realtime_stt",
+      asr_whisper_compute_type: "float16",
+      asr_whisper_device: "cuda",
+      asr_whisper_model_size: "small",
+    });
+  });
+
+  it("preserves custom ASR and model options for existing configs", () => {
+    expect(resolveAsrWhisperPresetValue("large-v3")).toBe("large-v3");
+    expect(resolveAsrWhisperPresetValue("custom-model")).toBe("__custom__");
+
+    expect(
+      withCurrentOption(
+        [
+          { label: "Vosk", value: "vosk" },
+          { label: "RealtimeSTT", value: "realtime_stt" },
+        ],
+        "custom_asr",
+      ),
+    ).toEqual([
+      { label: "Vosk", value: "vosk" },
+      { label: "RealtimeSTT", value: "realtime_stt" },
+      { label: "custom_asr", value: "custom_asr" },
+    ]);
+
+    expect(
+      mergeModelOptions(
+        [
+          { id: "deepseek-chat", tags: ["stable"] },
+          { id: " ", tags: ["skip"] },
+        ],
+        [
+          { id: "deepseek-chat", tags: ["duplicate"] },
+          { id: "deepseek-reasoner", tags: [] },
+        ],
+      ),
+    ).toEqual([
+      { id: "deepseek-chat", tags: ["stable"] },
+      { id: "deepseek-reasoner", tags: [] },
+    ]);
+  });
+
+  it("adds the default Vosk model path only when saving Vosk configs", () => {
+    expect(normalizeApiAsrForSave(apiConfig(), systemConfig()).asr_extra_configs?.vosk?.model_path).toBe(
+      VOSK_MODEL_PATH,
+    );
+
+    expect(
+      normalizeApiAsrForSave(
+        apiConfig({ asr_extra_configs: { vosk: { model_path: "D:/models/vosk" } } }),
+        systemConfig(),
+      ).asr_extra_configs?.vosk?.model_path,
+    ).toBe("D:/models/vosk");
+
+    expect(normalizeApiAsrForSave(apiConfig(), systemConfig({ asr_provider: "faster_whisper" }))).toEqual(apiConfig());
+  });
+
+  it("updates nested ASR extras without dropping provider-specific keys", () => {
+    expect(
+      updateAsrExtraConfig(
+        apiConfig({
+          asr_extra_configs: {
+            vosk: { model_path: "D:/models/vosk", sample_rate: 16000 },
+          },
+        }),
+        "vosk",
+        "model_path",
+        "D:/models/new-vosk",
+      ).asr_extra_configs?.vosk,
+    ).toEqual({
+      model_path: "D:/models/new-vosk",
+      sample_rate: 16000,
+    });
+  });
+
+  it("detects running tasks and quoted paths", () => {
+    expect(isTaskRunning(task("queued"))).toBe(true);
+    expect(isTaskRunning(task("running"))).toBe(true);
+    expect(isTaskRunning(task("succeeded"))).toBe(false);
+    expect(isTaskRunning(null)).toBe(false);
+
+    expect(containsPathQuotes('D:/Models/"bad"')).toBe(true);
+    expect(containsPathQuotes("D:/Models/good")).toBe(false);
+  });
+});

--- a/frontend/src/test/features/background-manager/BackgroundMusicSection.test.tsx
+++ b/frontend/src/test/features/background-manager/BackgroundMusicSection.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { BackgroundMusicSection } from "../../../features/background-manager/BackgroundMusicSection";
+import type { BackgroundBgmItem } from "../../../features/background-manager/backgroundUtils";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+let originalMediaLoad: PropertyDescriptor | undefined;
+let originalMediaPause: PropertyDescriptor | undefined;
+
+beforeAll(() => {
+  originalMediaLoad = Object.getOwnPropertyDescriptor(window.HTMLMediaElement.prototype, "load");
+  originalMediaPause = Object.getOwnPropertyDescriptor(window.HTMLMediaElement.prototype, "pause");
+  Object.defineProperty(window.HTMLMediaElement.prototype, "load", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterAll(() => {
+  if (originalMediaLoad) {
+    Object.defineProperty(window.HTMLMediaElement.prototype, "load", originalMediaLoad);
+  }
+  if (originalMediaPause) {
+    Object.defineProperty(window.HTMLMediaElement.prototype, "pause", originalMediaPause);
+  }
+});
+
+function renderSection(overrides: Partial<Parameters<typeof BackgroundMusicSection>[0]> = {}) {
+  const props: Parameters<typeof BackgroundMusicSection>[0] = {
+    batchDeletePending: false,
+    bgmList: ["D:/bgm/track-10.mp3", "D:/bgm/track-2.mp3", "D:/bgm/ambient.mp3"],
+    bgmRowTags: ["tense", "active", "calm"],
+    currentBackgroundName: "school",
+    deletePending: false,
+    onBatchDelete: vi.fn(),
+    onClearAll: vi.fn(),
+    onDelete: vi.fn(),
+    onOpenBulkTags: vi.fn(),
+    onSortToggle: vi.fn(),
+    onTagChange: vi.fn(),
+    onToggleAllSelection: vi.fn(),
+    onToggleSelection: vi.fn(),
+    onUpload: vi.fn(),
+    selectedBgmIndexSet: new Set<number>(),
+    sortDirection: "asc",
+    sortKey: "filename",
+    sortedBgmItems: [
+      { filename: "ambient.mp3", originalIndex: 2, path: "D:/bgm/ambient.mp3" },
+      { filename: "track-2.mp3", originalIndex: 1, path: "D:/bgm/track-2.mp3" },
+      { filename: "track-10.mp3", originalIndex: 0, path: "D:/bgm/track-10.mp3" },
+    ] satisfies BackgroundBgmItem[],
+    uploadPending: false,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <BackgroundMusicSection {...props} {...overrides} />
+    </I18nProvider>,
+  );
+
+  return { props: { ...props, ...overrides }, ...result };
+}
+
+describe("BackgroundMusicSection", () => {
+  it("renders sorted BGM rows while preserving original row indexes for actions", () => {
+    const { props } = renderSection();
+
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent("ambient.mp3");
+    expect(rows[1]).toHaveTextContent("track-2.mp3");
+    expect(rows[2]).toHaveTextContent("track-10.mp3");
+
+    fireEvent.click(screen.getByLabelText("Select 3"));
+    expect(props.onToggleSelection).toHaveBeenCalledWith(2, true);
+
+    fireEvent.change(screen.getAllByLabelText("Tag")[0], { target: { value: "quiet" } });
+    expect(props.onTagChange).toHaveBeenCalledWith(2, "quiet");
+
+    fireEvent.click(screen.getByLabelText("Remove ambient.mp3"));
+    expect(props.onDelete).toHaveBeenCalledWith(2);
+  });
+
+  it("routes toolbar actions through public callbacks", () => {
+    const { props } = renderSection({
+      selectedBgmIndexSet: new Set([1]),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload BGM" }));
+    expect(screen.getByRole("dialog", { name: "Select BGM files" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Batch BGM tags" }));
+    expect(props.onOpenBulkTags).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete selected BGM" }));
+    expect(props.onBatchDelete).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete all BGM" }));
+    expect(props.onClearAll).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "File name ascending" }));
+    expect(props.onSortToggle).toHaveBeenCalledWith("filename");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select all BGM" }));
+    expect(props.onToggleAllSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables destructive and upload actions when no background context exists", () => {
+    renderSection({
+      currentBackgroundName: "",
+      selectedBgmIndexSet: new Set([1]),
+    });
+
+    expect(screen.getByRole("button", { name: "Upload BGM" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete selected BGM" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete all BGM" })).toBeDisabled();
+  });
+});

--- a/frontend/src/test/features/background-manager/BackgroundSpriteGallery.test.tsx
+++ b/frontend/src/test/features/background-manager/BackgroundSpriteGallery.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BackgroundSpriteGallery } from "../../../features/background-manager/BackgroundSpriteGallery";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+vi.mock("../../../entities/files/repository", () => ({
+  fileUrl: (path: string) => `asset://${path}`,
+}));
+
+function renderGallery(overrides: Partial<Parameters<typeof BackgroundSpriteGallery>[0]> = {}) {
+  const props: Parameters<typeof BackgroundSpriteGallery>[0] = {
+    currentBackgroundName: "school",
+    deletePending: false,
+    imageRowTags: ["day", "night"],
+    onClearImages: vi.fn(),
+    onDeleteImage: vi.fn(),
+    onOpenBulkTags: vi.fn(),
+    onSaveImageTags: vi.fn(),
+    onSelectImage: vi.fn(),
+    onUpdateImageTag: vi.fn(),
+    onUploadImages: vi.fn(),
+    saveTagsPending: false,
+    selectedImageIndex: 1,
+    sprites: [{ path: "D:/bg/scene-a.png" }, { path: "D:/bg/scene-b.png" }],
+    uploadPending: false,
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <BackgroundSpriteGallery {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("BackgroundSpriteGallery", () => {
+  it("shows empty image state and disables actions without a background context", () => {
+    renderGallery({
+      currentBackgroundName: "",
+      sprites: [],
+    });
+
+    expect(screen.getByRole("button", { name: "Upload images" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete all images" })).toBeDisabled();
+  });
+
+  it("routes selected image inspection actions by the selected sprite index", () => {
+    const { props } = renderGallery();
+
+    fireEvent.click(screen.getByRole("button", { name: /scene-a\.png/ }));
+    expect(props.onSelectImage).toHaveBeenCalledWith(0);
+
+    expect(screen.getByTitle("D:/bg/scene-b.png")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Tag"), { target: { value: "rainy night" } });
+    expect(props.onUpdateImageTag).toHaveBeenCalledWith(1, "rainy night");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save image description" }));
+    expect(props.onSaveImageTags).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(props.onDeleteImage).toHaveBeenCalledWith(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload images" }));
+    expect(screen.getByRole("dialog", { name: "Select image files" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Batch image tags" }));
+    expect(props.onOpenBulkTags).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/features/background-manager/backgroundUtils.test.ts
+++ b/frontend/src/test/features/background-manager/backgroundUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { createBackground } from "../../../features/background-manager/backgroundUtils";
+
+describe("background manager utilities", () => {
+  it("creates a safe empty background draft", () => {
+    expect(createBackground()).toEqual({
+      bg_tags: "",
+      bgm_list: [],
+      bgm_tags: "",
+      name: "",
+      sprite_prefix: "temp",
+      sprites: [],
+    });
+  });
+});

--- a/frontend/src/test/features/character-editor/CharacterBasicSection.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterBasicSection.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CharacterBasicSection } from "../../../features/character-editor/CharacterBasicSection";
+import { createCharacter } from "../../../features/character-editor/characterEditorUtils";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+function renderSection() {
+  const props: Parameters<typeof CharacterBasicSection>[0] = {
+    colorPickerValue: "#ff66aa",
+    draft: {
+      ...createCharacter(),
+      color: "#ff66aa",
+      name: "Mio",
+      sprite_prefix: "mio",
+    },
+    nameError: "Name is required",
+    onChange: vi.fn(),
+    onColorInputRef: vi.fn(),
+    onDelete: vi.fn(),
+    onPickColor: vi.fn(),
+    onPronunciationTextChange: vi.fn(),
+    pronunciationText: "Mio=mio",
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <CharacterBasicSection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("CharacterBasicSection", () => {
+  it("routes editable field changes through public callbacks", () => {
+    const { props } = renderSection();
+
+    fireEvent.change(screen.getByLabelText(/Character name/), { target: { value: "Mio New" } });
+    expect(props.onChange).toHaveBeenCalledWith("name", "Mio New");
+
+    fireEvent.change(screen.getAllByDisplayValue("#ff66aa")[0], { target: { value: "#abcdef" } });
+    expect(props.onChange).toHaveBeenCalledWith("color", "#abcdef");
+
+    fireEvent.change(screen.getByLabelText("Upload directory name (ASCII)"), { target: { value: "mio_new" } });
+    expect(props.onChange).toHaveBeenCalledWith("sprite_prefix", "mio_new");
+
+    fireEvent.change(screen.getByLabelText("Pronunciation map"), { target: { value: "Mio=miyo" } });
+    expect(props.onPronunciationTextChange).toHaveBeenCalledWith("Mio=miyo");
+  });
+
+  it("exposes validation and destructive actions through the rendered UI", () => {
+    const { props } = renderSection();
+
+    expect(screen.getByText("Name is required")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Pick color" }));
+    expect(props.onPickColor).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(props.onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/features/character-editor/CharacterMemorySection.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterMemorySection.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CharacterMemorySection } from "../../../features/character-editor/CharacterMemorySection";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+function renderSection(overrides: Partial<Parameters<typeof CharacterMemorySection>[0]> = {}) {
+  const props: Parameters<typeof CharacterMemorySection>[0] = {
+    addPending: false,
+    data: undefined,
+    deletePending: false,
+    error: null,
+    isError: false,
+    isFetched: false,
+    isFetching: false,
+    isLoading: false,
+    memoryInput: "",
+    memoryName: "",
+    onAddMemory: vi.fn(),
+    onDeleteMemory: vi.fn(),
+    onMemoryInputChange: vi.fn(),
+    onRefresh: vi.fn(),
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <CharacterMemorySection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("CharacterMemorySection", () => {
+  it("keeps memory actions disabled until a character name and memory text are available", () => {
+    renderSection({ memoryInput: "A remembered line" });
+
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeDisabled();
+    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add memory" })).toBeDisabled();
+  });
+
+  it("renders memory rows and guards deletion for rows without ids", () => {
+    const { props } = renderSection({
+      data: {
+        agentId: "agent-1",
+        count: 2,
+        memories: [
+          { id: "mem-1", memory: "Likes the rooftop." },
+          { id: "", memory: "Draft memory without an id." },
+        ],
+      },
+      isFetched: true,
+      memoryInput: "New memory",
+      memoryName: "Mio",
+    });
+
+    expect(screen.getByText("Likes the rooftop.")).toBeInTheDocument();
+    expect(screen.getByText("Draft memory without an id.")).toBeInTheDocument();
+
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButtons[0]);
+    expect(props.onDeleteMemory).toHaveBeenCalledWith({ id: "mem-1", memory: "Likes the rooftop." });
+    expect(deleteButtons[1]).toBeDisabled();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Fresh memory" } });
+    expect(props.onMemoryInputChange).toHaveBeenCalledWith("Fresh memory");
+
+    fireEvent.click(screen.getByRole("button", { name: "Add memory" }));
+    expect(props.onAddMemory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/features/character-editor/CharacterPageHeader.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterPageHeader.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CharacterPageHeader } from "../../../features/character-editor/CharacterPageHeader";
+import { createCharacter } from "../../../features/character-editor/characterEditorUtils";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+const mocks = {
+  openExternal: vi.fn(),
+};
+
+vi.mock("../../../entities/files/repository", () => ({
+  openExternal: (url: string) => mocks.openExternal(url),
+}));
+
+function renderHeader(overrides: Partial<Parameters<typeof CharacterPageHeader>[0]> = {}) {
+  const props: Parameters<typeof CharacterPageHeader>[0] = {
+    characters: [
+      { ...createCharacter(), name: "Mio" },
+      { ...createCharacter(), name: "Aki" },
+    ],
+    exportPending: false,
+    importPending: false,
+    isCreating: false,
+    isLoading: false,
+    onCreate: vi.fn(),
+    onExport: vi.fn(),
+    onImport: vi.fn(),
+    onSave: vi.fn(),
+    onSelectCharacter: vi.fn(),
+    savePending: false,
+    selectedName: "Mio",
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <CharacterPageHeader {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("CharacterPageHeader", () => {
+  it("routes primary toolbar actions through public callbacks", () => {
+    const { props } = renderHeader();
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    expect(props.onCreate).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Export" }));
+    expect(props.onExport).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(props.onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects characters and opens community links without touching production APIs", () => {
+    const { props } = renderHeader();
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "Aki" }));
+    expect(props.onSelectCharacter).toHaveBeenCalledWith("Aki");
+
+    fireEvent.click(screen.getByRole("button", { name: "Community characters" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upload contribution" }));
+    expect(mocks.openExternal).toHaveBeenCalledTimes(2);
+    expect(mocks.openExternal.mock.calls[0][0]).toContain("resources");
+  });
+});

--- a/frontend/src/test/features/character-editor/CharacterPersonalitySection.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterPersonalitySection.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CharacterPersonalitySection } from "../../../features/character-editor/CharacterPersonalitySection";
+import { createCharacter } from "../../../features/character-editor/characterEditorUtils";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+function renderSection() {
+  const props: Parameters<typeof CharacterPersonalitySection>[0] = {
+    aiPending: false,
+    draft: {
+      ...createCharacter(),
+      character_setting: "A bright student council member.",
+    },
+    onAiWrite: vi.fn(),
+    onChange: vi.fn(),
+    onTranslate: vi.fn(),
+    translatePending: false,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <CharacterPersonalitySection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("CharacterPersonalitySection", () => {
+  it("edits character setting text and exposes AI actions", () => {
+    const { props } = renderSection();
+
+    fireEvent.change(screen.getByLabelText("Character setting"), { target: { value: "Updated profile" } });
+    expect(props.onChange).toHaveBeenCalledWith("character_setting", "Updated profile");
+
+    fireEvent.click(screen.getByRole("button", { name: "AI write" }));
+    expect(props.onAiWrite).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "AI translate" }));
+    expect(props.onTranslate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/features/character-editor/CharacterSpritesSection.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterSpritesSection.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { CharacterSpritesSection } from "../../../features/character-editor/CharacterSpritesSection";
+import { createCharacter } from "../../../features/character-editor/characterEditorUtils";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+let originalMediaLoad: PropertyDescriptor | undefined;
+let originalMediaPause: PropertyDescriptor | undefined;
+
+beforeAll(() => {
+  originalMediaLoad = Object.getOwnPropertyDescriptor(window.HTMLMediaElement.prototype, "load");
+  originalMediaPause = Object.getOwnPropertyDescriptor(window.HTMLMediaElement.prototype, "pause");
+  Object.defineProperty(window.HTMLMediaElement.prototype, "load", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterAll(() => {
+  if (originalMediaLoad) {
+    Object.defineProperty(window.HTMLMediaElement.prototype, "load", originalMediaLoad);
+  }
+  if (originalMediaPause) {
+    Object.defineProperty(window.HTMLMediaElement.prototype, "pause", originalMediaPause);
+  }
+});
+
+vi.mock("../../../entities/files/repository", () => ({
+  fileUrl: (path: string) => `asset://${path}`,
+}));
+
+function renderSection(overrides: Partial<Parameters<typeof CharacterSpritesSection>[0]> = {}) {
+  const draft = {
+    ...createCharacter(),
+    sprite_scale: 1.25,
+    sprites: [
+      { path: "D:/sprites/sprite-a.png" },
+      { path: "D:/sprites/sprite-b.png", voice_path: "D:/voices/sprite-b.wav", voice_text: "Hello" },
+    ],
+  };
+  const props: Parameters<typeof CharacterSpritesSection>[0] = {
+    draft,
+    emotionTagsPending: false,
+    onClearSprites: vi.fn(),
+    onOpenBulkTags: vi.fn(),
+    onPendingSpritePathsChange: vi.fn(),
+    onPendingVoicePathChange: vi.fn(),
+    onSaveScale: vi.fn(),
+    onSaveTags: vi.fn(),
+    onScaleChange: vi.fn(),
+    onScaleWheel: vi.fn(),
+    onSelectSprite: vi.fn(),
+    onSpriteDelete: vi.fn(),
+    onSpriteTagChange: vi.fn(),
+    onSpriteUpload: vi.fn(),
+    onSpriteVoiceDelete: vi.fn(),
+    onSpriteVoiceTextBlur: vi.fn(),
+    onSpriteVoiceTextChange: vi.fn(),
+    onSpriteVoiceUpload: vi.fn(),
+    pendingSpritePaths: ["D:/new/sprite-c.png"],
+    pendingVoicePath: "D:/new/voice.wav",
+    selectedSprite: draft.sprites[1],
+    selectedSpriteIndex: 1,
+    selectedSpriteTag: "happy",
+    spriteDeletePending: false,
+    spriteGalleryItems: [
+      { id: "sprite-a", imageSrc: "asset://D:/sprites/sprite-a.png", meta: "neutral", title: "sprite-a.png" },
+      { id: "sprite-b", imageSrc: "asset://D:/sprites/sprite-b.png", meta: "happy", title: "sprite-b.png" },
+    ],
+    spriteScalePending: false,
+    spriteUploadPending: false,
+    voiceDeletePending: false,
+    voiceUploadPending: false,
+    ...overrides,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <CharacterSpritesSection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("CharacterSpritesSection", () => {
+  it("shows an empty state and disables batch tagging when there are no sprites", () => {
+    renderSection({
+      draft: { ...createCharacter(), sprites: [] },
+      selectedSprite: undefined,
+      spriteGalleryItems: [],
+    });
+
+    expect(screen.getByRole("button", { name: "Batch tags" })).toBeDisabled();
+  });
+
+  it("routes gallery, scale, tag, voice, and destructive actions through callbacks", () => {
+    const { props } = renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: /sprite-a\.png/ }));
+    expect(props.onSelectSprite).toHaveBeenCalledWith(0);
+
+    fireEvent.change(screen.getByDisplayValue("1.25"), { target: { value: "1.5" } });
+    expect(props.onScaleChange).toHaveBeenCalledWith("sprite_scale", 1.5);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save scale" }));
+    expect(props.onSaveScale).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload" }));
+    expect(props.onSpriteUpload).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Batch tags" }));
+    expect(props.onOpenBulkTags).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete all sprites" }));
+    expect(props.onClearSprites).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText("Sprite tag"), { target: { value: "surprised" } });
+    expect(props.onSpriteTagChange).toHaveBeenCalledWith("surprised");
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload tags" }));
+    expect(props.onSaveTags).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByDisplayValue("Hello"), { target: { value: "Updated voice line" } });
+    expect(props.onSpriteVoiceTextChange).toHaveBeenCalledWith("Updated voice line");
+    fireEvent.blur(screen.getByDisplayValue("Hello"), { target: { value: "Updated voice line" } });
+    expect(props.onSpriteVoiceTextBlur).toHaveBeenCalledWith("Updated voice line");
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload voice" }));
+    expect(props.onSpriteVoiceUpload).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete voice" }));
+    expect(props.onSpriteVoiceDelete).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(props.onSpriteDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/features/character-editor/CharacterVoiceSection.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterVoiceSection.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CharacterVoiceSection } from "../../../features/character-editor/CharacterVoiceSection";
+import { createCharacter } from "../../../features/character-editor/characterEditorUtils";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+function renderSection() {
+  const props: Parameters<typeof CharacterVoiceSection>[0] = {
+    draft: {
+      ...createCharacter(),
+      gpt_model_path: "D:/models/gpt.ckpt",
+      prompt_lang: "ja",
+      prompt_text: "hello",
+      refer_audio_path: "D:/audio/ref.wav",
+      sovits_model_path: "D:/models/sovits.pth",
+      speech_speed: 1,
+      speech_volume: 1,
+    },
+    onChange: vi.fn(),
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <CharacterVoiceSection {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("CharacterVoiceSection", () => {
+  it("routes voice reference paths and numeric settings through public callbacks", () => {
+    const { props } = renderSection();
+
+    fireEvent.change(screen.getByDisplayValue("D:/models/gpt.ckpt"), { target: { value: "D:/models/new.ckpt" } });
+    expect(props.onChange).toHaveBeenCalledWith("gpt_model_path", "D:/models/new.ckpt");
+
+    fireEvent.change(screen.getByDisplayValue("D:/models/sovits.pth"), { target: { value: "D:/models/new.pth" } });
+    expect(props.onChange).toHaveBeenCalledWith("sovits_model_path", "D:/models/new.pth");
+
+    fireEvent.change(screen.getByDisplayValue("D:/audio/ref.wav"), { target: { value: "D:/audio/new.wav" } });
+    expect(props.onChange).toHaveBeenCalledWith("refer_audio_path", "D:/audio/new.wav");
+
+    fireEvent.change(screen.getByDisplayValue("ja"), { target: { value: "en" } });
+    expect(props.onChange).toHaveBeenCalledWith("prompt_lang", "en");
+
+    fireEvent.change(screen.getByDisplayValue("hello"), { target: { value: "updated line" } });
+    expect(props.onChange).toHaveBeenCalledWith("prompt_text", "updated line");
+
+    fireEvent.change(screen.getAllByDisplayValue("1")[0], { target: { value: "1.25" } });
+    expect(props.onChange).toHaveBeenCalledWith("speech_speed", 1.25);
+
+    fireEvent.change(screen.getAllByDisplayValue("1")[1], { target: { value: "0.8" } });
+    expect(props.onChange).toHaveBeenCalledWith("speech_volume", 0.8);
+  });
+});

--- a/frontend/src/test/features/character-editor/SpriteTagsDialog.test.tsx
+++ b/frontend/src/test/features/character-editor/SpriteTagsDialog.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SpriteTagsDialog } from "../../../features/character-editor/SpriteTagsDialog";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+
+function renderDialog(open = true) {
+  const props: Parameters<typeof SpriteTagsDialog>[0] = {
+    draft: "1. smile\n2. angry",
+    onChange: vi.fn(),
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    open,
+  };
+
+  const result = render(
+    <I18nProvider language="en">
+      <SpriteTagsDialog {...props} />
+    </I18nProvider>,
+  );
+
+  return { props, ...result };
+}
+
+describe("SpriteTagsDialog", () => {
+  it("does not render dialog content while closed", () => {
+    renderDialog(false);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("edits draft text and routes close/confirm actions", () => {
+    const { props } = renderDialog();
+    const dialog = screen.getByRole("dialog", { name: "Batch sprite tags" });
+
+    fireEvent.change(within(dialog).getByLabelText("Emotion tags (per upload / order)"), {
+      target: { value: "1. smile" },
+    });
+    expect(props.onChange).toHaveBeenCalledWith("1. smile");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Confirm" }));
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close" }));
+    expect(props.onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/test/features/character-editor/characterEditorUtils.test.ts
+++ b/frontend/src/test/features/character-editor/characterEditorUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampSpriteScale,
+  createCharacter,
+  pronunciationMapToText,
+  pronunciationTextToMap,
+  SPRITE_SCALE_MAX,
+  SPRITE_SCALE_MIN,
+} from "../../../features/character-editor/characterEditorUtils";
+import { DEFAULT_CHARACTER_COLOR } from "../../../shared/constants";
+
+describe("character editor utilities", () => {
+  it("creates a safe empty character draft", () => {
+    expect(createCharacter()).toEqual({
+      character_setting: "",
+      color: DEFAULT_CHARACTER_COLOR,
+      emotion_tags: "",
+      name: "",
+      pronunciation_map: {},
+      speech_speed: 1,
+      speech_volume: 1,
+      sprite_prefix: "temp",
+      sprite_scale: 1,
+      sprites: [],
+    });
+  });
+
+  it("parses pronunciation map text and ignores invalid rows", () => {
+    expect(
+      pronunciationTextToMap(`
+        Hanadan = hanadan
+        no-separator
+        = missing-key
+        mood= calm = soft
+      `),
+    ).toEqual({
+      Hanadan: "hanadan",
+      mood: "calm = soft",
+    });
+  });
+
+  it("serializes pronunciation maps one entry per line", () => {
+    expect(pronunciationMapToText({ Shinsekai: "shinsekai", Senpai: "senpai" })).toBe(
+      "Shinsekai=shinsekai\nSenpai=senpai",
+    );
+  });
+
+  it("rounds and clamps sprite scale values", () => {
+    expect(clampSpriteScale(-0.2)).toBe(SPRITE_SCALE_MIN);
+    expect(clampSpriteScale(1.234)).toBe(1.23);
+    expect(clampSpriteScale(4.2)).toBe(SPRITE_SCALE_MAX);
+  });
+});

--- a/frontend/src/test/features/chat-launcher/ChatLauncherPage.test.tsx
+++ b/frontend/src/test/features/chat-launcher/ChatLauncherPage.test.tsx
@@ -1,18 +1,21 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChatLauncherPage } from "../../../features/chat-launcher/ChatLauncherPage";
 import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+import type { TemplateLaunchSession } from "../../../shared/platform/types";
 import { ToastProvider } from "../../../shared/ui";
 
 const mocks = {
+  getAppConfig: vi.fn(),
+  getTemplateSession: vi.fn(),
+  launchChat: vi.fn(),
   listBackgrounds: vi.fn(),
   listCharacters: vi.fn(),
   listTemplates: vi.fn(),
-  getAppConfig: vi.fn(),
-  getTemplateSession: vi.fn(),
+  saveTemplateSession: vi.fn(),
 };
 
 vi.mock("../../../entities/background/repository", () => ({
@@ -24,20 +27,24 @@ vi.mock("../../../entities/character/repository", () => ({
   listCharacters: () => mocks.listCharacters(),
 }));
 vi.mock("../../../entities/template/repository", () => ({
-  templatesQueryKey: ["templates"],
-  listTemplates: () => mocks.listTemplates(),
   getTemplateSession: () => mocks.getTemplateSession(),
+  listTemplates: () => mocks.listTemplates(),
+  saveTemplateSession: (session: TemplateLaunchSession) => mocks.saveTemplateSession(session),
+  templatesQueryKey: ["templates"],
 }));
 vi.mock("../../../entities/config/repository", () => ({
   configQueryKey: ["config"],
   getAppConfig: () => mocks.getAppConfig(),
+}));
+vi.mock("../../../entities/chat/repository", () => ({
+  launchChat: (payload: unknown) => mocks.launchChat(payload),
 }));
 
 function renderPage() {
   return render(
     <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
       <ToastProvider>
-        <I18nProvider language="zh_CN">
+        <I18nProvider language="en">
           <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
             <ChatLauncherPage />
           </MemoryRouter>
@@ -57,10 +64,130 @@ describe("ChatLauncherPage", () => {
       system_config: { voice_language: "ja" },
     });
     mocks.getTemplateSession.mockResolvedValue(null);
+    mocks.saveTemplateSession.mockImplementation(async (session: TemplateLaunchSession) => session);
+    mocks.launchChat.mockResolvedValue({
+      dialogText: "Ready",
+      inputDraft: "",
+      options: [],
+      sprites: [],
+      status: "idle",
+    });
   });
 
   it("renders the page title", async () => {
     renderPage();
-    expect(await screen.findByText("启动聊天")).toBeInTheDocument();
+    expect(await screen.findByText("Launch chat")).toBeInTheDocument();
+  });
+
+  it("restores saved launch session values before starting chat", async () => {
+    mocks.listTemplates.mockResolvedValue([
+      {
+        content: "template content",
+        id: "tpl-session",
+        name: "Session Template",
+        path: "D:/templates/session.yaml",
+        scenario: "festival night",
+        system: "stay in character",
+        updatedAt: "2026-01-01",
+      },
+    ]);
+    mocks.listBackgrounds.mockResolvedValue([
+      {
+        bg_tags: "",
+        bgm_list: [],
+        bgm_tags: "",
+        name: "school",
+        sprite_prefix: "school",
+        sprites: [],
+      },
+    ]);
+    mocks.listCharacters.mockResolvedValue([{ name: "Mio" }, { name: "Aki" }]);
+    mocks.getTemplateSession.mockResolvedValue({
+      background: "school",
+      filenameStub: "Session Template",
+      historyPath: " D:/history/session.json ",
+      initSpritePath: " D:/sprites/init.png ",
+      maxDialogItems: 12,
+      maxSpeechChars: 160,
+      roomId: "room-7",
+      scenario: "old scenario",
+      selectedCharacters: ["Mio", "Aki"],
+      system: "old system",
+      templateFileDropdown: "tpl-session",
+      useCg: true,
+      useChoice: false,
+      useCot: true,
+      useEffect: false,
+      useNarration: true,
+      useStat: false,
+      useTranslation: true,
+      voiceLanguage: "en",
+    } satisfies TemplateLaunchSession);
+
+    renderPage();
+
+    expect(await screen.findByText("Session Template")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByDisplayValue(/session\.json/).length).toBeGreaterThan(0));
+    expect(screen.getByDisplayValue(/D:\/sprites\/init\.png/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Launch" }));
+
+    await waitFor(() => expect(mocks.launchChat).toHaveBeenCalledTimes(1));
+    expect(mocks.saveTemplateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        background: "school",
+        historyPath: "D:/history/session.json",
+        initSpritePath: "D:/sprites/init.png",
+        roomId: "room-7",
+        selectedCharacters: ["Mio", "Aki"],
+        templateFileDropdown: "tpl-session",
+        useCg: true,
+        voiceLanguage: "en",
+      }),
+    );
+    expect(mocks.launchChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backgroundName: "school",
+        characters: ["Mio", "Aki"],
+        historyPath: "D:/history/session.json",
+        initSpritePath: "D:/sprites/init.png",
+        resetHistory: false,
+        roomId: "room-7",
+        scenario: "festival night",
+        system: "stay in character",
+        templateId: "tpl-session",
+        templateName: "Session Template",
+        useCg: true,
+      }),
+    );
+  });
+
+  it("requires quick restart confirmation before launching with resetHistory", async () => {
+    mocks.listTemplates.mockResolvedValue([
+      {
+        content: "template content",
+        id: "tpl-1",
+        name: "Default Template",
+        path: "D:/templates/default.yaml",
+        scenario: "",
+        system: "",
+        updatedAt: "2026-01-01",
+      },
+    ]);
+    mocks.listBackgrounds.mockResolvedValue([]);
+    mocks.listCharacters.mockResolvedValue([{ name: "Mio" }]);
+
+    renderPage();
+
+    expect(await screen.findByText("Default Template")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Quick restart" }));
+    expect(mocks.launchChat).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog", { name: "Quick restart" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Quick restart" }));
+
+    await waitFor(() => expect(mocks.launchChat).toHaveBeenCalledTimes(1));
+    expect(mocks.launchChat).toHaveBeenCalledWith(expect.objectContaining({ resetHistory: true }));
   });
 });

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatStagePage } from "../../../features/chat-stage/ChatStagePage";
+import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+import type { ChatCommand, ChatSnapshot } from "../../../shared/platform/types";
+import { ToastProvider } from "../../../shared/ui";
+
+const mocks = {
+  getChatSnapshot: vi.fn(),
+  getChatTheme: vi.fn(),
+  sendChatCommand: vi.fn(),
+  subscribeChat: vi.fn(),
+};
+
+vi.mock("../../../entities/chat/repository", () => ({
+  getChatSnapshot: () => mocks.getChatSnapshot(),
+  getChatTheme: () => mocks.getChatTheme(),
+  sendChatCommand: (command: ChatCommand) => mocks.sendChatCommand(command),
+  subscribeChat: (listener: (snapshot: ChatSnapshot) => void) => mocks.subscribeChat(listener),
+}));
+
+vi.mock("../../../shared/plugin/PluginSlot", () => ({
+  PluginSlot: () => null,
+}));
+
+function snapshot(overrides: Partial<ChatSnapshot> = {}): ChatSnapshot {
+  return {
+    backgroundPath: "asset://school.png",
+    characterName: "Mio",
+    dialogText: "Ready",
+    historyPath: "D:/history/session.json",
+    inputDraft: "",
+    numericInfo: "idle / 2",
+    options: ["Take the shortcut"],
+    sprites: [{ id: "mio", label: "Mio", path: "asset://mio.png" }],
+    status: "idle",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <I18nProvider language="en">
+        <ChatStagePage />
+      </I18nProvider>
+    </ToastProvider>,
+  );
+}
+
+describe("ChatStagePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getChatTheme.mockResolvedValue({});
+    mocks.getChatSnapshot.mockResolvedValue(snapshot());
+    mocks.sendChatCommand.mockImplementation(async (command: ChatCommand) =>
+      snapshot({
+        dialogText: command.type,
+        inputDraft: "",
+        options: [],
+      }),
+    );
+    mocks.subscribeChat.mockReturnValue(vi.fn());
+  });
+
+  it("sends option selections and typed dialogue through chat commands", async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Take the shortcut" }));
+    await waitFor(() =>
+      expect(mocks.sendChatCommand).toHaveBeenCalledWith({
+        payload: "Take the shortcut",
+        type: "submit-option",
+      }),
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "  hello  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(mocks.sendChatCommand).toHaveBeenCalledWith({
+        payload: "hello",
+        type: "send-message",
+      }),
+    );
+  });
+
+  it("requires confirmation before clearing chat history", async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Clear history" }));
+    expect(mocks.sendChatCommand).not.toHaveBeenCalledWith({ type: "clear-history" });
+
+    const dialog = screen.getByRole("dialog", { name: "Clear history" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Clear" }));
+
+    await waitFor(() => expect(mocks.sendChatCommand).toHaveBeenCalledWith({ type: "clear-history" }));
+  });
+});

--- a/frontend/src/test/features/template-editor/TemplateEditorPage.test.tsx
+++ b/frontend/src/test/features/template-editor/TemplateEditorPage.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TemplateEditorPage } from "../../../features/template-editor/TemplateEditorPage";
-import { sampleConfig } from "../../../shared/platform/sampleData";
 import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+import { sampleConfig } from "../../../shared/platform/sampleData";
+import type { TemplateLaunchSession } from "../../../shared/platform/types";
 import { ToastProvider } from "../../../shared/ui";
 
 const mockListBackgrounds = vi.fn();
@@ -131,5 +132,64 @@ describe("TemplateEditorPage", () => {
       ),
     );
     expect(await screen.findByDisplayValue("Generated scenario")).toBeInTheDocument();
+  });
+
+  it("launches restored sessions only after quick restart confirmation", async () => {
+    mockGetTemplateSession.mockResolvedValue({
+      background: "默认房间",
+      filenameStub: "Session Draft",
+      historyPath: " D:/history/session.json ",
+      initSpritePath: " D:/sprites/init.png ",
+      maxDialogItems: 8,
+      maxSpeechChars: 120,
+      roomId: " room-9 ",
+      scenario: "Restored scene",
+      selectedCharacters: ["Nanami", "Mika"],
+      system: "Restored system",
+      templateFileDropdown: "opening",
+      useCg: true,
+      useChoice: false,
+      useCot: true,
+      useEffect: false,
+      useNarration: true,
+      useStat: false,
+      useTranslation: true,
+      voiceLanguage: "en",
+    } satisfies TemplateLaunchSession);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByLabelText("Template name")).toHaveValue("Session Draft"));
+    fireEvent.click(screen.getByRole("button", { name: "Quick restart" }));
+    expect(mockLaunchChat).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog", { name: "Quick restart" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Quick restart" }));
+
+    await waitFor(() => expect(mockLaunchChat).toHaveBeenCalledTimes(1));
+    expect(mockSaveTemplateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        background: "默认房间",
+        historyPath: "D:/history/session.json",
+        initSpritePath: "D:/sprites/init.png",
+        roomId: "room-9",
+        selectedCharacters: ["Nanami", "Mika"],
+        useCg: true,
+        voiceLanguage: "en",
+      }),
+    );
+    expect(mockLaunchChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backgroundName: "默认房间",
+        characters: ["Nanami", "Mika"],
+        resetHistory: true,
+        roomId: "room-9",
+        scenario: "Restored scene",
+        system: "Restored system",
+        templateId: "opening",
+        templateName: "Session Draft",
+        useCg: true,
+      }),
+    );
   });
 });


### PR DESCRIPTION
## 变更内容

- 补充 `api-settings`、`character-editor`、`background-manager` 相关单元测试
- 扩展 `chat-launcher` 会话恢复、启动和快速重开测试
- 新增 `chat-stage` 对话发送、选项提交、清空历史确认测试
- 新增 `template-editor` 模板保存、内容组合、快速重开和 launch payload 测试

## 测试策略

测试以用户可观察行为和功能契约为主，优先通过 role、label、控件状态、用户操作和回调 payload 进行断言。  
避免依赖说明文案、placeholder、空态提示等容易随 UI 微调变化的文本。

## 验证结果

```text
pnpm format:check
PASS

pnpm lint:types
PASS

pnpm test
PASS
66 test files / 233 tests

pnpm build
PASS
```