### PR TITLE
[Feature] 增加 on_before_compact 生命周期钩子

### DIFF
--- a/llm/compact_manager.py
+++ b/llm/compact_manager.py
@@ -235,6 +235,17 @@ class CompactManager:
             recent_messages = messages_to_compact[recent_start:]
         if not older_messages:
             return messages
+
+        # [MemorySystem] 触发所有已注册的精简前钩子（插件可在此阶段执行归档写入等操作）
+        try:
+            from sdk.register import PluginCapabilityRegistry
+            for hook in PluginCapabilityRegistry().compact_hooks:
+                try:
+                    hook(messages)
+                except Exception as e:
+                    logger.warning(f"精简前钩子执行失败（已跳过，不影响精简流程）: {e}")
+        except Exception:
+            pass
         
         # 准备压缩提示
         compact_prompt = self._create_compact_prompt(older_messages)

--- a/sdk/register.py
+++ b/sdk/register.py
@@ -134,6 +134,8 @@ class PluginCapabilityRegistry:
         self._dag_node_factories: list[tuple[Callable[[], list], bool]] = []
         self._workflow_contributions: list[WorkflowContribution] = []
         self._output_contract_patches: list[OutputContractPatch] = []
+        # [MemorySystem] 精简前钩子存储列表
+        self._compact_hooks: list[Callable[[list], None]] = []
 
     def register_llm_adapter(self, provider: str, adapter_cls: Type[LLMAdapter]) -> None:
         self._llm_adapters[provider] = adapter_cls
@@ -253,6 +255,11 @@ class PluginCapabilityRegistry:
             raise ValueError("OutputContractPatch.target_contract cannot be empty")
         self._output_contract_patches.append(patch)
 
+    # [MemorySystem] 注册精简前回调钩子
+    def register_compact_hook(self, hook: Callable[[list], None]) -> None:
+        """注册精简前回调。回调接收即将被精简的完整消息列表，在 compact_messages() 执行前调用。"""
+        self._compact_hooks.append(hook)
+
     @property
     def llm_adapters(self) -> dict[str, Type[LLMAdapter]]:
         return dict(self._llm_adapters)
@@ -307,10 +314,15 @@ class PluginCapabilityRegistry:
     def output_contract_patches(self) -> list[OutputContractPatch]:
         return sorted(self._output_contract_patches, key=lambda p: p.priority)
 
+    # [MemorySystem] 暴露已注册的精简前钩子列表
+    @property
+    def compact_hooks(self) -> list[Callable[[list], None]]:
+        return list(self._compact_hooks)
+
     def apply_llm_tools(self, tool_manager: ToolManager) -> None:
         for registrar in self._llm_tool_registrars:
             registrar(tool_manager)
 
 
 # Backward-compatible name: plugins should type-hint this in ``initialize(register, ...)``.
-PluginRegister = PluginCapabilityRegistry
+PluginRegister = PluginCapabilityRegistry 


### PR DESCRIPTION
## 背景
在开发长期记忆管理插件时，需要在记忆精简前将原始对话归档保存。此前 compact_messages() 没有对应的插件钩子，归档操作需手动修改核心文件。

## 改动内容
- PluginCapabilityRegistry 新增 `register_compact_hook()` 方法，供插件注册精简前回调
- PluginCapabilityRegistry 新增 `compact_hooks` 属性，暴露已注册的钩子列表
- compact_manager 在 `compact_messages()` 执行精简前触发所有已注册钩子
- 每个钩子独立 try/except，单个插件出错不影响精简流程和主对话

## 使用方式
插件在 initialize() 中调用：
register.register_compact_hook(my_archive_function)
回调接收即将被精简的完整消息列表，可在此阶段执行归档写入等操作。

## 为什么有用
- 记忆类插件可实现完全免手动改动的安装体验
- 任何需要在精简前做日志记录、数据备份、合规检查的插件都会用到
- 通用的生命周期扩展点

Closes #65