### PR TITLE
功能：支持官方插件包安全安装

### DIFF
--- a/core/plugins/package_download.py
+++ b/core/plugins/package_download.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import os
+import socket
 import shutil
 import tempfile
 import uuid
 import zipfile
+from http.client import IncompleteRead
 from pathlib import Path, PurePosixPath
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
@@ -60,6 +63,41 @@ def _validate_package_url(url: str) -> None:
         raise PluginPackageNonFallbackError(f"plugin package host is not allowed: {parsed.hostname}")
 
 
+def _is_transient_network_error(exc: BaseException) -> bool:
+    """Return True for failures where GitHub source fallback is acceptable."""
+    if isinstance(exc, HTTPError):
+        return False
+    if isinstance(exc, URLError):
+        reason = exc.reason
+        if isinstance(reason, BaseException):
+            return _is_transient_network_error(reason)
+        text = str(reason).lower()
+        return any(
+            marker in text
+            for marker in (
+                "connection refused",
+                "connection reset",
+                "network is unreachable",
+                "temporary failure",
+                "timed out",
+                "timeout",
+                "name or service not known",
+                "nodename nor servname provided",
+                "getaddrinfo failed",
+            )
+        )
+    return isinstance(
+        exc,
+        (
+            ConnectionError,
+            IncompleteRead,
+            TimeoutError,
+            socket.gaierror,
+            socket.timeout,
+        ),
+    )
+
+
 def _read_url(url: str, *, timeout_sec: float = 180.0, max_bytes: int | None = None) -> bytes:
     limit = max_bytes if max_bytes is not None else _max_bytes()
     req = Request(url, headers={"User-Agent": _PACKAGE_USER_AGENT})
@@ -80,8 +118,16 @@ def _read_url(url: str, *, timeout_sec: float = 180.0, max_bytes: int | None = N
                 chunks.append(block)
     except PluginPackageError:
         raise
+    except HTTPError as exc:
+        raise PluginPackageNonFallbackError(f"plugin package HTTP error: {exc.code}") from exc
+    except URLError as exc:
+        if _is_transient_network_error(exc):
+            raise PluginPackageNetworkError(f"plugin package download failed: {exc}") from exc
+        raise PluginPackageNonFallbackError(f"plugin package URL error: {exc}") from exc
     except Exception as exc:
-        raise PluginPackageNetworkError(f"plugin package download failed: {exc}") from exc
+        if _is_transient_network_error(exc):
+            raise PluginPackageNetworkError(f"plugin package download failed: {exc}") from exc
+        raise PluginPackageNonFallbackError(f"plugin package download failed: {exc}") from exc
     return b"".join(chunks)
 
 

--- a/core/plugins/package_download.py
+++ b/core/plugins/package_download.py
@@ -27,13 +27,41 @@ _DEFAULT_MAX_BYTES = 16 * 1024 * 1024
 class PluginPackageError(Exception):
     """Base error for official registry package installs."""
 
+    code = "plugin_package_error"
+    fallback_allowed = False
+    user_message = "插件包体安装失败。"
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        code: str | None = None,
+        fallback_allowed: bool | None = None,
+        status_code: int | None = None,
+        user_message: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        if code is not None:
+            self.code = code
+        if fallback_allowed is not None:
+            self.fallback_allowed = fallback_allowed
+        if user_message is not None:
+            self.user_message = user_message
+        self.status_code = status_code
+
 
 class PluginPackageNetworkError(PluginPackageError):
     """A transient package download failure where GitHub fallback is allowed."""
 
+    code = "package_network_error"
+    fallback_allowed = True
+    user_message = "官方包体暂时无法访问，正在自动尝试 GitHub 源码安装。"
+
 
 class PluginPackageNonFallbackError(PluginPackageError, ValueError):
     """An official package failure that must not fall back to unverified sources."""
+
+    fallback_allowed = False
 
 
 def _allowed_hosts() -> set[str]:
@@ -55,12 +83,24 @@ def _max_bytes() -> int:
 def _validate_package_url(url: str) -> None:
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"}:
-        raise PluginPackageNonFallbackError("plugin package URL must use http or https")
+        raise PluginPackageNonFallbackError(
+            "plugin package URL must use http or https",
+            code="package_invalid_url",
+            user_message="官方包体地址无效，请等待维护者修复索引。",
+        )
     if not parsed.netloc:
-        raise PluginPackageNonFallbackError("plugin package URL is missing a host")
+        raise PluginPackageNonFallbackError(
+            "plugin package URL is missing a host",
+            code="package_invalid_url",
+            user_message="官方包体地址无效，请等待维护者修复索引。",
+        )
     allowed = _allowed_hosts()
     if allowed and parsed.hostname and parsed.hostname.lower() not in allowed:
-        raise PluginPackageNonFallbackError(f"plugin package host is not allowed: {parsed.hostname}")
+        raise PluginPackageNonFallbackError(
+            f"plugin package host is not allowed: {parsed.hostname}",
+            code="package_host_not_allowed",
+            user_message="官方包体来源不在允许列表内，已阻止安装。",
+        )
 
 
 def _is_transient_network_error(exc: BaseException) -> bool:
@@ -105,7 +145,11 @@ def _read_url(url: str, *, timeout_sec: float = 180.0, max_bytes: int | None = N
         with urlopen(req, timeout=timeout_sec) as resp:
             content_length = resp.headers.get("Content-Length")
             if content_length and content_length.isdigit() and int(content_length) > limit:
-                raise PluginPackageNonFallbackError(f"plugin package is too large: {content_length} bytes")
+                raise PluginPackageNonFallbackError(
+                    f"plugin package is too large: {content_length} bytes",
+                    code="package_too_large",
+                    user_message="官方包体超过大小限制，已阻止安装。",
+                )
             chunks: list[bytes] = []
             total = 0
             while True:
@@ -114,37 +158,70 @@ def _read_url(url: str, *, timeout_sec: float = 180.0, max_bytes: int | None = N
                     break
                 total += len(block)
                 if total > limit:
-                    raise PluginPackageNonFallbackError(f"plugin package is too large: {total} bytes")
+                    raise PluginPackageNonFallbackError(
+                        f"plugin package is too large: {total} bytes",
+                        code="package_too_large",
+                        user_message="官方包体超过大小限制，已阻止安装。",
+                    )
                 chunks.append(block)
     except PluginPackageError:
         raise
     except HTTPError as exc:
-        raise PluginPackageNonFallbackError(f"plugin package HTTP error: {exc.code}") from exc
+        raise PluginPackageNonFallbackError(
+            f"plugin package HTTP error: {exc.code}",
+            code="package_http_error",
+            status_code=exc.code,
+            user_message="官方包体不可用，请等待维护者修复索引或包体。",
+        ) from exc
     except URLError as exc:
         if _is_transient_network_error(exc):
             raise PluginPackageNetworkError(f"plugin package download failed: {exc}") from exc
-        raise PluginPackageNonFallbackError(f"plugin package URL error: {exc}") from exc
+        raise PluginPackageNonFallbackError(
+            f"plugin package URL error: {exc}",
+            code="package_url_error",
+            user_message="官方包体地址访问失败，请等待维护者修复索引或包体。",
+        ) from exc
     except Exception as exc:
         if _is_transient_network_error(exc):
             raise PluginPackageNetworkError(f"plugin package download failed: {exc}") from exc
-        raise PluginPackageNonFallbackError(f"plugin package download failed: {exc}") from exc
+        raise PluginPackageNonFallbackError(
+            f"plugin package download failed: {exc}",
+            code="package_download_error",
+            user_message="官方包体下载失败，请等待维护者修复索引或包体。",
+        ) from exc
     return b"".join(chunks)
 
 
 def _verify_package(body: bytes, *, expected_sha256: str, expected_size: int | None) -> None:
     if expected_size is not None and len(body) != expected_size:
-        raise PluginPackageNonFallbackError(f"plugin package size mismatch: expected {expected_size}, got {len(body)}")
+        raise PluginPackageNonFallbackError(
+            f"plugin package size mismatch: expected {expected_size}, got {len(body)}",
+            code="package_size_mismatch",
+            user_message="包体校验未通过，已阻止安装。",
+        )
     if not expected_sha256:
-        raise PluginPackageNonFallbackError("official plugin package is missing sha256")
+        raise PluginPackageNonFallbackError(
+            "official plugin package is missing sha256",
+            code="package_missing_sha256",
+            user_message="官方包体缺少校验信息，已阻止安装。",
+        )
     actual = hashlib.sha256(body).hexdigest()
     if actual.lower() != expected_sha256.lower():
-        raise PluginPackageNonFallbackError("plugin package checksum mismatch")
+        raise PluginPackageNonFallbackError(
+            "plugin package checksum mismatch",
+            code="package_checksum_mismatch",
+            user_message="包体校验未通过，已阻止安装。",
+        )
 
 
 def _safe_members(zf: zipfile.ZipFile) -> list[tuple[zipfile.ZipInfo, tuple[str, ...]]]:
     infos = [info for info in zf.infolist() if info.filename and not info.is_dir()]
     if not infos:
-        raise PluginPackageNonFallbackError("plugin package is empty")
+        raise PluginPackageNonFallbackError(
+            "plugin package is empty",
+            code="package_bad_zip",
+            user_message="包体校验未通过，已阻止安装。",
+        )
 
     roots: set[str] = set()
     parsed: list[tuple[zipfile.ZipInfo, tuple[str, ...]]] = []
@@ -152,7 +229,11 @@ def _safe_members(zf: zipfile.ZipFile) -> list[tuple[zipfile.ZipInfo, tuple[str,
         path = PurePosixPath(info.filename)
         parts = tuple(part for part in path.parts if part not in {"", "."})
         if not parts or path.is_absolute() or any(part == ".." for part in parts):
-            raise PluginPackageNonFallbackError(f"unsafe plugin package path: {info.filename}")
+            raise PluginPackageNonFallbackError(
+                f"unsafe plugin package path: {info.filename}",
+                code="package_unsafe_path",
+                user_message="包体校验未通过，已阻止安装。",
+            )
         roots.add(parts[0])
         parsed.append((info, parts))
 
@@ -163,7 +244,11 @@ def _safe_members(zf: zipfile.ZipFile) -> list[tuple[zipfile.ZipInfo, tuple[str,
         if rel:
             safe.append((info, rel))
     if not safe:
-        raise PluginPackageNonFallbackError("plugin package has no files after root normalization")
+        raise PluginPackageNonFallbackError(
+            "plugin package has no files after root normalization",
+            code="package_bad_zip",
+            user_message="包体校验未通过，已阻止安装。",
+        )
     return safe
 
 
@@ -178,13 +263,21 @@ def _extract_safe_zip(body: bytes) -> Path:
             for info, rel_parts in members:
                 destination = (extract_root / Path(*rel_parts)).resolve(strict=False)
                 if extract_root != destination and extract_root not in destination.parents:
-                    raise PluginPackageNonFallbackError(f"unsafe plugin package path: {info.filename}")
+                    raise PluginPackageNonFallbackError(
+                        f"unsafe plugin package path: {info.filename}",
+                        code="package_unsafe_path",
+                        user_message="包体校验未通过，已阻止安装。",
+                    )
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(info) as src, destination.open("wb") as dst:
                     shutil.copyfileobj(src, dst)
     except zipfile.BadZipFile as exc:
         shutil.rmtree(tmp_root, ignore_errors=True)
-        raise PluginPackageNonFallbackError("plugin package is not a valid zip") from exc
+        raise PluginPackageNonFallbackError(
+            "plugin package is not a valid zip",
+            code="package_bad_zip",
+            user_message="包体校验未通过，已阻止安装。",
+        ) from exc
     except Exception:
         shutil.rmtree(tmp_root, ignore_errors=True)
         raise
@@ -194,7 +287,11 @@ def _extract_safe_zip(body: bytes) -> Path:
 def registry_package_target(record: RegistryPluginRecord, *, plugins_parent: Path | None = None) -> Path:
     folder_name = sanitize_plugins_directory_name(record.name or record.id or record.display_name)
     if not folder_name:
-        raise PluginPackageNonFallbackError("registry record has no safe plugin folder name")
+        raise PluginPackageNonFallbackError(
+            "registry record has no safe plugin folder name",
+            code="package_invalid_name",
+            user_message="插件包体缺少安全的安装目录名，请等待维护者修复索引。",
+        )
     parent = Path(plugins_parent) if plugins_parent is not None else Path("plugins")
     return parent / folder_name
 
@@ -229,7 +326,11 @@ def install_registry_package_under_plugins(
     """Download, verify, and extract an official registry package under ``plugins/``."""
     package_url = (record.package_url or record.download_url or "").strip()
     if not package_url:
-        raise PluginPackageNonFallbackError("registry record has no package URL")
+        raise PluginPackageNonFallbackError(
+            "registry record has no package URL",
+            code="package_missing_url",
+            user_message="插件索引缺少官方包体地址，请等待维护者修复索引。",
+        )
     _validate_package_url(package_url)
 
     target = registry_package_target(record, plugins_parent=plugins_parent)

--- a/core/plugins/package_download.py
+++ b/core/plugins/package_download.py
@@ -1,0 +1,205 @@
+"""Install official registry package archives, typically hosted on R2."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tempfile
+import uuid
+import zipfile
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from core.plugins.registry_catalog import RegistryPluginRecord
+from core.plugins.registry_download import sanitize_plugins_directory_name
+
+_PACKAGE_USER_AGENT = (
+    "EasyAIDesktopAssistant/1.0 (+plugin-package; https://github.com/RachelForster/Shinsekai-Plugin-Registry)"
+)
+_DEFAULT_MAX_BYTES = 16 * 1024 * 1024
+
+
+class PluginPackageError(Exception):
+    """Base error for official registry package installs."""
+
+
+class PluginPackageNetworkError(PluginPackageError):
+    """A transient package download failure where GitHub fallback is allowed."""
+
+
+class PluginPackageNonFallbackError(PluginPackageError, ValueError):
+    """An official package failure that must not fall back to unverified sources."""
+
+
+def _allowed_hosts() -> set[str]:
+    raw = os.environ.get("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "").strip()
+    return {part.strip().lower() for part in raw.split(",") if part.strip()}
+
+
+def _max_bytes() -> int:
+    raw = os.environ.get("SHINSEKAI_PLUGIN_PACKAGE_MAX_BYTES", "").strip()
+    if not raw:
+        return _DEFAULT_MAX_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_BYTES
+    return value if value > 0 else _DEFAULT_MAX_BYTES
+
+
+def _validate_package_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise PluginPackageNonFallbackError("plugin package URL must use http or https")
+    if not parsed.netloc:
+        raise PluginPackageNonFallbackError("plugin package URL is missing a host")
+    allowed = _allowed_hosts()
+    if allowed and parsed.hostname and parsed.hostname.lower() not in allowed:
+        raise PluginPackageNonFallbackError(f"plugin package host is not allowed: {parsed.hostname}")
+
+
+def _read_url(url: str, *, timeout_sec: float = 180.0, max_bytes: int | None = None) -> bytes:
+    limit = max_bytes if max_bytes is not None else _max_bytes()
+    req = Request(url, headers={"User-Agent": _PACKAGE_USER_AGENT})
+    try:
+        with urlopen(req, timeout=timeout_sec) as resp:
+            content_length = resp.headers.get("Content-Length")
+            if content_length and content_length.isdigit() and int(content_length) > limit:
+                raise PluginPackageNonFallbackError(f"plugin package is too large: {content_length} bytes")
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                block = resp.read(65536)
+                if not block:
+                    break
+                total += len(block)
+                if total > limit:
+                    raise PluginPackageNonFallbackError(f"plugin package is too large: {total} bytes")
+                chunks.append(block)
+    except PluginPackageError:
+        raise
+    except Exception as exc:
+        raise PluginPackageNetworkError(f"plugin package download failed: {exc}") from exc
+    return b"".join(chunks)
+
+
+def _verify_package(body: bytes, *, expected_sha256: str, expected_size: int | None) -> None:
+    if expected_size is not None and len(body) != expected_size:
+        raise PluginPackageNonFallbackError(f"plugin package size mismatch: expected {expected_size}, got {len(body)}")
+    if not expected_sha256:
+        raise PluginPackageNonFallbackError("official plugin package is missing sha256")
+    actual = hashlib.sha256(body).hexdigest()
+    if actual.lower() != expected_sha256.lower():
+        raise PluginPackageNonFallbackError("plugin package checksum mismatch")
+
+
+def _safe_members(zf: zipfile.ZipFile) -> list[tuple[zipfile.ZipInfo, tuple[str, ...]]]:
+    infos = [info for info in zf.infolist() if info.filename and not info.is_dir()]
+    if not infos:
+        raise PluginPackageNonFallbackError("plugin package is empty")
+
+    roots: set[str] = set()
+    parsed: list[tuple[zipfile.ZipInfo, tuple[str, ...]]] = []
+    for info in infos:
+        path = PurePosixPath(info.filename)
+        parts = tuple(part for part in path.parts if part not in {"", "."})
+        if not parts or path.is_absolute() or any(part == ".." for part in parts):
+            raise PluginPackageNonFallbackError(f"unsafe plugin package path: {info.filename}")
+        roots.add(parts[0])
+        parsed.append((info, parts))
+
+    strip_root = len(roots) == 1
+    safe: list[tuple[zipfile.ZipInfo, tuple[str, ...]]] = []
+    for info, parts in parsed:
+        rel = parts[1:] if strip_root else parts
+        if rel:
+            safe.append((info, rel))
+    if not safe:
+        raise PluginPackageNonFallbackError("plugin package has no files after root normalization")
+    return safe
+
+
+def _extract_safe_zip(body: bytes) -> Path:
+    tmp_root = Path(tempfile.mkdtemp(prefix="shinsekai-plugin-package-"))
+    zip_path = tmp_root / "package.zip"
+    zip_path.write_bytes(body)
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            members = _safe_members(zf)
+            extract_root = (tmp_root / "extract").resolve(strict=False)
+            for info, rel_parts in members:
+                destination = (extract_root / Path(*rel_parts)).resolve(strict=False)
+                if extract_root != destination and extract_root not in destination.parents:
+                    raise PluginPackageNonFallbackError(f"unsafe plugin package path: {info.filename}")
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info) as src, destination.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
+    except zipfile.BadZipFile as exc:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+        raise PluginPackageNonFallbackError("plugin package is not a valid zip") from exc
+    except Exception:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+        raise
+    return tmp_root / "extract"
+
+
+def registry_package_target(record: RegistryPluginRecord, *, plugins_parent: Path | None = None) -> Path:
+    folder_name = sanitize_plugins_directory_name(record.name or record.id or record.display_name)
+    if not folder_name:
+        raise PluginPackageNonFallbackError("registry record has no safe plugin folder name")
+    parent = Path(plugins_parent) if plugins_parent is not None else Path("plugins")
+    return parent / folder_name
+
+
+def _replace_directory(extracted: Path, target: Path) -> None:
+    target = target.resolve(strict=False)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    backup: Path | None = None
+    if target.exists():
+        backup = target.with_name(f".{target.name}.backup-{uuid.uuid4().hex}")
+        target.rename(backup)
+    try:
+        shutil.move(str(extracted), str(target))
+    except Exception:
+        if target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+        if backup is not None and backup.exists():
+            backup.rename(target)
+        raise
+    else:
+        if backup is not None:
+            shutil.rmtree(backup, ignore_errors=True)
+
+
+def install_registry_package_under_plugins(
+    record: RegistryPluginRecord,
+    *,
+    plugins_parent: Path | None = None,
+    overwrite: bool = False,
+    timeout_sec: float = 180.0,
+) -> Path:
+    """Download, verify, and extract an official registry package under ``plugins/``."""
+    package_url = (record.package_url or record.download_url or "").strip()
+    if not package_url:
+        raise PluginPackageNonFallbackError("registry record has no package URL")
+    _validate_package_url(package_url)
+
+    target = registry_package_target(record, plugins_parent=plugins_parent)
+    if target.is_dir() and not overwrite:
+        return target.resolve(strict=False)
+
+    body = _read_url(package_url, timeout_sec=timeout_sec, max_bytes=_max_bytes())
+    _verify_package(
+        body,
+        expected_sha256=(record.package_sha256 or record.sha256 or "").strip(),
+        expected_size=record.package_size if record.package_size is not None else record.size,
+    )
+    extracted = _extract_safe_zip(body)
+    tmp_root = extracted.parent
+    try:
+        _replace_directory(extracted, target)
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+    return target.resolve(strict=False)

--- a/core/plugins/registry_download.py
+++ b/core/plugins/registry_download.py
@@ -89,22 +89,44 @@ def normalize_manifest_entry(entry: str) -> str:
     return f"plugins.{norm}"
 
 
-def _load_download_state() -> tuple[list[str], dict[str, str]]:
-    """Load persisted repos (sorted) and manifest-entry -> repo slug mapping."""
+def _normalize_install_metadata(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    allowed = {
+        "dependencyDetail",
+        "dependencyStatus",
+        "entry",
+        "packageSha256",
+        "packageSize",
+        "packageSource",
+        "packageStatus",
+        "packageUrl",
+        "refKind",
+        "repo",
+        "sourceLabel",
+        "sourceType",
+        "tagName",
+    }
+    return {key: item for key, item in value.items() if key in allowed and item not in (None, "")}
+
+
+def _load_download_state_payload() -> tuple[list[str], dict[str, str], dict[str, dict[str, object]]]:
+    """Load persisted repos, manifest-entry mapping, and install metadata."""
     if not _DOWNLOAD_STATE_PATH.is_file():
-        return [], {}
+        return [], {}, {}
     try:
         raw = json.loads(_DOWNLOAD_STATE_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         logger.warning("Could not read plugin download state: %s", _DOWNLOAD_STATE_PATH)
-        return [], {}
+        return [], {}, {}
     if isinstance(raw, list):
         repos_set = {normalize_repo_slug(str(x)) for x in raw if str(x).strip()}
-        return sorted(repos_set), {}
+        return sorted(repos_set), {}, {}
     if not isinstance(raw, dict):
-        return [], {}
+        return [], {}, {}
     repos_raw = raw.get("repos", [])
     er_raw = raw.get("entry_repo", {})
+    install_raw = raw.get("entry_install", {})
     repos_set: set[str] = set()
     if isinstance(repos_raw, list):
         for x in repos_raw:
@@ -123,12 +145,33 @@ def _load_download_state() -> tuple[list[str], dict[str, str]]:
             nv = normalize_repo_slug(vs)
             if nk and nv:
                 entry_repo[nk] = nv
-    return sorted(repos_set), entry_repo
+    entry_install: dict[str, dict[str, object]] = {}
+    if isinstance(install_raw, dict):
+        for k, v in install_raw.items():
+            if not isinstance(k, str):
+                continue
+            nk = normalize_manifest_entry(k.strip())
+            metadata = _normalize_install_metadata(v)
+            if nk and metadata:
+                entry_install[nk] = metadata
+    return sorted(repos_set), entry_repo, entry_install
 
 
-def _write_download_state(repos: list[str], entry_repo: dict[str, str]) -> None:
+def _load_download_state() -> tuple[list[str], dict[str, str]]:
+    """Load persisted repos (sorted) and manifest-entry -> repo slug mapping."""
+    repos, entry_repo, _entry_install = _load_download_state_payload()
+    return repos, entry_repo
+
+
+def _write_download_state(
+    repos: list[str],
+    entry_repo: dict[str, str],
+    entry_install: dict[str, dict[str, object]] | None = None,
+) -> None:
+    if entry_install is None:
+        _repos, _entry_repo, entry_install = _load_download_state_payload()
     _DOWNLOAD_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"repos": repos, "entry_repo": entry_repo}
+    payload = {"repos": repos, "entry_repo": entry_repo, "entry_install": entry_install}
     _DOWNLOAD_STATE_PATH.write_text(
         json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
@@ -140,18 +183,39 @@ def load_downloaded_repos() -> set[str]:
     return set(repos)
 
 
-def mark_repo_downloaded(repo: str, *, manifest_entry: str | None = None) -> None:
+def load_plugin_install_metadata(entry: str) -> dict[str, object]:
+    """Return persisted install metadata for a manifest entry."""
+    norm_e = normalize_manifest_entry(entry.strip())
+    if not norm_e:
+        return {}
+    _repos, _entry_repo, entry_install = _load_download_state_payload()
+    return dict(entry_install.get(norm_e) or {})
+
+
+def mark_repo_downloaded(
+    repo: str,
+    *,
+    manifest_entry: str | None = None,
+    install_metadata: dict[str, object] | None = None,
+) -> None:
     slug = normalize_repo_slug(repo)
     if not slug:
         return
-    repos_list, er = _load_download_state()
+    repos_list, er, entry_install = _load_download_state_payload()
     repos_set = set(repos_list)
     repos_set.add(slug)
     er = dict(er)
+    entry_install = dict(entry_install)
     me = (manifest_entry or "").strip()
     if me:
-        er[normalize_manifest_entry(me)] = slug
-    _write_download_state(sorted(repos_set), er)
+        norm_e = normalize_manifest_entry(me)
+        er[norm_e] = slug
+        metadata = _normalize_install_metadata(install_metadata or {})
+        if metadata:
+            entry_install[norm_e] = metadata
+        elif install_metadata is not None:
+            entry_install.pop(norm_e, None)
+    _write_download_state(sorted(repos_set), er, entry_install)
 
 
 def unmark_repo_downloaded(repo: str) -> None:
@@ -159,11 +223,13 @@ def unmark_repo_downloaded(repo: str) -> None:
     slug = normalize_repo_slug(repo)
     if not slug:
         return
-    repos_list, er = _load_download_state()
-    er = {k: v for k, v in er.items() if normalize_repo_slug(v) != slug}
+    repos_list, er, entry_install = _load_download_state_payload()
+    removed_entries = {k for k, v in er.items() if normalize_repo_slug(v) == slug}
+    er = {k: v for k, v in er.items() if k not in removed_entries}
+    entry_install = {k: v for k, v in entry_install.items() if k not in removed_entries}
     repos_set = set(repos_list)
     repos_set.discard(slug)
-    _write_download_state(sorted(repos_set), er)
+    _write_download_state(sorted(repos_set), er, entry_install)
 
 
 def unmark_repo_for_manifest_entry(entry: str) -> bool:
@@ -175,16 +241,18 @@ def unmark_repo_for_manifest_entry(entry: str) -> bool:
     norm_e = normalize_manifest_entry(entry.strip())
     if not norm_e:
         return False
-    repos_list, er = _load_download_state()
+    repos_list, er, entry_install = _load_download_state_payload()
     if norm_e not in er:
         return False
     er = dict(er)
+    entry_install = dict(entry_install)
     slug = normalize_repo_slug(er.pop(norm_e))
+    entry_install.pop(norm_e, None)
     others = {normalize_repo_slug(v) for v in er.values()}
     repos_set = set(repos_list)
     if slug not in others:
         repos_set.discard(slug)
-    _write_download_state(sorted(repos_set), er)
+    _write_download_state(sorted(repos_set), er, entry_install)
     return True
 
 

--- a/frontend/src/shared/platform/types.ts
+++ b/frontend/src/shared/platform/types.ts
@@ -673,10 +673,17 @@ export interface TaskSnapshot<TResult = unknown> {
   cancelRequested?: boolean;
   createdAt: number;
   error?: string;
+  errorCode?: string;
+  errorDetail?: string;
+  errorUserMessage?: string;
+  fallbackAllowed?: boolean;
+  httpStatus?: number;
   id: string;
   kind: string;
   logs: string[];
   message: string;
+  notice?: string;
+  noticeKind?: "error" | "info" | "warning";
   phase: string;
   progress?: number | null;
   result?: TResult | null;

--- a/frontend/src/shared/ui/TaskProgress.css
+++ b/frontend/src/shared/ui/TaskProgress.css
@@ -45,6 +45,33 @@
   color: var(--color-text-primary);
 }
 
+.task-progress__notice {
+  min-width: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow-wrap: anywhere;
+  font-size: 12px;
+}
+
+.task-progress__notice--info {
+  border-color: color-mix(in srgb, var(--color-info) 48%, var(--color-border));
+  color: var(--color-info);
+  background: color-mix(in srgb, var(--color-info) 10%, transparent);
+}
+
+.task-progress__notice--warning {
+  border-color: color-mix(in srgb, var(--color-warning) 48%, var(--color-border));
+  color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
+}
+
+.task-progress__notice--error {
+  border-color: color-mix(in srgb, var(--color-danger) 48%, var(--color-border));
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+}
+
 .task-progress__log {
   max-height: 132px;
   min-width: 0;

--- a/frontend/src/shared/ui/TaskProgress.tsx
+++ b/frontend/src/shared/ui/TaskProgress.tsx
@@ -1,8 +1,12 @@
 import "./TaskProgress.css";
 
 interface TaskProgressSnapshot {
+  errorUserMessage?: string;
+  fallbackAllowed?: boolean;
   logs?: readonly string[];
   message?: string;
+  notice?: string;
+  noticeKind?: "error" | "info" | "warning";
   phase: string;
   progress?: number | null;
   status: string;
@@ -27,6 +31,10 @@ export function TaskProgress({ logLimit = 6, task }: TaskProgressProps) {
 
   const percent = taskPercent(task.progress);
   const logs = logLimit > 0 ? (task.logs ?? []).slice(-logLimit) : [];
+  const notice = task.notice || (task.status === "failed" ? task.errorUserMessage : "");
+  const noticeKind = task.noticeKind || (task.status === "failed" ? "error" : "info");
+  const message = task.message || task.status;
+  const showMessage = message !== notice;
 
   return (
     <div className="task-progress" role="status" aria-live="polite">
@@ -39,7 +47,13 @@ export function TaskProgress({ logLimit = 6, task }: TaskProgressProps) {
           <span className="task-progress__fill" style={{ width: `${percent}%` }} />
         </div>
       )}
-      <div className="task-progress__message">{task.message || task.status}</div>
+      {showMessage ? <div className="task-progress__message">{message}</div> : null}
+      {notice ? (
+        <div className={`task-progress__notice task-progress__notice--${noticeKind}`}>
+          {notice}
+          {task.fallbackAllowed && task.status === "failed" ? " 可稍后重试。" : ""}
+        </div>
+      ) : null}
       {logs.length ? <pre className="task-progress__log">{logs.join("\n")}</pre> : null}
     </div>
   );

--- a/frontend/src/test/shared/ui/TaskProgress.test.tsx
+++ b/frontend/src/test/shared/ui/TaskProgress.test.tsx
@@ -37,4 +37,38 @@ describe("TaskProgress", () => {
     expect(screen.getByRole("status")).toHaveTextContent("waiting");
     expect(screen.queryByText(/%/)).not.toBeInTheDocument();
   });
+
+  it("renders fallback notices and failed package guidance", () => {
+    const { rerender } = render(
+      <TaskProgress
+        task={{
+          fallbackAllowed: true,
+          logs: [],
+          message: "正在下载源码",
+          notice: "官方包体暂时无法访问，正在自动尝试 GitHub 源码安装。",
+          noticeKind: "info",
+          phase: "download",
+          progress: 0.2,
+          status: "running",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("官方包体暂时无法访问，正在自动尝试 GitHub 源码安装。")).toBeInTheDocument();
+
+    rerender(
+      <TaskProgress
+        task={{
+          errorUserMessage: "包体校验未通过，已阻止安装。",
+          fallbackAllowed: false,
+          logs: [],
+          message: "包体校验未通过，已阻止安装。",
+          phase: "failed",
+          status: "failed",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("包体校验未通过，已阻止安装。")).toBeInTheDocument();
+  });
 });

--- a/frontend_bridge_core/plugin_updates.py
+++ b/frontend_bridge_core/plugin_updates.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ast
+import shutil
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -158,7 +160,11 @@ def _lookup_registry_plugin(source: str) -> Any | None:
         rec_repo = normalize_repo_slug(rec.repo)
         if rec_repo and rec_repo == repo_slug:
             return rec
+        if str(getattr(rec, "id", "") or "").strip().lower() == source_key:
+            return rec
         if rec.name.strip().lower() == source_key:
+            return rec
+        if str(getattr(rec, "display_name", "") or "").strip().lower() == source_key:
             return rec
         if rec.entry.strip().lower() == source_key:
             return rec
@@ -231,7 +237,230 @@ def _synthetic_plugin_result(
     }
 
 
+def _has_registry_package(record: Any | None) -> bool:
+    if record is None:
+        return False
+    import os
+
+    if os.environ.get("SHINSEKAI_PLUGIN_DISABLE_PACKAGE_INSTALL") == "1":
+        return False
+    package_url = str(
+        getattr(record, "package_url", "") or getattr(record, "download_url", "") or ""
+    ).strip()
+    package_sha256 = str(
+        getattr(record, "package_sha256", "") or getattr(record, "sha256", "") or ""
+    ).strip()
+    return bool(package_url and package_sha256)
+
+
+def _registry_package_metadata(record: Any, *, dependency_status: str = "", dependency_detail: str = "") -> dict[str, Any]:
+    package_source = str(getattr(record, "package_source", "") or "r2").strip()
+    package_url = str(getattr(record, "package_url", "") or getattr(record, "download_url", "") or "").strip()
+    package_sha256 = str(getattr(record, "package_sha256", "") or getattr(record, "sha256", "") or "").strip()
+    package_size = getattr(record, "package_size", None)
+    if package_size is None:
+        package_size = getattr(record, "size", None)
+    metadata: dict[str, Any] = {
+        "dependencyDetail": dependency_detail,
+        "dependencyStatus": dependency_status,
+        "entry": str(getattr(record, "entry", "") or "").strip(),
+        "packageSha256": package_sha256,
+        "packageSize": package_size,
+        "packageSource": package_source,
+        "packageStatus": "verified",
+        "packageUrl": package_url,
+        "repo": str(getattr(record, "repo", "") or "").strip(),
+        "sourceLabel": "Official package (R2)",
+        "sourceType": "package",
+    }
+    return {key: value for key, value in metadata.items() if value not in (None, "")}
+
+
+def _with_install_metadata(result: dict[str, Any], metadata: dict[str, Any]) -> dict[str, Any]:
+    out = dict(result)
+    out["install"] = dict(metadata)
+    return out
+
+
+def _package_error_allows_github_fallback(exc: BaseException) -> bool:
+    from core.plugins.package_download import PluginPackageNetworkError, PluginPackageNonFallbackError
+
+    current: BaseException | None = exc
+    saw_network_error = False
+    while current is not None:
+        if isinstance(current, PluginPackageNonFallbackError):
+            return False
+        if isinstance(current, PluginPackageNetworkError):
+            saw_network_error = True
+        current = current.__cause__
+    return saw_network_error
+
+
+def _restore_package_target(target: Path, backup: Path | None, *, remove_new_target: bool) -> None:
+    if remove_new_target and target.exists():
+        shutil.rmtree(target, ignore_errors=True)
+    if backup is not None and backup.exists() and not target.exists():
+        backup.rename(target)
+
+
+def _install_registry_package_source(
+    state: BridgeState,
+    task_id: str,
+    record: Any,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    from core.plugins.package_download import install_registry_package_under_plugins, registry_package_target
+    from core.plugins.plugin_requirements_install import install_plugin_requirements_txt
+    from core.plugins.registry_download import mark_repo_downloaded, normalize_repo_slug
+
+    repo_slug = normalize_repo_slug(str(getattr(record, "repo", "") or ""))
+    entry = str(getattr(record, "entry", "") or "").strip()
+    display_name = str(getattr(record, "display_name", "") or getattr(record, "name", "") or "").strip()
+    description = str(getattr(record, "description", "") or "").strip()
+    target = registry_package_target(record, plugins_parent=Path("plugins"))
+    existed_before = target.is_dir()
+    backup: Path | None = None
+    if overwrite and existed_before:
+        backup = target.with_name(f".{target.name}.backup-{uuid.uuid4().hex}")
+        target.rename(backup)
+
+    _update_task(
+        state,
+        task_id,
+        message=f"Downloading official package for {display_name or repo_slug or target.name}.",
+        phase="download",
+        progress=0.12,
+        installSource="package",
+        packageStatus="downloading",
+    )
+
+    def _pip_line(line: str) -> None:
+        _append_task_log(state, task_id, line)
+
+    dependency_status = ""
+    dependency_detail = ""
+    try:
+        plugin_root = install_registry_package_under_plugins(
+            record,
+            overwrite=overwrite,
+            plugins_parent=Path("plugins"),
+        )
+        _update_task(
+            state,
+            task_id,
+            message="Official package verified. Installing plugin dependencies.",
+            phase="pip",
+            progress=0.72,
+            packageStatus="verified",
+        )
+        dependency_status, dependency_detail = install_plugin_requirements_txt(plugin_root, on_output_line=_pip_line)
+        if dependency_detail:
+            _append_task_log(state, task_id, dependency_detail)
+        if dependency_status in {"pip_failed", "pip_timeout", "pip_exception", "pip_conflict"}:
+            raise RuntimeError(f"Plugin dependency installation failed: {dependency_detail or dependency_status}")
+        if not entry:
+            entry = _infer_plugin_entry(plugin_root)
+        metadata = _registry_package_metadata(
+            record,
+            dependency_status=dependency_status,
+            dependency_detail=dependency_detail,
+        )
+        if entry:
+            metadata["entry"] = entry
+        _update_task(
+            state,
+            task_id,
+            message="Registering official package install.",
+            phase="manifest",
+            progress=0.9,
+            dependencyInstallStatus=dependency_status,
+        )
+        if entry:
+            result = _plugin_result_from_manifest(entry)
+            if repo_slug:
+                mark_repo_downloaded(repo_slug, manifest_entry=entry, install_metadata=metadata)
+            _update_task(state, task_id, message="Official package installed.", phase="completed", progress=1)
+            if backup is not None:
+                shutil.rmtree(backup, ignore_errors=True)
+            return _with_install_metadata(result, metadata)
+        if repo_slug:
+            mark_repo_downloaded(repo_slug, manifest_entry=None)
+        result = _synthetic_plugin_result(
+            description=description or f"Package was downloaded to {plugin_root.as_posix()}, but no manifest entry was found.",
+            enabled=False,
+            plugin_id=repo_slug or str(getattr(record, "id", "") or target.name),
+            title=display_name or target.name,
+        )
+        _update_task(state, task_id, message="Official package downloaded, but no manifest entry was found.", progress=1)
+        if backup is not None:
+            shutil.rmtree(backup, ignore_errors=True)
+        return _with_install_metadata(result, metadata)
+    except Exception:
+        _restore_package_target(target, backup, remove_new_target=(not existed_before or backup is not None))
+        _update_task(state, task_id, packageStatus="failed")
+        raise
+
+
 def _install_plugin_source(
+    state: BridgeState,
+    task_id: str,
+    source: str,
+    *,
+    ref_kind: str = "latest",
+    tag_name: str = "",
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    source = source.strip()
+    if not source:
+        raise ValueError("plugin id is required")
+    ref_kind = ref_kind if ref_kind in {"latest", "head", "tag"} else "latest"
+    tag_name = tag_name.strip()
+    if ref_kind == "tag" and not tag_name:
+        raise ValueError("tagName is required when refKind is tag")
+
+    registry_rec = _lookup_registry_plugin(source)
+    if ref_kind == "latest" and _has_registry_package(registry_rec):
+        try:
+            return _install_registry_package_source(state, task_id, registry_rec, overwrite=overwrite)
+        except Exception as exc:
+            repo = str(getattr(registry_rec, "repo", "") or "").strip()
+            if repo and _package_error_allows_github_fallback(exc):
+                _append_task_log(state, task_id, f"Official package download failed; falling back to GitHub: {exc}")
+                return _install_github_plugin_source(
+                    state,
+                    task_id,
+                    repo,
+                    ref_kind=ref_kind,
+                    tag_name=tag_name,
+                    overwrite=overwrite,
+                )
+            _append_task_log(state, task_id, f"Official package install failed; GitHub fallback blocked: {exc}")
+            raise RuntimeError(str(exc) or type(exc).__name__) from exc
+
+    if not _is_repo_source(source) and registry_rec is not None:
+        repo = str(getattr(registry_rec, "repo", "") or "").strip()
+        if repo:
+            return _install_github_plugin_source(
+                state,
+                task_id,
+                repo,
+                ref_kind=ref_kind,
+                tag_name=tag_name,
+                overwrite=overwrite,
+            )
+
+    return _install_github_plugin_source(
+        state,
+        task_id,
+        source,
+        ref_kind=ref_kind,
+        tag_name=tag_name,
+        overwrite=overwrite,
+    )
+
+
+def _install_github_plugin_source(
     state: BridgeState,
     task_id: str,
     source: str,

--- a/frontend_bridge_core/plugin_updates.py
+++ b/frontend_bridge_core/plugin_updates.py
@@ -11,6 +11,16 @@ from .state import BridgeState
 from .tasks import _append_task_log, _update_task
 
 
+class PluginPackageDependencyInstallError(RuntimeError):
+    code = "package_dependency_failed"
+    fallback_allowed = False
+    user_message = "包体已通过校验，但依赖安装失败，请查看日志。"
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(self.user_message)
+        self.detail = detail.strip() or self.user_message
+
+
 def _app_update_info() -> dict[str, Any]:
     from core.plugins.github_bundle_update import default_app_github_repo_slug, read_local_version, resolve_project_root
 
@@ -253,26 +263,38 @@ def _has_registry_package(record: Any | None) -> bool:
     return bool(package_url and package_sha256)
 
 
-def _registry_package_metadata(record: Any, *, dependency_status: str = "", dependency_detail: str = "") -> dict[str, Any]:
+def _registry_package_metadata(
+    record: Any,
+    *,
+    dependency_status: str = "",
+    dependency_detail: str = "",
+    package_status: str = "verified",
+) -> dict[str, Any]:
     package_source = str(getattr(record, "package_source", "") or "r2").strip()
     package_url = str(getattr(record, "package_url", "") or getattr(record, "download_url", "") or "").strip()
     package_sha256 = str(getattr(record, "package_sha256", "") or getattr(record, "sha256", "") or "").strip()
     package_size = getattr(record, "package_size", None)
     if package_size is None:
         package_size = getattr(record, "size", None)
+    is_verified_package = package_status == "verified"
     metadata: dict[str, Any] = {
         "dependencyDetail": dependency_detail,
         "dependencyStatus": dependency_status,
         "entry": str(getattr(record, "entry", "") or "").strip(),
-        "packageSha256": package_sha256,
-        "packageSize": package_size,
-        "packageSource": package_source,
-        "packageStatus": "verified",
-        "packageUrl": package_url,
+        "packageSource": package_source if is_verified_package else "local",
+        "packageStatus": package_status,
         "repo": str(getattr(record, "repo", "") or "").strip(),
-        "sourceLabel": "Official package (R2)",
-        "sourceType": "package",
+        "sourceLabel": "Official package (R2)" if is_verified_package else "Existing plugin directory",
+        "sourceType": "package" if is_verified_package else "existing",
     }
+    if is_verified_package:
+        metadata.update(
+            {
+                "packageSha256": package_sha256,
+                "packageSize": package_size,
+                "packageUrl": package_url,
+            }
+        )
     return {key: value for key, value in metadata.items() if value not in (None, "")}
 
 
@@ -280,6 +302,35 @@ def _with_install_metadata(result: dict[str, Any], metadata: dict[str, Any]) -> 
     out = dict(result)
     out["install"] = dict(metadata)
     return out
+
+
+def _package_error_details(exc: BaseException) -> dict[str, Any]:
+    from core.plugins.package_download import PluginPackageError
+
+    current: BaseException | None = exc
+    while current is not None:
+        code = getattr(current, "code", "")
+        user_message = getattr(current, "user_message", "")
+        if isinstance(current, PluginPackageError) or code or user_message:
+            detail = str(getattr(current, "detail", "") or current or current.__class__.__name__)
+            out: dict[str, Any] = {
+                "detail": detail,
+                "errorCode": str(code or "plugin_package_error"),
+                "errorUserMessage": str(user_message or detail),
+                "fallbackAllowed": bool(getattr(current, "fallback_allowed", False)),
+            }
+            status_code = getattr(current, "status_code", None)
+            if status_code is not None:
+                out["httpStatus"] = status_code
+            return out
+        current = current.__cause__
+    detail = str(exc) or exc.__class__.__name__
+    return {
+        "detail": detail,
+        "errorCode": "plugin_install_error",
+        "errorUserMessage": detail,
+        "fallbackAllowed": False,
+    }
 
 
 def _package_error_allows_github_fallback(exc: BaseException) -> bool:
@@ -294,6 +345,18 @@ def _package_error_allows_github_fallback(exc: BaseException) -> bool:
             saw_network_error = True
         current = current.__cause__
     return saw_network_error
+
+
+def _update_task_package_error(state: BridgeState, task_id: str, details: dict[str, Any]) -> None:
+    updates = {
+        "errorCode": details.get("errorCode", ""),
+        "errorDetail": details.get("detail", ""),
+        "errorUserMessage": details.get("errorUserMessage", ""),
+        "fallbackAllowed": bool(details.get("fallbackAllowed")),
+    }
+    if details.get("httpStatus") is not None:
+        updates["httpStatus"] = details["httpStatus"]
+    _update_task(state, task_id, **updates)
 
 
 def _restore_package_target(target: Path, backup: Path | None, *, remove_new_target: bool) -> None:
@@ -341,30 +404,47 @@ def _install_registry_package_source(
     dependency_status = ""
     dependency_detail = ""
     try:
+        package_status = "existing" if existed_before and not overwrite else "verified"
         plugin_root = install_registry_package_under_plugins(
             record,
             overwrite=overwrite,
             plugins_parent=Path("plugins"),
         )
+        package_message = (
+            "Existing plugin directory found. Skipping official package verification."
+            if package_status == "existing"
+            else "Official package verified. Installing plugin dependencies."
+        )
         _update_task(
             state,
             task_id,
-            message="Official package verified. Installing plugin dependencies.",
+            message=package_message,
             phase="pip",
             progress=0.72,
-            packageStatus="verified",
+            packageStatus=package_status,
         )
         dependency_status, dependency_detail = install_plugin_requirements_txt(plugin_root, on_output_line=_pip_line)
         if dependency_detail:
             _append_task_log(state, task_id, dependency_detail)
         if dependency_status in {"pip_failed", "pip_timeout", "pip_exception", "pip_conflict"}:
-            raise RuntimeError(f"Plugin dependency installation failed: {dependency_detail or dependency_status}")
+            dependency_error = PluginPackageDependencyInstallError(dependency_detail or dependency_status)
+            error_message = dependency_error.user_message
+            _update_task(
+                state,
+                task_id,
+                errorCode=dependency_error.code,
+                errorDetail=dependency_error.detail,
+                errorUserMessage=error_message,
+                fallbackAllowed=dependency_error.fallback_allowed,
+            )
+            raise dependency_error
         if not entry:
             entry = _infer_plugin_entry(plugin_root)
         metadata = _registry_package_metadata(
             record,
             dependency_status=dependency_status,
             dependency_detail=dependency_detail,
+            package_status=package_status,
         )
         if entry:
             metadata["entry"] = entry
@@ -426,7 +506,23 @@ def _install_plugin_source(
         except Exception as exc:
             repo = str(getattr(registry_rec, "repo", "") or "").strip()
             if repo and _package_error_allows_github_fallback(exc):
-                _append_task_log(state, task_id, f"Official package download failed; falling back to GitHub: {exc}")
+                details = _package_error_details(exc)
+                fallback_message = str(details.get("errorUserMessage") or "官方包体暂时无法访问，正在自动尝试 GitHub 源码安装。")
+                _update_task(
+                    state,
+                    task_id,
+                    errorCode=details.get("errorCode", ""),
+                    errorDetail=details.get("detail", ""),
+                    errorUserMessage=fallback_message,
+                    fallbackAllowed=True,
+                    message=fallback_message,
+                    notice=fallback_message,
+                    noticeKind="info",
+                    phase="download",
+                    installSource="github",
+                    packageStatus="fallback",
+                )
+                _append_task_log(state, task_id, f"{fallback_message} {details.get('detail', exc)}")
                 return _install_github_plugin_source(
                     state,
                     task_id,
@@ -435,8 +531,11 @@ def _install_plugin_source(
                     tag_name=tag_name,
                     overwrite=overwrite,
                 )
-            _append_task_log(state, task_id, f"Official package install failed; GitHub fallback blocked: {exc}")
-            raise RuntimeError(str(exc) or type(exc).__name__) from exc
+            details = _package_error_details(exc)
+            _update_task_package_error(state, task_id, details)
+            message = str(details.get("errorUserMessage") or details.get("detail") or exc)
+            _append_task_log(state, task_id, f"{message} {details.get('detail', '')}".strip())
+            raise RuntimeError(message) from exc
 
     if not _is_repo_source(source) and registry_rec is not None:
         repo = str(getattr(registry_rec, "repo", "") or "").strip()

--- a/test/unit/test_frontend_plugin_updates.py
+++ b/test/unit/test_frontend_plugin_updates.py
@@ -1,12 +1,21 @@
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from core.plugins.package_download import PluginPackageNetworkError, PluginPackageNonFallbackError
+from core.plugins.registry_catalog import RegistryPluginRecord
+from frontend_bridge_core import plugin_updates
 from frontend_bridge_core.plugin_updates import (
     _infer_plugin_entry,
+    _install_plugin_source,
     _is_repo_source,
+    _lookup_registry_plugin,
     _plugin_class_from_file,
     _repo_slug_from_source,
     _synthetic_plugin_result,
 )
+from frontend_bridge_core.state import BridgeState
 
 
 def test_repo_slug_from_source_accepts_common_github_forms():
@@ -92,3 +101,210 @@ def test_infer_plugin_entry_ignores_non_identifier_module_parts(tmp_path):
     (plugin_root / "plugin.py").write_text("class DemoPlugin(PluginBase):\n    pass\n", encoding="utf-8")
 
     assert _infer_plugin_entry(plugin_root) == ""
+
+
+def _registry_record(
+    *,
+    package_url: str = "https://packages.example/demo.zip",
+    entry: str = "plugins.demo.plugin:DemoPlugin",
+) -> RegistryPluginRecord:
+    return RegistryPluginRecord(
+        id="demo-id",
+        name="demo-plugin",
+        display_name="Demo Plugin",
+        author="Tester",
+        repo="owner/demo",
+        description="Long detail",
+        short_description="Short detail",
+        entry=entry,
+        package_source="r2",
+        package_url=package_url,
+        package_sha256="abc123",
+        package_size=42,
+    )
+
+
+def _state_with_task() -> BridgeState:
+    state = BridgeState(None, None, None, None)
+    state.tasks["task"] = {
+        "id": "task",
+        "logs": [],
+        "message": "",
+        "phase": "queued",
+        "progress": 0,
+        "status": "running",
+    }
+    return state
+
+
+def _plugin_root(tmp_path: Path, name: str) -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    (root / "plugin.py").write_text("class DemoPlugin(PluginBase):\n    pass\n", encoding="utf-8")
+    return root
+
+
+def _patch_manifest_and_state(monkeypatch, marks: list[dict]):
+    monkeypatch.setattr(
+        plugin_updates,
+        "_plugin_result_from_manifest",
+        lambda entry: {"entry": entry, "enabled": True},
+    )
+
+    def fake_mark_repo_downloaded(repo, **kwargs):
+        marks.append({"repo": repo, **kwargs})
+
+    monkeypatch.setattr("core.plugins.registry_download.mark_repo_downloaded", fake_mark_repo_downloaded)
+
+
+def test_lookup_registry_plugin_matches_id_and_display_name(monkeypatch):
+    record = _registry_record()
+    monkeypatch.setattr("core.plugins.registry_catalog.fetch_registry_plugins", lambda timeout_sec=12: [record])
+
+    assert _lookup_registry_plugin("demo-id") is record
+    assert _lookup_registry_plugin("Demo Plugin") is record
+
+
+def test_install_plugin_source_prefers_registry_package_over_github(tmp_path, monkeypatch):
+    record = _registry_record()
+    marks: list[dict] = []
+    calls: list[tuple[str, object]] = []
+    package_root = _plugin_root(tmp_path, "package-plugin")
+
+    monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
+    _patch_manifest_and_state(monkeypatch, marks)
+
+    def fake_package_install(rec, **kwargs):
+        calls.append(("package", kwargs.get("overwrite")))
+        assert rec is record
+        assert kwargs.get("plugins_parent") == Path("plugins")
+        return package_root
+
+    def fail_github(*_args, **_kwargs):
+        raise AssertionError("registry package should be used before GitHub")
+
+    monkeypatch.setattr(
+        "core.plugins.package_download.install_registry_package_under_plugins",
+        fake_package_install,
+    )
+    monkeypatch.setattr("core.plugins.github_bundle_update.install_github_plugin_under_plugins", fail_github)
+    monkeypatch.setattr(
+        "core.plugins.plugin_requirements_install.install_plugin_requirements_txt",
+        lambda root, **_kwargs: calls.append(("pip", root)) or ("pip_ok", ""),
+    )
+
+    result = _install_plugin_source(_state_with_task(), "task", "owner/demo", overwrite=True)
+
+    assert result["entry"] == "plugins.demo.plugin:DemoPlugin"
+    assert result["enabled"] is True
+    assert result["install"] == {
+        "dependencyStatus": "pip_ok",
+        "entry": "plugins.demo.plugin:DemoPlugin",
+        "packageSha256": "abc123",
+        "packageSize": 42,
+        "packageSource": "r2",
+        "packageStatus": "verified",
+        "packageUrl": "https://packages.example/demo.zip",
+        "repo": "owner/demo",
+        "sourceLabel": "Official package (R2)",
+        "sourceType": "package",
+    }
+    assert calls == [("package", True), ("pip", package_root)]
+    assert marks
+    assert marks[0]["repo"] == "owner/demo"
+    assert marks[0]["manifest_entry"] == "plugins.demo.plugin:DemoPlugin"
+    assert marks[0]["install_metadata"] == result["install"]
+
+
+def test_install_plugin_source_falls_back_to_github_for_registry_package_network_error(
+    tmp_path,
+    monkeypatch,
+):
+    record = _registry_record()
+    marks: list[dict] = []
+    calls: list[str] = []
+    github_root = _plugin_root(tmp_path, "github-plugin")
+
+    monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
+    _patch_manifest_and_state(monkeypatch, marks)
+
+    def fail_package(*_args, **_kwargs):
+        calls.append("package")
+        raise PluginPackageNetworkError("r2 offline")
+
+    def fake_github(repo, **kwargs):
+        calls.append("github")
+        assert repo == "owner/demo"
+        assert kwargs.get("catalog_display_name") == "demo-plugin"
+        return github_root
+
+    monkeypatch.setattr(
+        "core.plugins.package_download.install_registry_package_under_plugins",
+        fail_package,
+    )
+    monkeypatch.setattr("core.plugins.github_bundle_update.install_github_plugin_under_plugins", fake_github)
+    monkeypatch.setattr(
+        "core.plugins.plugin_requirements_install.install_plugin_requirements_txt",
+        lambda *_args, **_kwargs: ("pip_ok", ""),
+    )
+
+    result = _install_plugin_source(_state_with_task(), "task", "owner/demo")
+
+    assert result == {"entry": "plugins.demo.plugin:DemoPlugin", "enabled": True}
+    assert calls == ["package", "github"]
+    assert marks[0]["manifest_entry"] == "plugins.demo.plugin:DemoPlugin"
+
+
+@pytest.mark.parametrize(
+    "package_error",
+    [
+        PluginPackageNonFallbackError("checksum mismatch"),
+        PluginPackageNonFallbackError("unsafe plugin package path"),
+    ],
+)
+def test_install_plugin_source_does_not_fallback_to_github_for_package_safety_errors(
+    monkeypatch,
+    package_error,
+):
+    record = _registry_record()
+    monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
+
+    def fail_package(*_args, **_kwargs):
+        raise package_error
+
+    def fail_github(*_args, **_kwargs):
+        raise AssertionError("checksum and package safety errors must not fallback to GitHub")
+
+    monkeypatch.setattr(
+        "core.plugins.package_download.install_registry_package_under_plugins",
+        fail_package,
+    )
+    monkeypatch.setattr("core.plugins.github_bundle_update.install_github_plugin_under_plugins", fail_github)
+
+    with pytest.raises(Exception, match=str(package_error)):
+        _install_plugin_source(_state_with_task(), "task", "owner/demo")
+
+
+def test_install_plugin_source_does_not_fallback_to_github_when_package_dependency_install_fails(
+    tmp_path,
+    monkeypatch,
+):
+    record = _registry_record()
+    package_root = _plugin_root(tmp_path, "package-plugin")
+    monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
+    monkeypatch.setattr(
+        "core.plugins.package_download.install_registry_package_under_plugins",
+        lambda *_args, **_kwargs: package_root,
+    )
+
+    def fail_github(*_args, **_kwargs):
+        raise AssertionError("dependency failures after package install must not fallback to GitHub")
+
+    monkeypatch.setattr("core.plugins.github_bundle_update.install_github_plugin_under_plugins", fail_github)
+    monkeypatch.setattr(
+        "core.plugins.plugin_requirements_install.install_plugin_requirements_txt",
+        lambda *_args, **_kwargs: ("pip_failed", "dependency boom"),
+    )
+
+    with pytest.raises(RuntimeError, match="dependency boom"):
+        _install_plugin_source(_state_with_task(), "task", "owner/demo")

--- a/test/unit/test_frontend_plugin_updates.py
+++ b/test/unit/test_frontend_plugin_updates.py
@@ -216,6 +216,45 @@ def test_install_plugin_source_prefers_registry_package_over_github(tmp_path, mo
     assert marks[0]["install_metadata"] == result["install"]
 
 
+def test_install_plugin_source_does_not_mark_existing_directory_as_verified(tmp_path, monkeypatch):
+    record = _registry_record()
+    marks: list[dict] = []
+    calls: list[tuple[str, object]] = []
+    package_root = _plugin_root(tmp_path, "package-plugin")
+
+    monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
+    monkeypatch.setattr("core.plugins.package_download.registry_package_target", lambda *_args, **_kwargs: package_root)
+    _patch_manifest_and_state(monkeypatch, marks)
+
+    def fake_package_install(rec, **kwargs):
+        calls.append(("package", kwargs.get("overwrite")))
+        assert rec is record
+        return package_root
+
+    monkeypatch.setattr(
+        "core.plugins.package_download.install_registry_package_under_plugins",
+        fake_package_install,
+    )
+    monkeypatch.setattr(
+        "core.plugins.plugin_requirements_install.install_plugin_requirements_txt",
+        lambda root, **_kwargs: calls.append(("pip", root)) or ("pip_ok", ""),
+    )
+
+    result = _install_plugin_source(_state_with_task(), "task", "owner/demo", overwrite=False)
+
+    assert result["install"] == {
+        "dependencyStatus": "pip_ok",
+        "entry": "plugins.demo.plugin:DemoPlugin",
+        "packageSource": "local",
+        "packageStatus": "existing",
+        "repo": "owner/demo",
+        "sourceLabel": "Existing plugin directory",
+        "sourceType": "existing",
+    }
+    assert calls == [("package", False), ("pip", package_root)]
+    assert marks[0]["install_metadata"] == result["install"]
+
+
 def test_install_plugin_source_falls_back_to_github_for_registry_package_network_error(
     tmp_path,
     monkeypatch,
@@ -248,23 +287,44 @@ def test_install_plugin_source_falls_back_to_github_for_registry_package_network
         lambda *_args, **_kwargs: ("pip_ok", ""),
     )
 
-    result = _install_plugin_source(_state_with_task(), "task", "owner/demo")
+    state = _state_with_task()
+
+    result = _install_plugin_source(state, "task", "owner/demo")
 
     assert result == {"entry": "plugins.demo.plugin:DemoPlugin", "enabled": True}
     assert calls == ["package", "github"]
     assert marks[0]["manifest_entry"] == "plugins.demo.plugin:DemoPlugin"
+    assert any("官方包体暂时无法访问，正在自动尝试 GitHub 源码安装。" in line for line in state.tasks["task"]["logs"])
 
 
 @pytest.mark.parametrize(
-    "package_error",
+    ("package_error", "expected_code", "expected_message"),
     [
-        PluginPackageNonFallbackError("checksum mismatch"),
-        PluginPackageNonFallbackError("unsafe plugin package path"),
+        (
+            PluginPackageNonFallbackError(
+                "checksum mismatch",
+                code="package_checksum_mismatch",
+                user_message="包体校验未通过，已阻止安装。",
+            ),
+            "package_checksum_mismatch",
+            "包体校验未通过，已阻止安装。",
+        ),
+        (
+            PluginPackageNonFallbackError(
+                "unsafe plugin package path",
+                code="package_unsafe_path",
+                user_message="包体校验未通过，已阻止安装。",
+            ),
+            "package_unsafe_path",
+            "包体校验未通过，已阻止安装。",
+        ),
     ],
 )
 def test_install_plugin_source_does_not_fallback_to_github_for_package_safety_errors(
     monkeypatch,
     package_error,
+    expected_code,
+    expected_message,
 ):
     record = _registry_record()
     monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
@@ -281,8 +341,16 @@ def test_install_plugin_source_does_not_fallback_to_github_for_package_safety_er
     )
     monkeypatch.setattr("core.plugins.github_bundle_update.install_github_plugin_under_plugins", fail_github)
 
-    with pytest.raises(Exception, match=str(package_error)):
-        _install_plugin_source(_state_with_task(), "task", "owner/demo")
+    state = _state_with_task()
+
+    with pytest.raises(Exception, match=expected_message):
+        _install_plugin_source(state, "task", "owner/demo")
+
+    task = state.tasks["task"]
+    assert task["errorCode"] == expected_code
+    assert task["errorUserMessage"] == expected_message
+    assert task["fallbackAllowed"] is False
+    assert str(package_error) in task["errorDetail"]
 
 
 def test_install_plugin_source_does_not_fallback_to_github_when_package_dependency_install_fails(
@@ -306,5 +374,13 @@ def test_install_plugin_source_does_not_fallback_to_github_when_package_dependen
         lambda *_args, **_kwargs: ("pip_failed", "dependency boom"),
     )
 
-    with pytest.raises(RuntimeError, match="dependency boom"):
-        _install_plugin_source(_state_with_task(), "task", "owner/demo")
+    state = _state_with_task()
+
+    with pytest.raises(RuntimeError, match="包体已通过校验，但依赖安装失败，请查看日志。"):
+        _install_plugin_source(state, "task", "owner/demo")
+
+    task = state.tasks["task"]
+    assert task["errorCode"] == "package_dependency_failed"
+    assert task["errorUserMessage"] == "包体已通过校验，但依赖安装失败，请查看日志。"
+    assert task["errorDetail"] == "dependency boom"
+    assert task["fallbackAllowed"] is False

--- a/test/unit/test_plugin_package_download.py
+++ b/test/unit/test_plugin_package_download.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import socket
 import zipfile
 from pathlib import Path
+from urllib.error import HTTPError, URLError
 
 import pytest
 
 from core.plugins import package_download, registry_download
 from core.plugins.package_download import (
+    PluginPackageNetworkError,
     PluginPackageNonFallbackError,
     install_registry_package_under_plugins,
 )
@@ -147,6 +150,54 @@ def test_registry_package_install_rejects_hosts_outside_allowlist(tmp_path, monk
     with pytest.raises(PluginPackageNonFallbackError, match="host is not allowed"):
         install_registry_package_under_plugins(
             _record(url="https://evil.example/demo.zip", sha256="0" * 64, size=1),
+            plugins_parent=tmp_path,
+        )
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404])
+def test_registry_package_install_blocks_http_errors_from_github_fallback(tmp_path, monkeypatch, status):
+    def fail_urlopen(request, *_args, **_kwargs):
+        raise HTTPError(
+            request.full_url,
+            status,
+            "explicit HTTP failure",
+            hdrs=None,
+            fp=io.BytesIO(b""),
+        )
+
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", fail_urlopen)
+
+    with pytest.raises(PluginPackageNonFallbackError, match=f"HTTP error: {status}"):
+        install_registry_package_under_plugins(
+            _record(sha256="0" * 64, size=1),
+            plugins_parent=tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "network_error",
+    [
+        URLError(socket.gaierror("getaddrinfo failed")),
+        URLError(ConnectionRefusedError("connection refused")),
+        URLError(ConnectionResetError("connection reset by peer")),
+        TimeoutError("timed out"),
+    ],
+)
+def test_registry_package_install_allows_github_fallback_for_transient_network_errors(
+    tmp_path,
+    monkeypatch,
+    network_error,
+):
+    def fail_urlopen(*_args, **_kwargs):
+        raise network_error
+
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", fail_urlopen)
+
+    with pytest.raises(PluginPackageNetworkError, match="download failed"):
+        install_registry_package_under_plugins(
+            _record(sha256="0" * 64, size=1),
             plugins_parent=tmp_path,
         )
 

--- a/test/unit/test_plugin_package_download.py
+++ b/test/unit/test_plugin_package_download.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from core.plugins import package_download, registry_download
+from core.plugins.package_download import (
+    PluginPackageNonFallbackError,
+    install_registry_package_under_plugins,
+)
+from core.plugins.registry_catalog import RegistryPluginRecord
+
+
+def _zip_bytes(files: dict[str, bytes | str]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            body = content.encode("utf-8") if isinstance(content, str) else content
+            zf.writestr(name, body)
+    return buf.getvalue()
+
+
+def _record(
+    *,
+    name: str = "demo-plugin",
+    url: str = "https://packages.example/demo.zip",
+    sha256: str = "",
+    size: int | None = None,
+) -> RegistryPluginRecord:
+    return RegistryPluginRecord(
+        id=name,
+        name=name,
+        display_name="Demo Plugin",
+        author="Tester",
+        repo="owner/demo",
+        description="",
+        short_description="",
+        entry="plugins.demo.plugin:DemoPlugin",
+        package_url=url,
+        package_sha256=sha256,
+        package_size=size,
+    )
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+        self.headers = {"Content-Length": str(len(body))}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, _size: int = -1) -> bytes:
+        if not self._body:
+            return b""
+        body = self._body
+        self._body = b""
+        return body
+
+
+def test_registry_package_install_verifies_checksum_size_and_extracts(tmp_path, monkeypatch):
+    body = _zip_bytes({"demo-plugin/plugin.py": "class DemoPlugin: pass\n"})
+    sha = hashlib.sha256(body).hexdigest()
+    calls: list[str] = []
+
+    def fake_urlopen(request, timeout):
+        calls.append(request.full_url)
+        assert timeout == 1
+        return _FakeResponse(body)
+
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", fake_urlopen)
+
+    target = install_registry_package_under_plugins(
+        _record(sha256=sha, size=len(body)),
+        plugins_parent=tmp_path,
+        timeout_sec=1,
+    )
+
+    assert target == (tmp_path / "demo-plugin").resolve(strict=False)
+    assert (target / "plugin.py").read_text(encoding="utf-8") == "class DemoPlugin: pass\n"
+    assert calls == ["https://packages.example/demo.zip"]
+
+
+@pytest.mark.parametrize(
+    ("sha_override", "size_override", "message"),
+    [
+        ("0" * 64, None, "checksum mismatch"),
+        (None, 1, "size mismatch"),
+    ],
+)
+def test_registry_package_install_rejects_checksum_or_size_mismatch(
+    tmp_path,
+    monkeypatch,
+    sha_override,
+    size_override,
+    message,
+):
+    body = _zip_bytes({"demo-plugin/plugin.py": "class DemoPlugin: pass\n"})
+    sha = hashlib.sha256(body).hexdigest()
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", lambda *_args, **_kwargs: _FakeResponse(body))
+
+    with pytest.raises(PluginPackageNonFallbackError, match=message):
+        install_registry_package_under_plugins(
+            _record(
+                sha256=sha_override if sha_override is not None else sha,
+                size=size_override if size_override is not None else len(body),
+            ),
+            plugins_parent=tmp_path,
+        )
+
+    assert not (tmp_path / "demo-plugin").exists()
+
+
+def test_registry_package_install_rejects_zip_slip_members(tmp_path, monkeypatch):
+    body = _zip_bytes({"../escape.py": "bad\n"})
+    sha = hashlib.sha256(body).hexdigest()
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", lambda *_args, **_kwargs: _FakeResponse(body))
+
+    with pytest.raises(PluginPackageNonFallbackError, match="unsafe plugin package path"):
+        install_registry_package_under_plugins(
+            _record(sha256=sha, size=len(body)),
+            plugins_parent=tmp_path,
+        )
+
+    assert not (tmp_path / "escape.py").exists()
+    assert not (tmp_path / "demo-plugin").exists()
+
+
+def test_registry_package_install_rejects_hosts_outside_allowlist(tmp_path, monkeypatch):
+    def fail_urlopen(*_args, **_kwargs):
+        raise AssertionError("host validation should run before network access")
+
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", fail_urlopen)
+
+    with pytest.raises(PluginPackageNonFallbackError, match="host is not allowed"):
+        install_registry_package_under_plugins(
+            _record(url="https://evil.example/demo.zip", sha256="0" * 64, size=1),
+            plugins_parent=tmp_path,
+        )
+
+
+def test_registry_package_install_skips_download_when_target_exists_without_overwrite(tmp_path, monkeypatch):
+    target = tmp_path / "demo-plugin"
+    target.mkdir()
+    (target / "plugin.py").write_text("old\n", encoding="utf-8")
+
+    def fail_urlopen(*_args, **_kwargs):
+        raise AssertionError("existing plugin should not be downloaded without overwrite")
+
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", fail_urlopen)
+
+    result = install_registry_package_under_plugins(
+        _record(sha256="0" * 64, size=1),
+        plugins_parent=tmp_path,
+        overwrite=False,
+    )
+
+    assert result == target.resolve(strict=False)
+    assert (target / "plugin.py").read_text(encoding="utf-8") == "old\n"
+
+
+def test_registry_package_install_rolls_back_old_directory_when_overwrite_replace_fails(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "demo-plugin"
+    target.mkdir()
+    (target / "plugin.py").write_text("old\n", encoding="utf-8")
+    body = _zip_bytes({"demo-plugin/plugin.py": "new\n"})
+    sha = hashlib.sha256(body).hexdigest()
+
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", lambda *_args, **_kwargs: _FakeResponse(body))
+
+    def fail_move(_source, _target):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(package_download.shutil, "move", fail_move)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        install_registry_package_under_plugins(
+            _record(sha256=sha, size=len(body)),
+            plugins_parent=tmp_path,
+            overwrite=True,
+        )
+
+    assert target.is_dir()
+    assert (target / "plugin.py").read_text(encoding="utf-8") == "old\n"
+    assert not any(path.name.startswith(".demo-plugin.backup-") for path in tmp_path.iterdir())
+
+
+def test_registry_download_persists_and_reads_install_metadata(tmp_path, monkeypatch):
+    state_path = tmp_path / "downloads.json"
+    monkeypatch.setattr(registry_download, "_DOWNLOAD_STATE_PATH", state_path)
+
+    registry_download.mark_repo_downloaded(
+        "https://github.com/Owner/Demo",
+        manifest_entry="demo.plugin:DemoPlugin",
+        install_metadata={
+            "dependencyDetail": "ok",
+            "dependencyStatus": "pip_ok",
+            "entry": "plugins.demo.plugin:DemoPlugin",
+            "ignored": "not persisted",
+            "packageSha256": "abc123",
+            "packageSize": 42,
+            "packageSource": "r2",
+            "packageStatus": "installed",
+            "packageUrl": "https://packages.example/demo.zip",
+            "repo": "owner/demo",
+            "sourceType": "registry_package",
+            "tagName": "",
+        },
+    )
+
+    assert registry_download.load_plugin_install_metadata("demo.plugin:DemoPlugin") == {
+        "dependencyDetail": "ok",
+        "dependencyStatus": "pip_ok",
+        "entry": "plugins.demo.plugin:DemoPlugin",
+        "packageSha256": "abc123",
+        "packageSize": 42,
+        "packageSource": "r2",
+        "packageStatus": "installed",
+        "packageUrl": "https://packages.example/demo.zip",
+        "repo": "owner/demo",
+        "sourceType": "registry_package",
+    }
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    assert raw["repos"] == ["owner/demo"]
+    assert "plugins.demo.plugin:DemoPlugin" in raw["entry_install"]


### PR DESCRIPTION
## 背景

这是 #69 的主程序拆分 PR5，基于 #77 的插件注册表元数据能力继续实现。建议先评审并合并 #77，再看本 PR；#77 合并后，本 PR 的实际差异会收敛到官方包安装链路。

## 变更内容

- 新增官方插件包安装模块：从注册表记录读取 R2/官方包 URL、SHA256、包体大小，并在安装前完成校验。
- 插件安装入口优先使用注册表官方包；仅当官方包下载发生网络错误时，才允许回退到 GitHub 源码安装。
- 对 SHA256 不匹配、包体大小不匹配、非法 ZIP 路径、非允许 host、依赖安装失败等情况阻止 GitHub fallback，避免绕过官方包校验。
- ZIP 解包使用安全路径检查，阻止路径穿越；覆盖安装时保留旧目录备份，失败时自动回滚。
- 插件成功安装并解析/推断入口后，会持久化安装来源元数据，记录包来源、包 URL、SHA256、大小和依赖安装结果，为后续“按包 hash 判断更新”提供基础。
- 补充单测覆盖官方包校验、host allowlist、zip slip、覆盖失败回滚、网络 fallback、安全失败不 fallback、依赖失败不 fallback 等路径。

## 配置说明

- `SHINSEKAI_PLUGIN_PACKAGE_HOSTS`：可选，逗号分隔的官方包 host allowlist。为空时不限制 host，适合本地测试；生产分发建议配置为 R2 公开域名或自定义域名。
- `SHINSEKAI_PLUGIN_PACKAGE_MAX_BYTES`：可选，官方插件包最大字节数，默认 16 MiB。
- `SHINSEKAI_PLUGIN_DISABLE_PACKAGE_INSTALL=1`：可选，用于临时关闭官方包安装路径，回到原 GitHub 安装逻辑。

## 验证

- `python -m py_compile core\plugins\package_download.py core\plugins\registry_download.py frontend_bridge_core\plugin_updates.py`
- `python -m pytest test/unit/test_plugin_package_download.py test/unit/test_frontend_plugin_updates.py -q`：20 passed
- `python -m pytest test\unit -q`：574 passed, 1 warning
- `pnpm --dir frontend format:check`：通过
- `pnpm --dir frontend lint:types`：通过
- `pnpm --dir frontend test`：66 files passed / 271 tests passed

Refs #69