### PR TITLE
功能：优化插件依赖安装

### DIFF
--- a/core/plugins/pip_index_config.py
+++ b/core/plugins/pip_index_config.py
@@ -6,7 +6,11 @@ import json
 import os
 from pathlib import Path
 
-_PIP_INDEX_FLAGS = frozenset({"-i", "--index-url", "--no-index"})
+# --extra-index-url 也算用户主动声明：只补 extra 源说明作者希望保持默认主源不变，
+# 这时再注入国内镜像当 primary index 会改变包解析来源。
+_PIP_INDEX_FLAGS = frozenset({"-i", "--index-url", "--extra-index-url", "--no-index"})
+_PIP_INDEX_FLAG_PREFIXES = ("--index-url=", "--extra-index-url=")
+_PIP_ENV_OVERRIDES = ("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL", "PIP_NO_INDEX", "PIP_CONFIG_FILE")
 _DEFAULT_OFFICIAL_INDEXES = ["https://pypi.org/simple/"]
 _DEFAULT_CHINA_INDEXES = [
     "https://pypi.tuna.tsinghua.edu.cn/simple/",
@@ -20,7 +24,7 @@ def has_explicit_pip_index(args: list[str]) -> bool:
     for arg in args:
         if arg in _PIP_INDEX_FLAGS:
             return True
-        if arg.startswith("--index-url="):
+        if arg.startswith(_PIP_INDEX_FLAG_PREFIXES):
             return True
         if arg.startswith("-i") and arg != "-i":
             return True
@@ -39,7 +43,7 @@ def pip_index_args(*, primary_flag: str = "--index-url") -> list[str]:
 
 def pip_index_urls(source_root: Path | None = None) -> list[str]:
     """Return pip indexes for this install, preferring China mirrors by default."""
-    if os.environ.get("PIP_INDEX_URL") or os.environ.get("PIP_CONFIG_FILE"):
+    if any(os.environ.get(name) for name in _PIP_ENV_OVERRIDES):
         return []
 
     custom_urls = _configured_urls_from_env()

--- a/core/plugins/pip_index_config.py
+++ b/core/plugins/pip_index_config.py
@@ -12,6 +12,8 @@ from pathlib import Path
 # 这时再注入国内镜像当 primary index 会改变包解析来源。
 _PIP_INDEX_FLAGS = frozenset({"-i", "--index-url", "--extra-index-url", "--no-index"})
 _PIP_INDEX_FLAG_PREFIXES = ("--index-url=", "--extra-index-url=")
+_NESTED_REQUIREMENT_FLAGS = frozenset({"-r", "--requirement", "-c", "--constraint"})
+_NESTED_REQUIREMENT_FLAG_PREFIXES = ("--requirement=", "--constraint=")
 _PIP_ENV_OVERRIDES = ("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL", "PIP_NO_INDEX", "PIP_CONFIG_FILE")
 _DEFAULT_OFFICIAL_INDEXES = ["https://pypi.org/simple/"]
 _DEFAULT_CHINA_INDEXES = [
@@ -39,7 +41,25 @@ def strip_inline_requirement_comment(raw_input: str) -> str:
     return re.split(r"[ \t]+#", raw_input, maxsplit=1)[0].strip()
 
 
+def _has_nested_requirement_reference(args: list[str]) -> bool:
+    for arg in args:
+        if arg in _NESTED_REQUIREMENT_FLAGS:
+            return True
+        if arg.startswith(_NESTED_REQUIREMENT_FLAG_PREFIXES):
+            return True
+        if arg.startswith(("-r", "-c")) and arg not in {"-r", "-c"}:
+            return True
+    return False
+
+
 def requirements_lines_define_index(lines: list[str]) -> bool:
+    """Return True when requirements should keep pip's own index resolution.
+
+    We intentionally do not follow nested ``-r`` / ``-c`` files here. If a plugin
+    delegates requirements to another file, that nested file may define a private
+    index, so injecting Shinsekai's mirror as the primary index would risk
+    changing the author's dependency source.
+    """
     for raw_line in lines:
         line = strip_inline_requirement_comment(raw_line)
         if not line:
@@ -48,7 +68,7 @@ def requirements_lines_define_index(lines: list[str]) -> bool:
             tokens = shlex.split(line)
         except ValueError:
             continue
-        if has_explicit_pip_index(tokens):
+        if has_explicit_pip_index(tokens) or _has_nested_requirement_reference(tokens):
             return True
     return False
 
@@ -76,8 +96,6 @@ def pip_index_urls(source_root: Path | None = None) -> list[str]:
     source = os.environ.get("SHINSEKAI_RUNTIME_SOURCE", "").strip().lower()
     if source == "official":
         return official
-    if source == "china":
-        return _ordered_urls(china, official)
     return _ordered_urls(china, official)
 
 

--- a/core/plugins/pip_index_config.py
+++ b/core/plugins/pip_index_config.py
@@ -1,0 +1,164 @@
+"""Shared pip index selection for runtime and plugin dependency installs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+_PIP_INDEX_FLAGS = frozenset({"-i", "--index-url", "--no-index"})
+_DEFAULT_OFFICIAL_INDEXES = ["https://pypi.org/simple/"]
+_DEFAULT_CHINA_INDEXES = [
+    "https://pypi.tuna.tsinghua.edu.cn/simple/",
+    "https://mirrors.aliyun.com/pypi/simple/",
+    "https://mirrors.ustc.edu.cn/pypi/simple/",
+    "https://mirrors.hit.edu.cn/pypi/web/simple/",
+]
+
+
+def has_explicit_pip_index(args: list[str]) -> bool:
+    for arg in args:
+        if arg in _PIP_INDEX_FLAGS:
+            return True
+        if arg.startswith("--index-url="):
+            return True
+        if arg.startswith("-i") and arg != "-i":
+            return True
+    return False
+
+
+def pip_index_args(*, primary_flag: str = "--index-url") -> list[str]:
+    urls = pip_index_urls()
+    if not urls:
+        return []
+    args = [primary_flag, urls[0]]
+    for url in urls[1:]:
+        args.extend(["--extra-index-url", url])
+    return args
+
+
+def pip_index_urls(source_root: Path | None = None) -> list[str]:
+    """Return pip indexes for this install, preferring China mirrors by default."""
+    if os.environ.get("PIP_INDEX_URL") or os.environ.get("PIP_CONFIG_FILE"):
+        return []
+
+    custom_urls = _configured_urls_from_env()
+    if custom_urls:
+        return custom_urls
+
+    official, china = _manifest_pip_indexes(source_root)
+    source = os.environ.get("SHINSEKAI_RUNTIME_SOURCE", "").strip().lower()
+    if source == "official":
+        return official
+    if source == "china":
+        return _ordered_urls(china, official)
+    return _ordered_urls(china, official)
+
+
+def _configured_urls_from_env() -> list[str]:
+    urls: list[str] = []
+    _push_url(urls, os.environ.get("SHINSEKAI_PIP_INDEX_URL"))
+    for raw in _split_env_urls(os.environ.get("SHINSEKAI_PIP_INDEX_URLS")):
+        _push_url(urls, raw)
+    return urls
+
+
+def _manifest_pip_indexes(source_root: Path | None) -> tuple[list[str], list[str]]:
+    manifest = _load_runtime_manifest(source_root)
+    if not isinstance(manifest, dict):
+        return _DEFAULT_OFFICIAL_INDEXES, _DEFAULT_CHINA_INDEXES
+    pip_indexes = manifest.get("pip_indexes")
+    if not isinstance(pip_indexes, dict):
+        return _DEFAULT_OFFICIAL_INDEXES, _DEFAULT_CHINA_INDEXES
+
+    official = _source_urls(
+        pip_indexes.get("official"),
+        pip_indexes.get("official_urls"),
+        _DEFAULT_OFFICIAL_INDEXES,
+    )
+    china = _source_urls(
+        pip_indexes.get("china"),
+        pip_indexes.get("china_urls"),
+        _DEFAULT_CHINA_INDEXES,
+    )
+    return official, china
+
+
+def _load_runtime_manifest(source_root: Path | None) -> dict[str, object] | None:
+    candidates: list[Path] = []
+    env_path = os.environ.get("SHINSEKAI_RUNTIME_MANIFEST")
+    if env_path:
+        candidates.append(Path(env_path))
+    for root in _source_root_candidates(source_root):
+        candidates.append(root / "frontend" / "src-tauri" / "runtime_manifest.json")
+    for candidate in candidates:
+        try:
+            with candidate.expanduser().resolve().open("r", encoding="utf-8") as file:
+                data = json.load(file)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            return data
+    return None
+
+
+def _source_root_candidates(source_root: Path | None) -> list[Path]:
+    candidates: list[Path] = []
+    if source_root is not None:
+        candidates.append(source_root)
+    for env_name in ("SHINSEKAI_SOURCE_ROOT", "SHINSEKAI_PROJECT_ROOT", "EASYAI_PROJECT_ROOT"):
+        value = os.environ.get(env_name)
+        if value:
+            candidates.append(Path(value))
+    candidates.append(Path.cwd())
+    candidates.append(Path(__file__).resolve().parents[2])
+    return _unique_paths(candidates)
+
+
+def _source_urls(single_index: object, index_urls: object, fallback: list[str]) -> list[str]:
+    urls: list[str] = []
+    if isinstance(single_index, str):
+        _push_url(urls, single_index)
+    if isinstance(index_urls, list):
+        for url in index_urls:
+            if isinstance(url, str):
+                _push_url(urls, url)
+    return urls or list(fallback)
+
+
+def _split_env_urls(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    urls: list[str] = []
+    for line in raw.splitlines():
+        for part in line.split(","):
+            _push_url(urls, part)
+    return urls
+
+
+def _ordered_urls(primary: list[str], fallback: list[str]) -> list[str]:
+    urls: list[str] = []
+    for url in [*primary, *fallback]:
+        _push_url(urls, url)
+    return urls
+
+
+def _push_url(urls: list[str], raw: str | None) -> None:
+    url = (raw or "").strip()
+    if url and url not in urls:
+        urls.append(url)
+
+
+def _unique_paths(paths: list[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        try:
+            key = str(path.expanduser().resolve())
+        except OSError:
+            key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique

--- a/core/plugins/pip_index_config.py
+++ b/core/plugins/pip_index_config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import shlex
 from pathlib import Path
 
 # --extra-index-url 也算用户主动声明：只补 extra 源说明作者希望保持默认主源不变，
@@ -27,6 +29,26 @@ def has_explicit_pip_index(args: list[str]) -> bool:
         if arg.startswith(_PIP_INDEX_FLAG_PREFIXES):
             return True
         if arg.startswith("-i") and arg != "-i":
+            return True
+    return False
+
+
+def strip_inline_requirement_comment(raw_input: str) -> str:
+    if raw_input.lstrip().startswith("#"):
+        return ""
+    return re.split(r"[ \t]+#", raw_input, maxsplit=1)[0].strip()
+
+
+def requirements_lines_define_index(lines: list[str]) -> bool:
+    for raw_line in lines:
+        line = strip_inline_requirement_comment(raw_line)
+        if not line:
+            continue
+        try:
+            tokens = shlex.split(line)
+        except ValueError:
+            continue
+        if has_explicit_pip_index(tokens):
             return True
     return False
 

--- a/core/plugins/pip_runner.py
+++ b/core/plugins/pip_runner.py
@@ -1,0 +1,164 @@
+"""Shared pip subprocess helpers for plugin and runtime dependency installs."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+import subprocess
+import sys
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import IO
+
+from core.plugins.pip_index_config import (
+    has_explicit_pip_index as _has_explicit_pip_index,
+    pip_index_args as _pip_index_args,
+    requirements_lines_define_index as _requirements_lines_define_index,
+)
+
+logger = logging.getLogger(__name__)
+
+_PIP_DETAIL_MAX = 1600
+_PIP_CONFLICT_RE = re.compile(
+    r"\b(conflict(?:ing)? dependencies|resolutionimpossible|cannot install|dependency conflict)\b",
+    re.IGNORECASE,
+)
+_URL_CREDENTIAL_RE = re.compile(
+    r"(?P<scheme>https?://)(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@"
+)
+
+
+def redact_url_credentials(text: str) -> str:
+    def _mask(match: re.Match[str]) -> str:
+        if match.group("password") is None:
+            # 只有用户名的形式（https://<token>@host）里用户名往往就是凭据本体。
+            return f"{match.group('scheme')}***@"
+        return f"{match.group('scheme')}{match.group('user')}:***@"
+
+    return _URL_CREDENTIAL_RE.sub(_mask, text or "")
+
+
+def pip_win_creationflags() -> int:
+    return getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+
+def pip_subprocess_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
+    env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    return env
+
+
+def extra_pip_install_args() -> list[str]:
+    raw = os.environ.get("SHINSEKAI_PIP_INSTALL_ARGS", "").strip()
+    if not raw:
+        return []
+    return shlex.split(raw)
+
+
+def apply_pip_index_and_extra_args(
+    cmd: list[str],
+    requirement_lines: list[str] | None = None,
+    *,
+    primary_flag: str = "--index-url",
+) -> list[str]:
+    final_cmd = list(cmd)
+    extra_args = extra_pip_install_args()
+    index_args = _pip_index_args(primary_flag=primary_flag)
+    if (
+        index_args
+        and not _has_explicit_pip_index(final_cmd)
+        and not _requirements_lines_define_index(requirement_lines or [])
+        and not _has_explicit_pip_index(extra_args)
+    ):
+        final_cmd.extend(index_args)
+    final_cmd.extend(extra_args)
+    return final_cmd
+
+
+def classify_pip_result(result: tuple[str, str]) -> tuple[str, str]:
+    # 依赖求解冲突单独分类，前端可以提示“版本冲突”，而不是笼统显示 pip failed。
+    code, detail = result
+    if code == "pip_failed" and _PIP_CONFLICT_RE.search(detail or ""):
+        return ("pip_conflict", detail)
+    return result
+
+
+def run_pip_install(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    timeout_sec: float,
+    on_output_line: Callable[[str], None] | None = None,
+) -> tuple[str, str]:
+    """
+    Run one pip subprocess and return ``(code, detail)``.
+
+    ``code`` is one of ``pip_ok`` / ``pip_failed`` / ``pip_conflict`` /
+    ``pip_timeout`` / ``pip_exception``; ``detail`` holds a short, already
+    credential-redacted output tail for failures (empty on success). Lines
+    forwarded to ``on_output_line`` are redacted the same way.
+    """
+    pop_kw: dict[str, object] = {
+        "cwd": str(cwd),
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "env": pip_subprocess_env(),
+    }
+    flags = pip_win_creationflags()
+    if sys.platform == "win32" and flags:
+        pop_kw["creationflags"] = flags
+    try:
+        proc = subprocess.Popen(cmd, **pop_kw)
+    except OSError as exc:
+        logger.warning("pip install could not run (cmd=%s): %s", cmd[:8], exc)
+        return ("pip_exception", str(exc))
+
+    combined_chunks: list[str] = []
+    lock = threading.Lock()
+
+    def relay(stream: IO[str] | None) -> None:
+        if stream is None:
+            return
+        try:
+            for line in iter(stream.readline, ""):
+                # 私有源 URL 可能带账号密码，先脱敏再进 UI 日志与错误详情。
+                line = redact_url_credentials(line)
+                with lock:
+                    combined_chunks.append(line)
+                if on_output_line:
+                    on_output_line(line.rstrip("\r\n"))
+        finally:
+            stream.close()
+
+    t_out = threading.Thread(target=relay, args=(proc.stdout,))
+    t_err = threading.Thread(target=relay, args=(proc.stderr,))
+    t_out.daemon = True
+    t_err.daemon = True
+    t_out.start()
+    t_err.start()
+    try:
+        proc.wait(timeout=timeout_sec)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        t_out.join(timeout=3.0)
+        t_err.join(timeout=3.0)
+        combined = "".join(combined_chunks)
+        tail = combined.strip()[-_PIP_DETAIL_MAX:]
+        logger.warning("pip install timed out (timeout_sec=%s)", timeout_sec)
+        return ("pip_timeout", tail or "pip install timed out")
+
+    t_out.join()
+    t_err.join()
+    combined = "".join(combined_chunks).strip()
+    if proc.returncode == 0:
+        logger.info("pip install ok")
+        return ("pip_ok", "")
+    tail = combined[-_PIP_DETAIL_MAX:] if combined else ""
+    logger.warning("pip install failed (exit %s)", proc.returncode)
+    return classify_pip_result(("pip_failed", tail or f"exit {proc.returncode}"))

--- a/core/plugins/pip_runner.py
+++ b/core/plugins/pip_runner.py
@@ -92,6 +92,7 @@ def run_pip_install(
     cmd: list[str],
     *,
     cwd: Path,
+    detail_max: int = _PIP_DETAIL_MAX,
     timeout_sec: float,
     on_output_line: Callable[[str], None] | None = None,
 ) -> tuple[str, str]:
@@ -149,7 +150,7 @@ def run_pip_install(
         t_out.join(timeout=3.0)
         t_err.join(timeout=3.0)
         combined = "".join(combined_chunks)
-        tail = combined.strip()[-_PIP_DETAIL_MAX:]
+        tail = combined.strip()[-max(1, detail_max):]
         logger.warning("pip install timed out (timeout_sec=%s)", timeout_sec)
         return ("pip_timeout", tail or "pip install timed out")
 
@@ -159,6 +160,6 @@ def run_pip_install(
     if proc.returncode == 0:
         logger.info("pip install ok")
         return ("pip_ok", "")
-    tail = combined[-_PIP_DETAIL_MAX:] if combined else ""
+    tail = combined[-max(1, detail_max):] if combined else ""
     logger.warning("pip install failed (exit %s)", proc.returncode)
     return classify_pip_result(("pip_failed", tail or f"exit {proc.returncode}"))

--- a/core/plugins/pip_runner.py
+++ b/core/plugins/pip_runner.py
@@ -57,7 +57,11 @@ def extra_pip_install_args() -> list[str]:
     raw = os.environ.get("SHINSEKAI_PIP_INSTALL_ARGS", "").strip()
     if not raw:
         return []
-    return shlex.split(raw)
+    try:
+        return shlex.split(raw)
+    except ValueError as exc:
+        logger.warning("Ignoring invalid SHINSEKAI_PIP_INSTALL_ARGS: %s", exc)
+        return []
 
 
 def apply_pip_index_and_extra_args(

--- a/core/plugins/plugin_requirements_install.py
+++ b/core/plugins/plugin_requirements_install.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import importlib.metadata as importlib_metadata
 import logging
@@ -251,39 +251,51 @@ def _requirement_line_can_be_pruned(line: str) -> bool:
     return True
 
 
-def _requirement_distribution_version(name: str) -> str | None:
-    canonical = _canonical_distribution_name(name)
+def _installed_distribution_versions() -> dict[str, str]:
     paths = list(sys.path)
     target = plugin_pip_target_directory()
     if target is not None and target.is_dir():
         # 打包版插件依赖会装进 data/plugin_site_packages，先查这里再看系统路径。
         target_s = str(target.resolve())
         paths = [target_s, *[path for path in paths if path != target_s]]
+    versions: dict[str, str] = {}
     for distribution in importlib_metadata.distributions(path=paths):
         dist_name = distribution.metadata.get("Name")
         if not dist_name:
             continue
-        if _canonical_distribution_name(dist_name) == canonical:
-            return distribution.version
-    return None
+        versions.setdefault(_canonical_distribution_name(dist_name), distribution.version)
+    return versions
 
 
-def _requirement_line_is_satisfied(line: str) -> bool:
+def _requirement_distribution_version(
+    name: str,
+    installed_versions: Mapping[str, str] | None = None,
+) -> str | None:
+    canonical = _canonical_distribution_name(name)
+    if installed_versions is None:
+        installed_versions = _installed_distribution_versions()
+    return installed_versions.get(canonical)
+
+
+def _requirement_line_is_satisfied(
+    line: str,
+    installed_versions: Mapping[str, str] | None = None,
+) -> bool:
     # 这里尽量按 PEP 508 判断：marker 不匹配就视为无需安装，版本不满足才进入 pip。
     stripped = _strip_inline_requirement_comment(line)
     if not stripped:
         return True
     if Requirement is None:
         name = _requirement_line_project_name(stripped)
-        return bool(name and _requirement_distribution_version(name) is not None)
+        return bool(name and _requirement_distribution_version(name, installed_versions) is not None)
     try:
         requirement = Requirement(stripped)
     except InvalidRequirement:
         name = _requirement_line_project_name(stripped)
-        return bool(name and _requirement_distribution_version(name) is not None)
+        return bool(name and _requirement_distribution_version(name, installed_versions) is not None)
     if requirement.marker and not requirement.marker.evaluate():
         return True
-    installed_version = _requirement_distribution_version(requirement.name)
+    installed_version = _requirement_distribution_version(requirement.name, installed_versions)
     if installed_version is None:
         return False
     if requirement.specifier:
@@ -296,14 +308,30 @@ def _install_lines_after_precheck(lines: list[str]) -> tuple[bool, list[str]]:
     # 这些行可能影响后续包解析，强行只装“缺失行”反而会破坏作者的安装意图。
     if not all(_requirement_line_can_be_pruned(line) for line in lines):
         return False, lines
+    installed_versions = _installed_distribution_versions()
     install_lines: list[str] = []
     for line in lines:
         stripped = _strip_inline_requirement_comment(line)
         if not stripped:
             continue
-        if not _requirement_line_is_satisfied(stripped):
+        if not _requirement_line_is_satisfied(stripped, installed_versions):
             install_lines.append(line.rstrip("\r\n"))
     return True, install_lines
+
+
+def _write_temp_requirements(prefix: str, lines: list[str]) -> Path:
+    fd, temp_path_str = tempfile.mkstemp(prefix=prefix, suffix=".txt")
+    path = Path(temp_path_str)
+    try:
+        os.close(fd)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+    except BaseException:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def _finish_install_result(
@@ -383,23 +411,19 @@ def install_plugin_requirements_txt(
     active_req = req
     active_lines = lines
     precheck_tf: Path | None = None
-    if can_prune:
-        # pip 仍然只认识 requirements 文件，所以把裁剪后的缺失列表写入临时文件。
-        fd, precheck_tf_str = tempfile.mkstemp(
-            prefix="easyai_missing_req_", suffix=".txt"
-        )
-        os.close(fd)
-        precheck_tf = Path(precheck_tf_str)
-        precheck_tf.write_text("\n".join(install_lines) + "\n", encoding="utf-8")
-        active_req = precheck_tf
-        active_lines = install_lines
-
-    torch_lines, other_lines = _partition_torch_requirement_lines(active_lines)
-    split_torch = bool(torch_lines) and sys.platform != "darwin"
-
     torch_tf: Path | None = None
     other_tf: Path | None = None
     try:
+        if can_prune:
+            # pip 仍然只认识 requirements 文件；在 finally 生效后再写临时文件，
+            # 确保写入成功后任何后续异常都会清理掉它。
+            precheck_tf = _write_temp_requirements("easyai_missing_req_", install_lines)
+            active_req = precheck_tf
+            active_lines = install_lines
+
+        torch_lines, other_lines = _partition_torch_requirement_lines(active_lines)
+        split_torch = bool(torch_lines) and sys.platform != "darwin"
+
         if split_torch:
             # torch/torchvision/torchaudio 不走普通 PyPI 镜像。
             # 这里先按本机 CUDA/CPU 选择 PyTorch 官方 wheel index，再安装剩余依赖。
@@ -409,12 +433,7 @@ def install_plugin_requirements_txt(
                 idx_url,
                 idx_reason,
             )
-            fd_t, torch_tf_str = tempfile.mkstemp(
-                prefix="easyai_torch_req_", suffix=".txt"
-            )
-            os.close(fd_t)
-            torch_tf = Path(torch_tf_str)
-            torch_tf.write_text("\n".join(torch_lines) + "\n", encoding="utf-8")
+            torch_tf = _write_temp_requirements("easyai_torch_req_", torch_lines)
 
             cmd_torch = [
                 *base_cmd,
@@ -440,12 +459,7 @@ def install_plugin_requirements_txt(
             if not _has_non_comment_requirement(other_lines):
                 return _finish_install_result(("pip_ok", ""), pip_target)
 
-            fd_o, other_tf_str = tempfile.mkstemp(
-                prefix="easyai_other_req_", suffix=".txt"
-            )
-            os.close(fd_o)
-            other_tf = Path(other_tf_str)
-            other_tf.write_text("\n".join(other_lines) + "\n", encoding="utf-8")
+            other_tf = _write_temp_requirements("easyai_other_req_", other_lines)
 
             cmd_other = _apply_pip_index_and_extra_args(
                 [*base_cmd, "-r", str(other_tf)],

--- a/core/plugins/plugin_requirements_install.py
+++ b/core/plugins/plugin_requirements_install.py
@@ -3,23 +3,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import IO
 
 import importlib.metadata as importlib_metadata
 import logging
 import os
 import re
-import shlex
 import subprocess
 import sys
 import tempfile
-import threading
 import time
 from pathlib import Path
 
 from core.plugins.pip_index_config import (
-    has_explicit_pip_index as _has_explicit_pip_index,
-    pip_index_args as _configured_pip_index_args,
+    strip_inline_requirement_comment as _strip_inline_requirement_comment,
+)
+from core.plugins.pip_runner import (
+    apply_pip_index_and_extra_args as _apply_pip_index_and_extra_args,
+    pip_win_creationflags as _pip_win_creationflags,
+    run_pip_install as _run_pip_install,
 )
 
 try:
@@ -30,13 +31,8 @@ except Exception:  # pragma: no cover - fallback for minimal embedded runtimes.
 
 logger = logging.getLogger(__name__)
 
-_PIP_DETAIL_MAX = 1600
 _TORCH_PROJECT_NAMES = frozenset({"torch", "torchvision", "torchaudio"})
 _CUDA_VER_LINE_RE = re.compile(r"CUDA Version:\s*(\d+)\.(\d+)")
-_PIP_CONFLICT_RE = re.compile(
-    r"\b(conflict(?:ing)? dependencies|resolutionimpossible|cannot install|dependency conflict)\b",
-    re.IGNORECASE,
-)
 
 
 def frozen_release_root() -> Path | None:
@@ -117,10 +113,6 @@ def ensure_plugins_namespace_on_syspath() -> None:
         if s not in sys.path:
             sys.path.insert(0, s)
             logger.info("Prepended cwd for plugins namespace: %s", s)
-
-
-def _pip_win_creationflags() -> int:
-    return getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
 
 def _nvidia_smi_cuda_driver_version() -> tuple[int, int] | None:
@@ -230,50 +222,8 @@ def _pip_base_install_cmd(py: Path, pip_target: Path | None) -> list[str]:
     return cmd
 
 
-def _strip_inline_requirement_comment(raw_input: str) -> str:
-    if raw_input.lstrip().startswith("#"):
-        return ""
-    return re.split(r"[ \t]+#", raw_input, maxsplit=1)[0].strip()
-
-
 def _canonical_distribution_name(name: str) -> str:
     return re.sub(r"[-_.]+", "-", name).strip("-").lower()
-
-
-def _requirements_lines_define_index(lines: list[str]) -> bool:
-    for raw_line in lines:
-        line = _strip_inline_requirement_comment(raw_line)
-        if not line:
-            continue
-        try:
-            tokens = shlex.split(line)
-        except ValueError:
-            continue
-        if _has_explicit_pip_index(tokens):
-            return True
-    return False
-
-
-def _extra_pip_install_args() -> list[str]:
-    raw = os.environ.get("SHINSEKAI_PIP_INSTALL_ARGS", "").strip()
-    if not raw:
-        return []
-    return shlex.split(raw)
-
-
-def _apply_pip_index_and_extra_args(cmd: list[str], requirement_lines: list[str]) -> list[str]:
-    final_cmd = list(cmd)
-    extra_args = _extra_pip_install_args()
-    index_args = _configured_pip_index_args(primary_flag="--index-url")
-    if (
-        index_args
-        and not _has_explicit_pip_index(final_cmd)
-        and not _requirements_lines_define_index(requirement_lines)
-        and not _has_explicit_pip_index(extra_args)
-    ):
-        final_cmd.extend(index_args)
-    final_cmd.extend(extra_args)
-    return final_cmd
 
 
 def _looks_like_direct_reference(line: str) -> bool:
@@ -356,86 +306,10 @@ def _install_lines_after_precheck(lines: list[str]) -> tuple[bool, list[str]]:
     return True, install_lines
 
 
-def _classify_pip_result(result: tuple[str, str]) -> tuple[str, str]:
-    # 依赖求解冲突单独分类，前端可以提示“版本冲突”，而不是笼统显示 pip failed。
-    code, detail = result
-    if code == "pip_failed" and _PIP_CONFLICT_RE.search(detail or ""):
-        return ("pip_conflict", detail)
-    return result
-
-
-def _run_pip_install(
-    cmd: list[str],
-    *,
-    cwd: Path,
-    timeout_sec: float,
-    on_output_line: Callable[[str], None] | None,
-) -> tuple[str, str]:
-    """Run one pip subprocess; same return convention as :func:`install_plugin_requirements_txt`."""
-    pop_kw: dict[str, object] = {
-        "cwd": str(cwd),
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
-        "text": True,
-        "env": _pip_subprocess_env(),
-    }
-    flags = _pip_win_creationflags()
-    if sys.platform == "win32" and flags:
-        pop_kw["creationflags"] = flags
-    try:
-        proc = subprocess.Popen(cmd, **pop_kw)
-    except OSError as exc:
-        logger.warning("pip install could not run (cmd=%s): %s", cmd[:8], exc)
-        return ("pip_exception", str(exc))
-
-    combined_chunks: list[str] = []
-    lock = threading.Lock()
-
-    def relay(stream: IO[str] | None) -> None:
-        if stream is None:
-            return
-        try:
-            for line in iter(stream.readline, ""):
-                with lock:
-                    combined_chunks.append(line)
-                if on_output_line:
-                    on_output_line(line.rstrip("\r\n"))
-        finally:
-            stream.close()
-
-    t_out = threading.Thread(target=relay, args=(proc.stdout,))
-    t_err = threading.Thread(target=relay, args=(proc.stderr,))
-    t_out.daemon = True
-    t_err.daemon = True
-    t_out.start()
-    t_err.start()
-    try:
-        proc.wait(timeout=timeout_sec)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        t_out.join(timeout=3.0)
-        t_err.join(timeout=3.0)
-        combined = "".join(combined_chunks)
-        tail = combined.strip()[-_PIP_DETAIL_MAX:]
-        logger.warning("pip install timed out (timeout_sec=%s)", timeout_sec)
-        return ("pip_timeout", tail or "pip install timed out")
-
-    t_out.join()
-    t_err.join()
-    combined = "".join(combined_chunks).strip()
-    if proc.returncode == 0:
-        logger.info("pip install ok")
-        return ("pip_ok", "")
-    tail = combined[-_PIP_DETAIL_MAX:] if combined else ""
-    logger.warning("pip install failed (exit %s)", proc.returncode)
-    return ("pip_failed", tail or f"exit {proc.returncode}")
-
-
 def _finish_install_result(
     result: tuple[str, str],
     pip_target: Path | None,
 ) -> tuple[str, str]:
-    result = _classify_pip_result(result)
     if result[0] == "pip_ok" and pip_target is not None:
         ensure_plugin_site_packages_on_syspath()
     return result
@@ -464,6 +338,7 @@ def install_plugin_requirements_txt(
     - ``pip_ok`` — successful install (or pip reported nothing to do).
     - ``pip_skip_no_requirements`` — no ``requirements.txt``.
     - ``pip_failed`` — non-zero exit.
+    - ``pip_conflict`` — non-zero exit caused by a dependency resolution conflict.
     - ``pip_timeout`` — killed after ``timeout_sec``.
     - ``pip_exception`` — could not start subprocess (missing ``runtime/python.exe`` or pip).
 
@@ -606,10 +481,3 @@ def install_plugin_requirements_txt(
                     path.unlink(missing_ok=True)
                 except OSError:
                     pass
-
-
-def _pip_subprocess_env() -> dict[str, str]:
-    env = dict(os.environ)
-    env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
-    env.setdefault("PYTHONUTF8", "1")
-    return env

--- a/core/plugins/plugin_requirements_install.py
+++ b/core/plugins/plugin_requirements_install.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import IO
 
+import importlib.metadata as importlib_metadata
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -15,11 +17,26 @@ import threading
 import time
 from pathlib import Path
 
+from core.plugins.pip_index_config import (
+    has_explicit_pip_index as _has_explicit_pip_index,
+    pip_index_args as _configured_pip_index_args,
+)
+
+try:
+    from packaging.requirements import InvalidRequirement, Requirement
+except Exception:  # pragma: no cover - fallback for minimal embedded runtimes.
+    InvalidRequirement = ValueError  # type: ignore[assignment]
+    Requirement = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 _PIP_DETAIL_MAX = 1600
 _TORCH_PROJECT_NAMES = frozenset({"torch", "torchvision", "torchaudio"})
 _CUDA_VER_LINE_RE = re.compile(r"CUDA Version:\s*(\d+)\.(\d+)")
+_PIP_CONFLICT_RE = re.compile(
+    r"\b(conflict(?:ing)? dependencies|resolutionimpossible|cannot install|dependency conflict)\b",
+    re.IGNORECASE,
+)
 
 
 def frozen_release_root() -> Path | None:
@@ -213,6 +230,140 @@ def _pip_base_install_cmd(py: Path, pip_target: Path | None) -> list[str]:
     return cmd
 
 
+def _strip_inline_requirement_comment(raw_input: str) -> str:
+    if raw_input.lstrip().startswith("#"):
+        return ""
+    return re.split(r"[ \t]+#", raw_input, maxsplit=1)[0].strip()
+
+
+def _canonical_distribution_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).strip("-").lower()
+
+
+def _requirements_lines_define_index(lines: list[str]) -> bool:
+    for raw_line in lines:
+        line = _strip_inline_requirement_comment(raw_line)
+        if not line:
+            continue
+        try:
+            tokens = shlex.split(line)
+        except ValueError:
+            continue
+        if _has_explicit_pip_index(tokens):
+            return True
+    return False
+
+
+def _extra_pip_install_args() -> list[str]:
+    raw = os.environ.get("SHINSEKAI_PIP_INSTALL_ARGS", "").strip()
+    if not raw:
+        return []
+    return shlex.split(raw)
+
+
+def _apply_pip_index_and_extra_args(cmd: list[str], requirement_lines: list[str]) -> list[str]:
+    final_cmd = list(cmd)
+    extra_args = _extra_pip_install_args()
+    index_args = _configured_pip_index_args(primary_flag="--index-url")
+    if (
+        index_args
+        and not _has_explicit_pip_index(final_cmd)
+        and not _requirements_lines_define_index(requirement_lines)
+        and not _has_explicit_pip_index(extra_args)
+    ):
+        final_cmd.extend(index_args)
+    final_cmd.extend(extra_args)
+    return final_cmd
+
+
+def _looks_like_direct_reference(line: str) -> bool:
+    candidate = line.strip()
+    if not candidate:
+        return False
+    first = candidate.split(maxsplit=1)[0]
+    return (
+        first in {".", ".."}
+        or first.startswith(("./", "../", "/", "~/", ".\\", "..\\", "\\"))
+        or first.startswith("git+")
+        or "://" in first
+        or " @ " in candidate
+    )
+
+
+def _requirement_line_can_be_pruned(line: str) -> bool:
+    stripped = _strip_inline_requirement_comment(line)
+    if not stripped:
+        return True
+    if stripped.startswith("-"):
+        return False
+    if _looks_like_direct_reference(stripped):
+        return False
+    return True
+
+
+def _requirement_distribution_version(name: str) -> str | None:
+    canonical = _canonical_distribution_name(name)
+    paths = list(sys.path)
+    target = plugin_pip_target_directory()
+    if target is not None and target.is_dir():
+        # 打包版插件依赖会装进 data/plugin_site_packages，先查这里再看系统路径。
+        target_s = str(target.resolve())
+        paths = [target_s, *[path for path in paths if path != target_s]]
+    for distribution in importlib_metadata.distributions(path=paths):
+        dist_name = distribution.metadata.get("Name")
+        if not dist_name:
+            continue
+        if _canonical_distribution_name(dist_name) == canonical:
+            return distribution.version
+    return None
+
+
+def _requirement_line_is_satisfied(line: str) -> bool:
+    # 这里尽量按 PEP 508 判断：marker 不匹配就视为无需安装，版本不满足才进入 pip。
+    stripped = _strip_inline_requirement_comment(line)
+    if not stripped:
+        return True
+    if Requirement is None:
+        name = _requirement_line_project_name(stripped)
+        return bool(name and _requirement_distribution_version(name) is not None)
+    try:
+        requirement = Requirement(stripped)
+    except InvalidRequirement:
+        name = _requirement_line_project_name(stripped)
+        return bool(name and _requirement_distribution_version(name) is not None)
+    if requirement.marker and not requirement.marker.evaluate():
+        return True
+    installed_version = _requirement_distribution_version(requirement.name)
+    if installed_version is None:
+        return False
+    if requirement.specifier:
+        return requirement.specifier.contains(installed_version, prereleases=True)
+    return True
+
+
+def _install_lines_after_precheck(lines: list[str]) -> tuple[bool, list[str]]:
+    # requirements 里出现 -e、--find-links、direct reference 等全局/本地语义时，不做裁剪。
+    # 这些行可能影响后续包解析，强行只装“缺失行”反而会破坏作者的安装意图。
+    if not all(_requirement_line_can_be_pruned(line) for line in lines):
+        return False, lines
+    install_lines: list[str] = []
+    for line in lines:
+        stripped = _strip_inline_requirement_comment(line)
+        if not stripped:
+            continue
+        if not _requirement_line_is_satisfied(stripped):
+            install_lines.append(line.rstrip("\r\n"))
+    return True, install_lines
+
+
+def _classify_pip_result(result: tuple[str, str]) -> tuple[str, str]:
+    # 依赖求解冲突单独分类，前端可以提示“版本冲突”，而不是笼统显示 pip failed。
+    code, detail = result
+    if code == "pip_failed" and _PIP_CONFLICT_RE.search(detail or ""):
+        return ("pip_conflict", detail)
+    return result
+
+
 def _run_pip_install(
     cmd: list[str],
     *,
@@ -284,6 +435,7 @@ def _finish_install_result(
     result: tuple[str, str],
     pip_target: Path | None,
 ) -> tuple[str, str]:
+    result = _classify_pip_result(result)
     if result[0] == "pip_ok" and pip_target is not None:
         ensure_plugin_site_packages_on_syspath()
     return result
@@ -346,13 +498,36 @@ def install_plugin_requirements_txt(
         logger.warning("Could not read %s: %s", req, exc)
         return ("pip_exception", str(exc))
 
-    torch_lines, other_lines = _partition_torch_requirement_lines(lines)
+    # 先在本地分发信息里做预检，普通包只把“缺失或版本不满足”的行交给 pip。
+    # 这样已安装依赖不会反复下载，国内用户装插件时能少等很多。
+    can_prune, install_lines = _install_lines_after_precheck(lines)
+    if can_prune and not install_lines:
+        logger.info("Plugin pip: all requirements already satisfied, skipping install.")
+        return ("pip_ok", "")
+
+    active_req = req
+    active_lines = lines
+    precheck_tf: Path | None = None
+    if can_prune:
+        # pip 仍然只认识 requirements 文件，所以把裁剪后的缺失列表写入临时文件。
+        fd, precheck_tf_str = tempfile.mkstemp(
+            prefix="easyai_missing_req_", suffix=".txt"
+        )
+        os.close(fd)
+        precheck_tf = Path(precheck_tf_str)
+        precheck_tf.write_text("\n".join(install_lines) + "\n", encoding="utf-8")
+        active_req = precheck_tf
+        active_lines = install_lines
+
+    torch_lines, other_lines = _partition_torch_requirement_lines(active_lines)
     split_torch = bool(torch_lines) and sys.platform != "darwin"
 
     torch_tf: Path | None = None
     other_tf: Path | None = None
     try:
         if split_torch:
+            # torch/torchvision/torchaudio 不走普通 PyPI 镜像。
+            # 这里先按本机 CUDA/CPU 选择 PyTorch 官方 wheel index，再安装剩余依赖。
             idx_url, idx_reason = _pytorch_wheel_index_url_for_this_machine()
             logger.info(
                 "Plugin pip: PyTorch packages use index %s (%s)",
@@ -375,11 +550,14 @@ def install_plugin_requirements_txt(
                 "-r",
                 str(torch_tf),
             ]
-            code1, detail1 = _run_pip_install(
-                cmd_torch,
-                cwd=root,
-                timeout_sec=remaining_budget(),
-                on_output_line=on_output_line,
+            code1, detail1 = _finish_install_result(
+                _run_pip_install(
+                    _apply_pip_index_and_extra_args(cmd_torch, torch_lines),
+                    cwd=root,
+                    timeout_sec=remaining_budget(),
+                    on_output_line=on_output_line,
+                ),
+                pip_target,
             )
             if code1 != "pip_ok":
                 return (code1, detail1)
@@ -394,7 +572,10 @@ def install_plugin_requirements_txt(
             other_tf = Path(other_tf_str)
             other_tf.write_text("\n".join(other_lines) + "\n", encoding="utf-8")
 
-            cmd_other = [*base_cmd, "-r", str(other_tf)]
+            cmd_other = _apply_pip_index_and_extra_args(
+                [*base_cmd, "-r", str(other_tf)],
+                other_lines,
+            )
             return _finish_install_result(
                 _run_pip_install(
                     cmd_other,
@@ -405,7 +586,10 @@ def install_plugin_requirements_txt(
                 pip_target,
             )
 
-        cmd = [*base_cmd, "-r", str(req)]
+        cmd = _apply_pip_index_and_extra_args(
+            [*base_cmd, "-r", str(active_req)],
+            active_lines,
+        )
         return _finish_install_result(
             _run_pip_install(
                 cmd,
@@ -416,7 +600,7 @@ def install_plugin_requirements_txt(
             pip_target,
         )
     finally:
-        for path in (torch_tf, other_tf):
+        for path in (precheck_tf, torch_tf, other_tf):
             if path is not None:
                 try:
                     path.unlink(missing_ok=True)

--- a/frontend_bridge_core/plugin_updates.py
+++ b/frontend_bridge_core/plugin_updates.py
@@ -653,7 +653,7 @@ def _install_github_plugin_source(
         _append_task_log(state, task_id, line)
 
     pip_code, pip_detail = install_plugin_requirements_txt(plugin_root, on_output_line=_pip_line)
-    if pip_code in {"pip_failed", "pip_timeout", "pip_exception"}:
+    if pip_code in {"pip_failed", "pip_timeout", "pip_exception", "pip_conflict"}:
         detail = pip_detail or pip_code
         raise RuntimeError(f"插件依赖安装失败：{detail}")
 

--- a/frontend_bridge_core/runtime_dependencies.py
+++ b/frontend_bridge_core/runtime_dependencies.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
+from core.plugins.pip_index_config import (
+    has_explicit_pip_index as _has_explicit_pip_index,
+    pip_index_args as _configured_pip_index_args,
+)
 from sdk.exception.types import (
     MODULE_PACKAGE_MAP,
     missing_module_from_text,
@@ -14,6 +19,23 @@ from sdk.exception.types import (
     runtime_dependency_error_from_text,
 )
 _SAFE_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_.-]+(?:\[[A-Za-z0-9_,.-]+\])?$")
+_URL_CREDENTIAL_RE = re.compile(r"(?P<scheme>https?://)(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@")
+
+
+def _redact_url_credentials(text: str) -> str:
+    return _URL_CREDENTIAL_RE.sub(lambda match: f"{match.group('scheme')}{match.group('user')}:***@", text or "")
+
+
+def _runtime_pip_install_cmd(package_name: str) -> list[str]:
+    extra_args_text = os.environ.get("SHINSEKAI_PIP_INSTALL_ARGS", "")
+    extra_args = shlex.split(extra_args_text) if extra_args_text.strip() else []
+
+    cmd = [sys.executable, "-m", "pip", "install", package_name]
+    index_args = _configured_pip_index_args(primary_flag="-i")
+    if index_args and not _has_explicit_pip_index([package_name, *extra_args]):
+        cmd.extend(index_args)
+    cmd.extend(extra_args)
+    return cmd
 
 
 def install_runtime_dependency(module_name: str) -> dict[str, Any]:
@@ -29,7 +51,7 @@ def install_runtime_dependency(module_name: str) -> dict[str, Any]:
     env = os.environ.copy()
     env.setdefault("PYTHONUTF8", "1")
     env.setdefault("PYTHONUNBUFFERED", "1")
-    cmd = [sys.executable, "-m", "pip", "install", package_name]
+    cmd = _runtime_pip_install_cmd(package_name)
     completed = subprocess.run(
         cmd,
         cwd=str(Path.cwd()),
@@ -38,7 +60,9 @@ def install_runtime_dependency(module_name: str) -> dict[str, Any]:
         capture_output=True,
         timeout=900,
     )
-    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part).strip()
+    output = _redact_url_credentials(
+        "\n".join(part for part in (completed.stdout, completed.stderr) if part).strip()
+    )
     if completed.returncode != 0:
         tail = output[-4000:] if output else f"pip exited with code {completed.returncode}"
         raise RuntimeError(tail)

--- a/frontend_bridge_core/runtime_dependencies.py
+++ b/frontend_bridge_core/runtime_dependencies.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-import os
 import re
-import shlex
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
-from core.plugins.pip_index_config import (
-    has_explicit_pip_index as _has_explicit_pip_index,
-    pip_index_args as _configured_pip_index_args,
+from core.plugins.pip_runner import (
+    apply_pip_index_and_extra_args as _apply_pip_index_and_extra_args,
+    run_pip_install as _run_pip_install,
 )
 from sdk.exception.types import (
     MODULE_PACKAGE_MAP,
@@ -19,23 +16,13 @@ from sdk.exception.types import (
     runtime_dependency_error_from_text,
 )
 _SAFE_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_.-]+(?:\[[A-Za-z0-9_,.-]+\])?$")
-_URL_CREDENTIAL_RE = re.compile(r"(?P<scheme>https?://)(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@")
-
-
-def _redact_url_credentials(text: str) -> str:
-    return _URL_CREDENTIAL_RE.sub(lambda match: f"{match.group('scheme')}{match.group('user')}:***@", text or "")
 
 
 def _runtime_pip_install_cmd(package_name: str) -> list[str]:
-    extra_args_text = os.environ.get("SHINSEKAI_PIP_INSTALL_ARGS", "")
-    extra_args = shlex.split(extra_args_text) if extra_args_text.strip() else []
-
-    cmd = [sys.executable, "-m", "pip", "install", package_name]
-    index_args = _configured_pip_index_args(primary_flag="-i")
-    if index_args and not _has_explicit_pip_index([package_name, *extra_args]):
-        cmd.extend(index_args)
-    cmd.extend(extra_args)
-    return cmd
+    return _apply_pip_index_and_extra_args(
+        [sys.executable, "-m", "pip", "install", package_name],
+        primary_flag="-i",
+    )
 
 
 def install_runtime_dependency(module_name: str) -> dict[str, Any]:
@@ -48,28 +35,20 @@ def install_runtime_dependency(module_name: str) -> dict[str, Any]:
     if getattr(sys, "frozen", False):
         raise RuntimeError("cannot run pip from a frozen executable; install dependencies in the bundled Python runtime")
 
-    env = os.environ.copy()
-    env.setdefault("PYTHONUTF8", "1")
-    env.setdefault("PYTHONUNBUFFERED", "1")
-    cmd = _runtime_pip_install_cmd(package_name)
-    completed = subprocess.run(
-        cmd,
-        cwd=str(Path.cwd()),
-        env=env,
-        text=True,
-        capture_output=True,
-        timeout=900,
+    output_lines: list[str] = []
+    code, detail = _run_pip_install(
+        _runtime_pip_install_cmd(package_name),
+        cwd=Path.cwd(),
+        timeout_sec=900,
+        on_output_line=output_lines.append,
     )
-    output = _redact_url_credentials(
-        "\n".join(part for part in (completed.stdout, completed.stderr) if part).strip()
-    )
-    if completed.returncode != 0:
-        tail = output[-4000:] if output else f"pip exited with code {completed.returncode}"
-        raise RuntimeError(tail)
+    output = "\n".join(output_lines).strip()
+    if code != "pip_ok":
+        raise RuntimeError(detail or output[-4000:] or f"pip install failed ({code})")
     return {
         "message": f"Installed {package_name}. Please launch chat again.",
         "moduleName": module_name,
         "packageName": package_name,
-        "pipCode": completed.returncode,
+        "pipCode": 0,
         "pipOutput": output[-4000:],
     }

--- a/frontend_bridge_core/runtime_dependencies.py
+++ b/frontend_bridge_core/runtime_dependencies.py
@@ -39,6 +39,7 @@ def install_runtime_dependency(module_name: str) -> dict[str, Any]:
     code, detail = _run_pip_install(
         _runtime_pip_install_cmd(package_name),
         cwd=Path.cwd(),
+        detail_max=4000,
         timeout_sec=900,
         on_output_line=output_lines.append,
     )

--- a/test/unit/test_frontend_plugin_updates.py
+++ b/test/unit/test_frontend_plugin_updates.py
@@ -384,3 +384,23 @@ def test_install_plugin_source_does_not_fallback_to_github_when_package_dependen
     assert task["errorUserMessage"] == "包体已通过校验，但依赖安装失败，请查看日志。"
     assert task["errorDetail"] == "dependency boom"
     assert task["fallbackAllowed"] is False
+
+
+def test_install_plugin_source_treats_github_dependency_conflicts_as_failures(
+    tmp_path,
+    monkeypatch,
+):
+    record = _registry_record(package_url="")
+    github_root = _plugin_root(tmp_path, "github-plugin")
+    monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
+    monkeypatch.setattr(
+        "core.plugins.github_bundle_update.install_github_plugin_under_plugins",
+        lambda *_args, **_kwargs: github_root,
+    )
+    monkeypatch.setattr(
+        "core.plugins.plugin_requirements_install.install_plugin_requirements_txt",
+        lambda *_args, **_kwargs: ("pip_conflict", "dependency conflict"),
+    )
+
+    with pytest.raises(RuntimeError, match="dependency conflict"):
+        _install_plugin_source(_state_with_task(), "task", "owner/demo")

--- a/test/unit/test_frontend_runtime_check.py
+++ b/test/unit/test_frontend_runtime_check.py
@@ -253,6 +253,8 @@ def test_install_runtime_dependency_uses_manifest_china_index_by_default(monkeyp
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.delenv("PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_EXTRA_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_NO_INDEX", raising=False)
     monkeypatch.delenv("PIP_CONFIG_FILE", raising=False)
     monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URL", raising=False)
     monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URLS", raising=False)

--- a/test/unit/test_frontend_runtime_check.py
+++ b/test/unit/test_frontend_runtime_check.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
-from types import SimpleNamespace
 
 
 def test_desktop_core_runtime_check_does_not_import_optional_packages(tmp_path):
@@ -211,23 +210,27 @@ def test_runtime_core_requirements_include_bridge_startup_sdks():
     assert "Pillow" in names
 
 
+def _fake_runtime_pip_install(calls):
+    def fake_run_pip_install(cmd, *, cwd, timeout_sec, on_output_line=None):
+        calls.append(cmd)
+        return ("pip_ok", "")
+
+    return fake_run_pip_install
+
+
 def test_install_runtime_dependency_uses_runtime_pip_index_and_extra_args(monkeypatch):
     from frontend_bridge_core import runtime_dependencies
 
     calls = []
 
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
-
     monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
     monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", "--timeout 60 --trusted-host mirror.example")
-    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+    monkeypatch.setattr(runtime_dependencies, "_run_pip_install", _fake_runtime_pip_install(calls))
 
     result = runtime_dependencies.install_runtime_dependency("openai")
 
     assert result["packageName"] == "openai"
-    assert calls[0][0] == [
+    assert calls[0] == [
         sys.executable,
         "-m",
         "pip",
@@ -240,17 +243,12 @@ def test_install_runtime_dependency_uses_runtime_pip_index_and_extra_args(monkey
         "--trusted-host",
         "mirror.example",
     ]
-    assert calls[0][1]["env"]["PYTHONUTF8"] == "1"
 
 
 def test_install_runtime_dependency_uses_manifest_china_index_by_default(monkeypatch):
     from frontend_bridge_core import runtime_dependencies
 
     calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.delenv("PIP_INDEX_URL", raising=False)
     monkeypatch.delenv("PIP_EXTRA_INDEX_URL", raising=False)
@@ -260,7 +258,7 @@ def test_install_runtime_dependency_uses_manifest_china_index_by_default(monkeyp
     monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URLS", raising=False)
     monkeypatch.delenv("SHINSEKAI_PIP_INSTALL_ARGS", raising=False)
     monkeypatch.delenv("SHINSEKAI_RUNTIME_SOURCE", raising=False)
-    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+    monkeypatch.setattr(runtime_dependencies, "_run_pip_install", _fake_runtime_pip_install(calls))
 
     runtime_dependencies.install_runtime_dependency("openai")
 
@@ -275,13 +273,9 @@ def test_install_runtime_dependency_does_not_add_index_when_pip_args_pick_one(mo
 
     calls = []
 
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
     monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
     monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", "--index-url=https://custom.example/simple")
-    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+    monkeypatch.setattr(runtime_dependencies, "_run_pip_install", _fake_runtime_pip_install(calls))
 
     runtime_dependencies.install_runtime_dependency("openai")
 
@@ -295,13 +289,9 @@ def test_install_runtime_dependency_does_not_add_index_when_pip_args_disable_ind
 
     calls = []
 
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
     monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
     monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", "--no-index --find-links C:\\wheelhouse")
-    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+    monkeypatch.setattr(runtime_dependencies, "_run_pip_install", _fake_runtime_pip_install(calls))
 
     runtime_dependencies.install_runtime_dependency("openai")
 
@@ -311,18 +301,28 @@ def test_install_runtime_dependency_does_not_add_index_when_pip_args_disable_ind
 
 
 def test_install_runtime_dependency_redacts_credential_urls_from_output(monkeypatch):
+    import io
+
+    from core.plugins import pip_runner
     from frontend_bridge_core import runtime_dependencies
 
-    def fake_run(cmd, **kwargs):
-        return SimpleNamespace(
-            returncode=0,
-            stdout="Looking in indexes: https://user:secret-token@mirror.example/simple",
-            stderr="",
-        )
+    class FakePopen:
+        def __init__(self, cmd, **kwargs):
+            self.stdout = io.StringIO(
+                "Looking in indexes: https://user:secret-token@mirror.example/simple\n"
+            )
+            self.stderr = io.StringIO("")
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            pass
 
     monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://user:secret-token@mirror.example/simple")
     monkeypatch.delenv("SHINSEKAI_PIP_INSTALL_ARGS", raising=False)
-    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+    monkeypatch.setattr(pip_runner.subprocess, "Popen", FakePopen)
 
     result = runtime_dependencies.install_runtime_dependency("openai")
 

--- a/test/unit/test_frontend_runtime_check.py
+++ b/test/unit/test_frontend_runtime_check.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def test_desktop_core_runtime_check_does_not_import_optional_packages(tmp_path):
@@ -208,3 +209,120 @@ def test_runtime_core_requirements_include_bridge_startup_sdks():
     assert "opencc-python-reimplemented" in names
     assert "PySide6" in names
     assert "Pillow" in names
+
+
+def test_install_runtime_dependency_uses_runtime_pip_index_and_extra_args(monkeypatch):
+    from frontend_bridge_core import runtime_dependencies
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+    monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", "--timeout 60 --trusted-host mirror.example")
+    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+
+    result = runtime_dependencies.install_runtime_dependency("openai")
+
+    assert result["packageName"] == "openai"
+    assert calls[0][0] == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "openai",
+        "-i",
+        "https://mirror.example/simple",
+        "--timeout",
+        "60",
+        "--trusted-host",
+        "mirror.example",
+    ]
+    assert calls[0][1]["env"]["PYTHONUTF8"] == "1"
+
+
+def test_install_runtime_dependency_uses_manifest_china_index_by_default(monkeypatch):
+    from frontend_bridge_core import runtime_dependencies
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.delenv("PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URLS", raising=False)
+    monkeypatch.delenv("SHINSEKAI_PIP_INSTALL_ARGS", raising=False)
+    monkeypatch.delenv("SHINSEKAI_RUNTIME_SOURCE", raising=False)
+    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+
+    runtime_dependencies.install_runtime_dependency("openai")
+
+    assert "-i" in calls[0]
+    assert calls[0][calls[0].index("-i") + 1] == "https://pypi.tuna.tsinghua.edu.cn/simple/"
+    assert "https://mirrors.aliyun.com/pypi/simple/" in calls[0]
+    assert "https://pypi.org/simple/" in calls[0]
+
+
+def test_install_runtime_dependency_does_not_add_index_when_pip_args_pick_one(monkeypatch):
+    from frontend_bridge_core import runtime_dependencies
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+    monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", "--index-url=https://custom.example/simple")
+    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+
+    runtime_dependencies.install_runtime_dependency("openai")
+
+    assert "-i" not in calls[0]
+    assert "https://mirror.example/simple" not in calls[0]
+    assert "--index-url=https://custom.example/simple" in calls[0]
+
+
+def test_install_runtime_dependency_does_not_add_index_when_pip_args_disable_index(monkeypatch):
+    from frontend_bridge_core import runtime_dependencies
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+    monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", "--no-index --find-links C:\\wheelhouse")
+    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+
+    runtime_dependencies.install_runtime_dependency("openai")
+
+    assert "-i" not in calls[0]
+    assert "https://mirror.example/simple" not in calls[0]
+    assert "--no-index" in calls[0]
+
+
+def test_install_runtime_dependency_redacts_credential_urls_from_output(monkeypatch):
+    from frontend_bridge_core import runtime_dependencies
+
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout="Looking in indexes: https://user:secret-token@mirror.example/simple",
+            stderr="",
+        )
+
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://user:secret-token@mirror.example/simple")
+    monkeypatch.delenv("SHINSEKAI_PIP_INSTALL_ARGS", raising=False)
+    monkeypatch.setattr(runtime_dependencies.subprocess, "run", fake_run)
+
+    result = runtime_dependencies.install_runtime_dependency("openai")
+
+    assert "secret-token" not in result["pipOutput"]
+    assert "https://user:***@mirror.example/simple" in result["pipOutput"]

--- a/test/unit/test_frontend_runtime_check.py
+++ b/test/unit/test_frontend_runtime_check.py
@@ -211,11 +211,33 @@ def test_runtime_core_requirements_include_bridge_startup_sdks():
 
 
 def _fake_runtime_pip_install(calls):
-    def fake_run_pip_install(cmd, *, cwd, timeout_sec, on_output_line=None):
+    def fake_run_pip_install(cmd, *, cwd, timeout_sec, detail_max=1600, on_output_line=None):
         calls.append(cmd)
         return ("pip_ok", "")
 
     return fake_run_pip_install
+
+
+def test_install_runtime_dependency_requests_long_failure_detail(monkeypatch):
+    from frontend_bridge_core import runtime_dependencies
+
+    captured: dict[str, int] = {}
+
+    def fake_run_pip_install(cmd, *, cwd, timeout_sec, detail_max=1600, on_output_line=None):
+        captured["detail_max"] = detail_max
+        return ("pip_failed", "x" * 3999)
+
+    monkeypatch.setattr(runtime_dependencies, "_run_pip_install", fake_run_pip_install)
+
+    try:
+        runtime_dependencies.install_runtime_dependency("openai")
+    except RuntimeError as exc:
+        error = exc
+    else:
+        raise AssertionError("install_runtime_dependency should raise on pip failure")
+
+    assert captured["detail_max"] == 4000
+    assert len(str(error)) >= 3999
 
 
 def test_install_runtime_dependency_uses_runtime_pip_index_and_extra_args(monkeypatch):

--- a/test/unit/test_pip_index_config.py
+++ b/test/unit/test_pip_index_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from core.plugins import pip_index_config
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["-i", "https://example.invalid/simple"],
+        ["-ihttps://example.invalid/simple"],
+        ["--index-url", "https://example.invalid/simple"],
+        ["--index-url=https://example.invalid/simple"],
+        ["--extra-index-url", "https://example.invalid/simple"],
+        ["--extra-index-url=https://example.invalid/simple"],
+        ["--no-index"],
+        ["--retries", "2", "--extra-index-url", "https://example.invalid/simple"],
+    ],
+)
+def test_has_explicit_pip_index_detects_index_intent(args):
+    assert pip_index_config.has_explicit_pip_index(args) is True
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],
+        ["requests>=2"],
+        ["--retries", "2", "--trusted-host", "mirror.example"],
+        ["--find-links", "./wheels"],
+    ],
+)
+def test_has_explicit_pip_index_ignores_non_index_args(args):
+    assert pip_index_config.has_explicit_pip_index(args) is False
+
+
+def _clear_index_env(monkeypatch):
+    for name in (
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+        "PIP_NO_INDEX",
+        "PIP_CONFIG_FILE",
+        "SHINSEKAI_PIP_INDEX_URL",
+        "SHINSEKAI_PIP_INDEX_URLS",
+        "SHINSEKAI_RUNTIME_SOURCE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL", "PIP_NO_INDEX", "PIP_CONFIG_FILE"],
+)
+def test_pip_index_urls_respects_user_pip_env_overrides(monkeypatch, env_name):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv(env_name, "https://user.example/simple")
+
+    assert pip_index_config.pip_index_urls() == []
+
+
+def test_pip_index_urls_prefers_china_mirrors_by_default(monkeypatch):
+    _clear_index_env(monkeypatch)
+
+    urls = pip_index_config.pip_index_urls()
+
+    assert urls[0] == "https://pypi.tuna.tsinghua.edu.cn/simple/"
+    assert "https://pypi.org/simple/" in urls

--- a/test/unit/test_pip_index_config.py
+++ b/test/unit/test_pip_index_config.py
@@ -66,3 +66,20 @@ def test_pip_index_urls_prefers_china_mirrors_by_default(monkeypatch):
 
     assert urls[0] == "https://pypi.tuna.tsinghua.edu.cn/simple/"
     assert "https://pypi.org/simple/" in urls
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "-r sub-requirements.txt",
+        "-rsub-requirements.txt",
+        "--requirement sub-requirements.txt",
+        "--requirement=sub-requirements.txt",
+        "-c constraints.txt",
+        "-cconstraints.txt",
+        "--constraint constraints.txt",
+        "--constraint=constraints.txt",
+    ],
+)
+def test_requirements_lines_define_index_keeps_nested_requirement_intent(line):
+    assert pip_index_config.requirements_lines_define_index([line]) is True

--- a/test/unit/test_pip_runner.py
+++ b/test/unit/test_pip_runner.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from core.plugins import pip_runner
+
+
+def _clear_index_env(monkeypatch):
+    for name in (
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+        "PIP_NO_INDEX",
+        "PIP_CONFIG_FILE",
+        "SHINSEKAI_PIP_INDEX_URL",
+        "SHINSEKAI_PIP_INDEX_URLS",
+        "SHINSEKAI_PIP_INSTALL_ARGS",
+        "SHINSEKAI_RUNTIME_SOURCE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_apply_pip_index_and_extra_args_injects_configured_index(monkeypatch):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+    monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", "--retries 2")
+
+    cmd = pip_runner.apply_pip_index_and_extra_args(["python", "-m", "pip", "install", "demo"])
+
+    assert cmd == [
+        "python",
+        "-m",
+        "pip",
+        "install",
+        "demo",
+        "--index-url",
+        "https://mirror.example/simple",
+        "--retries",
+        "2",
+    ]
+
+
+def test_apply_pip_index_and_extra_args_uses_primary_flag(monkeypatch):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+
+    cmd = pip_runner.apply_pip_index_and_extra_args(
+        ["python", "-m", "pip", "install", "demo"],
+        primary_flag="-i",
+    )
+
+    assert cmd[-2:] == ["-i", "https://mirror.example/simple"]
+
+
+@pytest.mark.parametrize(
+    ("cmd_args", "lines", "extra_args"),
+    [
+        (["--extra-index-url", "https://private.example/simple"], [], ""),
+        ([], ["--extra-index-url https://private.example/simple"], ""),
+        ([], [], "--extra-index-url=https://private.example/simple"),
+        ([], [], "--no-index"),
+    ],
+)
+def test_apply_pip_index_and_extra_args_respects_existing_intent(
+    monkeypatch,
+    cmd_args,
+    lines,
+    extra_args,
+):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+    if extra_args:
+        monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", extra_args)
+
+    cmd = pip_runner.apply_pip_index_and_extra_args(
+        ["python", "-m", "pip", "install", "demo", *cmd_args],
+        lines,
+    )
+
+    assert "https://mirror.example/simple" not in cmd
+
+
+def test_redact_url_credentials_masks_password_and_bare_tokens():
+    assert (
+        pip_runner.redact_url_credentials("https://user:secret@host/simple")
+        == "https://user:***@host/simple"
+    )
+    assert (
+        pip_runner.redact_url_credentials("https://only-token@host/simple")
+        == "https://***@host/simple"
+    )
+    assert pip_runner.redact_url_credentials("https://host/simple") == "https://host/simple"
+
+
+def test_pip_subprocess_env_sets_defaults(monkeypatch):
+    monkeypatch.delenv("PIP_DISABLE_PIP_VERSION_CHECK", raising=False)
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    monkeypatch.delenv("PYTHONUNBUFFERED", raising=False)
+
+    env = pip_runner.pip_subprocess_env()
+
+    assert env["PIP_DISABLE_PIP_VERSION_CHECK"] == "1"
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONUNBUFFERED"] == "1"
+
+
+def test_pip_subprocess_env_keeps_user_values(monkeypatch):
+    monkeypatch.setenv("PYTHONUTF8", "0")
+
+    assert pip_runner.pip_subprocess_env()["PYTHONUTF8"] == "0"
+
+
+class _FakePopen:
+    def __init__(self, stdout_text: str, returncode: int):
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO("")
+        self.returncode = returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def kill(self):
+        pass
+
+
+def _patch_popen(monkeypatch, stdout_text: str, returncode: int):
+    monkeypatch.setattr(
+        pip_runner.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: _FakePopen(stdout_text, returncode),
+    )
+
+
+def test_run_pip_install_redacts_relayed_lines(monkeypatch, tmp_path):
+    _patch_popen(
+        monkeypatch,
+        "Looking in indexes: https://user:secret@mirror.example/simple\n",
+        0,
+    )
+    lines: list[str] = []
+
+    code, detail = pip_runner.run_pip_install(
+        ["python", "-m", "pip", "install", "demo"],
+        cwd=tmp_path,
+        timeout_sec=30,
+        on_output_line=lines.append,
+    )
+
+    assert (code, detail) == ("pip_ok", "")
+    assert lines == ["Looking in indexes: https://user:***@mirror.example/simple"]
+
+
+def test_run_pip_install_classifies_conflicts(monkeypatch, tmp_path):
+    _patch_popen(monkeypatch, "ERROR: ResolutionImpossible: for help visit pip docs\n", 1)
+
+    code, detail = pip_runner.run_pip_install(
+        ["python", "-m", "pip", "install", "demo"],
+        cwd=tmp_path,
+        timeout_sec=30,
+    )
+
+    assert code == "pip_conflict"
+    assert "ResolutionImpossible" in detail
+
+
+def test_run_pip_install_reports_redacted_failure_tail(monkeypatch, tmp_path):
+    _patch_popen(
+        monkeypatch,
+        "ERROR: HTTP error 403 from https://user:secret@private.example/simple\n",
+        1,
+    )
+
+    code, detail = pip_runner.run_pip_install(
+        ["python", "-m", "pip", "install", "demo"],
+        cwd=tmp_path,
+        timeout_sec=30,
+    )
+
+    assert code == "pip_failed"
+    assert "secret" not in detail
+    assert "https://user:***@private.example/simple" in detail

--- a/test/unit/test_pip_runner.py
+++ b/test/unit/test_pip_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 
 import pytest
 
@@ -81,6 +82,15 @@ def test_apply_pip_index_and_extra_args_respects_existing_intent(
     )
 
     assert "https://mirror.example/simple" not in cmd
+
+
+def test_extra_pip_install_args_ignores_invalid_env_and_logs(monkeypatch, caplog):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv("SHINSEKAI_PIP_INSTALL_ARGS", '--trusted-host "mirror.example')
+    caplog.set_level(logging.WARNING, logger=pip_runner.logger.name)
+
+    assert pip_runner.extra_pip_install_args() == []
+    assert "Ignoring invalid SHINSEKAI_PIP_INSTALL_ARGS" in caplog.text
 
 
 def test_redact_url_credentials_masks_password_and_bare_tokens():

--- a/test/unit/test_pip_runner.py
+++ b/test/unit/test_pip_runner.py
@@ -58,6 +58,8 @@ def test_apply_pip_index_and_extra_args_uses_primary_flag(monkeypatch):
     [
         (["--extra-index-url", "https://private.example/simple"], [], ""),
         ([], ["--extra-index-url https://private.example/simple"], ""),
+        ([], ["-r sub-requirements.txt"], ""),
+        ([], ["--constraint constraints.txt"], ""),
         ([], [], "--extra-index-url=https://private.example/simple"),
         ([], [], "--no-index"),
     ],
@@ -180,3 +182,19 @@ def test_run_pip_install_reports_redacted_failure_tail(monkeypatch, tmp_path):
     assert code == "pip_failed"
     assert "secret" not in detail
     assert "https://user:***@private.example/simple" in detail
+
+
+def test_run_pip_install_allows_longer_failure_detail(monkeypatch, tmp_path):
+    output = "A" * 2000 + "KEEP-ME"
+    _patch_popen(monkeypatch, output, 1)
+
+    code, detail = pip_runner.run_pip_install(
+        ["python", "-m", "pip", "install", "demo"],
+        cwd=tmp_path,
+        timeout_sec=30,
+        detail_max=4000,
+    )
+
+    assert code == "pip_failed"
+    assert "KEEP-ME" in detail
+    assert len(detail) > 1600

--- a/test/unit/test_plugin_requirements_install.py
+++ b/test/unit/test_plugin_requirements_install.py
@@ -3,6 +3,44 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def _prepare_installer(monkeypatch, tmp_path):
+    from core.plugins import plugin_requirements_install as installer
+
+    monkeypatch.setattr(installer, "pip_python_executable", lambda: Path("python"))
+    monkeypatch.setattr(installer, "plugin_pip_target_directory", lambda: None)
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    return installer, plugin_root
+
+
+def _capture_pip_invocation(monkeypatch, installer, result=("pip_ok", "")):
+    calls: list[dict[str, object]] = []
+
+    def fake_run_pip_install(cmd, *, cwd, timeout_sec, on_output_line):
+        req_path = Path(cmd[cmd.index("-r") + 1])
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "cwd": cwd,
+                "timeout_sec": timeout_sec,
+                "requirements_path": req_path,
+                "requirements_text": req_path.read_text(encoding="utf-8"),
+            }
+        )
+        return result
+
+    monkeypatch.setattr(installer, "_run_pip_install", fake_run_pip_install)
+    return calls
+
+
+def _write_requirements(plugin_root: Path, text: str) -> Path:
+    req = plugin_root / "requirements.txt"
+    req.write_text(text, encoding="utf-8")
+    return req
+
+
 def test_finish_install_result_refreshes_plugin_target_on_success(monkeypatch):
     from core.plugins import plugin_requirements_install as installer
 
@@ -36,3 +74,180 @@ def test_finish_install_result_does_not_refresh_on_failed_install(monkeypatch):
 
     assert result == ("pip_failed", "boom")
     assert calls == []
+
+
+def test_install_plugin_requirements_prunes_installed_plain_packages(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    original_req = _write_requirements(
+        plugin_root,
+        "already-there==1.0\nmissing-package>=2\n",
+    )
+    calls = _capture_pip_invocation(monkeypatch, installer)
+
+    monkeypatch.setattr(
+        installer,
+        "_requirement_line_is_satisfied",
+        lambda line: line.startswith("already-there"),
+        raising=False,
+    )
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    assert len(calls) == 1
+    assert calls[0]["requirements_path"] != original_req
+    assert calls[0]["requirements_text"] == "missing-package>=2\n"
+
+
+def test_install_plugin_requirements_adds_env_index_url_to_pip_command(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(plugin_root, "missing-package>=2\n")
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    cmd = calls[0]["cmd"]
+    assert "--index-url" in cmd
+    assert cmd[cmd.index("--index-url") + 1] == "https://mirror.example/simple"
+
+
+def test_install_plugin_requirements_uses_manifest_china_index_by_default(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(plugin_root, "missing-package>=2\n")
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.delenv("PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URLS", raising=False)
+    monkeypatch.delenv("SHINSEKAI_PIP_INSTALL_ARGS", raising=False)
+    monkeypatch.delenv("SHINSEKAI_RUNTIME_SOURCE", raising=False)
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    cmd = calls[0]["cmd"]
+    assert "--index-url" in cmd
+    assert cmd[cmd.index("--index-url") + 1] == "https://pypi.tuna.tsinghua.edu.cn/simple/"
+    assert "https://mirrors.aliyun.com/pypi/simple/" in cmd
+    assert "https://pypi.org/simple/" in cmd
+
+
+def test_install_plugin_requirements_does_not_add_env_index_when_requirements_has_index(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(
+        plugin_root,
+        "--index-url https://requirements.example/simple\nmissing-package>=2\n",
+    )
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    cmd = calls[0]["cmd"]
+    assert "https://mirror.example/simple" not in cmd
+
+
+def test_install_plugin_requirements_shlex_parses_extra_pip_args(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(plugin_root, "missing-package>=2\n")
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.setenv(
+        "SHINSEKAI_PIP_INSTALL_ARGS",
+        '--retries 2 --trusted-host "mirror.example"',
+    )
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    cmd = calls[0]["cmd"]
+    assert cmd[cmd.index("--retries") + 1] == "2"
+    assert cmd[cmd.index("--trusted-host") + 1] == "mirror.example"
+
+
+def test_install_plugin_requirements_extra_pip_args_index_suppresses_env_index(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(plugin_root, "missing-package>=2\n")
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://env.example/simple")
+    monkeypatch.setenv(
+        "SHINSEKAI_PIP_INSTALL_ARGS",
+        "--index-url https://args.example/simple",
+    )
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    cmd = calls[0]["cmd"]
+    assert "https://args.example/simple" in cmd
+    assert "https://env.example/simple" not in cmd
+
+
+def test_install_plugin_requirements_classifies_pip_dependency_conflicts(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(plugin_root, "a==1\nb==2\n")
+    conflict_detail = (
+        "ERROR: Cannot install a==1 and b==2 because these package versions "
+        "have conflicting dependencies."
+    )
+    _capture_pip_invocation(monkeypatch, installer, result=("pip_failed", conflict_detail))
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_conflict", conflict_detail)
+
+
+def test_install_plugin_requirements_falls_back_to_original_file_for_unsafe_pruning(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    original_req = _write_requirements(
+        plugin_root,
+        "\n".join(
+            [
+                "already-there==1.0",
+                "editable-project @ git+https://example.invalid/pkg.git",
+                "-e ./local-project",
+                "--find-links ./wheels",
+                "missing-package>=2",
+                "",
+            ]
+        ),
+    )
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.setattr(
+        installer,
+        "_requirement_line_is_satisfied",
+        lambda line: line.startswith("already-there"),
+        raising=False,
+    )
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    assert calls[0]["requirements_path"] == original_req
+    assert calls[0]["requirements_text"] == original_req.read_text(encoding="utf-8")

--- a/test/unit/test_plugin_requirements_install.py
+++ b/test/unit/test_plugin_requirements_install.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 
 def _prepare_installer(monkeypatch, tmp_path):
@@ -90,7 +93,7 @@ def test_install_plugin_requirements_prunes_installed_plain_packages(
     monkeypatch.setattr(
         installer,
         "_requirement_line_is_satisfied",
-        lambda line: line.startswith("already-there"),
+        lambda line, installed_versions=None: line.startswith("already-there"),
         raising=False,
     )
 
@@ -303,7 +306,7 @@ def test_install_plugin_requirements_falls_back_to_original_file_for_unsafe_prun
     monkeypatch.setattr(
         installer,
         "_requirement_line_is_satisfied",
-        lambda line: line.startswith("already-there"),
+        lambda line, installed_versions=None: line.startswith("already-there"),
         raising=False,
     )
 
@@ -312,3 +315,53 @@ def test_install_plugin_requirements_falls_back_to_original_file_for_unsafe_prun
     assert result == ("pip_ok", "")
     assert calls[0]["requirements_path"] == original_req
     assert calls[0]["requirements_text"] == original_req.read_text(encoding="utf-8")
+
+
+def test_install_lines_after_precheck_scans_installed_distributions_once(monkeypatch):
+    from core.plugins import plugin_requirements_install as installer
+
+    calls: list[object] = []
+
+    class Dist:
+        metadata = {"Name": "already-there"}
+        version = "1.0"
+
+    monkeypatch.setattr(installer, "plugin_pip_target_directory", lambda: None)
+    monkeypatch.setattr(
+        installer.importlib_metadata,
+        "distributions",
+        lambda path=None: calls.append(path) or [Dist()],
+    )
+
+    can_prune, install_lines = installer._install_lines_after_precheck(
+        ["already-there==1.0", "missing-package>=2"],
+    )
+
+    assert can_prune is True
+    assert install_lines == ["missing-package>=2"]
+    assert len(calls) == 1
+
+
+def test_write_temp_requirements_removes_file_when_write_fails(monkeypatch, tmp_path):
+    from core.plugins import plugin_requirements_install as installer
+
+    created = tmp_path / "easyai_missing_req_fail.txt"
+
+    def fake_mkstemp(prefix, suffix):
+        fd = os.open(str(created), os.O_CREAT | os.O_TRUNC | os.O_RDWR)
+        return fd, str(created)
+
+    original_write_text = Path.write_text
+
+    def fail_write_text(self, *args, **kwargs):
+        if self == created:
+            raise OSError("disk full")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(installer.tempfile, "mkstemp", fake_mkstemp)
+    monkeypatch.setattr(Path, "write_text", fail_write_text)
+
+    with pytest.raises(OSError, match="disk full"):
+        installer._write_temp_requirements("easyai_missing_req_", ["missing-package>=2"])
+
+    assert not created.exists()

--- a/test/unit/test_plugin_requirements_install.py
+++ b/test/unit/test_plugin_requirements_install.py
@@ -250,17 +250,35 @@ def test_install_plugin_requirements_classifies_pip_dependency_conflicts(
     monkeypatch,
     tmp_path,
 ):
+    import io
+
+    from core.plugins import pip_runner
+
     installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
-    _write_requirements(plugin_root, "a==1\nb==2\n")
+    _write_requirements(plugin_root, "pkg-a==1\npkg-b==2\n")
     conflict_detail = (
-        "ERROR: Cannot install a==1 and b==2 because these package versions "
+        "ERROR: Cannot install pkg-a==1 and pkg-b==2 because these package versions "
         "have conflicting dependencies."
     )
-    _capture_pip_invocation(monkeypatch, installer, result=("pip_failed", conflict_detail))
 
-    result = installer.install_plugin_requirements_txt(plugin_root)
+    class FakePopen:
+        def __init__(self, cmd, **kwargs):
+            self.stdout = io.StringIO(conflict_detail + "\n")
+            self.stderr = io.StringIO("")
+            self.returncode = 1
 
-    assert result == ("pip_conflict", conflict_detail)
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(pip_runner.subprocess, "Popen", FakePopen)
+
+    code, detail = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert code == "pip_conflict"
+    assert "conflicting dependencies" in detail
 
 
 def test_install_plugin_requirements_falls_back_to_original_file_for_unsafe_pruning(

--- a/test/unit/test_plugin_requirements_install.py
+++ b/test/unit/test_plugin_requirements_install.py
@@ -127,6 +127,8 @@ def test_install_plugin_requirements_uses_manifest_china_index_by_default(
     _write_requirements(plugin_root, "missing-package>=2\n")
     calls = _capture_pip_invocation(monkeypatch, installer)
     monkeypatch.delenv("PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_EXTRA_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_NO_INDEX", raising=False)
     monkeypatch.delenv("PIP_CONFIG_FILE", raising=False)
     monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URL", raising=False)
     monkeypatch.delenv("SHINSEKAI_PIP_INDEX_URLS", raising=False)
@@ -160,6 +162,47 @@ def test_install_plugin_requirements_does_not_add_env_index_when_requirements_ha
     assert result == ("pip_ok", "")
     cmd = calls[0]["cmd"]
     assert "https://mirror.example/simple" not in cmd
+
+
+def test_install_plugin_requirements_keeps_default_index_when_requirements_add_extra_index(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(
+        plugin_root,
+        "--extra-index-url https://private.example/simple\nmissing-package>=2\n",
+    )
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    cmd = calls[0]["cmd"]
+    assert "https://mirror.example/simple" not in cmd
+    assert "--index-url" not in cmd
+
+
+def test_install_plugin_requirements_extra_pip_args_extra_index_suppresses_env_index(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(plugin_root, "missing-package>=2\n")
+    calls = _capture_pip_invocation(monkeypatch, installer)
+    monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://env.example/simple")
+    monkeypatch.setenv(
+        "SHINSEKAI_PIP_INSTALL_ARGS",
+        "--extra-index-url=https://private.example/simple",
+    )
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    cmd = calls[0]["cmd"]
+    assert "--extra-index-url=https://private.example/simple" in cmd
+    assert "https://env.example/simple" not in cmd
 
 
 def test_install_plugin_requirements_shlex_parses_extra_pip_args(


### PR DESCRIPTION
## 背景

这是 #69 的主程序拆分 PR6，基于 #77 和 #78 继续推进插件分发体验。建议按顺序先评审 #77、#78，再看本 PR；前置 PR 合并后，本 PR 的实际差异会收敛到依赖安装优化。

## 变更内容

- 新增共享 pip 源配置模块，插件依赖安装和运行时缺失依赖安装共用同一套 pip index 选择逻辑。
- 默认优先使用国内 PyPI 镜像，并保留官方 PyPI 作为 extra index，降低国内用户安装插件依赖时卡在 PyPI/GitHub 周边网络的概率。
- 支持通过环境变量覆盖安装行为：
  - `SHINSEKAI_PIP_INDEX_URL`
  - `SHINSEKAI_PIP_INDEX_URLS`
  - `SHINSEKAI_PIP_INSTALL_ARGS`
  - `SHINSEKAI_RUNTIME_SOURCE=official|china`
- 尊重用户已有 pip 配置：如果设置了 `PIP_INDEX_URL`、`PIP_CONFIG_FILE`，或 requirements / extra args 里已经指定 index / no-index，则不强行注入默认镜像。
- 插件 `requirements.txt` 安装前做本地预检查：普通依赖已满足时跳过，部分缺失时只把缺失或版本不满足的普通依赖交给 pip。
- 对 `-e`、本地路径、direct reference、`--find-links` 等有全局语义的 requirements 不做裁剪，避免破坏插件作者意图。
- 将 pip 依赖求解冲突单独分类为 `pip_conflict`，主程序插件安装入口会把它视为失败，避免误判为安装成功。
- 运行时缺失依赖安装复用 pip 源配置，并对输出中的带账号密码 URL 做脱敏，避免日志泄露 token。

## 与前置 PR 的关系

本 PR 专注依赖安装体验。Registry CI / R2 发布由 Registry PR #10-#12 承接，官方包安装链路由 #78 承接，提交助手和插件市场 UI 由 #80 承接。安全规则沿用 #78：只有官方包下载网络错误允许 fallback GitHub；hash、size、zip、host、依赖失败和依赖冲突会停止安装流程。

## 验证

- `python -m py_compile core\plugins\pip_index_config.py core\plugins\plugin_requirements_install.py frontend_bridge_core\runtime_dependencies.py frontend_bridge_core\plugin_updates.py`
- `python -m pytest test\unit\test_plugin_requirements_install.py test\unit\test_frontend_runtime_check.py test\unit\test_frontend_plugin_updates.py test\unit\test_plugin_package_download.py -q`：45 passed
- `python -m pytest test\unit -q`：588 passed, 1 warning
- `pnpm --dir frontend format:check`：通过
- `pnpm --dir frontend lint:types`：通过
- `pnpm --dir frontend test`：66 files passed / 271 tests passed

Refs #69