### PR TITLE
Add gradio to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ mem0ai
 mem0ai[nlp]
 sentence-transformers
 fastembed
+gradio


### PR DESCRIPTION
Issue: 
webui.py里使用的gradio library在requirements.txt里不存在，在git clone和直接使用pip install -r requirements.txt安装dependency后尝试编译会报错

Fix:
在requirements.txt中增加了gradio

