### PR TITLE
feat: support OpenAI-compatible API with custom baseurl

### DIFF
--- a/frontend/src/entities/config/schema.ts
+++ b/frontend/src/entities/config/schema.ts
@@ -8,6 +8,7 @@ export const llmProviderOptions = [
   { label: "Claude", value: "Claude" },
   { label: "豆包", value: "豆包" },
   { label: "通义千问", value: "通义千问" },
+  { label: "Ollama", value: "Ollama" },
 ] as const;
 
 export const llmDefaultBaseUrls: Record<string, string> = {
@@ -17,6 +18,7 @@ export const llmDefaultBaseUrls: Record<string, string> = {
   Gemini: "https://generativelanguage.googleapis.com/v1beta/openai",
   豆包: "https://ark.cn-beijing.volces.com/api/v3",
   通义千问: "https://dashscope.aliyuncs.com/api/v1",
+  Ollama: "http://127.0.0.1:11434/v1",
 };
 
 export function compactTargetRatioMax(draft: Pick<ApiConfig, "compact_threshold">) {

--- a/llm/constants.py
+++ b/llm/constants.py
@@ -6,6 +6,7 @@ LLM_BASE_URLS = {
     "Claude": "https://api.anthropic.com/v1",
     "豆包": "https://ark.cn-beijing.volces.com/api/v3",
     "通义千问": "https://dashscope.aliyuncs.com/api/v1",
+    "Ollama": "http://127.0.0.1:11434/v1"
 }
 
 # Add a dictionary to map LLM providers to their available models
@@ -16,4 +17,5 @@ LLM_MODELS = {
     "Claude": ["claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307"],
     "豆包": ["doubao-seed-1.6", "doubao-seed-1.6-flash", "doubao-seed-1.6-thinking"],
     "通义千问": ["qwen-max", "qwen-plus"],
+    "Ollama": []
 }

--- a/llm/llm_manager.py
+++ b/llm/llm_manager.py
@@ -165,6 +165,7 @@ class LLMAdapterFactory:
         "Claude": ClaudeAdapter,
         "豆包": OpenAIAdapter,
         "通义千问": OpenAIAdapter,
+        "Ollama": OpenAIAdapter
     }
 
     @staticmethod


### PR DESCRIPTION
## Overview
基于[Issue 91: Potential Ollama Integration](https://github.com/RachelForster/Shinsekai/issues/91)的PR

## Changes
增加了OpenAI Adapter对于Ollama模型的支持，以及在React端和QtPy端的Ollama Base Url


