### PR TITLE
fix(llm): omit scene output for transparent background

### DIFF
--- a/llm/template_generator.py
+++ b/llm/template_generator.py
@@ -367,7 +367,9 @@ class TemplateGenerator:
                 character_setting = char_detail.character_setting
                 template += f"{character_setting}\n\n"
 
-        if bg_name and not is_transparent_background(bg_name):
+        has_real_background = bool(bg_name) and not is_transparent_background(bg_name)
+
+        if has_real_background:
             bg = config_manager.get_background_by_name(bg_name)
             if bg and bg.sprites:
                 template += _T("scene_block_header")
@@ -380,12 +382,12 @@ class TemplateGenerator:
                 template += f"{bg.bgm_tags}\n\n"
 
         # 保留字新代号（与 core.messaging.dialog_tokens 及 handlers 一致；旧版中文仍兼容）
-        opt_scene = (f", {SCENE}" if bg_name else "")
-        opt_bgm = (f", {BGM}" if bg_name else "")
+        opt_scene = (f", {SCENE}" if has_real_background else "")
+        opt_bgm = (f", {BGM}" if has_real_background else "")
         opt_cg = (f", {CG}" if use_cg else "")
         cot_part = (f"{COT}," if use_cot else "")
 
-        need_real = bool(bg_name) and not is_transparent_background(bg_name)
+        need_real = has_real_background
 
         _toks = {
             "narr": _narr_label(),

--- a/test/unit/test_output_contracts.py
+++ b/test/unit/test_output_contracts.py
@@ -133,6 +133,56 @@ def test_template_generator_renders_added_field_aliases(monkeypatch) -> None:
     assert "camera (string, optional): Camera framing for this line. Aliases: shot, framing." in template
 
 
+def test_template_generator_omits_scene_and_bgm_for_transparent_background(monkeypatch) -> None:
+    character = SimpleNamespace(
+        sprites=[object()],
+        emotion_tags="happy: 01",
+        character_setting="A test character.",
+    )
+    background = SimpleNamespace(
+        sprites=[{"path": "room.png"}],
+        bg_tags="scene 1: room",
+        bgm_list=["room.mp3"],
+        bgm_tags="music 1: room theme",
+    )
+
+    monkeypatch.setattr(
+        "llm.template_generator.config_manager",
+        SimpleNamespace(
+            get_background_by_name=lambda name: background,
+            get_character_by_name=lambda name: character,
+        ),
+    )
+
+    transparent_template, transparent_warning = TemplateGenerator(output_contract_patches=[]).generate_chat_template(
+        selected_characters=["Alice"],
+        bg_name="透明场景",
+        use_effect=False,
+        use_cg=False,
+        use_llm_translation=False,
+    )
+    real_background_template, real_background_warning = TemplateGenerator(
+        output_contract_patches=[]
+    ).generate_chat_template(
+        selected_characters=["Alice"],
+        bg_name="Room",
+        use_effect=False,
+        use_cg=False,
+        use_llm_translation=False,
+    )
+
+    assert transparent_warning == ""
+    assert real_background_warning == ""
+    assert "template_gen.r_scene" not in transparent_template
+    assert "template_gen.r_bgm" not in transparent_template
+    assert "template_gen.scene_block_header" not in transparent_template
+    assert "template_gen.bgm_block_header" not in transparent_template
+    assert "template_gen.r_scene" in real_background_template
+    assert "template_gen.r_bgm" in real_background_template
+    assert "template_gen.scene_block_header" in real_background_template
+    assert "template_gen.bgm_block_header" in real_background_template
+
+
 def test_template_generator_warns_for_unknown_requirement_patch_mode(monkeypatch, caplog) -> None:
     character = SimpleNamespace(
         sprites=[object()],

--- a/test/unit/test_output_contracts.py
+++ b/test/unit/test_output_contracts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from core.messaging.dialog_tokens import BGM, SCENE
 from llm.template_generator import DEFAULT_DIALOG_CONTRACT_ID, TemplateGenerator
 from sdk.register import PluginCapabilityRegistry
 from sdk.types import (
@@ -153,6 +154,14 @@ def test_template_generator_omits_scene_and_bgm_for_transparent_background(monke
             get_character_by_name=lambda name: character,
         ),
     )
+    monkeypatch.setattr(
+        "llm.template_generator._T",
+        lambda key, **kwargs: (
+            f"template_gen.{key} opt_scene={kwargs.get('opt_scene', '')} opt_bgm={kwargs.get('opt_bgm', '')}"
+            if key == "r_cname"
+            else f"template_gen.{key}"
+        ),
+    )
 
     transparent_template, transparent_warning = TemplateGenerator(output_contract_patches=[]).generate_chat_template(
         selected_characters=["Alice"],
@@ -177,10 +186,14 @@ def test_template_generator_omits_scene_and_bgm_for_transparent_background(monke
     assert "template_gen.r_bgm" not in transparent_template
     assert "template_gen.scene_block_header" not in transparent_template
     assert "template_gen.bgm_block_header" not in transparent_template
+    assert f", {SCENE}" not in transparent_template
+    assert f", {BGM}" not in transparent_template
     assert "template_gen.r_scene" in real_background_template
     assert "template_gen.r_bgm" in real_background_template
     assert "template_gen.scene_block_header" in real_background_template
     assert "template_gen.bgm_block_header" in real_background_template
+    assert f", {SCENE}" in real_background_template
+    assert f", {BGM}" in real_background_template
 
 
 def test_template_generator_warns_for_unknown_requirement_patch_mode(monkeypatch, caplog) -> None:


### PR DESCRIPTION
**Bug: 透明背景模式下 SCENE/BGM 模板误生成导致舞台状态异常**

**复现路径**

1. 首次启动，正常背景（如"水葬银货"）——运行正常。
2. 再次启动，选择透明背景——后端按现有逻辑为选中角色补入初始立绘路径，行为符合预期。
3. 问题出在 `llm/template_generator.py:373`：旧代码仅判断 `bg_name` 是否存在，未区分"透明背景"这一特殊情况，因此即便背景实际为透明，仍将 `SCENE` / `BGM` 写入模型允许输出项。

**根因**

透明背景不持有 `bg_group` / `bgm_list`，模型一旦按模板输出 `SCENE` / `BGM`，运行时即抛出：

```
IndexError: 背景图片的index不正常
bgm path list index out of range
```

这些异常会产生额外的舞台状态更新，最终表现为：仅选择了一个角色，却出现多个立绘 / 残留舞台对象。

**修复**

引入明确的标志位以区分"真实背景"与"透明背景"：

```python
has_real_background = bool(bg_name) and not is_transparent_background(bg_name)
```

仅当 `has_real_background` 为 `True` 时，才生成 `SCENE` / `BGM` 相关模板及输出要求，从根源上避免模型在无资源可用时产生无效输出。

fix: #138 