### PR TITLE
fix: TTS 合成阻塞导致退出卡顿及文件写入不完整

### DIFF
--- a/core/runtime/workers.py
+++ b/core/runtime/workers.py
@@ -36,6 +36,25 @@ logger = get_logger(__name__)
 
 # --- QThread + DagNode 基类 ---
 
+class _CancelAwareQueue:
+    """Delegate queue operations, but drop new outputs after cancellation."""
+
+    def __init__(self, queue, cancel_event: threading.Event) -> None:
+        self._queue = queue
+        self._cancel_event = cancel_event
+
+    def put(self, *args, **kwargs):
+        if self._cancel_event.is_set():
+            return None
+        return self._queue.put(*args, **kwargs)
+
+    def put_nowait(self, item):
+        return self.put(item, block=False)
+
+    def __getattr__(self, name: str):
+        return getattr(self._queue, name)
+
+
 class QThreadDagNode(DagNode, QThread):
     """每个 DagNode 自带一个 QThread 运行循环。"""
 
@@ -264,7 +283,12 @@ class TTSWorker(QThreadDagNode):
     def outputs(self) -> dict[str, Port]:
         return {self.PORT_TTS_OUTPUT: Port(self.PORT_TTS_OUTPUT)}
 
-    # ---------- 新增方法 ----------
+    def start(self) -> None:
+        if self.isRunning():
+            return
+        self._cancel_event.clear()
+        super().start()
+
     def _dispatch_with_cancel(self, item):
         """
         在 daemon 子线程中执行 dispatcher.dispatch，主线程等待完成或取消。
@@ -275,11 +299,27 @@ class TTSWorker(QThreadDagNode):
         error = [None]
 
         def work():
+            rt = try_get_app_runtime()
+            original_audio_queue = None
+            guarded_audio_queue = None
             try:
+                if rt is not None:
+                    original_audio_queue = rt.audio_path_queue
+                    guarded_audio_queue = _CancelAwareQueue(original_audio_queue, self._cancel_event)
+                    rt.audio_path_queue = guarded_audio_queue
+                if self._cancel_event.is_set():
+                    return
                 self.tts_message_dispatcher.dispatch(item)
             except Exception as e:
-                error[0] = e
+                if not self._cancel_event.is_set():
+                    error[0] = e
             finally:
+                if (
+                    rt is not None
+                    and guarded_audio_queue is not None
+                    and rt.audio_path_queue is guarded_audio_queue
+                ):
+                    rt.audio_path_queue = original_audio_queue
                 done.set()
 
         t = threading.Thread(target=work, daemon=True)
@@ -294,7 +334,6 @@ class TTSWorker(QThreadDagNode):
         if error[0] is not None:
             raise error[0]
 
-    # ---------- 修改 run ----------
     def run(self):
         self._init_app()
         while self.running:
@@ -322,7 +361,6 @@ class TTSWorker(QThreadDagNode):
                 if got_item:
                     self.tts_queue.task_done()
 
-    # ---------- 修改 stop ----------
     def stop(self):
         self._cancel_event.set()        # 通知取消当前合成
         self.running = False

--- a/core/runtime/workers.py
+++ b/core/runtime/workers.py
@@ -235,6 +235,7 @@ class TTSWorker(QThreadDagNode):
         self.tts_queue = input_queue
         self.audio_path_queue = output_queue
         self.tts_message_dispatcher = None
+        self._cancel_event = threading.Event()          # 新增：取消当前合成用
         if input_queue is not None:
             self.bind_input(self.PORT_LLM_OUTPUT, input_queue)
         if output_queue is not None:
@@ -249,7 +250,8 @@ class TTSWorker(QThreadDagNode):
         self.tts_message_dispatcher.init_handlers()
         self._app_inited = True
 
-    def put_data(self, character_name: str, speech: str, sprite: str, audio_path, is_system_message: bool = False, effect: str = ""):
+    def put_data(self, character_name: str, speech: str, sprite: str, audio_path,
+                 is_system_message: bool = False, effect: str = ""):
         """与 handler 中 tts_emit_to_ui_queue 一致，供本 worker 异常路径使用。"""
         tts_emit_to_ui_queue(
             character_name, speech, sprite, audio_path or "",
@@ -262,6 +264,37 @@ class TTSWorker(QThreadDagNode):
     def outputs(self) -> dict[str, Port]:
         return {self.PORT_TTS_OUTPUT: Port(self.PORT_TTS_OUTPUT)}
 
+    # ---------- 新增方法 ----------
+    def _dispatch_with_cancel(self, item):
+        """
+        在 daemon 子线程中执行 dispatcher.dispatch，主线程等待完成或取消。
+        - 取消发生时（_cancel_event 被设置），直接返回，不等待子线程。
+        - 子线程异常会被捕获并在主线程重新抛出，保持原有异常处理路径。
+        """
+        done = threading.Event()
+        error = [None]
+
+        def work():
+            try:
+                self.tts_message_dispatcher.dispatch(item)
+            except Exception as e:
+                error[0] = e
+            finally:
+                done.set()
+
+        t = threading.Thread(target=work, daemon=True)
+        t.start()
+
+        while not done.is_set() and not self._cancel_event.is_set():
+            t.join(timeout=0.1)
+
+        if self._cancel_event.is_set() and not done.is_set():
+            return
+
+        if error[0] is not None:
+            raise error[0]
+
+    # ---------- 修改 run ----------
     def run(self):
         self._init_app()
         while self.running:
@@ -273,7 +306,7 @@ class TTSWorker(QThreadDagNode):
                 if item is None:
                     break
                 with tracker.track("TTS dispatch"):
-                    self.tts_message_dispatcher.dispatch(item)
+                    self._dispatch_with_cancel(item)   # ← 原来是直接 dispatch
             except Exception as e:
                 logger.exception("TTS worker task failed", extra={"event": "tts.worker.failed"})
                 if item is not None:
@@ -289,10 +322,13 @@ class TTSWorker(QThreadDagNode):
                 if got_item:
                     self.tts_queue.task_done()
 
+    # ---------- 修改 stop ----------
     def stop(self):
+        self._cancel_event.set()        # 通知取消当前合成
         self.running = False
-        self.tts_queue.put(None)
+        self.tts_queue.put(None)        # 唤醒 queue.get()
         super().stop()
+
 
 class UIWorker(QThreadDagNode):
     PORT_TTS_OUTPUT = "tts_output"

--- a/test/unit/managers/test_tts_manager.py
+++ b/test/unit/managers/test_tts_manager.py
@@ -58,6 +58,32 @@ class TestTTSManagerWithMock:
         assert call["kwargs"]["character_name"] == "TestChar"
         mgr.shutdown()
 
+    def test_generate_tts_replaces_existing_cache_file_and_removes_part(self, mock_tts_adapter, tmp_path):
+        mgr = TTSManager()
+        mgr.set_tts_adapter(mock_tts_adapter)
+        mgr.audio_cache_dir = tmp_path
+
+        final_audio = tmp_path / "0.wav"
+        part_audio = tmp_path / "0.wav.part"
+        final_audio.write_bytes(b"old audio")
+        ref_audio = tmp_path / "ref.wav"
+        ref_audio.write_text("fake ref")
+
+        try:
+            result = mgr.generate_tts(
+                text="Hello world",
+                ref_audio_path=str(ref_audio),
+                prompt_text="Hello",
+                prompt_lang="en",
+            )
+
+            assert result == str(final_audio)
+            assert final_audio.read_bytes() == b"fake audio data"
+            assert not part_audio.exists()
+            assert mock_tts_adapter.call_history[-1]["file_path"] == str(part_audio)
+        finally:
+            mgr.shutdown()
+
     def test_generate_tts_no_ref_audio_returns_empty(self, mock_tts_adapter):
         mgr = TTSManager()
         mgr.set_tts_adapter(mock_tts_adapter)

--- a/test/unit/test_workers_behavior.py
+++ b/test/unit/test_workers_behavior.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+import time
 from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -158,6 +160,65 @@ def test_tts_worker_exception_path_uses_original_put_data_fallback(
     assert output.effect == "shake"
     assert tts_queue.task_done_calls == 2
     assert tts_queue.unfinished_tasks == 0
+
+
+def test_tts_worker_start_clears_previous_cancel_state(monkeypatch) -> None:
+    worker = TTSWorker(Queue(), Queue())
+    worker._cancel_event.set()
+    starts = []
+
+    monkeypatch.setattr(
+        "core.runtime.workers.QThreadDagNode.start",
+        lambda self: starts.append(self),
+    )
+
+    worker.start()
+
+    assert not worker._cancel_event.is_set()
+    assert starts == [worker]
+
+
+def test_tts_worker_drops_dispatch_output_after_cancel() -> None:
+    audio_path_queue = CountingQueue()
+    _make_app_runtime(audio_path_queue=audio_path_queue)
+    worker = TTSWorker(CountingQueue(), audio_path_queue)
+    started = threading.Event()
+    release = threading.Event()
+    attempted_emit = threading.Event()
+
+    def dispatch(_item):
+        started.set()
+        assert release.wait(timeout=1)
+        get_app_runtime().audio_path_queue.put(
+            TTSOutputMessage(
+                audio_path="late.wav",
+                name="Alice",
+                text="late",
+                asset_id="-1",
+            )
+        )
+        attempted_emit.set()
+
+    worker.tts_message_dispatcher = SimpleNamespace(dispatch=dispatch)
+    runner = threading.Thread(
+        target=worker._dispatch_with_cancel,
+        args=(LLMDialogMessage(name="Alice", text="hello", asset_id="-1"),),
+    )
+
+    runner.start()
+    assert started.wait(timeout=1)
+    worker._cancel_event.set()
+    release.set()
+    assert attempted_emit.wait(timeout=1)
+    runner.join(timeout=1)
+
+    assert not runner.is_alive()
+    assert audio_path_queue.empty()
+    for _ in range(20):
+        if get_app_runtime().audio_path_queue is audio_path_queue:
+            break
+        time.sleep(0.01)
+    assert get_app_runtime().audio_path_queue is audio_path_queue
 
 
 def test_ui_worker_skip_speech_is_noop_when_queue_empty() -> None:

--- a/tts/tts_manager.py
+++ b/tts/tts_manager.py
@@ -1,5 +1,4 @@
 import requests
-import shutil
 import threading
 import queue
 import subprocess
@@ -90,32 +89,36 @@ class TTSManager:
             return ''
 
         # 最终文件路径
-        final_path = str(self.audio_cache_dir / f"{self.index % self.cache_num}.wav")
+        final_path = self.audio_cache_dir / f"{self.index % self.cache_num}.wav"
         self.index += 1
-        tmp_path = final_path + ".part"
+        tmp_path = final_path.with_suffix(final_path.suffix + ".part")
 
         # 清理上次残留的临时文件
-        if Path(tmp_path).exists():
-            Path(tmp_path).unlink()
+        tmp_path.unlink(missing_ok=True)
 
         # 引擎写入临时路径
-        result = self.tts_adapter.generate_speech(
-            text=text,
-            file_path=tmp_path,
-            ref_audio_path=ref_audio_path,
-            prompt_text=prompt_text,
-            prompt_lang=prompt_lang,
-            text_lang=self.voice_language,
-            character_name=character_name,
-            speed_factor=speed_factor,
-        )
+        moved = False
+        try:
+            result = self.tts_adapter.generate_speech(
+                text=text,
+                file_path=str(tmp_path),
+                ref_audio_path=ref_audio_path,
+                prompt_text=prompt_text,
+                prompt_lang=prompt_lang,
+                text_lang=self.voice_language,
+                character_name=character_name,
+                speed_factor=speed_factor,
+            )
 
-        # 成功写入临时文件则原子替换，否则返回空字符串
-        if result and Path(tmp_path).exists():
-            shutil.move(tmp_path, final_path)
-            return final_path
-        else:
+            # 成功写入临时文件则原子替换，否则返回空字符串
+            if result and tmp_path.exists():
+                tmp_path.replace(final_path)
+                moved = True
+                return str(final_path)
             return ''
+        finally:
+            if not moved:
+                tmp_path.unlink(missing_ok=True)
 
     def set_language(self, language):
         """Sets the voice language."""

--- a/tts/tts_manager.py
+++ b/tts/tts_manager.py
@@ -1,4 +1,5 @@
 import requests
+import shutil
 import threading
 import queue
 import subprocess
@@ -67,7 +68,9 @@ class TTSManager:
         """Allows switching the TTS adapter at runtime."""
         self.tts_adapter = adapter
 
-    def generate_tts(self, text, text_processor=None, ref_audio_path=None, prompt_text=None, prompt_lang=None, character_name=None, speed_factor=None):
+    def generate_tts(self, text, text_processor=None, ref_audio_path=None,
+                     prompt_text=None, prompt_lang=None, character_name=None,
+                     speed_factor=None):
         """Generates TTS audio using the currently set adapter."""
         print("Generating speech")
         
@@ -86,13 +89,19 @@ class TTSManager:
             print("No reference audio provided")
             return ''
 
-        # The adapter handles the specifics of the TTS generation
-        file_path = str(self.audio_cache_dir / f"{self.index % self.cache_num}.wav")
+        # 最终文件路径
+        final_path = str(self.audio_cache_dir / f"{self.index % self.cache_num}.wav")
         self.index += 1
-        
-        return self.tts_adapter.generate_speech(
+        tmp_path = final_path + ".part"
+
+        # 清理上次残留的临时文件
+        if Path(tmp_path).exists():
+            Path(tmp_path).unlink()
+
+        # 引擎写入临时路径
+        result = self.tts_adapter.generate_speech(
             text=text,
-            file_path=file_path,
+            file_path=tmp_path,
             ref_audio_path=ref_audio_path,
             prompt_text=prompt_text,
             prompt_lang=prompt_lang,
@@ -100,6 +109,13 @@ class TTSManager:
             character_name=character_name,
             speed_factor=speed_factor,
         )
+
+        # 成功写入临时文件则原子替换，否则返回空字符串
+        if result and Path(tmp_path).exists():
+            shutil.move(tmp_path, final_path)
+            return final_path
+        else:
+            return ''
 
     def set_language(self, language):
         """Sets the voice language."""


### PR DESCRIPTION
## 修复内容

修复了退出流程中 TTS 正在合成音频时 workflow.stop 阻塞导致关闭卡顿的问题。

### 改动

- **core/runtime/workers.py** — TTSWorker 增加 _cancel_event + _dispatch_with_cancel，将 dispatch 放入 daemon 子线程执行，主线程轮询等待（0.1 秒粒度），stop 时设置取消事件立即返回
- **tts/tts_manager.py** — generate_tts 改为 .part 临时文件写入，成功后原子替换，写入前清理残留文件

### 验证

正常退出总耗时约 10ms；中断退出场景 workflow.stop 从 3.7 秒降至 0.1–0.5 秒。


## 注意事项

**此方案仅适用于关闭流程。** 单独在运行中使用可能导致：

- 虚假取消 — 取消信号触发后子线程仍在后台运行，下次 dispatch 可能被上一轮的取消信号影响
- 异常丢失 — 子线程中的异常可能未被完整传递
- 停止后消息丢失 — 取消后该条 TTS 消息不会生成音频
- 未真正终止底层操作 — requests.post(stream=True) 的 socket 连接未被关闭，子线程仍在后台运行直到进程退出

详见 #131。