### PR TITLE
Fix/chat history crash recovery

### DIFF
--- a/core/sprite/chat_history.py
+++ b/core/sprite/chat_history.py
@@ -32,9 +32,9 @@ def getHistory() -> list[Any]:
     return get_history()
 
 
-def save_chat_history(file_path: str, history: Any) -> None:
+def save_chat_history(file_path: str, history: Any) -> bool:
     """根据提供的文件名保存聊天记录到 JSON 文件。"""
-    _get_history_manager().save_chat_history(file_path, history)
+    return _get_history_manager().save_chat_history(file_path, history)
 
 
 def load_chat_history(file_path: str) -> Any:

--- a/frontend_bridge_core/templates.py
+++ b/frontend_bridge_core/templates.py
@@ -58,10 +58,19 @@ def _latest_history_json(history_dir: str) -> Path | None:
     path = Path(history_dir)
     if not path.is_dir():
         return None
+    # 优先找正式 .json 文件
     files = [item for item in path.glob("*.json") if item.is_file()]
-    if not files:
-        return None
-    return max(files, key=lambda item: item.stat().st_mtime)
+    if files:
+        return max(files, key=lambda item: item.stat().st_mtime)
+    # 没有 .json 时，检查 .json.tmp，返回去掉 .tmp 后缀的 .json 路径
+    tmp_files = [item for item in path.glob("*.json.tmp") if item.is_file()]
+    if tmp_files:
+        latest_tmp = max(tmp_files, key=lambda item: item.stat().st_mtime)
+        # 去掉末尾 .tmp 后缀，返回 .json 路径
+        tmp_name = latest_tmp.name  # 如 "3cb1d79....json.tmp"
+        json_name = tmp_name[:-4]   # 去掉 ".tmp" → "3cb1d79....json"
+        return latest_tmp.parent / json_name
+    return None
 
 
 def _read_split_meta(template_dir: Path) -> tuple[str, str] | None:

--- a/llm/history_manager.py
+++ b/llm/history_manager.py
@@ -128,21 +128,30 @@ class HistoryManager:
 
     def save_chat_history(self, file_path, history):
         """
-        正常关闭：用传入的完整内存数据全量写入正式文件，然后删除临时文件。
+        正常关闭：用传入的完整内存数据全量写入正式文件。
+        返回 True 表示成功，False 表示失败。
         """
         if not file_path:
             print("没有提供历史文件名，跳过保存。")
-            return
+            return True
         history_path = Path(file_path)
-        tmp = self._tmp_path(file_path)
         try:
             history_path.parent.mkdir(parents=True, exist_ok=True)
             with open(history_path, 'w', encoding='utf-8') as f:
                 json.dump(history, f, ensure_ascii=False, indent=4)
             print(f"聊天记录已保存到 {history_path}")
-            tmp.unlink(missing_ok=True)
+            return True
         except Exception as e:
             print(f"保存聊天记录失败: {e}")
+            return False
+
+    @staticmethod
+    def delete_tmp(history_file: str) -> None:
+        """正常关闭成功后删除临时文件。"""
+        if not history_file:
+            return
+        tmp = HistoryManager._tmp_path(history_file)
+        tmp.unlink(missing_ok=True)
 
     def load_chat_history(self, file_path):
         """
@@ -176,13 +185,17 @@ class HistoryManager:
                 if raw:
                     raw = raw.rstrip(",\n\r")
                     tmp_messages = json.loads("[" + raw + "]")
-                    # 追加到正式记录后面
-                    messages.extend(tmp_messages)
-                    # 写回 .json 完成保存
-                    history_path.parent.mkdir(parents=True, exist_ok=True)
-                    with open(history_path, 'w', encoding='utf-8') as f:
-                        json.dump(messages, f, ensure_ascii=False, indent=4)
-                    print(f"临时记录已合并保存到 {history_path}")
+                    # 简单去重：如果 messages 最后一条与 tmp_messages 第一条相同，跳过 tmp 的第一条
+                    if messages and tmp_messages:
+                        if messages[-1] == tmp_messages[0]:
+                            tmp_messages = tmp_messages[1:]
+                    if tmp_messages:
+                        messages.extend(tmp_messages)
+                        # 写回 .json 完成保存
+                        history_path.parent.mkdir(parents=True, exist_ok=True)
+                        with open(history_path, 'w', encoding='utf-8') as f:
+                            json.dump(messages, f, ensure_ascii=False, indent=4)
+                        print(f"临时记录已合并保存到 {history_path}")
                     # 删除 .tmp
                     tmp.unlink(missing_ok=True)
             except Exception as e:

--- a/llm/history_manager.py
+++ b/llm/history_manager.py
@@ -246,6 +246,8 @@ class HistoryManager:
 
     def clear_chat_history(self, history_file):
         self.chat_history.clear()
+        if not history_file:
+            return
         history_file_path = Path(history_file)
-        if history_file_path.exists():
-            history_file_path.unlink()
+        history_file_path.unlink(missing_ok=True)
+        self.delete_tmp(history_file)

--- a/llm/history_manager.py
+++ b/llm/history_manager.py
@@ -146,7 +146,8 @@ class HistoryManager:
 
     def load_chat_history(self, file_path):
         """
-        启动时加载：.tmp 存在 → 上次异常退出，恢复；不存在 → 正常加载正式文件。
+        启动时加载：先加载正式 .json，如果有 .tmp 则将其内容追加合并，
+        写回 .json 后删除 .tmp，最后加载合并后的完整文件。
         """
         if not file_path:
             print("没有提供历史文件名，跳过加载。")
@@ -155,44 +156,39 @@ class HistoryManager:
         messages = []
         history_path = Path(file_path)
         tmp = self._tmp_path(file_path)
-        recovered = False
 
+        # 1. 先加载正式 .json（完整历史）
+        if history_path.exists():
+            try:
+                with open(history_path, 'r', encoding='utf-8') as f:
+                    messages = json.load(f)
+                print(f"聊天记录已从 {history_path} 加载。")
+            except Exception as e:
+                print(f"加载正式聊天记录失败: {e}")
+                messages = []
+
+        # 2. 如果有 .tmp，合并其中未保存的消息
         if tmp.exists() and tmp.stat().st_size > 0:
-            print("检测到未保存的临时聊天记录，正在恢复...")
-            source = tmp
-            recovered = True
-        elif history_path.exists():
-            source = history_path
-        else:
-            return messages
-
-        try:
-            with open(source, 'r', encoding='utf-8') as f:
-                raw = f.read().strip()
-            if not raw:
-                return messages
-
-            if recovered:
-                raw = raw.rstrip(",\n\r")
-                messages = json.loads("[" + raw + "]")
-                tmp.unlink(missing_ok=True)
-            else:
-                messages = json.loads(raw)
-
-            print(f"聊天记录已从 {source} 加载。")
-        except Exception as e:
-            print(f"加载聊天记录失败: {e}")
-            if recovered and history_path.exists():
-                try:
-                    with open(history_path, 'r', encoding='utf-8') as f:
-                        messages = json.load(f)
+            print("检测到未保存的临时聊天记录，正在合并...")
+            try:
+                with open(tmp, 'r', encoding='utf-8') as f:
+                    raw = f.read().strip()
+                if raw:
+                    raw = raw.rstrip(",\n\r")
+                    tmp_messages = json.loads("[" + raw + "]")
+                    # 追加到正式记录后面
+                    messages.extend(tmp_messages)
+                    # 写回 .json 完成保存
+                    history_path.parent.mkdir(parents=True, exist_ok=True)
+                    with open(history_path, 'w', encoding='utf-8') as f:
+                        json.dump(messages, f, ensure_ascii=False, indent=4)
+                    print(f"临时记录已合并保存到 {history_path}")
+                    # 删除 .tmp
                     tmp.unlink(missing_ok=True)
-                    print("已从正式文件中恢复。")
-                except Exception:
-                    pass
-            return messages
+            except Exception as e:
+                print(f"合并临时聊天记录失败: {e}")
 
-        # 重建 UI 聊天历史
+        # 3. 重建 UI 聊天历史
         self.chat_history.clear()
         try:
             for message in messages:
@@ -216,7 +212,6 @@ class HistoryManager:
                         )
         except Exception as e:
             print("显示聊天历史失败", e)
-            return messages
         return messages
 
     def copy_chat_history_to_clipboard(self):

--- a/llm/history_manager.py
+++ b/llm/history_manager.py
@@ -3,7 +3,11 @@ from typing import Any, Optional
 from pathlib import Path
 import json
 import re
+import threading
 from PySide6.QtWidgets import QApplication
+
+# 模块级写锁，保证临时文件写入的线程安全
+_tmp_write_lock = threading.Lock()
 
 
 def _repair_json_string(t: str) -> str:
@@ -96,63 +100,124 @@ class HistoryManager:
         return cls._instance
 
     def __init__(self, chat_history):
-        self.chat_history=chat_history
+        self.chat_history = chat_history
+        self._write_lock = threading.Lock()
+
+    @staticmethod
+    def _tmp_path(history_file: str) -> Path:
+        """正式文件路径 → 临时文件路径 (xxx.json → xxx.json.tmp)"""
+        return Path(str(history_file) + ".tmp")
+
+    @staticmethod
+    def append_message_to_tmp(history_file: str, message: dict) -> None:
+        """增量追加单条消息到临时文件，线程安全。"""
+        if not history_file:
+            return
+        tmp = HistoryManager._tmp_path(history_file)
+        try:
+            tmp.parent.mkdir(parents=True, exist_ok=True)
+            line = json.dumps(message, ensure_ascii=False) + ",\n"
+            with _tmp_write_lock:
+                with open(tmp, "a", encoding="utf-8") as f:
+                    f.write(line)
+        except Exception:
+            pass  # 增量保存失败不应影响聊天
 
     def get_history(self):
         return self.chat_history
 
     def save_chat_history(self, file_path, history):
-        """根据提供的文件名保存聊天记录到 JSON 文件。"""
+        """
+        正常关闭：用传入的完整内存数据全量写入正式文件，然后删除临时文件。
+        """
         if not file_path:
             print("没有提供历史文件名，跳过保存。")
             return
         history_path = Path(file_path)
+        tmp = self._tmp_path(file_path)
         try:
             history_path.parent.mkdir(parents=True, exist_ok=True)
             with open(history_path, 'w', encoding='utf-8') as f:
                 json.dump(history, f, ensure_ascii=False, indent=4)
             print(f"聊天记录已保存到 {history_path}")
+            tmp.unlink(missing_ok=True)
         except Exception as e:
-            # traceback.print_exc()
             print(f"保存聊天记录失败: {e}")
 
-    def load_chat_history(self,file_path):
-        """根据提供的文件名加载聊天记录。"""
+    def load_chat_history(self, file_path):
+        """
+        启动时加载：.tmp 存在 → 上次异常退出，恢复；不存在 → 正常加载正式文件。
+        """
         if not file_path:
             print("没有提供历史文件名，跳过加载。")
             return []
-        
-        messages=[]
-        history_path = Path(file_path)
-        if history_path.exists():
-            try:
-                with open(history_path, 'r', encoding='utf-8') as f:
-                    messages = json.load(f)
-                print(f"聊天记录已从 {history_path} 加载。")
-            except Exception as e:
-                print(f"加载聊天记录失败: {e}")
 
+        messages = []
+        history_path = Path(file_path)
+        tmp = self._tmp_path(file_path)
+        recovered = False
+
+        if tmp.exists() and tmp.stat().st_size > 0:
+            print("检测到未保存的临时聊天记录，正在恢复...")
+            source = tmp
+            recovered = True
+        elif history_path.exists():
+            source = history_path
+        else:
+            return messages
+
+        try:
+            with open(source, 'r', encoding='utf-8') as f:
+                raw = f.read().strip()
+            if not raw:
+                return messages
+
+            if recovered:
+                raw = raw.rstrip(",\n\r")
+                messages = json.loads("[" + raw + "]")
+                tmp.unlink(missing_ok=True)
+            else:
+                messages = json.loads(raw)
+
+            print(f"聊天记录已从 {source} 加载。")
+        except Exception as e:
+            print(f"加载聊天记录失败: {e}")
+            if recovered and history_path.exists():
+                try:
+                    with open(history_path, 'r', encoding='utf-8') as f:
+                        messages = json.load(f)
+                    tmp.unlink(missing_ok=True)
+                    print("已从正式文件中恢复。")
+                except Exception:
+                    pass
+            return messages
+
+        # 重建 UI 聊天历史
         self.chat_history.clear()
         try:
             for message in messages:
                 if message["role"] == 'user':
-                    self.chat_history.append(f"<p style='line-height: 135%; letter-spacing: 2px; color:white;'><b style='color:white;'>你</b>: {message['content']}</p>")
+                    self.chat_history.append(
+                        f"<p style='line-height: 135%; letter-spacing: 2px; color:white;'>"
+                        f"<b style='color:white;'>你</b>: {message['content']}</p>"
+                    )
                 if message['role'] == 'assistant':
                     content = message.get('content', '')
                     if not content:
-                        # 工具调用中间态可能写入空 assistant，跳过即可
                         continue
                     dialog = parse_assistant_dialog_content(content)
                     if not dialog:
                         continue
                     for item in dialog:
-                        self.chat_history.append(f"<p style='line-height: 135%; letter-spacing: 2px; color:white;'><b style='color:white;'>{item['character_name']}</b>: {item['speech']}</p>")
-
+                        self.chat_history.append(
+                            f"<p style='line-height: 135%; letter-spacing: 2px; color:white;'>"
+                            f"<b style='color:white;'>{item['character_name']}</b>: "
+                            f"{item['speech']}</p>"
+                        )
         except Exception as e:
             print("显示聊天历史失败", e)
             return messages
         return messages
-
 
     def copy_chat_history_to_clipboard(self):
         if not self.chat_history:
@@ -160,23 +225,19 @@ class HistoryManager:
             return
 
         formatted_text = ""
-        
         for entry in self.chat_history:
-            # 1. 使用正则表达式去除 HTML 标签
             clean_text = re.sub(r'<[^>]+>', '', entry)
-            
-            # 2. 确保格式为 "姓名: 话语" (通常正则清洗后已经是这个格式)
             formatted_text += clean_text.strip() + "\n"
 
-        # 3. 获取 Qt 剪贴板实例并设置文本
         clipboard = QApplication.clipboard()
         if clipboard:
             clipboard.setText(formatted_text)
             print("聊天记录已成功复制到剪贴板。")
         else:
             print("无法访问系统剪贴板。")
+
     def clear_chat_history(self, history_file):
         self.chat_history.clear()
-        history_file_path =Path(history_file)
+        history_file_path = Path(history_file)
         if history_file_path.exists():
             history_file_path.unlink()

--- a/llm/llm_manager.py
+++ b/llm/llm_manager.py
@@ -1,4 +1,3 @@
-
 from asyncio import Queue
 import json
 import threading
@@ -255,7 +254,8 @@ class LLMManager:
         history_recent_messages: int = 20,
         max_tool_result_chars: int = 6000,
         max_active_tool_groups: int = 3,
-        generation_config: Optional[Dict[str, Any]] = None
+        generation_config: Optional[Dict[str, Any]] = None,
+        history_file: str = "",
     ):
         self.llm_adapter = adapter
         self.messages = []
@@ -284,6 +284,7 @@ class LLMManager:
             "estimated_total_tokens": 0,
         }
         self._chat_depth = 0
+        self._history_file = history_file
         
         # 设置日志
         self.logger = logger
@@ -356,6 +357,11 @@ class LLMManager:
         msg.update(kwargs)
         self.messages.append(msg)
         
+        # --- 增量写入临时文件 ---
+        if self._history_file:
+            from llm.history_manager import HistoryManager
+            HistoryManager.append_message_to_tmp(self._history_file, msg)
+
         # --- Auto-Compact 逻辑 ---
         # 自动调用 compact_manager 检查 token 是否超限并执行压缩
         compacted_messages = self.compact_manager.auto_compact_if_needed(self.messages)

--- a/main.py
+++ b/main.py
@@ -70,12 +70,10 @@ from core.sprite.sprite_cli import parse_sprite_args
 try:
     from live.danmuku_handler import start_bilibili_service
 except ImportError as e:
-    # 早于 init_i18n，不调用 tr
-    # print("Bilibili import failed:", e)
     pass
 
 voice_lang = "ja"
-cc = OpenCC("t2s")  # 繁体到简体转换器
+cc = OpenCC("t2s")
 
 
 def _shutdown_plugins() -> None:
@@ -130,7 +128,7 @@ def main():
         except Exception:
             logger.exception("T2I initialization failed", extra={"event": "t2i.init.failed"})
 
-    # TTS：仅当 API 中语音引擎不是「不使用」时加载；命令行 --tts 可覆盖引擎名（与 api.yaml 一致）
+    # TTS
     gsv_url, gsv_api_path, config_tts_provider = config.get_gpt_sovits_config()
     adapter_name = (args.tts or "").strip() or config_tts_provider
     tts_manager = None
@@ -166,7 +164,6 @@ def main():
     ) as f:
         user_template = f.read()
 
-    # Init LLMManager before UI, so that handlers can access it via get_app_runtime().llm_manager
     llm_provider, llm_model, base_url, api_key = config.get_llm_api_config()
     logger.info(
         "LLM configuration selected",
@@ -208,13 +205,12 @@ def main():
             "frequency_penalty": float(config.config.api_config.frequency_penalty),
             "max_tokens": 4096,
         },
-        history_file=args.history,  # ← 新增，用于增量保存
+        history_file=args.history,
     )
 
     if messages:
         llm_manager.set_messages(messages)
 
-    # Legacy flow
     image_queue = Queue()
     emotion_queue = Queue()
 
@@ -223,14 +219,12 @@ def main():
 
     text_processor = TextProcessor()
 
-    # 将角色读音映射注入 text_processor.name_map
     for _char in config.config.characters:
         _pm = getattr(_char, "pronunciation_map", None)
         if _pm:
             from llm.text_processor import name_map
             name_map.update(_pm)
 
-    # 获取背景组
     bg_group = None
     try:
         bg_group = (
@@ -302,7 +296,6 @@ def main():
             save_chat_history(args.history, llm_manager.get_messages())
         return
 
-    # Init UI and connect to runtime
     from core.runtime.ui_update_manager import UIUpdateManager, connect_to_desktop_window
     from PySide6.QtGui import QIcon
     from PySide6.QtWidgets import QApplication
@@ -352,7 +345,7 @@ def main():
     else:
         _welcome_html = tr_i18n("main.welcome_html")
         _option_start = tr_i18n("main.option_start")
-    # 更新初始立绘（已从文件恢复会话时不要先刷欢迎语，否则会 hide 选项区并与恢复队列竞争）
+
     try:
         if not messages:
             window.setDisplayWords(_welcome_html)
@@ -368,7 +361,6 @@ def main():
     else:
         emit_user_text = None
 
-    # Update system_config with current session's bg/bgm so restore doesn't use stale values
     sc = config.config.system_config.model_copy(deep=True)
     if bg_group:
         sc.bgm_path = bgm_list[0] if bgm_list else ""
@@ -417,36 +409,40 @@ def main():
             try:
                 start_bilibili_service(args.room_id, user_input_queue=user_input_queue)
             except ImportError as e:
-                # print(tr_i18n("main.print_bili_import", e=str(e)))
                 pass
 
-    # 确保在程序退出时停止所有线程
     try:
         appIcon = QIcon(str(resource_path("assets/system/picture/Icon.png")))
         app.setWindowIcon(appIcon)
     except Exception as e:
         print(tr_i18n("main.print_icon_fail", e=str(e)))
 
-    # ----- 退出流程：独立 try-except 保护保存步骤 -----
-    def _safe_save_chat():
-        try:
-            save_chat_history(args.history, llm_manager.get_messages())
-        except Exception:
-            logger.exception("保存聊天记录失败", extra={"event": "chat.save.failed"})
+    # ----- 退出流程 -----
+    from llm.history_manager import HistoryManager
 
-    def _safe_save_bg():
+    def _safe_step(name, fn):
         try:
-            save_bg(bg_path=window.current_background_path, bgm_path=ui_updates.current_bgm_path)
+            fn()
         except Exception:
-            logger.exception("保存背景失败", extra={"event": "bg.save.failed"})
+            logger.exception(f"{name} 失败", extra={"event": f"{name}.failed"})
 
-    # 关闭顺序：插件 → TTS 服务器 → Worker 线程 → 保存数据
-    app.aboutToQuit.connect(workflow.stop)
-    app.aboutToQuit.connect(_shutdown_plugins)
-    app.aboutToQuit.connect(lambda: tts_manager and tts_manager.shutdown())
-    app.aboutToQuit.connect(_safe_save_chat)
-    app.aboutToQuit.connect(_safe_save_bg)
-    # -------------------------------------------------
+    # 前置步骤（异常不影响后续）
+    app.aboutToQuit.connect(lambda: _safe_step("workflow.stop", workflow.stop))
+    app.aboutToQuit.connect(lambda: _safe_step("shutdown_plugins", _shutdown_plugins))
+    app.aboutToQuit.connect(lambda: _safe_step("tts_manager.shutdown", lambda: tts_manager and tts_manager.shutdown()))
+    app.aboutToQuit.connect(lambda: _safe_step("save_bg", lambda: save_bg(bg_path=window.current_background_path, bgm_path=ui_updates.current_bgm_path)))
+
+    # 核心保存步骤：成功则删除 .tmp，失败则跳过删除保护 .tmp
+    def _save_chat_and_guard_tmp():
+        success = save_chat_history(args.history, llm_manager.get_messages())
+        if not success:
+            return
+        try:
+            HistoryManager.delete_tmp(args.history)
+        except Exception:
+            logger.exception("delete_tmp 失败", extra={"event": "delete_tmp.failed"})
+
+    app.aboutToQuit.connect(_save_chat_and_guard_tmp)
 
     window.show()
 

--- a/main.py
+++ b/main.py
@@ -208,6 +208,7 @@ def main():
             "frequency_penalty": float(config.config.api_config.frequency_penalty),
             "max_tokens": 4096,
         },
+        history_file=args.history,  # ← 新增，用于增量保存
     )
 
     if messages:
@@ -426,17 +427,26 @@ def main():
     except Exception as e:
         print(tr_i18n("main.print_icon_fail", e=str(e)))
 
+    # ----- 退出流程：独立 try-except 保护保存步骤 -----
+    def _safe_save_chat():
+        try:
+            save_chat_history(args.history, llm_manager.get_messages())
+        except Exception:
+            logger.exception("保存聊天记录失败", extra={"event": "chat.save.failed"})
+
+    def _safe_save_bg():
+        try:
+            save_bg(bg_path=window.current_background_path, bgm_path=ui_updates.current_bgm_path)
+        except Exception:
+            logger.exception("保存背景失败", extra={"event": "bg.save.failed"})
+
     # 关闭顺序：插件 → TTS 服务器 → Worker 线程 → 保存数据
     app.aboutToQuit.connect(workflow.stop)
     app.aboutToQuit.connect(_shutdown_plugins)
     app.aboutToQuit.connect(lambda: tts_manager and tts_manager.shutdown())
-    app.aboutToQuit.connect(lambda: save_chat_history(args.history, llm_manager.get_messages()))
-    app.aboutToQuit.connect(
-        lambda: save_bg(
-            bg_path=window.current_background_path,
-            bgm_path=ui_updates.current_bgm_path,
-        )
-    )
+    app.aboutToQuit.connect(_safe_save_chat)
+    app.aboutToQuit.connect(_safe_save_bg)
+    # -------------------------------------------------
 
     window.show()
 

--- a/test/unit/test_chat_history.py
+++ b/test/unit/test_chat_history.py
@@ -1,6 +1,9 @@
 """Unit tests for chat_history — pop_last_assistant_turn (reroll logic) and
 dialog content parsing."""
 
+import json
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock
 import sys
 
@@ -12,6 +15,7 @@ sys.modules.setdefault("PySide6.QtCore", MagicMock())
 from llm.history_manager import (
     _repair_json_string,
     parse_assistant_dialog_content,
+    HistoryManager,
 )
 from core.sprite.chat_history import pop_last_assistant_turn
 
@@ -259,3 +263,181 @@ class TestRepairJsonString:
             '{"speech": "he said \\"hello\\""}'
         )
         assert repaired.count('"') % 2 == 0  # balanced quotes
+
+
+# ====================== 新增：HistoryManager 增量保存与恢复测试 ======================
+
+class TestTmpPath:
+    """_tmp_path 静态方法"""
+
+    def test_appends_tmp_suffix(self):
+        path = HistoryManager._tmp_path("/data/chat/abc.json")
+        assert str(path).endswith(".json.tmp")
+
+    def test_handles_windows_paths(self):
+        path = HistoryManager._tmp_path("D:\\data\\chat\\abc.json")
+        assert str(path).endswith(".json.tmp")
+
+
+class TestAppendMessageToTmp:
+    """append_message_to_tmp 静态方法"""
+
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.history_file = str(Path(self.tmp_dir) / "test.json")
+
+    def test_creates_tmp_file_and_writes_line(self):
+        msg = {"role": "user", "content": "hello"}
+        HistoryManager.append_message_to_tmp(self.history_file, msg)
+
+        tmp_path = Path(self.history_file + ".tmp")
+        assert tmp_path.exists()
+        content = tmp_path.read_text(encoding="utf-8")
+        assert '"role"' in content
+        assert '"user"' in content
+        assert content.endswith(",\n")
+
+    def test_appends_multiple_messages(self):
+        HistoryManager.append_message_to_tmp(self.history_file, {"role": "user", "content": "a"})
+        HistoryManager.append_message_to_tmp(self.history_file, {"role": "assistant", "content": "b"})
+
+        tmp_path = Path(self.history_file + ".tmp")
+        lines = tmp_path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 2
+
+    def test_creates_parent_dirs(self):
+        deep_file = str(Path(self.tmp_dir) / "sub" / "deep" / "test.json")
+        HistoryManager.append_message_to_tmp(deep_file, {"role": "user", "content": "x"})
+        assert Path(deep_file + ".tmp").exists()
+
+    def test_does_not_raise_on_none_path(self):
+        HistoryManager.append_message_to_tmp(None, {"role": "user", "content": "x"})
+
+    def test_does_not_raise_on_empty_path(self):
+        HistoryManager.append_message_to_tmp("", {"role": "user", "content": "x"})
+
+
+class TestLoadChatHistoryRecovery:
+    """load_chat_history 崩溃恢复逻辑"""
+
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.history_file = str(Path(self.tmp_dir) / "test.json")
+
+    def _make_history_manager(self):
+        return HistoryManager([])
+
+    def test_normal_load_without_tmp(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        with open(self.history_file, "w", encoding="utf-8") as f:
+            json.dump(msgs, f)
+
+        hm = self._make_history_manager()
+        result = hm.load_chat_history(self.history_file)
+        assert len(result) == 1
+        assert result[0]["content"] == "hi"
+
+    def test_recovery_from_tmp_only(self):
+        tmp_path = Path(self.history_file + ".tmp")
+        tmp_path.write_text(
+            '{"role": "user", "content": "recovered"},\n',
+            encoding="utf-8"
+        )
+
+        hm = self._make_history_manager()
+        result = hm.load_chat_history(self.history_file)
+        assert len(result) == 1
+        assert result[0]["content"] == "recovered"
+        # 恢复后应该生成正式文件并删除 tmp
+        assert Path(self.history_file).exists()
+        assert not tmp_path.exists()
+
+    def test_merges_tmp_into_existing_json(self):
+        old_msgs = [{"role": "user", "content": "old"}]
+        with open(self.history_file, "w", encoding="utf-8") as f:
+            json.dump(old_msgs, f)
+
+        tmp_path = Path(self.history_file + ".tmp")
+        tmp_path.write_text(
+            '{"role": "assistant", "content": "new"},\n',
+            encoding="utf-8"
+        )
+
+        hm = self._make_history_manager()
+        result = hm.load_chat_history(self.history_file)
+        assert len(result) == 2
+        assert result[0]["content"] == "old"
+        assert result[1]["content"] == "new"
+        assert not tmp_path.exists()
+
+    def test_dedup_when_last_msg_matches_first_tmp_msg(self):
+        old_msgs = [{"role": "user", "content": "dup"}]
+        with open(self.history_file, "w", encoding="utf-8") as f:
+            json.dump(old_msgs, f)
+
+        tmp_path = Path(self.history_file + ".tmp")
+        tmp_path.write_text(
+            '{"role": "user", "content": "dup"},\n'
+            '{"role": "assistant", "content": "new"},\n',
+            encoding="utf-8"
+        )
+
+        hm = self._make_history_manager()
+        result = hm.load_chat_history(self.history_file)
+        assert len(result) == 2
+        assert result[0]["content"] == "dup"
+        assert result[1]["content"] == "new"
+
+    def test_returns_empty_when_both_missing(self):
+        hm = self._make_history_manager()
+        result = hm.load_chat_history(self.history_file)
+        assert result == []
+
+    def test_fallback_to_json_when_tmp_corrupt(self):
+        old_msgs = [{"role": "user", "content": "fallback"}]
+        with open(self.history_file, "w", encoding="utf-8") as f:
+            json.dump(old_msgs, f)
+
+        tmp_path = Path(self.history_file + ".tmp")
+        tmp_path.write_text("not valid json{{{", encoding="utf-8")
+
+        hm = self._make_history_manager()
+        result = hm.load_chat_history(self.history_file)
+        assert len(result) == 1
+        assert result[0]["content"] == "fallback"
+
+
+class TestSaveChatHistory:
+    """save_chat_history 返回 bool，tmp 由 delete_tmp 独立删除"""
+
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.history_file = str(Path(self.tmp_dir) / "test.json")
+
+    def _make_history_manager(self):
+        return HistoryManager([])
+
+    def test_returns_true_on_success(self):
+        hm = self._make_history_manager()
+        result = hm.save_chat_history(self.history_file, [{"role": "user", "content": "x"}])
+        assert result is True
+        assert Path(self.history_file).exists()
+
+    def test_returns_true_when_no_file_path(self):
+        hm = self._make_history_manager()
+        result = hm.save_chat_history(None, [{"role": "user", "content": "x"}])
+        assert result is True
+
+    def test_tmp_persists_until_delete_tmp_called(self):
+        """save_chat_history 不删 tmp，需要独立调用 delete_tmp"""
+        tmp_path = Path(self.history_file + ".tmp")
+        tmp_path.write_text("dummy", encoding="utf-8")
+
+        hm = self._make_history_manager()
+        hm.save_chat_history(self.history_file, [{"role": "user", "content": "x"}])
+        # tmp 仍然存在
+        assert tmp_path.exists()
+
+        # 独立调用 delete_tmp 后才删除
+        HistoryManager.delete_tmp(self.history_file)
+        assert not tmp_path.exists()

--- a/test/unit/test_chat_history.py
+++ b/test/unit/test_chat_history.py
@@ -4,6 +4,7 @@ dialog content parsing."""
 import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 import sys
 
@@ -428,6 +429,18 @@ class TestSaveChatHistory:
         result = hm.save_chat_history(None, [{"role": "user", "content": "x"}])
         assert result is True
 
+    def test_sprite_wrapper_returns_manager_result(self, monkeypatch):
+        from core.sprite import chat_history as chat_history_mod
+
+        monkeypatch.setattr(
+            chat_history_mod,
+            "_get_history_manager",
+            lambda: SimpleNamespace(save_chat_history=lambda file_path, history: True),
+        )
+
+        result = chat_history_mod.save_chat_history(self.history_file, [])
+        assert result is True
+
     def test_tmp_persists_until_delete_tmp_called(self):
         """save_chat_history 不删 tmp，需要独立调用 delete_tmp"""
         tmp_path = Path(self.history_file + ".tmp")
@@ -440,4 +453,25 @@ class TestSaveChatHistory:
 
         # 独立调用 delete_tmp 后才删除
         HistoryManager.delete_tmp(self.history_file)
+        assert not tmp_path.exists()
+
+
+class TestClearChatHistory:
+    """clear_chat_history 清理正式历史和增量 tmp。"""
+
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.history_file = str(Path(self.tmp_dir) / "test.json")
+
+    def test_removes_json_and_tmp(self):
+        history_path = Path(self.history_file)
+        tmp_path = Path(self.history_file + ".tmp")
+        history_path.write_text("[]", encoding="utf-8")
+        tmp_path.write_text('{"role": "user", "content": "secret"},\n', encoding="utf-8")
+
+        hm = HistoryManager(["visible"])
+        hm.clear_chat_history(self.history_file)
+
+        assert hm.get_history() == []
+        assert not history_path.exists()
         assert not tmp_path.exists()


### PR DESCRIPTION
## 修复内容

为聊天记录增加增量保存与崩溃恢复机制，解决进程异常终止或退出流程中断导致整场对话记录全部丢失的问题。

### 问题

聊天记录仅在 aboutToQuit 最后一步全量保存一次。进程崩溃、被强制结束、或退出流程中前序步骤异常时，保存步骤被跳过，本轮对话全部丢失。

### 方案

- 增量写入：聊天过程中每条消息追加写入临时文件（.json.tmp），单行 JSON + 逗号，模块级锁保证线程安全
- 正常关闭：前序步骤异常被吞，核心保存步骤写入 .json，成功后删除 .tmp；保存失败则跳过删除，保留 .tmp 供下次恢复
- 崩溃恢复：下次启动时先加载 .json，检测到 .tmp 存在则将其内容合并去重后写回 .json，然后删除 .tmp
- 无正式文件兜底：_latest_history_json 在找不到 .json 时返回对应的 .json 路径，load_chat_history 直接从 .tmp 恢复

### 改动

- llm/history_manager.py — 新增临时文件路径、追加写入（线程安全）、合并恢复、去重、独立删除方法；save_chat_history 返回 bool 不抛异常
- llm/llm_manager.py — 新增 history_file 参数，每次 add_message 时增量写入
- main.py — 传入 history_file；退出流程重排：前置步骤异常保护，核心保存步骤成功则删 .tmp、失败则跳过删除
- frontend_bridge_core/templates.py — _latest_history_json 在 .json 不存在时检查 .json.tmp 并返回正确路径

### 验证

- 正常关闭：.json 完整，.tmp 已删除
- 崩溃后重启：.tmp 合并进 .json，历史完整恢复，角色记忆正常
- 仅有 .tmp 无 .json：正常恢复
- .tmp 与 .json 尾部重叠：去重后不产生重复消息
- 保存失败：.tmp 保留，下次启动恢复
- 不同角色对话间隔离，无交叉污染

### 注意事项

- delete_tmp 失败导致 .tmp 残留时，去重只比较第一条，若 .tmp 与 .json 有多条重叠可能仍产生少量重复（概率极低）
- 长时间运行后 .tmp 持续增大，恢复时需读取整文件，但聊天消息体积小，实际影响可忽略

Ref #132