### PR TITLE
fix: wire compact hooks from plugin registry

### DIFF
--- a/core/plugins/plugin_host.py
+++ b/core/plugins/plugin_host.py
@@ -51,6 +51,7 @@ _plugin_ui_handlers: List["UIOutputMessageHandler"] = []
 _plugin_dag_yaml_paths: list[str] = []
 _plugin_workflow_contributions: list["WorkflowContribution"] = []
 _plugin_output_contract_patches: list["OutputContractPatch"] = []
+_plugin_compact_hooks: list[Callable[[list], None]] = []
 
 
 def get_plugin_manager() -> PluginManager | None:
@@ -85,6 +86,11 @@ def get_plugin_output_contract_patches(
     return patches
 
 
+def get_plugin_compact_hooks() -> list[Callable[[list], None]]:
+    """Return plugin-registered hooks that should run before conversation compaction."""
+    return list(_plugin_compact_hooks)
+
+
 def ensure_plugins_loaded(config: ConfigManager | None = None) -> PluginManager | None:
     """
     Load ``data/config/plugins.yaml`` if present, instantiate plugins, merge LLM/TTS/ASR/T2I
@@ -94,6 +100,7 @@ def ensure_plugins_loaded(config: ConfigManager | None = None) -> PluginManager 
     global _loaded, _plugin_manager, _plugin_tts_handlers, _plugin_ui_handlers
     global _plugin_dag_yaml_paths
     global _plugin_workflow_contributions, _plugin_output_contract_patches
+    global _plugin_compact_hooks
     if _loaded:
         return _plugin_manager
 
@@ -167,6 +174,11 @@ def ensure_plugins_loaded(config: ConfigManager | None = None) -> PluginManager 
     except Exception:
         logger.exception("collect_output_contract_patches failed")
         _plugin_output_contract_patches = []
+    try:
+        _plugin_compact_hooks = mgr.collect_compact_hooks()
+    except Exception:
+        logger.exception("collect_compact_hooks failed")
+        _plugin_compact_hooks = []
 
     _plugin_manager = mgr
     _loaded = True

--- a/llm/compact_manager.py
+++ b/llm/compact_manager.py
@@ -2,6 +2,7 @@
 import json
 import math
 import tiktoken
+from collections.abc import Callable, Iterable
 from typing import List, Dict, Any
 import logging
 
@@ -22,6 +23,7 @@ class CompactManager:
         compact_target_ratio: float = 0.3,
         recent_message_limit: int = 20,
         compact_summary_max_tokens: int = 2048,
+        compact_hooks: Iterable[Callable[[List[Dict[str, Any]]], None]] | None = None,
     ):
         """
         初始化CompactManager
@@ -33,6 +35,7 @@ class CompactManager:
             compact_target_ratio: 压缩后目标上下文占比
             recent_message_limit: 压缩/截断时保留的最近消息数量
             compact_summary_max_tokens: 历史总结自身的最大 token 预算
+            compact_hooks: 精简前执行的插件钩子
         """
         self.llm_adapter = llm_adapter
         self.max_tokens = max_tokens
@@ -43,6 +46,7 @@ class CompactManager:
         )
         self.recent_message_limit = max(1, int(recent_message_limit))
         self.compact_summary_max_tokens = max(128, int(compact_summary_max_tokens))
+        self._compact_hooks = list(compact_hooks or [])
         self.num_tokens = 0
         
         # 尝试使用tiktoken进行token计数
@@ -236,16 +240,12 @@ class CompactManager:
         if not older_messages:
             return messages
 
-        # [MemorySystem] 触发所有已注册的精简前钩子（插件可在此阶段执行归档写入等操作）
-        try:
-            from sdk.register import PluginCapabilityRegistry
-            for hook in PluginCapabilityRegistry().compact_hooks:
-                try:
-                    hook(messages)
-                except Exception as e:
-                    logger.warning(f"精简前钩子执行失败（已跳过，不影响精简流程）: {e}")
-        except Exception:
-            pass
+        # [MemorySystem] 触发宿主传入的精简前钩子（插件可在此阶段执行归档写入等操作）
+        for hook in self._compact_hooks:
+            try:
+                hook(messages)
+            except Exception as e:
+                logger.warning(f"精简前钩子执行失败（已跳过，不影响精简流程）: {e}")
         
         # 准备压缩提示
         compact_prompt = self._create_compact_prompt(older_messages)

--- a/llm/llm_manager.py
+++ b/llm/llm_manager.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 import json
 import threading
 import time
+from collections.abc import Callable, Iterable
 from datetime import datetime
 from threading import Thread
 from typing import Any, Dict, Generator, List, Optional, Union
@@ -297,6 +298,7 @@ class LLMManager:
         first_turn_tool_call_limit: int = FIRST_USER_TURN_TOOL_CALL_LIMIT,
         generation_config: Optional[Dict[str, Any]] = None,
         history_file: str = "",
+        compact_hooks: Optional[Iterable[Callable[[List[Dict[str, Any]]], None]]] = None,
     ):
         self.llm_adapter = adapter
         self.messages = []
@@ -311,6 +313,7 @@ class LLMManager:
             compact_threshold,
             compact_target_ratio=compact_target_ratio,
             recent_message_limit=self.history_recent_messages,
+            compact_hooks=compact_hooks,
         )
         self.generation_config = generation_config or {}
         self.set_user_template(user_template)

--- a/main.py
+++ b/main.py
@@ -260,7 +260,11 @@ def main():
         init_i18n(config.config.system_config.ui_language)
 
     with _startup_phase("plugins.import"):
-        from core.plugins.plugin_host import ensure_plugins_loaded, wire_user_input_plugins
+        from core.plugins.plugin_host import (
+            ensure_plugins_loaded,
+            get_plugin_compact_hooks,
+            wire_user_input_plugins,
+        )
 
     with _startup_phase("plugins.load"):
         ensure_plugins_loaded(config)
@@ -375,6 +379,7 @@ def main():
             history_recent_messages=int(config.config.api_config.history_recent_messages),
             max_tool_result_chars=int(config.config.api_config.max_tool_result_chars),
             max_active_tool_groups=int(config.config.api_config.max_active_tool_groups),
+            compact_hooks=get_plugin_compact_hooks(),
             generation_config={
                 "temperature": float(config.config.api_config.temperature),
                 "repetition_penalty": float(config.config.api_config.repetition_penalty),

--- a/sdk/manager.py
+++ b/sdk/manager.py
@@ -284,6 +284,12 @@ class PluginManager:
             return []
         return self._capabilities.output_contract_patches
 
+    def collect_compact_hooks(self) -> list[Callable[[list], None]]:
+        self._ensure_plugins_initialized()
+        if self._capabilities is None:
+            return []
+        return self._capabilities.compact_hooks
+
     def iter_plugin_ids(self) -> Iterator[str]:
         self._ensure_plugins_instantiated()
         return (p.plugin_id for p in self._instances)

--- a/test/unit/managers/test_llm_manager.py
+++ b/test/unit/managers/test_llm_manager.py
@@ -8,6 +8,7 @@ import pytest
 from llm.llm_manager import LLMManager, LLMAdapterFactory
 from llm.compact_manager import CompactManager
 from llm.tools.tool_manager import ToolManager
+from sdk.register import PluginCapabilityRegistry
 from test.mocks import MockLLMAdapter
 
 
@@ -265,6 +266,34 @@ class TestLLMManagerCompact:
         result = cm.compact_messages(messages)
         assert result[0]["role"] == "system"
         assert len(result) < len(messages)
+
+    def test_compact_messages_calls_registered_compact_hooks(self, mock_llm_adapter):
+        registry = PluginCapabilityRegistry()
+        hook_calls = []
+
+        def before_compact(messages):
+            hook_calls.append(list(messages))
+
+        registry.register_compact_hook(before_compact)
+        mock_llm_adapter.responses = ["A summary written after plugin hook."]
+        cm = CompactManager(
+            mock_llm_adapter,
+            max_tokens=10000,
+            compact_threshold=0.5,
+            recent_message_limit=1,
+            compact_hooks=registry.compact_hooks,
+        )
+        messages = [
+            {"role": "system", "content": "S"},
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "latest"},
+        ]
+
+        result = cm.compact_messages(messages)
+
+        assert hook_calls == [messages]
+        assert "历史对话总结" in result[1]["content"]
 
     def test_add_message_persists_same_length_compaction(self, mock_llm_adapter):
         mock_llm_adapter.responses = ["Condensed old turn."]


### PR DESCRIPTION
## Summary

- Collect compact hooks from the real plugin capability registry instead of constructing a new empty registry during compaction.
- Pass registered compact hooks through `plugin_host`, `main`, and `LLMManager` into `CompactManager`.
- Invoke registered hooks before compaction while keeping hook failures non-fatal.
- Add a regression test that verifies registered compact hooks are called.

## Validation

- `python -m pytest test/unit/managers/test_llm_manager.py::TestLLMManagerCompact -q`
- `python -m pytest test/unit/test_frontend_config_contributions.py test/unit/test_output_contracts.py -q`

Closes #156