### PR TITLE
fix: compact_messages 使用已加载 registry 替代新建空实例

### DIFF
--- a/core/plugins/plugin_host.py
+++ b/core/plugins/plugin_host.py
@@ -57,6 +57,14 @@ def get_plugin_manager() -> PluginManager | None:
     return _plugin_manager
 
 
+def get_plugin_registry():
+    """返回加载插件时使用的真实 PluginCapabilityRegistry 实例。"""
+    mgr = _plugin_manager
+    if mgr is None:
+        return None
+    return mgr.capabilities
+
+
 def get_plugin_tts_handlers() -> List["MessageHandler"]:
     return list(_plugin_tts_handlers)
 

--- a/llm/compact_manager.py
+++ b/llm/compact_manager.py
@@ -238,12 +238,15 @@ class CompactManager:
 
         # [MemorySystem] 触发所有已注册的精简前钩子（插件可在此阶段执行归档写入等操作）
         try:
-            from sdk.register import PluginCapabilityRegistry
-            for hook in PluginCapabilityRegistry().compact_hooks:
-                try:
-                    hook(messages)
-                except Exception as e:
-                    logger.warning(f"精简前钩子执行失败（已跳过，不影响精简流程）: {e}")
+            from core.plugins.plugin_host import get_plugin_registry
+
+            registry = get_plugin_registry()
+            if registry is not None:
+                for hook in registry.compact_hooks:
+                    try:
+                        hook(messages)
+                    except Exception as e:
+                        logger.warning(f"精简前钩子执行失败（已跳过，不影响精简流程）: {e}")
         except Exception:
             pass
         

--- a/test/unit/managers/test_llm_manager.py
+++ b/test/unit/managers/test_llm_manager.py
@@ -8,6 +8,7 @@ import pytest
 from llm.llm_manager import LLMManager, LLMAdapterFactory
 from llm.compact_manager import CompactManager
 from llm.tools.tool_manager import ToolManager
+from sdk.register import PluginCapabilityRegistry
 from test.mocks import MockLLMAdapter
 
 
@@ -265,6 +266,40 @@ class TestLLMManagerCompact:
         result = cm.compact_messages(messages)
         assert result[0]["role"] == "system"
         assert len(result) < len(messages)
+
+    def test_compact_messages_calls_registered_compact_hooks(self, mock_llm_adapter, monkeypatch):
+        import core.plugins.plugin_host as plugin_host
+
+        registry = PluginCapabilityRegistry()
+        hook_calls = []
+
+        def before_compact(messages):
+            hook_calls.append(list(messages))
+
+        registry.register_compact_hook(before_compact)
+        monkeypatch.setattr(
+            plugin_host,
+            "_plugin_manager",
+            SimpleNamespace(capabilities=registry),
+        )
+        mock_llm_adapter.responses = ["A summary written after plugin hook."]
+        cm = CompactManager(
+            mock_llm_adapter,
+            max_tokens=10000,
+            compact_threshold=0.5,
+            recent_message_limit=1,
+        )
+        messages = [
+            {"role": "system", "content": "S"},
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "latest"},
+        ]
+
+        result = cm.compact_messages(messages)
+
+        assert hook_calls == [messages]
+        assert "A summary written after plugin hook." in result[1]["content"]
 
     def test_add_message_persists_same_length_compaction(self, mock_llm_adapter):
         mock_llm_adapter.responses = ["Condensed old turn."]


### PR DESCRIPTION
### 问题
`compact_messages()` 中通过 `PluginCapabilityRegistry()` 新建空实例获取 hooks，
导致插件通过 `register_compact_hook()` 注册的钩子永远不会被触发。

### 修复
- 在 `plugin_host` 中新增 `get_plugin_registry()`，通过 `PluginManager.capabilities` 返回真实 registry。
- `compact_messages()` 改为调用 `get_plugin_registry()` 获取 hooks。

### 影响
所有依赖 compact hooks 的插件在此修复后可正常触发。