### PR TITLE
fix: issues found in v2.2.0-rc.1

### DIFF
--- a/frontend/src/features/character-editor/CharacterEditorPage.tsx
+++ b/frontend/src/features/character-editor/CharacterEditorPage.tsx
@@ -157,7 +157,15 @@ export function CharacterEditorPage() {
       showToast({ kind: "success", title: t("character.memory.depInstalled") });
       setMemoryDepOpen(false);
       setMemoryDepTask(null);
-      void memoryQuery.refetch();
+      queryClient.setQueryData(["character-memories", memoryName], {
+        agentId: memoryName || "user",
+        count: 0,
+        memories: [],
+      });
+      setMemoryDepInstalling(false);
+      if (await ensureMem0Ready()) {
+        void memoryQuery.refetch();
+      }
     } catch (error) {
       showToast({
         kind: "error",

--- a/frontend/src/features/character-editor/CharacterEditorPage.tsx
+++ b/frontend/src/features/character-editor/CharacterEditorPage.tsx
@@ -614,11 +614,13 @@ export function CharacterEditorPage() {
   const characterHasGptSovitsModel = (character: Character) =>
     Boolean(character.gpt_model_path?.trim() && character.sovits_model_path?.trim());
 
-  const defaultSpriteVoiceType = (character: Character): "preset" | "reference" =>
-    characterHasGptSovitsModel(character) ? "reference" : "preset";
+  const spriteHasReferenceVoiceText = (sprite: Sprite | undefined) => Boolean(sprite?.voice_text?.trim());
+
+  const defaultSpriteVoiceType = (sprite: Sprite | undefined, character: Character): "preset" | "reference" =>
+    characterHasGptSovitsModel(character) && spriteHasReferenceVoiceText(sprite) ? "reference" : "preset";
 
   const spriteVoiceType = (sprite: Sprite | undefined, character: Character): "preset" | "reference" =>
-    sprite?.voice_type ?? defaultSpriteVoiceType(character);
+    sprite?.voice_type ?? defaultSpriteVoiceType(sprite, character);
 
   const updateSpriteTag = (index: number, value: string) => {
     setDraft((current) => {

--- a/frontend/src/features/template-editor/TemplateEditorPage.tsx
+++ b/frontend/src/features/template-editor/TemplateEditorPage.tsx
@@ -290,7 +290,7 @@ export function TemplateEditorPage() {
 
   const scenarioForSelectedCharacters = () => {
     const currentScenario = String(draft.scenario ?? "");
-    const defaultScenario = buildDefaultTemplateScenario(selectedCharacters);
+    const defaultScenario = buildDefaultTemplateScenario(selectedCharacters, t("template.defaultScenario"));
     if (!defaultScenario) {
       if (currentScenario === lastAutoScenarioRef.current) {
         return "";

--- a/frontend/src/features/template-editor/templateFlow.ts
+++ b/frontend/src/features/template-editor/templateFlow.ts
@@ -48,12 +48,12 @@ export function composeTemplateContent(scenario: unknown, system: unknown) {
   return [String(scenario ?? "").trim(), String(system ?? "").trim()].filter(Boolean).join("\n\n");
 }
 
-export function buildDefaultTemplateScenario(selectedCharacters: string[]) {
+export function buildDefaultTemplateScenario(selectedCharacters: string[], defaultScenario: string) {
   const names = selectedCharacters.map((name) => name.trim()).filter(Boolean);
   if (!names.length) {
     return "";
   }
-  return `你需要模拟一个RPG剧情对话系统，出场人物有：${names.join("、")} 以及其他相关人物，请根据剧情调度人物。`;
+  return defaultScenario;
 }
 
 export function createTemplateDraft(name: string): TemplateSummary {

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -813,6 +813,7 @@ export type MessageKey =
   | "template.action.launch"
   | "template.action.quickRestart"
   | "template.defaultName"
+  | "template.defaultScenario"
   | "template.description"
   | "template.emptyBody"
   | "template.emptySelection"

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -873,6 +873,7 @@ export const enMessages: Record<MessageKey, string> = {
   "template.action.quickRestart": "Quick restart",
   "template.action.selectAllCharacters": "Select all characters",
   "template.defaultName": "New template",
+  "template.defaultScenario": "You play an RPG system. Schedule characters according to the scenario.",
   "template.description":
     "Template editing and generation reuse character and background queries, then refresh chat launch after saving.",
   "template.emptyBody": "Generate a template first.",

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -872,6 +872,7 @@ export const jaMessages: Record<MessageKey, string> = {
   "template.action.quickRestart": "クイック再起動",
   "template.action.selectAllCharacters": "全キャラクターを選択",
   "template.defaultName": "新規テンプレート",
+  "template.defaultScenario": "あなたはRPGシステムを演じ、シナリオに応じて登場人物を動かしてください",
   "template.description":
     "テンプレート編集と生成はキャラクター、背景 query を再利用し、保存後にチャット開始を更新します。",
   "template.emptyBody": "まずテンプレートを生成してください。",

--- a/frontend/src/shared/i18n/messages/zh_CN.ts
+++ b/frontend/src/shared/i18n/messages/zh_CN.ts
@@ -859,6 +859,7 @@ export const zhCNMessages: Record<MessageKey, string> = {
   "template.action.quickRestart": "快速重开",
   "template.action.selectAllCharacters": "全选角色",
   "template.defaultName": "新模板",
+  "template.defaultScenario": "你扮演一个RPG系统，请根据情景调度人物",
   "template.description": "模板编辑与生成功能复用角色、背景 query，保存后刷新启动聊天页。",
   "template.emptyBody": "先生成一个模板。",
   "template.emptySelection": "未选择模板",

--- a/frontend/src/test/features/character-editor/CharacterEditorPage.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterEditorPage.test.tsx
@@ -568,13 +568,17 @@ describe("CharacterEditorPage", () => {
     expect(mockUploadSpriteVoice).not.toHaveBeenCalled();
   });
 
-  it("surfaces missing memory dependencies and installs them with task progress", async () => {
-    mockGetMem0Status.mockResolvedValueOnce({ status: "missing_dependency" });
-    mockListCharacterMemories.mockResolvedValueOnce({
-      kind: "missing_dependency",
-      moduleName: "mem0",
-      packageName: "mem0ai",
-    });
+  it("installs missing memory dependencies and starts memory loading", async () => {
+    mockGetMem0Status
+      .mockResolvedValueOnce({ status: "missing_dependency" })
+      .mockResolvedValueOnce({ status: "ready" });
+    mockListCharacterMemories
+      .mockResolvedValueOnce({
+        kind: "missing_dependency",
+        moduleName: "mem0",
+        packageName: "mem0ai",
+      })
+      .mockResolvedValueOnce({ agentId: "Mika", count: 0, memories: [] });
     mockInstallMissingRuntimeDependency.mockImplementation(
       async (_input, options?: { onTaskUpdate?: (task: unknown) => void }) => {
         options?.onTaskUpdate?.({
@@ -600,6 +604,8 @@ describe("CharacterEditorPage", () => {
         expect.objectContaining({ onTaskUpdate: expect.any(Function) }),
       ),
     );
+    await waitFor(() => expect(screen.queryByText("Missing Python dependency")).not.toBeInTheDocument());
+    await waitFor(() => expect(mockGetMem0Status).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(mockListCharacterMemories).toHaveBeenCalledTimes(2));
   });
 });

--- a/frontend/src/test/features/character-editor/CharacterEditorPage.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterEditorPage.test.tsx
@@ -351,12 +351,40 @@ describe("CharacterEditorPage", () => {
     );
   });
 
-  it("defaults sprite voice uploads to reference when the character has GPT-SoVITS models", async () => {
+  it("keeps sprite voice uploads preset when GPT-SoVITS models have no sprite voice text", async () => {
     mockListCharacters.mockResolvedValue([
       {
         ...structuredClone(character),
         gpt_model_path: "D:/models/mika.ckpt",
         sovits_model_path: "D:/models/mika.pth",
+      },
+    ]);
+    renderPage();
+
+    await screen.findByDisplayValue("Mika");
+    expect(screen.getByRole("radio", { name: "Preset voice" })).toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Voice upload file" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upload voice" }));
+
+    await waitFor(() =>
+      expect(mockUploadSpriteVoice).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Mika",
+          spriteIndex: 0,
+          voicePath: "D:/new/sora.wav",
+          voiceType: "preset",
+        }),
+      ),
+    );
+  });
+
+  it("defaults sprite voice uploads to reference when GPT-SoVITS models have sprite voice text", async () => {
+    mockListCharacters.mockResolvedValue([
+      {
+        ...structuredClone(character),
+        gpt_model_path: "D:/models/mika.ckpt",
+        sovits_model_path: "D:/models/mika.pth",
+        sprites: [{ ...character.sprites[0], voice_text: "Reference line" }],
       },
     ]);
     renderPage();

--- a/frontend/src/test/features/template-editor/TemplateEditorPage.test.tsx
+++ b/frontend/src/test/features/template-editor/TemplateEditorPage.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TemplateEditorPage } from "../../../features/template-editor/TemplateEditorPage";
 import { buildDefaultTemplateScenario } from "../../../features/template-editor/templateFlow";
-import { I18nProvider } from "../../../shared/i18n/I18nProvider";
+import { I18nProvider, translateMessage } from "../../../shared/i18n/I18nProvider";
 import { sampleConfig } from "../../../shared/platform/sampleData";
 import type { TemplateLaunchSession } from "../../../shared/platform/types";
 import { ToastProvider } from "../../../shared/ui";
@@ -164,7 +164,10 @@ describe("TemplateEditorPage", () => {
     expect(await screen.findByDisplayValue("Opening")).toBeInTheDocument();
     fireEvent.change(screen.getByDisplayValue("Morning scene"), { target: { value: "" } });
     fireEvent.click(screen.getByRole("button", { name: "Nanami" }));
-    const defaultScenario = buildDefaultTemplateScenario(["Nanami"]);
+    const defaultScenario = buildDefaultTemplateScenario(
+      ["Nanami"],
+      translateMessage("en", "template.defaultScenario"),
+    );
 
     await waitFor(() =>
       expect(mockGenerateTemplate).toHaveBeenCalledWith(

--- a/frontend_bridge_core/chat.py
+++ b/frontend_bridge_core/chat.py
@@ -42,6 +42,7 @@ from .state import BridgeState
 from .runtime_dependencies import runtime_dependency_error_from_text
 from .templates import (
     TEMP_SPLIT_META,
+    _effective_user_scenario,
     _history_id_from_scenario,
     _template_dir,
 )
@@ -313,6 +314,7 @@ def _main_py_path() -> Path:
 def _launch_chat(
     state: BridgeState,
     *,
+    character_names: list[str] | None = None,
     effect_names: str = "",
     history_file: str,
     init_sprite_path: str,
@@ -333,13 +335,14 @@ def _launch_chat(
             return f"进程已经在运行中！PID: {_main_chat_process.pid}"
 
         # 把用户情景放在系统模板末尾（紧跟 closing 提示后）
+        effective_user_scenario = _effective_user_scenario(user_scenario)
         template = system_template.rstrip()
-        if user_scenario.strip():
-            template = template + "\n" + user_scenario.strip() + "\n"
+        if effective_user_scenario:
+            template = template + "\n" + effective_user_scenario + "\n"
         template_dir = _template_dir(state)
         (template_dir / "_temp.txt").write_text(template, encoding="utf-8")
         (template_dir / TEMP_SPLIT_META).write_text(
-            json.dumps({"scenario": user_scenario, "system": system_template}, ensure_ascii=False, indent=2),
+            json.dumps({"scenario": effective_user_scenario, "system": system_template}, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
 
@@ -348,7 +351,7 @@ def _launch_chat(
         state.config_manager.config.system_config = sc
         state.config_manager.save_system_config()
 
-        template_hash = _history_id_from_scenario(user_scenario, system_template)
+        template_hash = _history_id_from_scenario(user_scenario, system_template, character_names)
         history_path = Path(history_file) if history_file else Path(state.history_dir) / template_hash
         if history_path.suffix.lower() == ".json" and history_path.exists() and history_path.is_file():
             history_path.parent.mkdir(parents=True, exist_ok=True)
@@ -441,10 +444,11 @@ def _chat_history_path(state: BridgeState, payload: dict[str, Any], template: di
         if path.suffix.lower() == ".json" and not path.is_file():
             return path.with_suffix("")
         return path
-    template_hash = _history_id_from_scenario(
-        str(template.get("scenario") or template.get("content") or ""),
-        str(template.get("system") or ""),
-    )
+    characters = payload.get("characters")
+    if not isinstance(characters, list):
+        characters = template.get("selectedCharacters")
+    scenario = str(template.get("scenario") if "scenario" in template else template.get("content") or "")
+    template_hash = _history_id_from_scenario(scenario, str(template.get("system") or ""), characters)
     return _resolve_project_file(Path(state.history_dir) / template_hash)
 
 

--- a/frontend_bridge_core/chat.py
+++ b/frontend_bridge_core/chat.py
@@ -44,6 +44,7 @@ from .templates import (
     TEMP_SPLIT_META,
     _effective_user_scenario,
     _history_id_from_scenario,
+    _scenario_from_template_like,
     _template_dir,
 )
 
@@ -351,7 +352,7 @@ def _launch_chat(
         state.config_manager.config.system_config = sc
         state.config_manager.save_system_config()
 
-        template_hash = _history_id_from_scenario(user_scenario, system_template, character_names)
+        template_hash = _history_id_from_scenario(user_scenario, character_names)
         history_path = Path(history_file) if history_file else Path(state.history_dir) / template_hash
         if history_path.suffix.lower() == ".json" and history_path.exists() and history_path.is_file():
             history_path.parent.mkdir(parents=True, exist_ok=True)
@@ -447,8 +448,8 @@ def _chat_history_path(state: BridgeState, payload: dict[str, Any], template: di
     characters = payload.get("characters")
     if not isinstance(characters, list):
         characters = template.get("selectedCharacters")
-    scenario = str(template.get("scenario") if "scenario" in template else template.get("content") or "")
-    template_hash = _history_id_from_scenario(scenario, str(template.get("system") or ""), characters)
+    scenario = _scenario_from_template_like(template)
+    template_hash = _history_id_from_scenario(scenario, characters)
     return _resolve_project_file(Path(state.history_dir) / template_hash)
 
 

--- a/frontend_bridge_core/handler.py
+++ b/frontend_bridge_core/handler.py
@@ -976,12 +976,16 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         init_sprite_path = str(body.get("initSpritePath") or init_sprite_path)
         room_id = str(body.get("roomId") or self.state.config_manager.config.system_config.live_room_id or "")
         history_path = _chat_history_path(self.state, body, row)
-        default_history_path = _chat_history_path(self.state, {"historyPath": ""}, row)
+        default_history_path = _chat_history_path(
+            self.state,
+            {"historyPath": "", "characters": characters if isinstance(characters, list) else []},
+            row,
+        )
         reset_history = bool(body.get("resetHistory"))
         if reset_history:
             for item in {history_path, default_history_path}:
                 remove_chat_history_storage(item)
-        user_scenario = str(row.get("scenario") or row.get("content") or "")
+        user_scenario = str(row.get("scenario") if "scenario" in row else row.get("content") or "")
         system_template = str(row.get("system") or "")
         user_scenario, system_template = _repair_template_parts_from_session_if_needed(
             self.state,
@@ -1021,6 +1025,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             system_template = system_template.rstrip() + "\n\n" + effect_guide
         message = _launch_chat(
             self.state,
+            character_names=characters if isinstance(characters, list) else [],
             effect_names=effect_names_str,
             history_file=(default_history_path if reset_history else history_path).as_posix(),
             init_sprite_path=init_sprite_path,
@@ -1130,6 +1135,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         )
         message = _launch_chat(
             self.state,
+            character_names=selected_characters if isinstance(selected_characters, list) else [],
             history_file=history_path.resolve().as_posix(),
             init_sprite_path=init_sprite_path,
             room_id=room_id,

--- a/frontend_bridge_core/handler.py
+++ b/frontend_bridge_core/handler.py
@@ -121,6 +121,7 @@ from .templates import (
     _list_templates,
     _repair_template_parts_from_session_if_needed,
     _resume_template_parts,
+    _scenario_from_template_like,
     _save_template_session_payload,
     _save_template_summary,
     _generate_template_summary,
@@ -985,7 +986,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         if reset_history:
             for item in {history_path, default_history_path}:
                 remove_chat_history_storage(item)
-        user_scenario = str(row.get("scenario") if "scenario" in row else row.get("content") or "")
+        user_scenario = _scenario_from_template_like(row)
         system_template = str(row.get("system") or "")
         user_scenario, system_template = _repair_template_parts_from_session_if_needed(
             self.state,

--- a/frontend_bridge_core/runtime_dependencies.py
+++ b/frontend_bridge_core/runtime_dependencies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import re
 import sys
 from pathlib import Path
@@ -81,8 +82,9 @@ def install_runtime_dependency(
                 message=f"安装 {package_name} 失败。",
                 phase="failed",
                 status="failed",
-            )
+        )
         raise RuntimeError(detail or output[-4000:] or f"pip install failed ({code})")
+    importlib.invalidate_caches()
     return {
         "message": f"Installed {package_name}. Please launch chat again.",
         "moduleName": module_name,

--- a/frontend_bridge_core/templates.py
+++ b/frontend_bridge_core/templates.py
@@ -12,6 +12,7 @@ from .state import BridgeState
 MARK_SCENARIO = "<<<EASYAI_USER_SCENARIO>>>"
 MARK_SYSTEM = "<<<EASYAI_SYSTEM_TEMPLATE>>>"
 TEMP_SPLIT_META = "_temp_split.json"
+DEFAULT_EMPTY_SCENARIO = "你扮演一个RPG系统。"
 
 
 def _template_dir(state: BridgeState) -> Path:
@@ -51,9 +52,29 @@ def _compose_for_llm(scenario: str, system: str) -> str:
     return a or b
 
 
-def _history_id_from_scenario(user_scenario: str, system_template: str) -> str:
-    stable = (user_scenario or "").strip() or (system_template or "").strip()
-    return hashlib.md5(stable.encode("utf-8")).hexdigest()
+def _effective_user_scenario(user_scenario: str) -> str:
+    return (user_scenario or "").strip() or DEFAULT_EMPTY_SCENARIO
+
+
+def _normalize_hash_character_names(character_names: Any = None) -> list[str]:
+    if not isinstance(character_names, list):
+        return []
+    names = {str(item).strip() for item in character_names if str(item).strip()}
+    return sorted(names)
+
+
+def _history_id_from_scenario(
+    user_scenario: str,
+    system_template: str = "",
+    character_names: Any = None,
+) -> str:
+    stable = {
+        "characters": _normalize_hash_character_names(character_names),
+        "scenario": _effective_user_scenario(user_scenario),
+    }
+    return hashlib.md5(
+        json.dumps(stable, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
 
 
 def _latest_history_json(history_dir: str) -> Path | None:
@@ -186,7 +207,7 @@ def _save_template_summary(state: BridgeState, payload: dict[str, Any]) -> dict[
     name = str(template.get("name") or template.get("id") or "").strip()
     if not name:
         raise ValueError("template name is required")
-    scenario = str(template.get("scenario") or template.get("content") or "")
+    scenario = str(template.get("scenario") if "scenario" in template else template.get("content") or "")
     system = str(template.get("system") or "")
     file_name = name if name.endswith(".txt") else f"{name}.txt"
     (_template_dir(state) / file_name).write_text(_compose_stored_template(scenario, system), encoding="utf-8")

--- a/frontend_bridge_core/templates.py
+++ b/frontend_bridge_core/templates.py
@@ -63,9 +63,15 @@ def _normalize_hash_character_names(character_names: Any = None) -> list[str]:
     return sorted(names)
 
 
+def _scenario_from_template_like(template: dict[str, Any]) -> str:
+    raw_scenario = template.get("scenario")
+    if raw_scenario is not None:
+        return str(raw_scenario)
+    return str(template.get("content") or "")
+
+
 def _history_id_from_scenario(
     user_scenario: str,
-    system_template: str = "",
     character_names: Any = None,
 ) -> str:
     stable = {
@@ -207,7 +213,7 @@ def _save_template_summary(state: BridgeState, payload: dict[str, Any]) -> dict[
     name = str(template.get("name") or template.get("id") or "").strip()
     if not name:
         raise ValueError("template name is required")
-    scenario = str(template.get("scenario") if "scenario" in template else template.get("content") or "")
+    scenario = _scenario_from_template_like(template)
     system = str(template.get("system") or "")
     file_name = name if name.endswith(".txt") else f"{name}.txt"
     (_template_dir(state) / file_name).write_text(_compose_stored_template(scenario, system), encoding="utf-8")

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -656,7 +656,7 @@
     "narr_token": "NARR",
     "err_no_characters": "Select at least one character.",
     "name_sep": ", ",
-    "preamble": "You are simulating an RPG-style dialog system. Cast includes: {names} and other related characters; schedule who speaks as the story requires.\n",
+    "preamble": "Cast includes: {names}\n",
     "json_line_effect": "        \"effect\": \"Effect keyword (optional). Plain keyword = play once; loop:keyword = start loop; stop:keyword = stop loop; before:keyword = play before dialog; after:keyword = play after dialog. See effect list below for available keywords.\",\n",
     "voice_target_ja": "Japanese",
     "voice_target_en": "English",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -653,7 +653,7 @@
     "narr_token": "NARR",
     "err_no_characters": "少なくとも1人のキャラを選んでください。",
     "name_sep": "、",
-    "preamble": "RPG 形式の会話をシミュレートしてください。登場人物：{names}他、劇付き合わせで登場者を使い分けてください。\n",
+    "preamble": "登場人物：{names}\n",
     "json_line_effect": "        \"effect\": \"エフェクトキーワード（任意）。キーワードのみ = 1回再生; loop:キーワード = ループ開始; stop:キーワード = ループ停止; before:キーワード = セリフ前; after:キーワード = セリフ後。利用可能なキーワードは下記エフェクト一覧を参照\",\n",
     "voice_target_ja": "日本語",
     "voice_target_en": "英語",

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -652,8 +652,8 @@
   "template_gen": {
     "narr_token": "旁白",
     "err_no_characters": "请至少选择一个角色！",
-    "name_sep": "、",
-    "preamble": "你需要模拟一个RPG剧情对话系统，出场人物有：{names}以及其他相关人物，请根据剧情调度人物\n",
+    "name_sep": "，",
+    "preamble": "出场人物有：{names}\n",
     "json_line_effect": "        \"effect\": \"特效关键词（可选），直接写关键词播放一次；loop:关键词 循环播放；stop:关键词 停止循环；before:关键词 对话前播放；after:关键词 对话后播放。可用关键词见下方特效列表\",\n",
     "voice_target_ja": "日语",
     "voice_target_en": "英语",

--- a/llm/template_generator.py
+++ b/llm/template_generator.py
@@ -271,7 +271,7 @@ class TemplateGenerator:
         selected_characters = sorted(selected_characters)
 
         sep = _T("name_sep")
-        names = sep.join(selected_characters) + sep
+        names = sep.join(selected_characters)
 
         effect_line = _T("json_line_effect") if use_effect else ""
         vlang = _target_voice_display_name()

--- a/sdk/exception/handler.py
+++ b/sdk/exception/handler.py
@@ -111,6 +111,8 @@ def _show_qt_dialog(title: str, message: str, detail: str) -> bool:
 
 
 def _show_windows_dialog(title: str, message: str) -> bool:
+    if _dialog_suppressed():
+        return False
     if os.name != "nt":
         return False
     try:
@@ -122,8 +124,23 @@ def _show_windows_dialog(title: str, message: str) -> bool:
         return False
 
 
+def _running_under_pytest() -> bool:
+    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules
+
+
+def _dialog_suppressed() -> bool:
+    raw = (
+        os.environ.get("SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG")
+        or os.environ.get("SHINSEKAI_DISABLE_MAIN_ERROR_DIALOG")
+        or ""
+    )
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def show_error_dialog(title: str, message: str, detail: str = "") -> bool:
     global _dialog_shown
+    if _running_under_pytest() or _dialog_suppressed():
+        return False
     if _dialog_shown:
         return False
     _dialog_shown = True
@@ -133,12 +150,9 @@ def show_error_dialog(title: str, message: str, detail: str = "") -> bool:
 def _should_show_dialog(show_dialog: bool) -> bool:
     if not show_dialog:
         return False
-    raw = (
-        os.environ.get("SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG")
-        or os.environ.get("SHINSEKAI_DISABLE_MAIN_ERROR_DIALOG")
-        or ""
-    )
-    return raw.strip().lower() not in {"1", "true", "yes", "on"}
+    if _running_under_pytest():
+        return False
+    return not _dialog_suppressed()
 
 
 def report_main_exception(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,6 +43,7 @@ def _configure_test_temp_dir() -> None:
 
 
 _configure_test_temp_dir()
+os.environ.setdefault("SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG", "1")
 
 from queue import Queue
 from unittest.mock import MagicMock

--- a/test/unit/frontend_bridge_core/test_frontend_runtime_check.py
+++ b/test/unit/frontend_bridge_core/test_frontend_runtime_check.py
@@ -277,6 +277,19 @@ def test_install_runtime_dependency_uses_runtime_pip_index_and_extra_args(monkey
     ]
 
 
+def test_install_runtime_dependency_invalidates_import_caches_after_success(monkeypatch):
+    from frontend_bridge_core import runtime_dependencies
+
+    calls = []
+    invalidated = []
+    monkeypatch.setattr(runtime_dependencies, "_run_pip_install", _fake_runtime_pip_install(calls))
+    monkeypatch.setattr(runtime_dependencies.importlib, "invalidate_caches", lambda: invalidated.append(True))
+
+    runtime_dependencies.install_runtime_dependency("openai")
+
+    assert invalidated == [True]
+
+
 def test_install_runtime_dependency_uses_manifest_china_index_by_default(monkeypatch):
     from frontend_bridge_core import runtime_dependencies
 

--- a/test/unit/frontend_bridge_core/test_frontend_templates.py
+++ b/test/unit/frontend_bridge_core/test_frontend_templates.py
@@ -5,6 +5,7 @@ from frontend_bridge_core.templates import (
     _has_untranslated_template_keys,
     _history_id_from_scenario,
     _parse_stored_template,
+    _scenario_from_template_like,
     _safe_session_int,
     _template_session_to_frontend,
 )
@@ -23,14 +24,19 @@ def test_parse_stored_template_handles_legacy_single_body_text():
 
 
 def test_history_id_uses_effective_scenario_and_selected_characters():
-    scenario_id = _history_id_from_scenario("scenario", "system", ["Alice", "Bob"])
-    assert scenario_id == _history_id_from_scenario(" scenario ", "ignored", ["Bob", "Alice", "Alice"])
-    assert scenario_id != _history_id_from_scenario("scenario", "system", ["Alice"])
-    assert scenario_id != _history_id_from_scenario("another scenario", "system", ["Alice", "Bob"])
-    assert _history_id_from_scenario("", "system") == _history_id_from_scenario(
+    scenario_id = _history_id_from_scenario("scenario", ["Alice", "Bob"])
+    assert scenario_id == _history_id_from_scenario(" scenario ", ["Bob", "Alice", "Alice"])
+    assert scenario_id != _history_id_from_scenario("scenario", ["Alice"])
+    assert scenario_id != _history_id_from_scenario("another scenario", ["Alice", "Bob"])
+    assert _history_id_from_scenario("") == _history_id_from_scenario(
         "你扮演一个RPG系统。",
-        "ignored",
     )
+
+
+def test_scenario_from_template_like_falls_back_only_for_none():
+    assert _scenario_from_template_like({"scenario": None, "content": "legacy"}) == "legacy"
+    assert _scenario_from_template_like({"scenario": "", "content": "legacy"}) == ""
+    assert _scenario_from_template_like({"content": "legacy"}) == "legacy"
 
 
 def test_template_session_to_frontend_normalizes_types_and_defaults():

--- a/test/unit/frontend_bridge_core/test_frontend_templates.py
+++ b/test/unit/frontend_bridge_core/test_frontend_templates.py
@@ -22,11 +22,15 @@ def test_parse_stored_template_handles_legacy_single_body_text():
     assert _parse_stored_template("  \n") == ("", "")
 
 
-def test_history_id_prefers_user_scenario_then_system_template():
-    scenario_id = _history_id_from_scenario("scenario", "system")
-    assert scenario_id == _history_id_from_scenario(" scenario ", "ignored")
-    assert scenario_id != _history_id_from_scenario("", "system")
-    assert _history_id_from_scenario("", "system") == _history_id_from_scenario("", " system ")
+def test_history_id_uses_effective_scenario_and_selected_characters():
+    scenario_id = _history_id_from_scenario("scenario", "system", ["Alice", "Bob"])
+    assert scenario_id == _history_id_from_scenario(" scenario ", "ignored", ["Bob", "Alice", "Alice"])
+    assert scenario_id != _history_id_from_scenario("scenario", "system", ["Alice"])
+    assert scenario_id != _history_id_from_scenario("another scenario", "system", ["Alice", "Bob"])
+    assert _history_id_from_scenario("", "system") == _history_id_from_scenario(
+        "你扮演一个RPG系统。",
+        "ignored",
+    )
 
 
 def test_template_session_to_frontend_normalizes_types_and_defaults():

--- a/test/unit/sdk/test_sdk_runtime_errors.py
+++ b/test/unit/sdk/test_sdk_runtime_errors.py
@@ -290,9 +290,13 @@ def test_dialog_helpers_handle_import_failure_and_single_display(monkeypatch):
 
     monkeypatch.setattr("builtins.__import__", fake_import)
     assert handler._show_qt_dialog("Title", "Message", "detail") is False
+    monkeypatch.setenv("SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG", "1")
     assert handler._show_windows_dialog("Title", "Message") is False
 
     calls = []
+    monkeypatch.delenv("SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG", raising=False)
+    monkeypatch.delenv("SHINSEKAI_DISABLE_MAIN_ERROR_DIALOG", raising=False)
+    monkeypatch.setattr(handler, "_running_under_pytest", lambda: False)
     monkeypatch.setattr(handler, "_dialog_shown", False)
     monkeypatch.setattr(
         handler,
@@ -366,6 +370,7 @@ def test_report_main_exception_still_reports_when_logger_or_stderr_fail(monkeypa
     dialog_calls = []
     monkeypatch.delenv("SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG", raising=False)
     monkeypatch.delenv("SHINSEKAI_DISABLE_MAIN_ERROR_DIALOG", raising=False)
+    monkeypatch.setattr(handler, "_running_under_pytest", lambda: False)
     monkeypatch.setattr(
         handler,
         "show_error_dialog",
@@ -394,6 +399,31 @@ def test_report_main_exception_still_reports_when_logger_or_stderr_fail(monkeypa
 
     monkeypatch.setattr(handler.sys, "stderr", BrokenStderr())
     handler._write_stderr("App", RuntimeError, RuntimeError("boom"), "detail", None)
+
+
+def test_report_main_exception_suppresses_dialog_under_pytest(monkeypatch, capsys):
+    dialog_calls = []
+    monkeypatch.delenv("SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG", raising=False)
+    monkeypatch.delenv("SHINSEKAI_DISABLE_MAIN_ERROR_DIALOG", raising=False)
+    monkeypatch.setattr(handler, "_running_under_pytest", lambda: True)
+    monkeypatch.setattr(
+        handler,
+        "show_error_dialog",
+        lambda *args: dialog_calls.append(args) or True,
+    )
+
+    exc = RuntimeError("boom")
+    handler.report_main_exception(
+        type(exc),
+        exc,
+        exc.__traceback__,
+        app_name="App",
+        logger=None,
+        show_dialog=True,
+    )
+
+    assert "App startup failed: RuntimeError: boom" in capsys.readouterr().err
+    assert dialog_calls == []
 
 
 def test_main_exception_hooks_report_sys_and_thread_exceptions(monkeypatch):


### PR DESCRIPTION
- if the default voice type is not set, check the gsv model
- if the model is not set, mark as preset
- if the model is set, and no reference text is set, set the voice type as reference, else preset


And make the dialog unable to pop up in pytest

- Fixes the long-term memory refreshing button paused at downloading dependencies and never proceed to next step

<!-- issue-link-bot:start -->

### Linked issues

Refs RachelForster/Shinsekai#184
Refs RachelForster/Shinsekai#183
Refs RachelForster/Shinsekai#186

<!-- issue-link-bot:end -->

## Summary by Sourcery

调整 GPT-SoVITS 角色的精灵语音默认逻辑，改进聊天的模板/历史记录处理，并确保错误对话框和内存依赖在测试与运行时行为正确。

New Features:
- 在聊天历史身份中支持按角色选择的名称，使历史记录可随场景和参与者而变化。
- 提供在生成基于角色的模板时使用的、本地化的默认模板场景字符串。

Bug Fixes:
- 当 GPT-SoVITS 模型缺少参考文本时，将精灵语音上传保持为预设，仅在存在参考文本时才回退到参考文本。
- 在 pytest 下运行或设置了对话框抑制环境变量时，防止主错误对话框弹出，包括在 Windows 上。
- 在安装缺失的内存依赖后，通过更新查询数据、重置安装状态，并在重新获取前等待就绪，确保长时记忆加载能够解除阻塞。
- 在运行时依赖成功安装后，使导入缓存失效，以便新安装的包可以被发现。
- 在计算历史路径和修复模板时使用明确的模板场景内容和所选角色，避免意外的回退行为。
- 修正模板生成器中角色名称的拼接逻辑，移除末尾多余的分隔符。

Enhancements:
- 在对聊天场景进行哈希时规范化角色名称，以生成与顺序和重复无关的稳定历史 ID。
- 在没有提供用户场景时使用有效的默认用户场景，以稳定模板哈希和存储行为。
- 调整模板保存与聊天启动逻辑，统一从显式模板字段派生场景，从而改进长期历史记录行为。

Tests:
- 扩展角色编辑器测试，覆盖 GPT-SoVITS 模型在有无参考文本时的精灵语音默认行为。
- 加强内存依赖测试，以断言状态转换，并确认在安装后缺失依赖的横幅不再出现。
- 添加测试以验证运行时依赖安装会使导入缓存失效。
- 添加测试以验证主异常上报在 pytest 下会抑制对话框，并遵守对话框抑制状态。
- 更新模板编辑器测试，在基于所选角色生成模板时使用新的默认场景消息。
- 刷新前端模板哈希测试，以验证有效场景和所选角色的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust sprite voice defaulting logic for GPT-SoVITS characters, improve template/history handling for chats, and ensure error dialogs and memory dependencies behave correctly in tests and runtime.

New Features:
- Support character-selected names in chat history identity so histories vary by scenario and participants.
- Provide a localized default template scenario string used when generating character-based templates.

Bug Fixes:
- Keep sprite voice uploads as preset when GPT-SoVITS models lack reference text and only default to reference when text is present.
- Prevent main error dialogs from appearing when running under pytest or when dialog suppression env vars are set, including on Windows.
- Ensure installing missing memory dependencies unblocks long-term memory loading by updating query data, resetting installing state, and waiting for readiness before refetching.
- Invalidate import caches after successful runtime dependency installation so newly installed packages are discoverable.
- Use explicit template scenario content and selected characters when computing history paths and repairing templates, avoiding unintended fallbacks.
- Correct template generator character name joining by removing an extra separator at the end.

Enhancements:
- Normalize character names when hashing chat scenarios to produce stable history IDs independent of ordering and duplicates.
- Use an effective default user scenario when none is provided to stabilize template hashing and storage.
- Adjust template saving and chat launch to consistently derive scenarios from explicit template fields, improving long-term history behavior.

Tests:
- Extend character editor tests to cover sprite voice default behavior with and without reference text for GPT-SoVITS models.
- Strengthen memory dependency tests to assert status transitions and absence of the missing dependency banner after installation.
- Add tests that verify runtime dependency installation invalidates import caches.
- Add tests that verify main exception reporting suppresses dialogs under pytest and respect dialog suppression state.
- Update template editor tests to use the new default scenario message when generating templates based on selected characters.
- Refresh frontend template hashing tests to validate effective scenario and selected character behavior.

</details>