### PR TITLE
fix windows chat stage window loading

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1255,14 +1255,52 @@ fn desktop_window_close(
 }
 
 #[tauri::command]
+#[cfg(target_os = "windows")]
 fn desktop_open_chat_window(app: AppHandle, state: State<'_, DesktopState>) -> Result<(), String> {
+    debug_assert!(current_chat_window_open_plan().defer_command);
+    let thread_app = app.clone();
+    let bridge_port = state.bridge_port;
+    let auth_token = state.bridge_auth_token.clone();
+    restart_debug_log("desktop_open_chat_window windows schedule requested");
+    thread::spawn(move || {
+        restart_debug_log("desktop_open_chat_window windows thread start");
+        thread::sleep(Duration::from_millis(100));
+        let scheduled_app = thread_app.clone();
+        match thread_app.run_on_main_thread(move || {
+            restart_debug_log("desktop_open_chat_window windows scheduled start");
+            match open_chat_window(&scheduled_app, bridge_port, &auth_token) {
+                Ok(()) => restart_debug_log("desktop_open_chat_window windows scheduled completed"),
+                Err(error) => restart_debug_log(format!(
+                    "desktop_open_chat_window windows scheduled failed error={error}"
+                )),
+            }
+        }) {
+            Ok(()) => restart_debug_log("desktop_open_chat_window windows run_on_main_thread ok"),
+            Err(error) => restart_debug_log(format!(
+                "desktop_open_chat_window windows run_on_main_thread failed error={error}"
+            )),
+        }
+    });
+    restart_debug_log("desktop_open_chat_window windows command returned after spawn");
+    Ok(())
+}
+
+#[tauri::command]
+#[cfg(not(target_os = "windows"))]
+fn desktop_open_chat_window(app: AppHandle, state: State<'_, DesktopState>) -> Result<(), String> {
+    debug_assert!(!current_chat_window_open_plan().defer_command);
+    open_chat_window(&app, state.bridge_port, &state.bridge_auth_token)
+}
+
+fn open_chat_window(app: &AppHandle, bridge_port: u16, auth_token: &str) -> Result<(), String> {
+    let open_plan = current_chat_window_open_plan();
     let chat_window = if let Some(window) = app.get_webview_window("chat") {
         restart_debug_log("desktop_open_chat_window reuse existing window");
         window
     } else {
-        let url = chat_window_url(state.bridge_port, &state.bridge_auth_token);
+        let url = chat_window_url(bridge_port, auth_token);
         restart_debug_log(format!("desktop_open_chat_window create url={url}"));
-        WebviewWindowBuilder::new(&app, "chat", WebviewUrl::App(url.into()))
+        WebviewWindowBuilder::new(app, "chat", WebviewUrl::App(url.into()))
             .title("Shinsekai Chat")
             .inner_size(1280.0, 820.0)
             .min_inner_size(960.0, 620.0)
@@ -1277,11 +1315,47 @@ fn desktop_open_chat_window(app: AppHandle, state: State<'_, DesktopState>) -> R
             .map_err(|error| error.to_string())?
     };
 
-    navigate_chat_window_to_live_frontend(&app, state.bridge_port, &state.bridge_auth_token)?;
+    #[cfg(not(target_os = "windows"))]
+    if open_plan.navigate_after_create {
+        navigate_chat_window_to_live_frontend(app, bridge_port, auth_token)?;
+    }
     let _ = chat_window.show();
     let _ = chat_window.unminimize();
-    let _ = chat_window.set_focus();
+
+    if open_plan.focus_after_show {
+        let _ = chat_window.set_focus();
+    } else {
+        restart_debug_log("desktop_open_chat_window windows focus skipped");
+    }
+
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ChatWindowOpenPlan {
+    defer_command: bool,
+    navigate_after_create: bool,
+    focus_after_show: bool,
+}
+
+fn current_chat_window_open_plan() -> ChatWindowOpenPlan {
+    chat_window_open_plan_for_windows(cfg!(target_os = "windows"))
+}
+
+fn chat_window_open_plan_for_windows(is_windows: bool) -> ChatWindowOpenPlan {
+    if is_windows {
+        ChatWindowOpenPlan {
+            defer_command: true,
+            focus_after_show: false,
+            navigate_after_create: false,
+        }
+    } else {
+        ChatWindowOpenPlan {
+            defer_command: false,
+            focus_after_show: true,
+            navigate_after_create: true,
+        }
+    }
 }
 
 #[tauri::command]
@@ -1414,6 +1488,7 @@ fn navigate_main_window_to_live_frontend(
     navigate_window_to_live_frontend(app, "main", &live_frontend_url(bridge_port, auth_token))
 }
 
+#[cfg(not(target_os = "windows"))]
 fn navigate_chat_window_to_live_frontend(
     app: &AppHandle,
     bridge_port: u16,
@@ -1825,6 +1900,24 @@ mod tests {
         assert!(targets[0].1.contains("#/settings/api"));
         assert_eq!(targets[1].0, "chat");
         assert!(targets[1].1.contains("#/chat-stage"));
+    }
+
+    #[test]
+    fn windows_chat_window_open_plan_avoids_webview_timing_hazards() {
+        let plan = chat_window_open_plan_for_windows(true);
+
+        assert!(plan.defer_command);
+        assert!(!plan.navigate_after_create);
+        assert!(!plan.focus_after_show);
+    }
+
+    #[test]
+    fn non_windows_chat_window_open_plan_keeps_existing_live_navigation() {
+        let plan = chat_window_open_plan_for_windows(false);
+
+        assert!(!plan.defer_command);
+        assert!(plan.navigate_after_create);
+        assert!(plan.focus_after_show);
     }
 
     #[test]

--- a/frontend/src/features/chat-stage/hooks/useDesktopClickThrough.ts
+++ b/frontend/src/features/chat-stage/hooks/useDesktopClickThrough.ts
@@ -7,7 +7,11 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 
-import { getDesktopWindowCursorPosition, setDesktopWindowClickThrough } from "../../../shared/desktop/desktopApi";
+import {
+  getDesktopWindowCursorPosition,
+  setDesktopWindowClickThrough,
+  writeDesktopRestartDebugLog,
+} from "../../../shared/desktop/desktopApi";
 import { isChatStageHitbox, isPointInsideChatStageHitbox } from "../chatStageUtils";
 import { clickThroughGuardIntervalMs } from "../runtimeConfig";
 
@@ -32,20 +36,24 @@ export function useDesktopClickThrough({
     clickThroughGuardIntervalRef.current = null;
   }, []);
 
-  const applyClickThroughIgnored = useCallback((ignore: boolean) => {
+  const applyClickThroughIgnored = useCallback((ignore: boolean, reason: string) => {
     if (clickThroughIgnoredRef.current === ignore) {
       return;
     }
     clickThroughIgnoredRef.current = ignore;
+    void writeDesktopRestartDebugLog(`ChatStage click_through_ignore=${ignore} reason=${reason}`);
     void setDesktopWindowClickThrough(ignore).catch((error) => {
       console.error("Desktop chat window click-through update failed", error);
     });
   }, []);
 
-  const disableClickThrough = useCallback(() => {
-    stopClickThroughGuard();
-    applyClickThroughIgnored(false);
-  }, [applyClickThroughIgnored, stopClickThroughGuard]);
+  const disableClickThrough = useCallback(
+    (reason: string) => {
+      stopClickThroughGuard();
+      applyClickThroughIgnored(false, reason);
+    },
+    [applyClickThroughIgnored, stopClickThroughGuard],
+  );
 
   const startClickThroughGuard = useCallback(() => {
     if (clickThroughGuardIntervalRef.current != null) {
@@ -59,11 +67,11 @@ export function useDesktopClickThrough({
       try {
         const cursor = await getDesktopWindowCursorPosition();
         if (isPointInsideChatStageHitbox(cursor.x, cursor.y)) {
-          disableClickThrough();
+          disableClickThrough("guard-hitbox");
         }
       } catch (error) {
         console.error("Desktop chat window cursor guard failed", error);
-        disableClickThrough();
+        disableClickThrough("guard-error");
       } finally {
         clickThroughGuardPollingRef.current = false;
       }
@@ -72,21 +80,30 @@ export function useDesktopClickThrough({
     void pollCursor();
   }, [disableClickThrough]);
 
-  const enableClickThrough = useCallback(() => {
-    applyClickThroughIgnored(true);
-    startClickThroughGuard();
-  }, [applyClickThroughIgnored, startClickThroughGuard]);
+  const enableClickThrough = useCallback(
+    (reason: string) => {
+      applyClickThroughIgnored(true, reason);
+      startClickThroughGuard();
+    },
+    [applyClickThroughIgnored, startClickThroughGuard],
+  );
 
   const setClickThroughIgnored = useCallback(
-    (ignore: boolean) => {
+    (ignore: boolean, reason: string) => {
       if (ignore) {
-        enableClickThrough();
+        enableClickThrough(reason);
       } else {
-        disableClickThrough();
+        disableClickThrough(reason);
       }
     },
     [disableClickThrough, enableClickThrough],
   );
+
+  useEffect(() => {
+    void writeDesktopRestartDebugLog(
+      `ChatStage click_through_state enabled=${clickThroughEnabled} standalone=${standaloneDesktopWindow} transparent=${transparentBackground}`,
+    );
+  }, [clickThroughEnabled, standaloneDesktopWindow, transparentBackground]);
 
   useEffect(() => {
     if (transparentBackground) {
@@ -106,11 +123,9 @@ export function useDesktopClickThrough({
     if (!standaloneDesktopWindow) {
       return;
     }
-    if (!clickThroughEnabled) {
-      setClickThroughIgnored(false);
-    }
+    setClickThroughIgnored(clickThroughEnabled, clickThroughEnabled ? "enabled-transparent-stage" : "disabled-stage");
     return () => {
-      setClickThroughIgnored(false);
+      setClickThroughIgnored(false, "cleanup");
     };
   }, [clickThroughEnabled, setClickThroughIgnored, standaloneDesktopWindow]);
 
@@ -127,34 +142,38 @@ export function useDesktopClickThrough({
         return;
       }
       if (isChatStageHitbox(event.target)) {
-        setClickThroughIgnored(false);
+        setClickThroughIgnored(false, "pointer-hitbox");
         return;
       }
-      setClickThroughIgnored(true);
+      setClickThroughIgnored(true, "pointer-transparent");
     },
     [clickThroughEnabled, setClickThroughIgnored],
   );
 
   const handleStagePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
-      if (!clickThroughEnabled || isChatStageHitbox(event.target)) {
+      if (!clickThroughEnabled) {
         return;
       }
-      setClickThroughIgnored(true);
+      setClickThroughIgnored(!isChatStageHitbox(event.target), "pointer-down");
     },
     [clickThroughEnabled, setClickThroughIgnored],
   );
 
   const handleStagePointerLeave = useCallback(() => {
-    if (standaloneDesktopWindow) {
-      setClickThroughIgnored(false);
+    if (!standaloneDesktopWindow) {
+      return;
     }
-  }, [setClickThroughIgnored, standaloneDesktopWindow]);
+    setClickThroughIgnored(
+      clickThroughEnabled,
+      clickThroughEnabled ? "pointer-leave-transparent" : "pointer-leave-disabled",
+    );
+  }, [clickThroughEnabled, setClickThroughIgnored, standaloneDesktopWindow]);
 
   const handleStageFocus = useCallback(
     (event: FocusEvent<HTMLElement>) => {
       if (clickThroughEnabled && isChatStageHitbox(event.target)) {
-        setClickThroughIgnored(false);
+        setClickThroughIgnored(false, "focus-hitbox");
       }
     },
     [clickThroughEnabled, setClickThroughIgnored],

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -255,7 +255,6 @@ describe("ChatStagePage", () => {
     expect(stage).toHaveAttribute("data-click-through", "true");
     expect(document.querySelector(".desktop-resize-handles")).not.toBeNull();
 
-    fireEvent.pointerMove(stage!);
     await waitFor(() => expect(desktopApiMocks.setDesktopWindowClickThrough).toHaveBeenCalledWith(true));
 
     const input = screen.getByRole("textbox");


### PR DESCRIPTION
## Summary by Sourcery

调整桌面端聊天窗口的启动和点击穿透行为，以避免在 Windows 上出现定时相关问题，同时提升对聊天阶段交互状态的可观测性。

Bug 修复：
- 更改 Windows 桌面聊天窗口的打开方式，将执行推迟到主线程上，避免过早导航和聚焦，从而防止导致 webview 加载问题。
- 通过将测试预期与新的点击穿透初始化行为对齐，消除在聊天阶段测试中对不必要指针移动的要求。

增强：
- 引入一个可配置的聊天窗口打开方案，根据 Windows 与其他平台的差异，在导航与焦点处理上采用不同的行为。
- 优化桌面聊天阶段的点击穿透开关逻辑，使用明确的原因标记，增加调试日志，并更好地处理指针与焦点交互。

测试：
- 添加单元测试以验证 Windows 与非 Windows 聊天窗口打开方案的差异，并更新聊天阶段页面测试以适配新的点击穿透行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust desktop chat window startup and click-through behavior to avoid timing issues on Windows while improving observability of chat stage interaction states.

Bug Fixes:
- Change Windows desktop chat window opening to defer execution on the main thread and avoid early navigation and focus that can cause webview loading issues.
- Prevent unnecessary pointer move requirement in chat stage tests by aligning expectations with the new click-through initialization behavior.

Enhancements:
- Introduce a configurable chat window open plan that differentiates behavior between Windows and other platforms for navigation and focus handling.
- Refine desktop chat stage click-through toggling to use explicit reasons, add debug logging, and better handle pointer and focus interactions.

Tests:
- Add unit tests to validate Windows vs non-Windows chat window open plans and update chat stage page tests for the new click-through behavior.

</details>

<!-- issue-link-bot:start -->

### Linked issues

Refs RachelForster/Shinsekai#187

<!-- issue-link-bot:end -->