### PR TITLE
ci: define cherrypick commands and workflow

### DIFF
--- a/.github/workflows/release-cherry-pick-command.yml
+++ b/.github/workflows/release-cherry-pick-command.yml
@@ -1,0 +1,42 @@
+name: Release cherry-pick command
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  cherry-pick:
+    if: >-
+      ${{
+        !github.event.issue.pull_request &&
+        (
+          startsWith(github.event.comment.body, '/cherry-pick') ||
+          startsWith(github.event.comment.body, '/cherrypick')
+        )
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Cherry-pick to release branch and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: python3 scripts/release_cherry_pick_command.py

--- a/docs/RELEASE_PROCESS_zh-CN.md
+++ b/docs/RELEASE_PROCESS_zh-CN.md
@@ -139,6 +139,16 @@ git cherry-pick -x <fix_commit_sha>
 git push
 ```
 
+也可以在 RC bug issue 里使用评论命令让 GitHub Actions 自动创建 cherry-pick PR：
+
+```markdown
+/cherry-pick
+/cherry-pick <fix_commit_sha>
+/cherry-pick <fix_commit_sha> release/2.1
+```
+
+当命令省略 commit 或 release 分支时，workflow 会从 issue 的 `Fix commit on main`、`Parent release`、`Found in RC`、父级 release tracking issue 等字段推断。只有仓库 maintainer 可以使用该命令；如果 cherry-pick 发生冲突，workflow 会在 issue 中评论冲突信息，等待人工处理。
+
 `-x` 会在提交信息中记录来源 commit，方便追踪 release 分支与 `main` 的差异。
 
 如果 bug 只存在于 release 分支，可以直接修 release 分支，但 PR 描述里需要说明为什么不需要回灌 `main`。

--- a/scripts/release_cherry_pick_command.py
+++ b/scripts/release_cherry_pick_command.py
@@ -4,6 +4,7 @@ import re
 import shlex
 import subprocess
 import sys
+from collections.abc import Sequence
 from urllib.parse import quote
 
 
@@ -15,20 +16,56 @@ ISSUE_NUMBER = int(os.environ["ISSUE_NUMBER"])
 RUN_ID = os.environ.get("RUN_ID") or "manual"
 
 ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
-ALLOWED_EXECUTABLES = {"gh", "git"}
+ALLOWED_SUBCOMMANDS = {
+    "gh": {"api", "pr"},
+    "git": {"checkout", "cherry-pick", "config", "fetch", "push", "rev-parse"},
+}
+RELEASE_PROCESS_LINK = (
+    f"https://github.com/{REPO}/blob/main/"
+    "docs/RELEASE_PROCESS_zh-CN.md#5-bug-修复与-cherry-pick"
+)
+INPUT_HINT = (
+    "Expected command examples: `/cherry-pick <commit-sha>` or "
+    "`/cherry-pick <commit-sha> release/2.1`.\n\n"
+    "Expected RC bug fields:\n"
+    "```markdown\n"
+    "- Parent release: v2.1.0\n"
+    "- Found in RC: v2.1.0-rc.1\n"
+    "- Fix commit on `main`: <commit-sha>\n"
+    "```\n"
+    f"See the release process: {RELEASE_PROCESS_LINK}."
+)
+
+
+def input_error(message: str) -> str:
+    return f"{message}\n\n{INPUT_HINT}"
+
+
+def validate_subprocess_command(command: Sequence[str]) -> list[str]:
+    if not command:
+        raise ValueError("Refused empty subprocess command")
+    if any(not isinstance(part, str) or not part for part in command):
+        raise ValueError("Refused subprocess command with an empty or non-string part")
+
+    executable = command[0]
+    subcommand = command[1] if len(command) > 1 else ""
+    if subcommand not in ALLOWED_SUBCOMMANDS.get(executable, set()):
+        raise ValueError(f"Refused subprocess command: {shlex.join(command)}")
+    return list(command)
 
 
 def run(
-    command: list[str],
+    command: Sequence[str],
     *,
     input_text: str | None = None,
     check: bool = True,
 ) -> subprocess.CompletedProcess:
-    if not command or command[0] not in ALLOWED_EXECUTABLES:
-        raise ValueError(f"Refused subprocess command: {shlex.join(command)}")
+    safe_command = validate_subprocess_command(command)
 
+    # nosemgrep justification: argv is validated against a gh/git subcommand
+    # allowlist, shell is disabled, and user-controlled values stay literal args.
     result = subprocess.run(
-        command,
+        safe_command,
         input=input_text,
         shell=False,
         text=True,
@@ -104,8 +141,10 @@ def parse_command(body: str) -> tuple[str | None, str | None]:
             branch = arg
         else:
             raise ValueError(
-                "Usage: `/cherry-pick [commit-sha] [release/x.y]`. "
-                "If omitted, the workflow reads them from the release issue fields."
+                input_error(
+                    "Usage: `/cherry-pick [commit-sha] [release/x.y]`. "
+                    "If omitted, the workflow reads them from the release issue fields."
+                )
             )
     return commit, branch
 
@@ -168,43 +207,73 @@ def search_tracking_issue(release_branch: str) -> dict | None:
     return None
 
 
+def as_release_tracking_issue(issue: dict | None) -> dict | None:
+    if issue and (issue.get("title") or "").startswith("Release tracking:"):
+        return issue
+    return None
+
+
+def resolve_commit(
+    command_commit: str | None,
+    issue: dict,
+    parent: dict | None,
+) -> str | None:
+    if command_commit:
+        return command_commit
+    issue_commit = parse_commit_from_issue(issue)
+    if issue_commit:
+        return issue_commit
+    return parse_commit_from_issue(parent) if parent is not None else None
+
+
+def resolve_branch(
+    command_branch: str | None,
+    issue: dict,
+    parent: dict | None,
+) -> str | None:
+    if command_branch:
+        return command_branch
+    issue_branch = parse_branch_from_issue(issue)
+    if issue_branch:
+        return issue_branch
+    return parse_branch_from_issue(parent) if parent is not None else None
+
+
+def resolve_tracking_parent(parent: dict | None, branch: str | None) -> dict | None:
+    if parent is not None or branch is None:
+        return parent
+    return search_tracking_issue(branch)
+
+
 def resolve_inputs() -> tuple[str, str, dict | None]:
-    commit, branch = parse_command(COMMENT_BODY)
+    # Precedence is deliberately explicit:
+    # 1. command arguments
+    # 2. fields on the commented issue
+    # 3. fields on the GitHub sub-issue parent, when it is a release tracking issue
+    # 4. release tracking search by the resolved branch, only to recover PR linkage
+    command_commit, command_branch = parse_command(COMMENT_BODY)
     issue = fetch_issue(ISSUE_NUMBER)
-    parent = fetch_parent_issue(ISSUE_NUMBER)
-    parent = (
-        parent
-        if parent and (parent.get("title") or "").startswith("Release tracking:")
-        else None
-    )
-
-    if commit is None:
-        commit = parse_commit_from_issue(issue)
-    if commit is None and parent is not None:
-        commit = parse_commit_from_issue(parent)
-
-    if branch is None:
-        branch = parse_branch_from_issue(issue)
-    if branch is None and parent is not None:
-        branch = parse_branch_from_issue(parent)
-    if branch is None and commit:
-        inferred = parse_branch_from_issue(issue)
-        parent = search_tracking_issue(inferred) if inferred else parent
-        if parent is not None:
-            branch = parse_branch_from_issue(parent)
+    parent = as_release_tracking_issue(fetch_parent_issue(ISSUE_NUMBER))
+    commit = resolve_commit(command_commit, issue, parent)
+    branch = resolve_branch(command_branch, issue, parent)
 
     if not commit:
         raise ValueError(
-            "No commit SHA found. Use `/cherry-pick <commit-sha>` or fill the "
-            "`Fix commit on main` field on this issue."
+            input_error(
+                "No commit SHA found. Use `/cherry-pick <commit-sha>` or fill the "
+                "`Fix commit on main` field on this issue."
+            )
         )
     if not branch:
         raise ValueError(
-            "No release branch found. Use `/cherry-pick <commit-sha> release/x.y` "
-            "or fill release linkage fields."
+            input_error(
+                "No release branch found. Use `/cherry-pick <commit-sha> release/x.y` "
+                "or fill release linkage fields."
+            )
         )
     if not re.fullmatch(r"release/[A-Za-z0-9._-]+", branch):
-        raise ValueError(f"Refused non-release target branch: `{branch}`")
+        raise ValueError(input_error(f"Refused non-release target branch: `{branch}`"))
+    parent = resolve_tracking_parent(parent, branch)
     return commit, branch, parent
 
 

--- a/scripts/release_cherry_pick_command.py
+++ b/scripts/release_cherry_pick_command.py
@@ -1,0 +1,352 @@
+import json
+import os
+import re
+import subprocess
+import sys
+from urllib.parse import quote
+
+
+REPO = os.environ["REPO"]
+COMMENT_BODY = os.environ.get("COMMENT_BODY") or ""
+COMMENT_AUTHOR = os.environ.get("COMMENT_AUTHOR") or ""
+AUTHOR_ASSOCIATION = (os.environ.get("AUTHOR_ASSOCIATION") or "").upper()
+ISSUE_NUMBER = int(os.environ["ISSUE_NUMBER"])
+RUN_ID = os.environ.get("RUN_ID") or "manual"
+
+ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+
+def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        print(f"Command failed: {' '.join(command)}", file=sys.stderr)
+        if result.stdout:
+            print(result.stdout, file=sys.stderr)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result
+
+
+def gh_api(*args: str, input_json: dict | None = None, check: bool = True) -> str:
+    command = ["gh", "api", *args]
+    payload = None if input_json is None else json.dumps(input_json)
+    result = subprocess.run(
+        command,
+        input=payload,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        print(f"gh api failed: {' '.join(command[2:])}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+
+def comment(body: str) -> None:
+    gh_api(
+        f"repos/{REPO}/issues/{ISSUE_NUMBER}/comments",
+        "--method",
+        "POST",
+        "--input",
+        "-",
+        input_json={"body": body},
+    )
+
+
+def fetch_issue(number: int) -> dict:
+    return json.loads(gh_api(f"repos/{REPO}/issues/{number}"))
+
+
+def fetch_parent_issue(number: int) -> dict | None:
+    result = run(["gh", "api", f"repos/{REPO}/issues/{number}/parent"], check=False)
+    if result.returncode == 0:
+        return json.loads(result.stdout)
+    if "not found" in result.stderr.lower() or "404" in result.stderr:
+        return None
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit(result.returncode)
+
+
+def parse_command(body: str) -> tuple[str | None, str | None]:
+    first_line = (body or "").splitlines()[0].strip()
+    match = re.match(
+        r"^/(?:cherry-pick|cherrypick)(?:\s+(.+))?$",
+        first_line,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        raise SystemExit(0)
+    args = (match.group(1) or "").split()
+    commit = None
+    branch = None
+    for arg in args:
+        if re.fullmatch(r"[0-9a-fA-F]{7,40}", arg):
+            commit = arg
+        elif re.fullmatch(r"release/[A-Za-z0-9._-]+", arg):
+            branch = arg
+        else:
+            raise ValueError(
+                "Usage: `/cherry-pick [commit-sha] [release/x.y]`. "
+                "If omitted, the workflow reads them from the release issue fields."
+            )
+    return commit, branch
+
+
+def parse_field(body: str, field: str) -> str | None:
+    match = re.search(
+        rf"^\s*-\s*{re.escape(field)}\s*:\s*(.+?)\s*$",
+        body or "",
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+    if not match:
+        return None
+    value = match.group(1).strip()
+    return value if value and value.upper() != "TBD" else None
+
+
+def parse_commit_from_issue(issue: dict) -> str | None:
+    value = parse_field(issue.get("body") or "", "Fix commit on `main`")
+    if not value:
+        return None
+    match = re.search(r"\b([0-9a-fA-F]{7,40})\b", value)
+    return match.group(1) if match else None
+
+
+def release_branch_from_version(version: str) -> str | None:
+    match = re.search(r"v?(\d+)\.(\d+)(?:\.\d+)?", version or "")
+    if not match:
+        return None
+    return f"release/{match.group(1)}.{match.group(2)}"
+
+
+def parse_branch_from_issue(issue: dict) -> str | None:
+    body = issue.get("body") or ""
+    for field in ("Release branch", "Cherry-picked to release branch"):
+        value = parse_field(body, field)
+        if value:
+            match = re.search(r"\brelease/[A-Za-z0-9._-]+\b", value)
+            if match:
+                return match.group(0)
+
+    for field in ("Parent release", "Found in RC", "Version", "Current RC tag"):
+        value = parse_field(body, field)
+        branch = release_branch_from_version(value or "")
+        if branch:
+            return branch
+
+    branch = release_branch_from_version(issue.get("title") or "")
+    if branch:
+        return branch
+    return None
+
+
+def search_tracking_issue(release_branch: str) -> dict | None:
+    version = release_branch.split("/", 1)[1]
+    query = f'repo:{REPO} is:issue in:title "Release tracking: v{version}"'
+    output = gh_api(f"search/issues?q={quote(query, safe='')}&per_page=10")
+    for item in json.loads(output).get("items", []):
+        if (item.get("title") or "").startswith(f"Release tracking: v{version}"):
+            return fetch_issue(int(item["number"]))
+    return None
+
+
+def resolve_inputs() -> tuple[str, str, dict | None]:
+    commit, branch = parse_command(COMMENT_BODY)
+    issue = fetch_issue(ISSUE_NUMBER)
+    parent = fetch_parent_issue(ISSUE_NUMBER)
+    parent = (
+        parent
+        if parent and (parent.get("title") or "").startswith("Release tracking:")
+        else None
+    )
+
+    if commit is None:
+        commit = parse_commit_from_issue(issue)
+    if commit is None and parent is not None:
+        commit = parse_commit_from_issue(parent)
+
+    if branch is None:
+        branch = parse_branch_from_issue(issue)
+    if branch is None and parent is not None:
+        branch = parse_branch_from_issue(parent)
+    if branch is None and commit:
+        inferred = parse_branch_from_issue(issue)
+        parent = search_tracking_issue(inferred) if inferred else parent
+        if parent is not None:
+            branch = parse_branch_from_issue(parent)
+
+    if not commit:
+        raise ValueError(
+            "No commit SHA found. Use `/cherry-pick <commit-sha>` or fill the "
+            "`Fix commit on main` field on this issue."
+        )
+    if not branch:
+        raise ValueError(
+            "No release branch found. Use `/cherry-pick <commit-sha> release/x.y` "
+            "or fill release linkage fields."
+        )
+    if not re.fullmatch(r"release/[A-Za-z0-9._-]+", branch):
+        raise ValueError(f"Refused non-release target branch: `{branch}`")
+    return commit, branch, parent
+
+
+def ensure_maintainer() -> None:
+    if AUTHOR_ASSOCIATION in ALLOWED_ASSOCIATIONS:
+        return
+    response = gh_api(
+        f"repos/{REPO}/collaborators/{COMMENT_AUTHOR}/permission",
+        check=False,
+    )
+    permission = json.loads(response or "{}").get("permission", "")
+    if permission in {"admin", "maintain", "write"}:
+        return
+    raise PermissionError(
+        f"Sorry @{COMMENT_AUTHOR}, only maintainers can use `/cherry-pick`."
+    )
+
+
+def create_cherry_pick_pr(commit: str, release_branch: str, parent: dict | None) -> str:
+    run(["git", "config", "user.name", "github-actions[bot]"])
+    run(
+        [
+            "git",
+            "config",
+            "user.email",
+            "41898282+github-actions[bot]@users.noreply.github.com",
+        ]
+    )
+
+    run(
+        [
+            "git",
+            "fetch",
+            "origin",
+            f"+refs/heads/{release_branch}:refs/remotes/origin/{release_branch}",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ]
+    )
+    rev_parse = run(["git", "rev-parse", "--verify", f"{commit}^{{commit}}"], check=False)
+    if rev_parse.returncode != 0 and re.fullmatch(r"[0-9a-fA-F]{40}", commit):
+        run(["git", "fetch", "origin", commit], check=False)
+        rev_parse = run(
+            ["git", "rev-parse", "--verify", f"{commit}^{{commit}}"],
+            check=False,
+        )
+    if rev_parse.returncode != 0:
+        comment(
+            f"Cherry-pick command could not find commit `{commit}`. Make sure it "
+            "exists on `main` or pass the full SHA."
+        )
+        raise SystemExit(0)
+
+    full_sha = rev_parse.stdout.strip()
+    short_sha = full_sha[:12]
+    safe_release = release_branch.replace("/", "-")
+    work_branch = f"automation/cherry-pick-{safe_release}-{short_sha}-{RUN_ID}"
+
+    run(["git", "checkout", "-B", work_branch, f"origin/{release_branch}"])
+    cherry_pick = run(["git", "cherry-pick", "-x", full_sha], check=False)
+    if cherry_pick.returncode != 0:
+        run(["git", "cherry-pick", "--abort"], check=False)
+        detail = (cherry_pick.stderr or cherry_pick.stdout or "unknown conflict").strip()
+        comment(
+            "Cherry-pick needs manual resolution.\n\n"
+            f"- Commit: `{short_sha}`\n"
+            f"- Target: `{release_branch}`\n\n"
+            "```text\n"
+            f"{detail[-3500:]}\n"
+            "```"
+        )
+        raise SystemExit(0)
+
+    run(["git", "push", "--set-upstream", "origin", work_branch])
+
+    title = f"chore(release): cherry-pick {short_sha} to {release_branch}"
+    body_lines = [
+        f"Cherry-picks `{full_sha}` to `{release_branch}`.",
+        "",
+        f"Refs #{ISSUE_NUMBER}",
+    ]
+    if parent:
+        body_lines.append(f"Release tracking: #{parent['number']}")
+    body_lines.extend(
+        [
+            "",
+            "Created by `/cherry-pick`.",
+        ]
+    )
+    pr_create = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            REPO,
+            "--base",
+            release_branch,
+            "--head",
+            work_branch,
+            "--title",
+            title,
+            "--body",
+            "\n".join(body_lines),
+        ],
+        check=False,
+    )
+    if pr_create.returncode != 0:
+        existing = run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                REPO,
+                "--head",
+                work_branch,
+                "--json",
+                "url",
+                "--jq",
+                ".[0].url",
+            ],
+            check=False,
+        )
+        pr_url = existing.stdout.strip()
+        if not pr_url:
+            print(pr_create.stderr, file=sys.stderr)
+            raise SystemExit(pr_create.returncode)
+    else:
+        pr_url = pr_create.stdout.strip()
+
+    comment(
+        "Cherry-pick PR created.\n\n"
+        f"- Commit: `{short_sha}`\n"
+        f"- Target: `{release_branch}`\n"
+        f"- PR: {pr_url}"
+    )
+    return pr_url
+
+
+def main() -> None:
+    try:
+        ensure_maintainer()
+        commit, release_branch, parent = resolve_inputs()
+    except PermissionError as exc:
+        comment(str(exc))
+        return
+    except ValueError as exc:
+        comment(f"Cherry-pick command could not run: {exc}")
+        return
+
+    create_cherry_pick_pr(commit, release_branch, parent)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release_cherry_pick_command.py
+++ b/scripts/release_cherry_pick_command.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from urllib.parse import quote
@@ -14,17 +15,28 @@ ISSUE_NUMBER = int(os.environ["ISSUE_NUMBER"])
 RUN_ID = os.environ.get("RUN_ID") or "manual"
 
 ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+ALLOWED_EXECUTABLES = {"gh", "git"}
 
 
-def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+def run(
+    command: list[str],
+    *,
+    input_text: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess:
+    if not command or command[0] not in ALLOWED_EXECUTABLES:
+        raise ValueError(f"Refused subprocess command: {shlex.join(command)}")
+
     result = subprocess.run(
         command,
+        input=input_text,
+        shell=False,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-    )
+    )  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
     if check and result.returncode != 0:
-        print(f"Command failed: {' '.join(command)}", file=sys.stderr)
+        print(f"Command failed: {shlex.join(command)}", file=sys.stderr)
         if result.stdout:
             print(result.stdout, file=sys.stderr)
         if result.stderr:
@@ -36,15 +48,13 @@ def run(command: list[str], *, check: bool = True) -> subprocess.CompletedProces
 def gh_api(*args: str, input_json: dict | None = None, check: bool = True) -> str:
     command = ["gh", "api", *args]
     payload = None if input_json is None else json.dumps(input_json)
-    result = subprocess.run(
+    result = run(
         command,
-        input=payload,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        input_text=payload,
+        check=False,
     )
     if check and result.returncode != 0:
-        print(f"gh api failed: {' '.join(command[2:])}", file=sys.stderr)
+        print(f"gh api failed: {shlex.join(command[2:])}", file=sys.stderr)
         print(result.stderr, file=sys.stderr)
         raise SystemExit(result.returncode)
     return result.stdout

--- a/test/unit/scripts/test_release_cherry_pick_command.py
+++ b/test/unit/scripts/test_release_cherry_pick_command.py
@@ -1,0 +1,123 @@
+import importlib
+import sys
+
+import pytest
+
+
+def load_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("ISSUE_NUMBER", "123")
+    monkeypatch.setenv("COMMENT_BODY", "/cherry-pick")
+    monkeypatch.setenv("COMMENT_AUTHOR", "maintainer")
+    monkeypatch.setenv("AUTHOR_ASSOCIATION", "MEMBER")
+    monkeypatch.setenv("RUN_ID", "1")
+    sys.modules.pop("scripts.release_cherry_pick_command", None)
+    return importlib.import_module("scripts.release_cherry_pick_command")
+
+
+def test_resolve_inputs_searches_tracking_issue_from_resolved_branch(monkeypatch):
+    module = load_module(monkeypatch)
+    issue = {
+        "number": 123,
+        "title": "[RC v2.1.0-rc.1] crash",
+        "body": "\n".join(
+            [
+                "- Parent release: v2.1.0",
+                "- Fix commit on `main`: abcdef1234567890",
+            ]
+        ),
+    }
+    tracking_issue = {
+        "number": 456,
+        "title": "Release tracking: v2.1.0",
+        "body": "- Release branch: `release/2.1`",
+    }
+    searched = []
+
+    monkeypatch.setattr(module, "fetch_issue", lambda number: issue)
+    monkeypatch.setattr(module, "fetch_parent_issue", lambda number: None)
+
+    def fake_search_tracking_issue(branch):
+        searched.append(branch)
+        return tracking_issue
+
+    monkeypatch.setattr(module, "search_tracking_issue", fake_search_tracking_issue)
+
+    commit, branch, parent = module.resolve_inputs()
+
+    assert commit == "abcdef1234567890"
+    assert branch == "release/2.1"
+    assert parent == tracking_issue
+    assert searched == ["release/2.1"]
+
+
+def test_resolve_inputs_uses_release_tracking_parent_fields(monkeypatch):
+    module = load_module(monkeypatch)
+    monkeypatch.setenv("COMMENT_BODY", "/cherry-pick abcdef1")
+    module.COMMENT_BODY = "/cherry-pick abcdef1"
+    issue = {"number": 123, "title": "Bug", "body": ""}
+    parent = {
+        "number": 456,
+        "title": "Release tracking: v2.2.0",
+        "body": "- Release branch: `release/2.2`",
+    }
+    search_calls = []
+
+    monkeypatch.setattr(module, "fetch_issue", lambda number: issue)
+    monkeypatch.setattr(module, "fetch_parent_issue", lambda number: parent)
+    monkeypatch.setattr(
+        module,
+        "search_tracking_issue",
+        lambda branch: search_calls.append(branch),
+    )
+
+    commit, branch, resolved_parent = module.resolve_inputs()
+
+    assert commit == "abcdef1"
+    assert branch == "release/2.2"
+    assert resolved_parent == parent
+    assert search_calls == []
+
+
+def test_missing_branch_error_includes_template_hint(monkeypatch):
+    module = load_module(monkeypatch)
+    issue = {
+        "number": 123,
+        "title": "Bug",
+        "body": "- Fix commit on `main`: abcdef1",
+    }
+
+    monkeypatch.setattr(module, "fetch_issue", lambda number: issue)
+    monkeypatch.setattr(module, "fetch_parent_issue", lambda number: None)
+
+    with pytest.raises(ValueError) as exc_info:
+        module.resolve_inputs()
+
+    message = str(exc_info.value)
+    assert "No release branch found" in message
+    assert "- Parent release: v2.1.0" in message
+    assert "docs/RELEASE_PROCESS_zh-CN.md#5-bug-修复与-cherry-pick" in message
+
+
+def test_run_rejects_unsupported_subprocess_command(monkeypatch):
+    module = load_module(monkeypatch)
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(module.subprocess, "run", fail_run)
+
+    with pytest.raises(ValueError, match="Refused subprocess command"):
+        module.run(["python", "-c", "print(1)"])
+
+
+def test_run_rejects_unsupported_subcommand(monkeypatch):
+    module = load_module(monkeypatch)
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(module.subprocess, "run", fail_run)
+
+    with pytest.raises(ValueError, match="Refused subprocess command"):
+        module.run(["git", "remote", "-v"])


### PR DESCRIPTION
## Summary by Sourcery

引入一个自动化的 `/cherry-pick` Issue 评论指令和工作流程，用于从 main 到发布分支创建 cherry-pick PR。

新功能：
- 添加仅限维护者使用的 `/cherry-pick` Issue 评论指令，可自动推断目标提交和发布分支，并自动创建 cherry-pick PR。

改进：
- 实现一个通过 GitHub CLI 和 git 驱动 cherry-pick 自动化的 Python 辅助脚本，包括权限检查和冲突处理。

CI：
- 新增一个 GitHub Actions 工作流，监听 `/cherry-pick` Issue 评论，并在适用时运行 cherry-pick 自动化脚本。

文档：
- 更新中文版发布流程文档，说明 `/cherry-pick` 指令的使用方法，以及提交和分支推断的工作机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an automated `/cherry-pick` issue comment command and workflow to create cherry-pick PRs from main to release branches.

New Features:
- Add a maintainer-only `/cherry-pick` issue comment command that infers target commit and release branch and automatically opens a cherry-pick PR.

Enhancements:
- Implement a Python helper script that drives the cherry-pick automation via GitHub CLI and git, including permission checks and conflict handling.

CI:
- Add a GitHub Actions workflow that listens to `/cherry-pick` issue comments and runs the cherry-pick automation script when applicable.

Documentation:
- Update the Chinese release process documentation to describe the `/cherry-pick` command usage and how commit and branch inference works.

</details>

新功能：
- 引入 `/cherry-pick` issue 评论命令，自动从 main 分支创建到发布分支的 cherry-pick PR，仅限维护者使用，并支持冲突报告。

增强：
- 设计并实现基于发布 issue 字段和上层跟踪 issue 自动推断 cherry-pick 目标提交和发布分支的逻辑与文档说明。
- 添加一个 Python 辅助脚本，使用 GitHub CLI 和 git 驱动 cherry-pick 自动化，包括权限检查和健壮的错误处理。

CI：
- 添加一个 GitHub Actions 工作流，监听 `/cherry-pick` issue 评论，并在具备适当权限的情况下运行 cherry-pick 自动化脚本。

文档：
- 更新中文发布流程文档，说明新的 `/cherry-pick` 评论命令，以及提交与分支自动推断的工作原理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个自动化的 `/cherry-pick` Issue 评论指令和工作流程，用于从 main 到发布分支创建 cherry-pick PR。

新功能：
- 添加仅限维护者使用的 `/cherry-pick` Issue 评论指令，可自动推断目标提交和发布分支，并自动创建 cherry-pick PR。

改进：
- 实现一个通过 GitHub CLI 和 git 驱动 cherry-pick 自动化的 Python 辅助脚本，包括权限检查和冲突处理。

CI：
- 新增一个 GitHub Actions 工作流，监听 `/cherry-pick` Issue 评论，并在适用时运行 cherry-pick 自动化脚本。

文档：
- 更新中文版发布流程文档，说明 `/cherry-pick` 指令的使用方法，以及提交和分支推断的工作机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an automated `/cherry-pick` issue comment command and workflow to create cherry-pick PRs from main to release branches.

New Features:
- Add a maintainer-only `/cherry-pick` issue comment command that infers target commit and release branch and automatically opens a cherry-pick PR.

Enhancements:
- Implement a Python helper script that drives the cherry-pick automation via GitHub CLI and git, including permission checks and conflict handling.

CI:
- Add a GitHub Actions workflow that listens to `/cherry-pick` issue comments and runs the cherry-pick automation script when applicable.

Documentation:
- Update the Chinese release process documentation to describe the `/cherry-pick` command usage and how commit and branch inference works.

</details>

</details>