### PR TITLE
fix: cherrypick merge commit

### DIFF
--- a/docs/RELEASE_PROCESS_zh-CN.md
+++ b/docs/RELEASE_PROCESS_zh-CN.md
@@ -145,6 +145,8 @@ git push
 /cherry-pick
 /cherry-pick <fix_commit_sha>
 /cherry-pick <fix_commit_sha> release/2.1
+/cherrypick <fix_commit_sha>
+/cherrypick <fix_commit_sha> release/2.1
 ```
 
 当命令省略 commit 或 release 分支时，workflow 会从 issue 的 `Fix commit on main`、`Parent release`、`Found in RC`、父级 release tracking issue 等字段推断。只有仓库 maintainer 可以使用该命令；如果 cherry-pick 发生冲突，workflow 会在 issue 中评论冲突信息，等待人工处理。

--- a/scripts/release_cherry_pick_command.py
+++ b/scripts/release_cherry_pick_command.py
@@ -18,14 +18,23 @@ RUN_ID = os.environ.get("RUN_ID") or "manual"
 ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 ALLOWED_SUBCOMMANDS = {
     "gh": {"api", "pr"},
-    "git": {"checkout", "cherry-pick", "config", "fetch", "push", "rev-parse"},
+    "git": {
+        "checkout",
+        "cherry-pick",
+        "config",
+        "fetch",
+        "push",
+        "rev-list",
+        "rev-parse",
+    },
 }
 RELEASE_PROCESS_LINK = (
     f"https://github.com/{REPO}/blob/main/"
     "docs/RELEASE_PROCESS_zh-CN.md#5-bug-修复与-cherry-pick"
 )
 INPUT_HINT = (
-    "Expected command examples: `/cherry-pick <commit-sha>` or "
+    "Expected command examples: `/cherry-pick <commit-sha>`, "
+    "`/cherrypick <commit-sha>`, or "
     "`/cherry-pick <commit-sha> release/2.1`.\n\n"
     "Expected RC bug fields:\n"
     "```markdown\n"
@@ -142,7 +151,8 @@ def parse_command(body: str) -> tuple[str | None, str | None]:
         else:
             raise ValueError(
                 input_error(
-                    "Usage: `/cherry-pick [commit-sha] [release/x.y]`. "
+                    "Usage: `/cherry-pick [commit-sha] [release/x.y]` "
+                    "or `/cherrypick [commit-sha] [release/x.y]`. "
                     "If omitted, the workflow reads them from the release issue fields."
                 )
             )
@@ -260,14 +270,16 @@ def resolve_inputs() -> tuple[str, str, dict | None]:
     if not commit:
         raise ValueError(
             input_error(
-                "No commit SHA found. Use `/cherry-pick <commit-sha>` or fill the "
+                "No commit SHA found. Use `/cherry-pick <commit-sha>`, "
+                "`/cherrypick <commit-sha>`, or fill the "
                 "`Fix commit on main` field on this issue."
             )
         )
     if not branch:
         raise ValueError(
             input_error(
-                "No release branch found. Use `/cherry-pick <commit-sha> release/x.y` "
+                "No release branch found. Use `/cherry-pick <commit-sha> release/x.y`, "
+                "`/cherrypick <commit-sha> release/x.y`, "
                 "or fill release linkage fields."
             )
         )
@@ -290,6 +302,18 @@ def ensure_maintainer() -> None:
     raise PermissionError(
         f"Sorry @{COMMENT_AUTHOR}, only maintainers can use `/cherry-pick`."
     )
+
+
+def commit_parent_count(commit: str) -> int:
+    result = run(["git", "rev-list", "--parents", "-n", "1", commit])
+    parts = result.stdout.strip().split()
+    return max(0, len(parts) - 1)
+
+
+def cherry_pick_command_for_commit(commit: str) -> list[str]:
+    if commit_parent_count(commit) > 1:
+        return ["git", "cherry-pick", "-m", "1", "-x", commit]
+    return ["git", "cherry-pick", "-x", commit]
 
 
 def create_cherry_pick_pr(commit: str, release_branch: str, parent: dict | None) -> str:
@@ -332,7 +356,7 @@ def create_cherry_pick_pr(commit: str, release_branch: str, parent: dict | None)
     work_branch = f"automation/cherry-pick-{safe_release}-{short_sha}-{RUN_ID}"
 
     run(["git", "checkout", "-B", work_branch, f"origin/{release_branch}"])
-    cherry_pick = run(["git", "cherry-pick", "-x", full_sha], check=False)
+    cherry_pick = run(cherry_pick_command_for_commit(full_sha), check=False)
     if cherry_pick.returncode != 0:
         run(["git", "cherry-pick", "--abort"], check=False)
         detail = (cherry_pick.stderr or cherry_pick.stdout or "unknown conflict").strip()

--- a/test/unit/scripts/test_release_cherry_pick_command.py
+++ b/test/unit/scripts/test_release_cherry_pick_command.py
@@ -53,8 +53,8 @@ def test_resolve_inputs_searches_tracking_issue_from_resolved_branch(monkeypatch
 
 def test_resolve_inputs_uses_release_tracking_parent_fields(monkeypatch):
     module = load_module(monkeypatch)
-    monkeypatch.setenv("COMMENT_BODY", "/cherry-pick abcdef1")
-    module.COMMENT_BODY = "/cherry-pick abcdef1"
+    monkeypatch.setenv("COMMENT_BODY", "/cherrypick abcdef1")
+    module.COMMENT_BODY = "/cherrypick abcdef1"
     issue = {"number": 123, "title": "Bug", "body": ""}
     parent = {
         "number": 456,
@@ -121,3 +121,49 @@ def test_run_rejects_unsupported_subcommand(monkeypatch):
 
     with pytest.raises(ValueError, match="Refused subprocess command"):
         module.run(["git", "remote", "-v"])
+
+
+def test_cherry_pick_command_keeps_regular_commit_simple(monkeypatch):
+    module = load_module(monkeypatch)
+
+    def fake_run(command, **kwargs):
+        assert command == ["git", "rev-list", "--parents", "-n", "1", "abc123"]
+        return module.subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="abc123 parent1\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    assert module.cherry_pick_command_for_commit("abc123") == [
+        "git",
+        "cherry-pick",
+        "-x",
+        "abc123",
+    ]
+
+
+def test_cherry_pick_command_uses_mainline_for_merge_commit(monkeypatch):
+    module = load_module(monkeypatch)
+
+    def fake_run(command, **kwargs):
+        assert command == ["git", "rev-list", "--parents", "-n", "1", "merge123"]
+        return module.subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="merge123 parent1 parent2\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    assert module.cherry_pick_command_for_commit("merge123") == [
+        "git",
+        "cherry-pick",
+        "-m",
+        "1",
+        "-x",
+        "merge123",
+    ]


### PR DESCRIPTION
## Summary by Sourcery

在发布分支的 cherry-pick 工作流中支持对合并提交进行 cherry-pick，并支持备用命令拼写。

New Features:
- 在发布 cherry-pick 命令中支持将 `/cherrypick` 作为 `/cherry-pick` 的替代写法。

Enhancements:
- 通过 `git rev-list` 检测提交的父提交数量，并根据普通提交和合并提交选择合适的 cherry-pick 调用方式。
- 通过将 `git rev-list` 加入允许的子命令白名单，使发布 cherry-pick 脚本可以调用 `git rev-list`。

Documentation:
- 在中文版发布流程指南中记录 `/cherrypick` 命令变体及其使用方法。

Tests:
- 添加单元测试，覆盖普通提交和合并提交下新的 cherry-pick 命令行为以及 `/cherrypick` 语法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle cherry-picking merge commits in the release cherry-pick workflow and support an alternate command spelling.

New Features:
- Support `/cherrypick` as an alternative to `/cherry-pick` in the release cherry-pick command.

Enhancements:
- Detect commit parent count via `git rev-list` and choose the appropriate cherry-pick invocation for regular vs merge commits.
- Allow the release cherry-pick script to call `git rev-list` by whitelisting it in the allowed subcommands.

Documentation:
- Document the `/cherrypick` command variant and its usage in the Chinese release process guide.

Tests:
- Add unit tests covering the new cherry-pick command behavior for regular and merge commits and the `/cherrypick` syntax.

</details>