### PR TITLE
fix(tts): normalize Windows long-path prefix on auto bundle path

### DIFF
--- a/frontend_bridge_core/path_utils.py
+++ b/frontend_bridge_core/path_utils.py
@@ -1,0 +1,25 @@
+"""Lightweight, dependency-free path helpers.
+
+Kept import-light on purpose so any module can reuse these without pulling
+in the rest of the frontend bridge.
+"""
+
+from __future__ import annotations
+
+
+def strip_windows_verbatim_prefix(value: str) -> str:
+    r"""Drop Windows extended-length path prefixes (``\\?\`` / ``//?/``, incl. UNC).
+
+    ``Path.resolve()`` can hand back such a prefixed path for long paths on
+    Windows; stripping it yields the plain form callers and external tools
+    (e.g. the file browser, the TTS engine) expect.
+    """
+    if value.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + value[len("\\\\?\\UNC\\") :]
+    if value.startswith("\\\\?\\"):
+        return value[len("\\\\?\\") :]
+    if value.startswith("//?/UNC/"):
+        return "//" + value[len("//?/UNC/") :]
+    if value.startswith("//?/"):
+        return value[len("//?/") :]
+    return value

--- a/frontend_bridge_core/tools.py
+++ b/frontend_bridge_core/tools.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from .path_utils import strip_windows_verbatim_prefix as _strip_windows_verbatim_prefix
 from .security import reject_control_chars, safe_existing_dir_path, safe_existing_file_path
 from .state import BridgeState
 from .tasks import _update_task
@@ -117,18 +118,6 @@ def _remove_sprite_background(state: BridgeState, task_id: str, payload: dict[st
     result = {"message": str(message), "outputDir": output_dir.as_posix()}
     _update_task(state, task_id, message=result["message"], phase="completed", progress=1, result=result)
     return result
-
-
-def _strip_windows_verbatim_prefix(value: str) -> str:
-    if value.startswith("\\\\?\\UNC\\"):
-        return "\\\\" + value[len("\\\\?\\UNC\\") :]
-    if value.startswith("\\\\?\\"):
-        return value[len("\\\\?\\") :]
-    if value.startswith("//?/UNC/"):
-        return "//" + value[len("//?/UNC/") :]
-    if value.startswith("//?/"):
-        return value[len("//?/") :]
-    return value
 
 
 def _display_path(path: Path) -> str:

--- a/test/unit/frontend_bridge_core/test_path_utils.py
+++ b/test/unit/frontend_bridge_core/test_path_utils.py
@@ -1,0 +1,15 @@
+from frontend_bridge_core.path_utils import strip_windows_verbatim_prefix
+
+
+def test_strip_drops_long_path_prefix():
+    assert strip_windows_verbatim_prefix("\\\\?\\D:\\tts_bundles\\gpt") == "D:\\tts_bundles\\gpt"
+    assert strip_windows_verbatim_prefix("//?/D:/tts_bundles/gpt") == "D:/tts_bundles/gpt"
+
+
+def test_strip_keeps_unc_root():
+    assert strip_windows_verbatim_prefix(r"\\?\UNC\server\share\tts") == r"\\server\share\tts"
+    assert strip_windows_verbatim_prefix("//?/UNC/server/share/tts") == "//server/share/tts"
+
+
+def test_strip_leaves_plain_path_untouched():
+    assert strip_windows_verbatim_prefix("D:/tts_bundles/gpt") == "D:/tts_bundles/gpt"

--- a/test/unit/ui_helpers/test_tts_bundle_worker.py
+++ b/test/unit/ui_helpers/test_tts_bundle_worker.py
@@ -268,17 +268,3 @@ def test_extract_archive_reports_bcj2_when_no_external_cli(tmp_path, monkeypatch
     assert err is not None
     assert "external 7-Zip CLI is required" in err
     assert "BCJ2 filter is not supported by py7zr" in err
-
-
-def test_strip_verbatim_prefix_drops_long_path_prefix():
-    assert worker_mod._strip_verbatim_prefix("\\\\?\\D:\\tts_bundles\\gpt") == "D:\\tts_bundles\\gpt"
-    assert worker_mod._strip_verbatim_prefix("//?/D:/tts_bundles/gpt") == "D:/tts_bundles/gpt"
-
-
-def test_strip_verbatim_prefix_keeps_unc_root():
-    assert worker_mod._strip_verbatim_prefix(r"\\?\UNC\server\share\tts") == r"\\server\share\tts"
-    assert worker_mod._strip_verbatim_prefix("//?/UNC/server/share/tts") == "//server/share/tts"
-
-
-def test_strip_verbatim_prefix_leaves_plain_path_untouched():
-    assert worker_mod._strip_verbatim_prefix("D:/tts_bundles/gpt") == "D:/tts_bundles/gpt"

--- a/test/unit/ui_helpers/test_tts_bundle_worker.py
+++ b/test/unit/ui_helpers/test_tts_bundle_worker.py
@@ -268,3 +268,17 @@ def test_extract_archive_reports_bcj2_when_no_external_cli(tmp_path, monkeypatch
     assert err is not None
     assert "external 7-Zip CLI is required" in err
     assert "BCJ2 filter is not supported by py7zr" in err
+
+
+def test_strip_verbatim_prefix_drops_long_path_prefix():
+    assert worker_mod._strip_verbatim_prefix("\\\\?\\D:\\tts_bundles\\gpt") == "D:\\tts_bundles\\gpt"
+    assert worker_mod._strip_verbatim_prefix("//?/D:/tts_bundles/gpt") == "D:/tts_bundles/gpt"
+
+
+def test_strip_verbatim_prefix_keeps_unc_root():
+    assert worker_mod._strip_verbatim_prefix(r"\\?\UNC\server\share\tts") == r"\\server\share\tts"
+    assert worker_mod._strip_verbatim_prefix("//?/UNC/server/share/tts") == "//server/share/tts"
+
+
+def test_strip_verbatim_prefix_leaves_plain_path_untouched():
+    assert worker_mod._strip_verbatim_prefix("D:/tts_bundles/gpt") == "D:/tts_bundles/gpt"

--- a/ui/settings_ui/tts/tts_bundle_worker.py
+++ b/ui/settings_ui/tts/tts_bundle_worker.py
@@ -15,6 +15,7 @@ from urllib.parse import unquote, urlparse
 import requests
 from PySide6.QtCore import QObject, QThread, Signal
 
+from frontend_bridge_core.path_utils import strip_windows_verbatim_prefix
 from ui.settings_ui.tts.tts_bundle_manifest import (
     TtsBundleManifestEntry,
     bundle_manifest_for_key,
@@ -342,21 +343,6 @@ def _rmtree(p: Path) -> None:
         shutil.rmtree(p, ignore_errors=True)
 
 
-def _strip_verbatim_prefix(path: str) -> str:
-    # Path.resolve() can return an extended-length path on Windows; the `\\?\`
-    # prefix breaks the TTS engine, so normalize it to the plain form a manual
-    # directory pick produces.
-    if path.startswith("\\\\?\\UNC\\"):
-        return "\\\\" + path[len("\\\\?\\UNC\\") :]
-    if path.startswith("\\\\?\\"):
-        return path[len("\\\\?\\") :]
-    if path.startswith("//?/UNC/"):
-        return "//" + path[len("//?/UNC/") :]
-    if path.startswith("//?/"):
-        return path[len("//?/") :]
-    return path
-
-
 def _resolve_extracted_root(extract_to: Path) -> Path:
     if not extract_to.is_dir():
         return extract_to.resolve()
@@ -460,4 +446,4 @@ class TtsBundleDownloadWorker(QThread):
 
         self.progress.emit(100)
         root = _resolve_extracted_root(out_dir)
-        self.finished_ok.emit(_strip_verbatim_prefix(str(root.resolve())))
+        self.finished_ok.emit(strip_windows_verbatim_prefix(str(root.resolve())))

--- a/ui/settings_ui/tts/tts_bundle_worker.py
+++ b/ui/settings_ui/tts/tts_bundle_worker.py
@@ -342,6 +342,21 @@ def _rmtree(p: Path) -> None:
         shutil.rmtree(p, ignore_errors=True)
 
 
+def _strip_verbatim_prefix(path: str) -> str:
+    # Path.resolve() can return an extended-length path on Windows; the `\\?\`
+    # prefix breaks the TTS engine, so normalize it to the plain form a manual
+    # directory pick produces.
+    if path.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path[len("\\\\?\\UNC\\") :]
+    if path.startswith("\\\\?\\"):
+        return path[len("\\\\?\\") :]
+    if path.startswith("//?/UNC/"):
+        return "//" + path[len("//?/UNC/") :]
+    if path.startswith("//?/"):
+        return path[len("//?/") :]
+    return path
+
+
 def _resolve_extracted_root(extract_to: Path) -> Path:
     if not extract_to.is_dir():
         return extract_to.resolve()
@@ -445,4 +460,4 @@ class TtsBundleDownloadWorker(QThread):
 
         self.progress.emit(100)
         root = _resolve_extracted_root(out_dir)
-        self.finished_ok.emit(str(root.resolve()))
+        self.finished_ok.emit(_strip_verbatim_prefix(str(root.resolve())))


### PR DESCRIPTION
## 问题

#151：一键下载 / 新手引导生成的 TTS 整合包路径，在 Windows 上可能带 `\\?\` / `//?/` 扩展长度前缀，导致 TTS 引擎启动失败；手动选目录则正常。

## 原因

`ui/settings_ui/tts/tts_bundle_worker.py` 下载解压后用 `Path.resolve()` 得到路径，并 `finished_ok.emit(str(root.resolve()))`。Windows 上 `resolve()` 对长路径会返回带 `\\?\` 前缀的扩展长度路径，这个路径被存成整合包目录后引擎就起不来；手动选目录是系统对话框返回的普通路径，所以不受影响。

## 改动

- 在 emit 前规范化路径，剥掉 `\\?\` / `//?/`（含 UNC）前缀，与文件浏览器里已有的 `_strip_windows_verbatim_prefix`（`frontend_bridge_core/tools.py`）保持一致的处理方式。考虑到该函数所在模块依赖较重（会连带引入 bridge 相关模块），这里在 worker 内放了一个等价的小工具函数，避免给 TTS worker 引入额外依赖。
- 补充单元测试覆盖该规范化逻辑（`test/unit/ui_helpers/test_tts_bundle_worker.py`）。

行为只在路径带前缀时改变，未带前缀的路径保持原样。

Closes #151

## Summary by Sourcery

规范化 Windows TTS 捆绑包路径，避免使用会破坏引擎启动的长路径前缀。

Bug Fixes:
- 修复 Windows TTS 捆绑包自动下载路径中包含扩展长度前缀的问题，确保引擎能够正确启动。

Tests:
- 添加单元测试，用于覆盖 TTS 捆绑包工作器中 Windows 长路径和 UNC 前缀的规范化逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Windows TTS bundle paths to avoid long-path prefixes that break engine startup.

Bug Fixes:
- Fix Windows TTS bundle auto-download paths that include extended-length prefixes so the engine starts correctly.

Tests:
- Add unit tests covering Windows long-path and UNC prefix normalization in the TTS bundle worker.

</details>