### PR TITLE
feat: 安装插件后自动重载，无需重启

### DIFF
--- a/frontend/src/features/plugin-manager/PluginManagerPage.tsx
+++ b/frontend/src/features/plugin-manager/PluginManagerPage.tsx
@@ -275,6 +275,18 @@ function hasCatalogUpdate(catalog: PluginCatalogItem | null | undefined, plugin:
   return hasVersionUpdate(catalog?.version, plugin?.version);
 }
 
+class PluginInstallReloadError extends Error {
+  plugin: PluginManifest;
+  reason: unknown;
+
+  constructor(plugin: PluginManifest, reason: unknown) {
+    super("Plugin reload after install failed.");
+    this.name = "PluginInstallReloadError";
+    this.plugin = plugin;
+    this.reason = reason;
+  }
+}
+
 export function PluginManagerPage() {
   const queryClient = useQueryClient();
   const location = useLocation();
@@ -359,12 +371,36 @@ export function PluginManagerPage() {
   });
 
   const installMutation = useMutation({
-    mutationFn: (input: PluginInstallInput | string) => installPlugin(input, { onTaskUpdate: setInstallTask }),
+    mutationFn: async (input: PluginInstallInput | string) => {
+      const plugin = await installPlugin(input, { onTaskUpdate: setInstallTask });
+      if (isTauriDesktop()) {
+        setPluginReloadPending(true);
+        try {
+          await reloadPluginService();
+        } catch (error) {
+          await writeDesktopRestartDebugLog(
+            `PluginManagerPage install reload catch: ${desktopRestartErrorMessage(error)}`,
+          );
+          throw new PluginInstallReloadError(plugin, error);
+        }
+      }
+      return plugin;
+    },
     onMutate(input) {
       setInstallTask(null);
       setInstallingSource(pluginInstallSource(input));
     },
     onError(error) {
+      if (error instanceof PluginInstallReloadError) {
+        queryClient.invalidateQueries({ queryKey: pluginsQueryKey });
+        queryClient.invalidateQueries({ queryKey: pluginCatalogQueryKey });
+        showToast({
+          kind: "error",
+          message: `${error.plugin.title}: ${desktopRestartErrorMessage(error.reason) || t("plugin.appRestart.failed")}`,
+          title: t("plugin.appRestart.failed"),
+        });
+        return;
+      }
       showToast({
         kind: "error",
         message: error instanceof Error ? error.message : t("plugin.error.installFallback"),
@@ -376,12 +412,13 @@ export function PluginManagerPage() {
       queryClient.invalidateQueries({ queryKey: pluginCatalogQueryKey });
       showToast({
         kind: "success",
-        message: `${plugin.title}。${t("plugin.toast.restartHint")}`,
+        message: `${plugin.title}。${isTauriDesktop() ? t("plugin.toast.activated") : t("plugin.toast.restartHint")}`,
         title: t("plugin.toast.installSuccess"),
       });
     },
     onSettled() {
       setInstallingSource("");
+      setPluginReloadPending(false);
     },
   });
 

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -761,6 +761,7 @@ export type MessageKey =
   | "plugin.supportBadge"
   | "plugin.table.actionHeader"
   | "plugin.table.slots"
+  | "plugin.toast.activated"
   | "plugin.toast.disabled"
   | "plugin.toast.enabled"
   | "plugin.toast.installFailed"

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -818,6 +818,7 @@ export const enMessages: Record<MessageKey, string> = {
   "plugin.supportBadge": "Supports {version}",
   "plugin.table.actionHeader": "Actions",
   "plugin.table.slots": "Slots",
+  "plugin.toast.activated": "The plugin is ready to use.",
   "plugin.toast.disabled": "Plugin disabled",
   "plugin.toast.enabled": "Plugin enabled",
   "plugin.toast.installFailed": "Install failed",

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -818,6 +818,7 @@ export const jaMessages: Record<MessageKey, string> = {
   "plugin.supportBadge": "{version} 対応",
   "plugin.table.actionHeader": "操作",
   "plugin.table.slots": "Slots",
+  "plugin.toast.activated": "プラグインが有効になりました。",
   "plugin.toast.disabled": "プラグインを無効化しました",
   "plugin.toast.enabled": "プラグインを有効化しました",
   "plugin.toast.installFailed": "インストール失敗",

--- a/frontend/src/shared/i18n/messages/zh_CN.ts
+++ b/frontend/src/shared/i18n/messages/zh_CN.ts
@@ -805,6 +805,7 @@ export const zhCNMessages: Record<MessageKey, string> = {
   "plugin.supportBadge": "支持 {version}",
   "plugin.table.actionHeader": "操作",
   "plugin.table.slots": "Slot",
+  "plugin.toast.activated": "插件已生效。",
   "plugin.toast.disabled": "插件已停用",
   "plugin.toast.enabled": "插件已启用",
   "plugin.toast.installFailed": "安装失败",

--- a/frontend/src/test/features/plugin-manager/PluginManagerPage.test.tsx
+++ b/frontend/src/test/features/plugin-manager/PluginManagerPage.test.tsx
@@ -27,6 +27,8 @@ const mockListPlugins = vi.fn<() => Promise<PluginManifest[]>>();
 const mockListRepoTags = vi.fn<() => Promise<string[]>>();
 const mockOpenExternal = vi.fn();
 const mockRunAppUpdate = vi.fn();
+const mockIsTauriDesktop = vi.fn(() => false);
+const mockReloadPluginService = vi.fn<() => Promise<unknown>>();
 
 vi.mock("../../../entities/plugin/repository", () => ({
   getAppUpdateInfo: () => mockGetAppUpdateInfo(),
@@ -57,6 +59,18 @@ vi.mock("../../../entities/files/repository", async (importOriginal) => {
     openExternal: (...args: unknown[]) => mockOpenExternal(...args),
   };
 });
+
+vi.mock("../../../shared/desktop/desktopApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../shared/desktop/desktopApi")>();
+  return {
+    ...actual,
+    isTauriDesktop: () => mockIsTauriDesktop(),
+  };
+});
+
+vi.mock("../../../features/plugin-manager/pluginReload", () => ({
+  reloadPluginService: () => mockReloadPluginService(),
+}));
 
 const configurablePlugin: PluginManifest = {
   author: "Tester",
@@ -190,6 +204,8 @@ async function findPluginCard(title: string) {
 describe("PluginManagerPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsTauriDesktop.mockReturnValue(false);
+    mockReloadPluginService.mockResolvedValue(undefined);
     mockGetPluginUiDetail.mockResolvedValue({ pages: [detailPage], plugin: configurablePlugin });
     mockInstallPlugin.mockImplementation(async (_input, options) => {
       options?.onTaskUpdate?.({
@@ -545,6 +561,43 @@ describe("PluginManagerPage", () => {
         expect.any(Object),
       ),
     );
+  });
+
+  it("reloads the plugin service after installing a plugin on desktop", async () => {
+    mockIsTauriDesktop.mockReturnValue(true);
+    mockListPlugins.mockResolvedValue([]);
+    mockListPluginCatalog.mockResolvedValue([catalogItem]);
+
+    renderPage();
+    fireEvent.click(await screen.findByRole("tab", { name: "Discover" }));
+    const card = (await screen.findByRole("heading", { name: "Registry Display" })).closest(
+      ".plugin-market-card",
+    ) as HTMLElement;
+    fireEvent.click(within(card).getByRole("button", { name: "Install" }));
+    const dialog = await screen.findByRole("dialog", { name: "Choose plugin version" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Install" }));
+
+    await waitFor(() => expect(mockInstallPlugin).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockReloadPluginService).toHaveBeenCalledTimes(1));
+  });
+
+  it("surfaces a reload failure after install instead of reporting success", async () => {
+    mockIsTauriDesktop.mockReturnValue(true);
+    mockReloadPluginService.mockRejectedValue(new Error("bridge restart failed"));
+    mockListPlugins.mockResolvedValue([]);
+    mockListPluginCatalog.mockResolvedValue([catalogItem]);
+
+    renderPage();
+    fireEvent.click(await screen.findByRole("tab", { name: "Discover" }));
+    const card = (await screen.findByRole("heading", { name: "Registry Display" })).closest(
+      ".plugin-market-card",
+    ) as HTMLElement;
+    fireEvent.click(within(card).getByRole("button", { name: "Install" }));
+    const dialog = await screen.findByRole("dialog", { name: "Choose plugin version" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Install" }));
+
+    expect(await screen.findByText(/bridge restart failed/)).toBeInTheDocument();
+    expect(screen.queryByText("Plugin installed")).not.toBeInTheDocument();
   });
 
   it("installs a repository catalog plugin from a selected tag", async () => {


### PR DESCRIPTION
## 做了什么

实现 #203：插件安装成功后自动重载，桌面端装完不用再手动点“重载插件”或重启就能用。

## 实现

按 review 反馈调整了思路——不再单独搞一套后端重载，直接复用现有的重载入口：

- 安装成功后，桌面端复用现成的 `reloadPluginService()`：它会 `restartDesktopBridge()` 重启 bridge 进程，再等 `/api/health`、`/api/plugins/status` 进入 ready。这和“重载插件”按钮（`plugin.appRestart.button`）、新手引导里的安装流程是同一条链路，健康检查 / 错误展示 / 重启状态都不会再分叉。
- 重载放进 `installMutation` 的 `mutationFn` 里（跟 onboarding 一致），重载没结束前安装任务一直是 pending，顶部会显示“正在重载插件服务…”。
- 重载**失败**会单独提示（`<插件名>: <原因>`）并刷新列表，不会误报成功；Web 端没有桌面 bridge，保留原来的“重载插件后生效”提示。

走重启整个 bridge 进程这条路，也顺带避免了 issue 里担心的重复安装 / 更新时 handler、UI contribution、TTS/LLM adapter 重复注册的问题（新进程从头加载，不会有残留）。

后端这次不再改动，之前那版的 `reload_plugins()`、`install_plugin_source` 包装和 `completionMessage` 都撤掉了。

## 测试

`frontend/src/test/features/plugin-manager/PluginManagerPage.test.tsx` 新增两条：

- 桌面端装完插件会触发 `reloadPluginService()`；
- 重载失败时给出错误提示、且不报“安装成功”。

`pnpm test`、`pnpm lint:types`、`prettier --check` 均通过。

Closes #203
