### PR TITLE
fix: keep sprite voice bindings stable

### DIFF
--- a/config/character_manager.py
+++ b/config/character_manager.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+import hashlib
+import re
 from pathlib import Path
 from typing import List, Dict, Any, Tuple, Optional, Union
 from config.schema import Character, Sprite
@@ -10,6 +12,31 @@ UPLOAD_DIR = "data/sprite"
 VOICE_DIR = "data/speech"
 MODEL_DIR = "data/models"
 CHARACTER_CONFIG_PATH = ConfigManager._CHARACTERS_CONFIG_PATH 
+
+
+def _sprite_field(sprite_data: Union[Sprite, dict], key: str, default: Any = "") -> Any:
+    if isinstance(sprite_data, Sprite):
+        return getattr(sprite_data, key, default)
+    return sprite_data.get(key, default)
+
+
+def _voice_filename_for_sprite(sprite_data: Union[Sprite, dict], sprite_index: int, file_ext: str) -> str:
+    sprite_path = str(_sprite_field(sprite_data, "path", "") or "")
+    sprite_stem = Path(sprite_path).stem
+    safe_stem = re.sub(r"[^A-Za-z0-9._-]+", "_", sprite_stem).strip("._-")
+    if not safe_stem:
+        safe_stem = f"sprite_{sprite_index:02d}"
+    digest_source = sprite_path or safe_stem or str(sprite_index)
+    digest = hashlib.sha1(digest_source.encode("utf-8")).hexdigest()[:10]
+    return f"voice_{safe_stem}_{digest}{file_ext}"
+
+
+def _is_path_inside_directory(path: str, directory: str) -> bool:
+    try:
+        Path(path).resolve(strict=False).relative_to(Path(directory).resolve(strict=False))
+        return True
+    except (OSError, ValueError):
+        return False
 
 
 class CharacterManager:
@@ -504,7 +531,7 @@ class CharacterManager:
             return "立绘不存在！", None
         
         sprite_data: Union[Sprite, dict] = character.sprites[sprite_index]
-        original_voice_path = sprite_data.voice_path if isinstance(sprite_data, Sprite) else sprite_data.get("voice_path", "")
+        original_voice_path = str(_sprite_field(sprite_data, "voice_path", "") or "")
         
         if (not voice_file) and (not original_voice_path):
             return "请选择语音文件！", None
@@ -513,7 +540,7 @@ class CharacterManager:
         Path(voice_char_dir).mkdir(parents=True, exist_ok=True)
         
         file_ext = Path(voice_file).suffix
-        voice_filename = f"voice_{sprite_index:02d}{file_ext}"
+        voice_filename = _voice_filename_for_sprite(sprite_data, sprite_index, file_ext)
         voice_path = os.path.join(voice_char_dir, voice_filename)
         shutil.copyfile(voice_file, voice_path)
         
@@ -530,6 +557,17 @@ class CharacterManager:
                 character.sprites[sprite_index]["voice_type"] = voice_type
             
         self._config_manager.save_characters_config()
+
+        if (
+            original_voice_path
+            and os.path.abspath(original_voice_path) != os.path.abspath(voice_path)
+            and _is_path_inside_directory(original_voice_path, voice_char_dir)
+        ):
+            try:
+                if os.path.isfile(original_voice_path):
+                    os.remove(original_voice_path)
+            except OSError:
+                pass
         
         return f"语音已上传到立绘 {sprite_index+1}！", voice_path
 

--- a/config/sprite_voice.py
+++ b/config/sprite_voice.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import Any, MutableMapping
 
 
+VALID_SPRITE_VOICE_TYPES = {"fallback", "preset", "reference"}
+
+
 def normalize_sprite_voice_types(character_data: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
     """Normalize legacy sprite voice semantics while reading characters."""
     sprites = character_data.get("sprites")
@@ -11,12 +14,13 @@ def normalize_sprite_voice_types(character_data: MutableMapping[str, Any]) -> Mu
     for sprite in sprites:
         if not isinstance(sprite, dict):
             continue
+        voice_type = str(sprite.get("voice_type") or "").strip().lower()
+        if voice_type in VALID_SPRITE_VOICE_TYPES:
+            sprite["voice_type"] = voice_type
+            continue
         voice_path = str(sprite.get("voice_path") or "").strip()
         if not voice_path:
             continue
         voice_text = str(sprite.get("voice_text") or "").strip()
-        if voice_text:
-            sprite["voice_type"] = str(sprite.get("voice_type") or "reference").strip().lower() or "reference"
-        else:
-            sprite["voice_type"] = "fallback"
+        sprite["voice_type"] = "reference" if voice_text else "fallback"
     return character_data

--- a/frontend/src/features/character-editor/CharacterEditorPage.tsx
+++ b/frontend/src/features/character-editor/CharacterEditorPage.tsx
@@ -51,6 +51,21 @@ import {
 } from "./characterEditorUtils";
 import "./CharacterEditorPage.css";
 
+export function mergeSprites(serverSprites: Sprite[], current: Character) {
+  const currentSpritesByPath = new Map(
+    current.sprites.filter((sprite) => sprite.path).map((sprite) => [sprite.path, sprite]),
+  );
+  const canFallbackToIndex = serverSprites.length === current.sprites.length;
+  return serverSprites.map((sprite, index) => {
+    const currentSprite =
+      currentSpritesByPath.get(sprite.path) ?? (canFallbackToIndex ? current.sprites[index] : undefined);
+    return {
+      ...sprite,
+      voice_type: sprite.voice_type ?? currentSprite?.voice_type,
+    };
+  });
+}
+
 export function CharacterEditorPage() {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
@@ -614,10 +629,6 @@ export function CharacterEditorPage() {
       return { ...current, sprites };
     });
   };
-
-  /** Merge server sprites while preserving local per-sprite voice_type. */
-  const mergeSprites = (serverSprites: Sprite[], current: Character) =>
-    serverSprites.map((s, i) => ({ ...s, voice_type: current.sprites[i]?.voice_type ?? s.voice_type }));
 
   const characterHasGptSovitsModel = (character: Character) =>
     Boolean(character.gpt_model_path?.trim() && character.sovits_model_path?.trim());

--- a/frontend/src/test/features/character-editor/CharacterEditorPage.test.tsx
+++ b/frontend/src/test/features/character-editor/CharacterEditorPage.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CharacterEditorPage } from "../../../features/character-editor/CharacterEditorPage";
+import { CharacterEditorPage, mergeSprites } from "../../../features/character-editor/CharacterEditorPage";
 import type { Character } from "../../../entities/config/types";
 import { I18nProvider } from "../../../shared/i18n/I18nProvider";
 import { sampleConfig } from "../../../shared/platform/sampleData";
@@ -170,6 +170,28 @@ function renderPage() {
     </QueryClientProvider>,
   );
 }
+
+describe("mergeSprites", () => {
+  it("falls back to index only when rewritten paths keep the same list shape", () => {
+    const current = {
+      ...structuredClone(character),
+      sprites: [
+        { path: "D:/old/sprite-a.png", voice_type: "preset" as const },
+        { path: "D:/old/sprite-b.png", voice_type: "reference" as const },
+      ],
+    };
+
+    expect(
+      mergeSprites([{ path: "D:/new/sprite-a.png" }, { path: "D:/new/sprite-b.png" }], current).map(
+        (sprite) => sprite.voice_type,
+      ),
+    ).toEqual(["preset", "reference"]);
+
+    expect(mergeSprites([{ path: "D:/new/sprite-b.png" }], current).map((sprite) => sprite.voice_type)).toEqual([
+      undefined,
+    ]);
+  });
+});
 
 describe("CharacterEditorPage", () => {
   beforeEach(() => {
@@ -500,6 +522,55 @@ describe("CharacterEditorPage", () => {
     dialog = screen.getByRole("dialog", { name: "Delete all sprites" });
     fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
     await waitFor(() => expect(mockDeleteAllCharacterSprites).toHaveBeenCalledWith("Mika"));
+  });
+
+  it("keeps sprite voice types aligned by path after deleting a sprite", async () => {
+    const sprites = [
+      {
+        path: "D:/sprites/mika/sprite-a.png",
+        voice_path: "D:/voices/a.wav",
+        voice_type: "preset" as const,
+      },
+      {
+        path: "D:/sprites/mika/sprite-b.png",
+        voice_path: "D:/voices/b.wav",
+        voice_type: "fallback" as const,
+      },
+      {
+        path: "D:/sprites/mika/sprite-c.png",
+        voice_path: "D:/voices/c.wav",
+        voice_text: "reference line",
+        voice_type: "reference" as const,
+      },
+    ];
+    const originalCharacter = {
+      ...structuredClone(character),
+      emotion_tags: "Sprite 1: first\nSprite 2: second\nSprite 3: third\n",
+      sprites,
+    };
+    const updatedCharacter = {
+      ...originalCharacter,
+      emotion_tags: "Sprite 1: second\nSprite 2: third\n",
+      sprites: sprites.slice(1),
+    };
+    mockListCharacters.mockResolvedValueOnce([originalCharacter]).mockResolvedValue([updatedCharacter]);
+    mockDeleteCharacterSprite.mockResolvedValue(updatedCharacter);
+    renderPage();
+
+    await screen.findByDisplayValue("Mika");
+    expect(screen.getByRole("radio", { name: "Preset voice" })).toBeChecked();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    const dialog = screen.getByRole("dialog", { name: "Remove" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(mockDeleteCharacterSprite).toHaveBeenCalledWith("Mika", 0));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Remove" })).not.toBeInTheDocument());
+    expect(screen.getByTitle("sprite-b.png")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("radio", { name: "Fallback voice" })).toBeChecked();
+
+    fireEvent.click(screen.getByTitle("sprite-c.png"));
+    expect(screen.getByRole("radio", { name: "Reference voice" })).toBeChecked();
   });
 
   it("refreshes, adds, and deletes long-term memories", async () => {

--- a/test/unit/config/test_character_manager.py
+++ b/test/unit/config/test_character_manager.py
@@ -22,6 +22,10 @@ def build_manager(characters):
     return manager
 
 
+def sprite_field(sprite, key):
+    return getattr(sprite, key, None) if hasattr(sprite, key) else sprite.get(key)
+
+
 def test_add_character_updates_existing_emotion_tags():
     character = Character(name="Mika", color="#66ccff", sprite_prefix="mika", emotion_tags="Sprite 1: old\n")
     manager = build_manager([character])
@@ -84,4 +88,74 @@ def test_add_character_creates_when_edit_target_is_missing():
     assert len(manager._config_manager.config.characters) == 1
     assert manager._config_manager.config.characters[0].name == "Sora"
     assert manager._config_manager.config.characters[0].emotion_tags == "Sprite 1: smile\n"
+    assert manager._config_manager.save_count == 1
+
+
+def test_upload_voice_after_sprite_delete_does_not_overwrite_shifted_sprite_voice(tmp_path, monkeypatch):
+    voice_dir = tmp_path / "speech"
+    char_voice_dir = voice_dir / "mika"
+    char_voice_dir.mkdir(parents=True)
+    old_a = char_voice_dir / "voice_00.wav"
+    old_b = char_voice_dir / "voice_01.wav"
+    old_c = char_voice_dir / "voice_02.wav"
+    old_a.write_bytes(b"old-a")
+    old_b.write_bytes(b"old-b")
+    old_c.write_bytes(b"old-c")
+    new_c = tmp_path / "new-c.wav"
+    new_c.write_bytes(b"new-c")
+    monkeypatch.setattr("config.character_manager.VOICE_DIR", str(voice_dir))
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[
+            {"path": "data/sprite/mika/sprite-a.png", "voice_path": str(old_a)},
+            {"path": "data/sprite/mika/sprite-b.png", "voice_path": str(old_b), "voice_type": "preset"},
+            {"path": "data/sprite/mika/sprite-c.png", "voice_path": str(old_c), "voice_type": "preset"},
+        ],
+    )
+    manager = build_manager([character])
+
+    manager.delete_single_sprite("Mika", 0)
+    _message, uploaded_path = manager.upload_voice("Mika", 1, str(new_c), "", "preset")
+
+    assert sprite_field(character.sprites[0], "voice_path") == str(old_b)
+    assert old_b.read_bytes() == b"old-b"
+    assert uploaded_path
+    assert sprite_field(character.sprites[1], "voice_path") == uploaded_path
+    assert uploaded_path != str(old_b)
+    assert "voice_01" not in uploaded_path
+    assert old_c.exists() is False
+    assert old_a.exists() is False
+    assert manager._config_manager.save_count == 2
+
+
+def test_upload_voice_does_not_delete_original_voice_outside_character_voice_dir(tmp_path, monkeypatch):
+    voice_dir = tmp_path / "speech"
+    voice_dir.mkdir()
+    external_voice = tmp_path / "external.wav"
+    external_voice.write_bytes(b"external")
+    new_voice = tmp_path / "new.wav"
+    new_voice.write_bytes(b"new")
+    monkeypatch.setattr("config.character_manager.VOICE_DIR", str(voice_dir))
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[
+            {
+                "path": "data/sprite/mika/sprite-a.png",
+                "voice_path": str(external_voice),
+                "voice_type": "preset",
+            },
+        ],
+    )
+    manager = build_manager([character])
+
+    _message, uploaded_path = manager.upload_voice("Mika", 0, str(new_voice), "", "preset")
+
+    assert external_voice.read_bytes() == b"external"
+    assert uploaded_path
+    assert uploaded_path.startswith(str(voice_dir / "mika"))
+    assert sprite_field(character.sprites[0], "voice_path") == uploaded_path
     assert manager._config_manager.save_count == 1

--- a/test/unit/managers/test_config_manager.py
+++ b/test/unit/managers/test_config_manager.py
@@ -65,11 +65,26 @@ def test_get_llm_api_config_defaults_known_provider_base_url_when_empty():
     assert api_key == "sk-test"
 
 
-def test_normalize_sprite_voice_types_sets_voice_without_text_to_fallback():
+def test_normalize_sprite_voice_types_preserves_explicit_voice_type():
     data = {
         "name": "Mika",
         "sprites": [
             {"path": "sprite.png", "voice_path": "voice.wav", "voice_type": "preset"},
+            {"path": "ref.png", "voice_path": "ref.wav", "voice_text": "hello", "voice_type": "reference"},
+        ],
+    }
+
+    normalized = normalize_sprite_voice_types(data)
+
+    assert normalized["sprites"][0]["voice_type"] == "preset"
+    assert normalized["sprites"][1]["voice_type"] == "reference"
+
+
+def test_normalize_sprite_voice_types_infers_legacy_voice_type_when_missing():
+    data = {
+        "name": "Mika",
+        "sprites": [
+            {"path": "sprite.png", "voice_path": "voice.wav"},
             {"path": "ref.png", "voice_path": "ref.wav", "voice_text": "hello"},
         ],
     }

--- a/test/unit/tools/test_character_import.py
+++ b/test/unit/tools/test_character_import.py
@@ -104,7 +104,7 @@ BASIC_CHAR = {
 # ── Import tests ────────────────────────────────────────────────────────────
 
 class TestImport:
-    def test_character_config_parse_normalizes_voice_without_text_to_fallback(self):
+    def test_character_config_parse_preserves_explicit_preset_voice(self):
         from config.character_config import CharacterConfig
 
         data = dict(BASIC_CHAR)
@@ -112,7 +112,7 @@ class TestImport:
 
         result = CharacterConfig.parse_dic(data)
 
-        assert result.sprites[0]["voice_type"] == "fallback"
+        assert result.sprites[0]["voice_type"] == "preset"
 
     def test_sprite_paths_rewritten(self, tmp_path):
         """Imported sprite paths point to the local data/sprite/{prefix}/ dir."""


### PR DESCRIPTION
Refs #205

## Summary by Sourcery

通过在角色编辑、删除和导入的整个流程中稳定语音文件命名方式以及 `voice_type` 的持久化，来保护精灵的语音绑定关系。

Bug Fixes:
- 确保在删除某个精灵后上传新的语音文件时，即使精灵索引发生变化，也不会覆盖其他精灵已有的语音文件。
- 在配置规范化和角色导入过程中保留精灵显式设定的 `voice_type` 值，而不是对这些值重新推断。
- 当精灵被删除或从服务器重新加载时，确保编辑器中选中的精灵 `voice_type` 始终与正确的精灵保持对齐。

Enhancements:
- 基于精灵路径和内容派生的哈希值为每个精灵生成语音文件名，而不是使用精灵索引，并清理被取代的语音文件以避免产生孤立音频。
- 将精灵的 `voice_type` 值规范化为受限的有效类型集合，仅在缺失时才推断遗留值。

Tests:
- 增加前端测试，以验证在精灵删除后精灵语音选择仍与精灵路径保持对齐。
- 增加后端测试，覆盖精灵删除后的语音上传行为、`voice_type` 规范化语义，以及在角色导入过程中保留预设语音类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve sprite voice bindings by stabilizing voice file naming and voice_type persistence across character edits, deletions, and imports.

Bug Fixes:
- Ensure uploading a new voice after deleting a sprite does not overwrite another sprite’s existing voice file when indices shift.
- Preserve explicit sprite voice_type values during config normalization and character import instead of inferring over them.
- Keep selected sprite voice_type in the editor aligned with the correct sprite when sprites are deleted or reloaded from the server.

Enhancements:
- Generate per-sprite voice filenames based on sprite path and a content-derived hash instead of the sprite index, and clean up superseded voice files to avoid orphaned audio.
- Normalize sprite voice_type values to a constrained set of valid types and infer legacy values only when missing.

Tests:
- Add frontend tests to verify sprite voice selection stays aligned with sprite paths after sprite deletion.
- Add backend tests for voice upload behavior after sprite deletion, voice_type normalization semantics, and preserving preset voice types during character import.

</details>