### PR TITLE
feat(plugin): Modify the ui to fix the pagination

### DIFF
--- a/frontend/src/features/plugin-manager/PluginManagerPage.css
+++ b/frontend/src/features/plugin-manager/PluginManagerPage.css
@@ -20,11 +20,19 @@
 }
 
 .plugin-list-controls {
+  position: sticky;
+  top: calc(var(--plugin-sticky-header-height, 64px) + var(--space-2));
+  z-index: 12;
   display: grid;
   grid-template-columns: minmax(180px, 1fr) auto auto;
   align-items: center;
   gap: var(--space-2);
   margin: var(--space-3) 0;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--color-border) 72%, transparent);
+  background: color-mix(in oklch, var(--color-surface) 92%, transparent);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 8px 18px color-mix(in oklch, var(--color-shadow) 42%, transparent);
 }
 
 .plugin-list-controls__search {

--- a/frontend/src/features/plugin-manager/PluginManagerPage.tsx
+++ b/frontend/src/features/plugin-manager/PluginManagerPage.tsx
@@ -58,6 +58,7 @@ import { reloadPluginService } from "./pluginReload";
 import "./PluginManagerPage.css";
 
 const INSTALLED_PLUGIN_PAGE_SIZE = 8;
+const PLUGIN_DEVELOPER_DOCS_URL = "https://plugins.shinsekai.studio/docs/plugin";
 
 interface PluginRouteReturnTo {
   hash?: string;
@@ -293,6 +294,8 @@ export function PluginManagerPage() {
   const navigate = useNavigate();
   const { showToast } = useToast();
   const { t } = useI18n();
+  const pageRef = useRef<HTMLDivElement | null>(null);
+  const headerRef = useRef<HTMLElement | null>(null);
   const pluginsQuery = useQuery({ queryFn: listPlugins, queryKey: pluginsQueryKey });
   const data = pluginsQuery.data ?? [];
   const isLoading = pluginsQuery.isLoading;
@@ -324,6 +327,34 @@ export function PluginManagerPage() {
     matcher: installedPluginMatches,
     pageSize: INSTALLED_PLUGIN_PAGE_SIZE,
   });
+
+  useEffect(() => {
+    const page = pageRef.current;
+    const header = headerRef.current;
+    if (!page || !header) {
+      return undefined;
+    }
+
+    const updateStickyHeaderHeight = () => {
+      page.style.setProperty("--plugin-sticky-header-height", `${Math.ceil(header.getBoundingClientRect().height)}px`);
+    };
+
+    updateStickyHeaderHeight();
+    window.addEventListener("resize", updateStickyHeaderHeight);
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        window.removeEventListener("resize", updateStickyHeaderHeight);
+      };
+    }
+
+    const observer = new ResizeObserver(updateStickyHeaderHeight);
+    observer.observe(header);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateStickyHeaderHeight);
+    };
+  }, []);
 
   useEffect(() => {
     const state = location.state as PluginRouteState | null;
@@ -544,8 +575,8 @@ export function PluginManagerPage() {
   }
 
   return (
-    <div className="page plugin-page">
-      <header className="page__header">
+    <div className="page plugin-page" ref={pageRef}>
+      <header className="page__header" ref={headerRef}>
         <div>
           <h1 className="page__title">{t("nav.plugins")}</h1>
           {pluginReloadPending ? (
@@ -553,6 +584,13 @@ export function PluginManagerPage() {
           ) : null}
         </div>
         <div className="page__actions plugin-page__actions">
+          <Button
+            icon={<BookOpen aria-hidden className="button__icon" />}
+            onClick={() => openExternal(PLUGIN_DEVELOPER_DOCS_URL)}
+            variant="ghost"
+          >
+            {t("plugin.action.developerDocs")}
+          </Button>
           <Button
             icon={<Send aria-hidden className="button__icon" />}
             onClick={() => setPublisherOpen(true)}

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -673,6 +673,7 @@ export type MessageKey =
   | "plugin.catalog.securityScanPassed"
   | "plugin.catalog.title"
   | "plugin.description"
+  | "plugin.action.developerDocs"
   | "plugin.action.docs"
   | "plugin.publisher.author"
   | "plugin.publisher.copy"

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -727,6 +727,7 @@ export const enMessages: Record<MessageKey, string> = {
   "plugin.catalog.title": "Discover",
   "plugin.description":
     "Plugins contribute only to fixed slots and are installed, enabled, or disabled through the platform layer.",
+  "plugin.action.developerDocs": "Developer docs",
   "plugin.action.docs": "Docs",
   "plugin.publisher.author": "Author",
   "plugin.publisher.copy": "Copy payload",

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -726,6 +726,7 @@ export const jaMessages: Record<MessageKey, string> = {
   "plugin.catalog.securityScanPassed": "スキャン通過",
   "plugin.catalog.title": "発見",
   "plugin.description": "プラグインは固定 slot にのみ貢献し、platform 層を通じてインストール、有効化、無効化します。",
+  "plugin.action.developerDocs": "開発者ドキュメント",
   "plugin.action.docs": "ドキュメント",
   "plugin.publisher.author": "作者",
   "plugin.publisher.copy": "Payload をコピー",

--- a/frontend/src/shared/i18n/messages/zh_CN.ts
+++ b/frontend/src/shared/i18n/messages/zh_CN.ts
@@ -716,6 +716,7 @@ export const zhCNMessages: Record<MessageKey, string> = {
   "plugin.catalog.securityScanPassed": "扫描通过",
   "plugin.catalog.title": "发现",
   "plugin.description": "插件只能贡献到固定 slot，并通过平台层安装、启用和停用。",
+  "plugin.action.developerDocs": "插件开发文档",
   "plugin.action.docs": "文档",
   "plugin.publisher.author": "作者",
   "plugin.publisher.copy": "复制 Payload",

--- a/frontend/src/test/features/plugin-manager/PluginManagerPage.test.tsx
+++ b/frontend/src/test/features/plugin-manager/PluginManagerPage.test.tsx
@@ -322,6 +322,14 @@ describe("PluginManagerPage", () => {
     expect(screen.getByRole("button", { name: "Read metadata" })).toBeInTheDocument();
   });
 
+  it("opens the plugin developer documentation from the page header", async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Developer docs" }));
+
+    expect(mockOpenExternal).toHaveBeenCalledWith("https://plugins.shinsekai.studio/docs/plugin");
+  });
+
   it("uses the installed manifest title as the primary name and the registry name as the secondary name", async () => {
     const installedPlugin = {
       ...plainPlugin,


### PR DESCRIPTION
## Summary by Sourcery

通过让筛选控件相对于页眉保持固定，并提供指向插件开发者文档的直接链接，改进插件管理页面的用户体验。

新功能：
- 在插件管理页面添加一个页眉操作按钮，用于打开外部的插件开发者文档

增强：
- 使插件列表控件具有基于页眉高度的动态偏移的吸顶效果，以提升滚动和分页的可用性

文档：
- 将新的开发者文档操作标签在所有支持的语言中进行本地化

测试：
- 添加测试，确保开发者文档按钮会打开正确的外部 URL

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the plugin manager page UX by making the filter controls sticky relative to the header and exposing a direct link to plugin developer documentation.

New Features:
- Add a header action button that opens external plugin developer documentation from the plugin manager page

Enhancements:
- Make plugin list controls sticky with a dynamic offset based on the header height to improve scrolling and pagination usability

Documentation:
- Localize the new developer documentation action label across supported languages

Tests:
- Add a test ensuring the developer documentation button opens the correct external URL

</details>