### PR TITLE
fix(plugin): pass bridge auth token to plugin frontend iframe pages

### DIFF
--- a/frontend_bridge_core/handler.py
+++ b/frontend_bridge_core/handler.py
@@ -12,7 +12,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any, Callable
-from urllib.parse import parse_qs, unquote, urlparse, urlunparse
+from urllib.parse import parse_qs, quote, unquote, urlparse, urlunparse
 
 from sdk.logging import get_logger, log_context, new_log_id
 from core.sprite.chat_branch_storage import remove_chat_history_storage
@@ -249,6 +249,17 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         supplied = self._auth_token_from_request()
         return bool(supplied) and hmac.compare_digest(supplied, required)
 
+    def _inject_bridge_token(self, detail: dict[str, Any]) -> dict[str, Any]:
+        token = str(getattr(self.state, "auth_token", "") or "").strip()
+        if not token:
+            return detail
+        for page in detail.get("pages") or []:
+            url = str(page.get("frontendUrl") or "")
+            if url.startswith("/api/") and BRIDGE_AUTH_QUERY not in url:
+                sep = "&" if "?" in url else "?"
+                page["frontendUrl"] = f"{url}{sep}{BRIDGE_AUTH_QUERY}={quote(token, safe='')}"
+        return detail
+
     def _require_authorized_write(self, path: str) -> None:
         if not self._request_origin_allowed():
             raise PermissionError("request origin is not allowed")
@@ -427,7 +438,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 self._send_json(plugin_load_snapshot(self.state))
             elif path.startswith("/api/plugins/") and path.endswith("/ui"):
                 plugin_id = unquote(path[len("/api/plugins/") : -len("/ui")])
-                self._send_json(_plugin_ui_detail(plugin_id))
+                self._send_json(self._inject_bridge_token(_plugin_ui_detail(plugin_id)))
             elif path.startswith("/api/plugins/") and "/frontend/" in path:
                 rest = path[len("/api/plugins/") :]
                 plugin_part, _, frontend_tail = rest.partition("/frontend/")

--- a/test/unit/frontend_bridge_core/test_security.py
+++ b/test/unit/frontend_bridge_core/test_security.py
@@ -191,6 +191,29 @@ def test_inject_bridge_token_appends_token_to_frontend_urls():
     assert result["pages"][1]["frontendUrl"].endswith("?shinsekai_bridge_token=secret-token")
 
 
+def test_inject_bridge_token_leaves_non_api_frontend_urls_unchanged():
+    handler = _handler_with_auth_token("secret-token")
+    detail = {
+        "pages": [
+            {
+                "id": "external-page",
+                "kind": "settings",
+                "frontendUrl": "https://example.com/plugin",
+            },
+            {
+                "id": "internal-non-api-page",
+                "kind": "settings",
+                "frontendUrl": "/plugins/demo/frontend/page/",
+            },
+        ]
+    }
+
+    result = handler._inject_bridge_token(detail)
+
+    assert result["pages"][0]["frontendUrl"] == "https://example.com/plugin"
+    assert result["pages"][1]["frontendUrl"] == "/plugins/demo/frontend/page/"
+
+
 def test_inject_bridge_token_leaves_pages_without_frontend_url_untouched():
     handler = _handler_with_auth_token("secret-token")
     detail = {"pages": [{"id": "widget-page", "kind": "settings"}]}

--- a/test/unit/frontend_bridge_core/test_security.py
+++ b/test/unit/frontend_bridge_core/test_security.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from frontend_bridge_core.config import _openai_chat_endpoint
@@ -166,3 +168,53 @@ def test_cors_drops_crlf_origin():
     handler._send_cors()
 
     assert not any(key == "Access-Control-Allow-Origin" for key, _value in headers)
+
+
+def _handler_with_auth_token(token: str) -> FrontendBridgeHandler:
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+    handler.server = SimpleNamespace(state=SimpleNamespace(auth_token=token))  # type: ignore[assignment]
+    return handler
+
+
+def test_inject_bridge_token_appends_token_to_frontend_urls():
+    handler = _handler_with_auth_token("secret-token")
+    detail = {
+        "pages": [
+            {"frontendUrl": "/api/plugins/demo/frontend/page/?pluginId=demo&pageId=page"},
+            {"frontendUrl": "/api/plugins/demo/frontend/bare/"},
+        ]
+    }
+
+    result = handler._inject_bridge_token(detail)
+
+    assert result["pages"][0]["frontendUrl"].endswith("&shinsekai_bridge_token=secret-token")
+    assert result["pages"][1]["frontendUrl"].endswith("?shinsekai_bridge_token=secret-token")
+
+
+def test_inject_bridge_token_leaves_pages_without_frontend_url_untouched():
+    handler = _handler_with_auth_token("secret-token")
+    detail = {"pages": [{"id": "widget-page", "kind": "settings"}]}
+
+    result = handler._inject_bridge_token(detail)
+
+    assert result["pages"][0] == {"id": "widget-page", "kind": "settings"}
+
+
+def test_inject_bridge_token_noop_when_auth_disabled():
+    handler = _handler_with_auth_token("")
+    url = "/api/plugins/demo/frontend/page/?pluginId=demo&pageId=page"
+    detail = {"pages": [{"frontendUrl": url}]}
+
+    result = handler._inject_bridge_token(detail)
+
+    assert result["pages"][0]["frontendUrl"] == url
+
+
+def test_inject_bridge_token_does_not_duplicate_existing_token():
+    handler = _handler_with_auth_token("secret-token")
+    url = "/api/plugins/demo/frontend/page/?shinsekai_bridge_token=secret-token"
+    detail = {"pages": [{"frontendUrl": url}]}
+
+    result = handler._inject_bridge_token(detail)
+
+    assert result["pages"][0]["frontendUrl"] == url


### PR DESCRIPTION
## 关联 issue

Closes #217

## 问题

插件 frontend 页面（iframe 嵌入）中所有写操作（保存配置、执行 action、文件浏览）都被 403 拒绝：`invalid bridge auth token`。

根因：`/api/plugins/<id>/ui` 返回的 `frontendUrl` 和前端 `resolvePluginFrontendFrameSrc()` 都不携带 bridge token。桌面壳下插件 iframe 与宿主页面跨源，插件端 `bridgeToken()` 的兜底（读 parent/top URL、referrer）全部失效，写请求裸发被 `_require_authorized_write` 拦截。GET 不校验 token，所以页面能打开、配置能读出，一执行动作就 403。详细分析见 #217。

## 修复（issue 中的方案 A）

`handler.py` 新增 `_inject_bridge_token()`：返回插件 UI 详情前，把 `state.auth_token` 追加到每个 page 的 `frontendUrl` query（`shinsekai_bridge_token=...`）。iframe 从自己 URL 的 query 读到 token 后，经 `X-Shinsekai-Bridge-Token` header 回传，走原有校验路径。

- `auth_token` 为空（auth 关闭）时不注入；
- URL 已含 token 时不重复追加；
- 无 `frontendUrl` 的 page（PyQt Widget 形式）不受影响；
- `resolvePluginFrontendFrameSrc()` 用 `new URL(frontendUrl, bridgeBase)` 解析，query 原样保留，浏览器直开模式同样兼容。

安全面与现状一致：启动时 token 本就以 query 形式出现在浏览器 URL（`_schedule_browser_open`），CORS 仍只放行 localhost 系 origin；不带 token 的写请求依旧 403。

## 测试

- `test_security.py` 新增 4 个单测覆盖注入/空 token/无 frontendUrl/不重复注入；
- `pytest test/unit/frontend_bridge_core` 223 项全部通过；
- 实机验证（v2.2.0，Windows 11 桌面壳）：打补丁后插件页 `switch_provider`、配置保存、`/api/files/browse` 均恢复 200，不带 token 的请求仍被 403 拦截。

## Summary by Sourcery

将桥接认证令牌注入到插件前端 iframe URL 中，以恢复从插件 UI 页面发起的授权写操作。

Enhancements:
- 添加服务端辅助函数，将桥接认证令牌附加到插件 UI 详情 API 返回的插件前端 URL 上。

Tests:
- 添加单元测试覆盖桥接令牌注入行为，包括认证禁用场景、无前端 URL 的页面，以及避免重复令牌的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject bridge auth tokens into plugin frontend iframe URLs to restore authorized write operations from plugin UI pages.

Enhancements:
- Add server-side helper to append bridge auth tokens to plugin frontend URLs returned by the plugin UI detail API.

Tests:
- Add unit tests covering bridge token injection behavior, including disabled auth, pages without frontend URLs, and avoidance of duplicate tokens.

</details>