### PR TITLE
feat(chat): refine message state, optimistic submissions, shutdown, and layout

### DIFF
--- a/core/runtime/event_sink.py
+++ b/core/runtime/event_sink.py
@@ -64,6 +64,7 @@ def make_empty_chat_snapshot() -> Dict[str, Any]:
         "options": [],
         "sprites": [],
         "status": "idle",
+        "systemMessageText": "",
         "userDisplayName": "你",
     }
 
@@ -180,10 +181,15 @@ def fold_event_into_snapshot(snapshot: Dict[str, Any], event: Dict[str, Any]) ->
         full_html = str(event.get("fullHtml") or "")
         next_snapshot["dialogHtml"] = full_html
         next_snapshot["dialogText"] = _plain_text(full_html)
-        if bool(event.get("isSystem")):
+        is_speakerless_system = bool(event.get("isSystem")) and not str(event.get("speaker") or "").strip()
+        if is_speakerless_system:
             next_snapshot["characterName"] = ""
+            next_snapshot["systemMessageText"] = _plain_text(full_html)
         else:
-            next_snapshot["characterName"] = str(event.get("speaker") or "")
+            next_snapshot["characterName"] = (
+                "" if bool(event.get("isSystem")) else str(event.get("speaker") or "")
+            )
+            next_snapshot["systemMessageText"] = ""
         if str(event.get("speaker") or "").strip() or not bool(event.get("isSystem")):
             next_snapshot["options"] = []
         return next_snapshot
@@ -328,6 +334,7 @@ def fold_event_into_snapshot(snapshot: Dict[str, Any], event: Dict[str, Any]) ->
         next_snapshot["options"] = []
         next_snapshot["sessionClosedReason"] = str(event.get("reason") or "")
         next_snapshot["status"] = "idle"
+        next_snapshot["systemMessageText"] = ""
         return next_snapshot
 
     return next_snapshot

--- a/core/runtime/shutdown.py
+++ b/core/runtime/shutdown.py
@@ -28,13 +28,16 @@ def shutdown_chat_runtime(
         steps.append(("emit_session_closed", emit_session_closed))
     if workflow is not None and hasattr(workflow, "stop"):
         steps.append(("workflow_stop", workflow.stop))
+    # Persist the conversation before plugin and memory shutdown hooks. Those
+    # hooks may perform network work, and the parent process may enforce an
+    # overall shutdown deadline.
+    if save_history is not None:
+        steps.append(("save_history", save_history))
     steps.extend(iter_shutdown_hooks())
     if plugin_shutdown is not None:
         steps.append(("plugin_shutdown", plugin_shutdown))
     if tts_shutdown is not None:
         steps.append(("tts_shutdown", tts_shutdown))
-    if save_history is not None:
-        steps.append(("save_history", save_history))
     if save_background is not None:
         steps.append(("save_background", save_background))
     if close_stream_sink is not None:

--- a/core/sprite/chat_branch_storage.py
+++ b/core/sprite/chat_branch_storage.py
@@ -134,6 +134,38 @@ def load_branch_state(path: str | Path) -> dict[str, Any] | None:
         return None
 
 
+def reconcile_active_branch_state(
+    branch_state: dict[str, Any],
+    loaded_messages: list[Any],
+    loaded_history: list[Any],
+) -> tuple[list[Any], list[Any]]:
+    """Reconcile branch metadata with the crash-recoverable active history.
+
+    ``active.json`` and its incremental ``.tmp`` file are loaded before the
+    branch tree. When they contain data, they are newer and must not be
+    overwritten by a stale ``branches.json`` left behind by an interrupted
+    shutdown.
+    """
+
+    branches = branch_state.get("branches")
+    if not isinstance(branches, dict):
+        return copy.deepcopy(loaded_messages), copy.deepcopy(loaded_history)
+    active_id = str(branch_state.get("active") or "").strip()
+    active_branch = branches.get(active_id)
+    if not isinstance(active_branch, dict):
+        return copy.deepcopy(loaded_messages), copy.deepcopy(loaded_history)
+
+    if loaded_messages or loaded_history:
+        active_branch["messages"] = copy.deepcopy(loaded_messages)
+        active_branch["history"] = copy.deepcopy(loaded_history)
+        return copy.deepcopy(loaded_messages), copy.deepcopy(loaded_history)
+
+    return (
+        _copy_jsonable_list(active_branch.get("messages")),
+        _copy_jsonable_list(active_branch.get("history")),
+    )
+
+
 def branch_state_payload(branch_state: dict[str, Any]) -> dict[str, Any]:
     branches = branch_state.get("branches") if isinstance(branch_state, dict) else {}
     if not isinstance(branches, dict):

--- a/core/sprite/initial_sprite.py
+++ b/core/sprite/initial_sprite.py
@@ -30,8 +30,8 @@ def resolve_runtime_path(raw_path: str) -> Path:
 
 
 def _sprite_path_key(raw_path: str) -> str:
-    """Normalize path identity consistently across host platforms and locales."""
-    return os.path.normcase(str(resolve_runtime_path(raw_path))).replace("\\", "/").casefold()
+    """Normalize path identity using the host filesystem's case semantics."""
+    return os.path.normcase(str(resolve_runtime_path(raw_path))).replace("\\", "/")
 
 
 def find_character_sprite_by_path(

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -387,6 +387,8 @@ pub fn run() {
             desktop_app_restart,
             desktop_bridge_restart,
             desktop_frontend_reload,
+            desktop_window_hide,
+            desktop_chat_window_destroy,
             desktop_window_minimize,
             desktop_window_toggle_maximize,
             desktop_window_start_drag,
@@ -1225,6 +1227,19 @@ Start-Process -FilePath $exe -ArgumentList $argv
             Err(error.to_string())
         }
     }
+}
+
+#[tauri::command]
+fn desktop_window_hide(window: WebviewWindow) -> Result<(), String> {
+    window.hide().map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn desktop_chat_window_destroy(window: WebviewWindow) -> Result<(), String> {
+    if window.label() != "chat" {
+        return Err("desktop_chat_window_destroy is only available to the chat window".to_string());
+    }
+    window.destroy().map_err(|error| error.to_string())
 }
 
 #[tauri::command]

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -185,12 +185,12 @@ export function ChatStagePage() {
     if (!text) {
       return;
     }
-    dispatch({ text, type: "submitUserMessage" });
+    dispatch({ source: "send-message", text, type: "submitUserMessage" });
     void sendCommand({ payload: text, type: "send-message" });
   };
 
   const submitOption = (option: string) => {
-    dispatch({ text: option, type: "submitUserMessage" });
+    dispatch({ source: "submit-option", text: option, type: "submitUserMessage" });
     void sendCommand({ payload: option, type: "submit-option" });
   };
 

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -121,19 +121,25 @@ export function ChatStagePage() {
   const autoAdvanceDialog = useCallback(() => {
     void sendCommand({ type: "dialog-advance" });
   }, [sendCommand]);
-  const { dialogTotalCharacters, displayedDialog, queueAnimatedDialog, showFullDialog, typingDialog } =
-    useDialogTypewriter({
-      auto: runtimeConfig.auto,
-      characterName: viewModel.dialogCharacterName,
-      dialogVisible: viewModel.layers.dialog,
-      html: viewModel.dialogHtml,
-      onAutoAdvance: autoAdvanceDialog,
-      optionsVisible: viewModel.layers.options,
-      status: viewModel.status,
-      text: viewModel.dialogText,
-      textDirection: dialogTextDirection,
-      typewriterCps,
-    });
+  const {
+    dialogTotalCharacters,
+    displayedDialog,
+    queueAnimatedDialog,
+    showDialogImmediately,
+    showFullDialog,
+    typingDialog,
+  } = useDialogTypewriter({
+    auto: runtimeConfig.auto,
+    characterName: viewModel.dialogCharacterName,
+    dialogVisible: viewModel.layers.dialog,
+    html: viewModel.dialogHtml,
+    onAutoAdvance: autoAdvanceDialog,
+    optionsVisible: viewModel.layers.options,
+    status: viewModel.status,
+    text: viewModel.dialogText,
+    textDirection: dialogTextDirection,
+    typewriterCps,
+  });
   const {
     handleStageContextMenu,
     handleStageFocus,
@@ -185,11 +191,13 @@ export function ChatStagePage() {
     if (!text) {
       return;
     }
+    showDialogImmediately();
     dispatch({ source: "send-message", text, type: "submitUserMessage" });
     void sendCommand({ payload: text, type: "send-message" });
   };
 
   const submitOption = (option: string) => {
+    showDialogImmediately();
     dispatch({ source: "submit-option", text: option, type: "submitUserMessage" });
     void sendCommand({ payload: option, type: "submit-option" });
   };
@@ -289,7 +297,7 @@ export function ChatStagePage() {
   };
 
   const closeSurface = () => {
-    void closeChatSurface({
+    return closeChatSurface({
       closeRuntime: closeChatRuntime,
       navigate,
       snapshot: state,
@@ -335,6 +343,7 @@ export function ChatStagePage() {
         <StandaloneDesktopResizeHandles hidden={!standaloneDesktopWindow} />
         <TopStageTools
           hidden={!viewModel.layers.toolbar}
+          onCloseDesktopWindow={closeSurface}
           onTokenUsageOpenChange={setTokenUsageOpen}
           standaloneDesktopWindow={standaloneDesktopWindow}
           status={viewModel.statusText}

--- a/frontend/src/features/chat-stage/components/TopStageTools.tsx
+++ b/frontend/src/features/chat-stage/components/TopStageTools.tsx
@@ -1,10 +1,6 @@
 import { Activity, Maximize2, Minus, X } from "lucide-react";
 
-import {
-  closeDesktopWindow,
-  minimizeDesktopWindow,
-  toggleMaximizeDesktopWindow,
-} from "../../../shared/desktop/desktopApi";
+import { minimizeDesktopWindow, toggleMaximizeDesktopWindow } from "../../../shared/desktop/desktopApi";
 import { useI18n } from "../../../shared/i18n";
 import type { ChatTransportMode, ChatTransportState } from "../../../shared/platform/types";
 import { IconButton } from "../../../shared/ui";
@@ -12,6 +8,7 @@ import { transportStatusText } from "../chatStageUtils";
 
 export function TopStageTools({
   hidden,
+  onCloseDesktopWindow,
   onTokenUsageOpenChange,
   standaloneDesktopWindow,
   status,
@@ -21,6 +18,7 @@ export function TopStageTools({
   transportState,
 }: {
   hidden: boolean;
+  onCloseDesktopWindow: () => Promise<void>;
   onTokenUsageOpenChange: (open: boolean) => void;
   standaloneDesktopWindow: boolean;
   status: string;
@@ -87,7 +85,7 @@ export function TopStageTools({
             <IconButton
               className="top-stage-tools__button"
               label={t("desktop.titlebar.close")}
-              onClick={() => runWindowAction(closeDesktopWindow)}
+              onClick={() => runWindowAction(onCloseDesktopWindow)}
             >
               <X aria-hidden className="icon-button__icon" />
             </IconButton>

--- a/frontend/src/features/chat-stage/hooks/useChatStageCommands.ts
+++ b/frontend/src/features/chat-stage/hooks/useChatStageCommands.ts
@@ -51,9 +51,6 @@ export function useChatStageCommands({
         if (command.type !== "copy-history" && !commandAlreadyApplied) {
           dispatch({ snapshot, type: "hydrate" });
         }
-        if (command.type === "send-message" || command.type === "submit-option") {
-          dispatch({ source: command.type, type: "commitUserSubmission" });
-        }
         if (command.type === "copy-history") {
           showToast({ kind: "success", title: t("chat.toast.historyCopied") });
         }

--- a/frontend/src/features/chat-stage/hooks/useChatStageCommands.ts
+++ b/frontend/src/features/chat-stage/hooks/useChatStageCommands.ts
@@ -51,6 +51,9 @@ export function useChatStageCommands({
         if (command.type !== "copy-history" && !commandAlreadyApplied) {
           dispatch({ snapshot, type: "hydrate" });
         }
+        if (command.type === "send-message" || command.type === "submit-option") {
+          dispatch({ source: command.type, type: "commitUserSubmission" });
+        }
         if (command.type === "copy-history") {
           showToast({ kind: "success", title: t("chat.toast.historyCopied") });
         }
@@ -66,9 +69,10 @@ export function useChatStageCommands({
           showToast({ kind: "success", title: t("chat.toast.historyCleared") });
         }
       } catch (error) {
-        dispatch({ status: "idle", type: "setStatus" });
-        if (command.type === "send-message" && typeof command.payload === "string") {
-          dispatch({ text: command.payload, type: "setDraft" });
+        if (command.type === "send-message" || command.type === "submit-option") {
+          dispatch({ source: command.type, type: "rollbackUserSubmission" });
+        } else {
+          dispatch({ status: "idle", type: "setStatus" });
         }
         showToast({
           kind: "error",

--- a/frontend/src/features/chat-stage/hooks/useDialogTypewriter.ts
+++ b/frontend/src/features/chat-stage/hooks/useDialogTypewriter.ts
@@ -62,6 +62,11 @@ export function useDialogTypewriter({
     setVisibleDialogCharacters(0);
   }, []);
 
+  const showDialogImmediately = useCallback(() => {
+    pendingAnimatedDialogKeyRef.current = null;
+    setVisibleDialogCharacters(Number.MAX_SAFE_INTEGER);
+  }, []);
+
   const showFullDialog = useCallback(() => {
     setVisibleDialogCharacters(dialogTotalCharacters);
   }, [dialogTotalCharacters]);
@@ -105,6 +110,7 @@ export function useDialogTypewriter({
     dialogTotalCharacters,
     displayedDialog,
     queueAnimatedDialog,
+    showDialogImmediately,
     showFullDialog,
     typingDialog,
   };

--- a/frontend/src/features/chat-stage/state/events.ts
+++ b/frontend/src/features/chat-stage/state/events.ts
@@ -82,12 +82,13 @@ export function applyStageEvent(state: ChatStageState, event: ChatStageEvent): C
         eventSeq: Math.max(state.eventSeq, event.seq),
         error: undefined,
         ...(event.isSystem && !event.speaker.trim()
-          ? { notificationText: htmlToText(event.fullHtml) }
+          ? { systemMessageText: htmlToText(event.fullHtml) }
           : {
               characterName: event.speaker,
               dialogHtml: event.fullHtml,
               dialogText: htmlToText(event.fullHtml),
               options: [],
+              systemMessageText: undefined,
             }),
       });
     case "user.display_name.change":
@@ -227,6 +228,7 @@ export function applyStageEvent(state: ChatStageState, event: ChatStageEvent): C
         options: [],
         sessionClosedReason: event.reason,
         status: "idle",
+        systemMessageText: undefined,
       });
     default:
       return state;

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -5,8 +5,13 @@ import type { ChatStageAction, ChatStageState } from "./types";
 
 export function chatStageReducer(state: ChatStageState, action: ChatStageAction): ChatStageState {
   switch (action.type) {
-    case "event":
-      return applyStageEvent(state, action.event);
+    case "event": {
+      const next = applyStageEvent(state, action.event);
+      const authoritativeEvent =
+        (action.event.type === "snapshot" && next !== state) ||
+        (action.event.type !== "transport.state" && action.event.seq > state.eventSeq);
+      return authoritativeEvent ? { ...next, optimisticSubmission: undefined } : next;
+    }
     case "hydrate":
       return hydrateFromSnapshot(state, action.snapshot);
     case "submitUserMessage":
@@ -17,10 +22,40 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
         dialogText: action.text,
         error: undefined,
         inputDraft: "",
+        optimisticSubmission: {
+          previous: {
+            characterName: state.characterName,
+            dialogHtml: state.dialogHtml,
+            dialogText: state.dialogText,
+            error: state.error,
+            inputDraft: state.inputDraft,
+            notificationText: state.notificationText,
+            options: [...state.options],
+            sessionClosedReason: state.sessionClosedReason,
+            status: state.status,
+          },
+          source: action.source ?? "send-message",
+        },
         options: [],
         sessionClosedReason: undefined,
         status: "generating",
       });
+    case "rollbackUserSubmission": {
+      const optimistic = state.optimisticSubmission;
+      if (!optimistic || optimistic.source !== action.source) {
+        return state;
+      }
+      return withResolvedLayers({
+        ...state,
+        ...optimistic.previous,
+        options: [...optimistic.previous.options],
+        optimisticSubmission: undefined,
+      });
+    }
+    case "commitUserSubmission":
+      return state.optimisticSubmission?.source === action.source
+        ? { ...state, optimisticSubmission: undefined }
+        : state;
     case "setHistoryEntries":
       return withResolvedLayers({
         ...state,

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -89,6 +89,7 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
         error: undefined,
         inputDraft: "",
         optimisticSubmission: {
+          draftEditedAfterSubmission: false,
           eventSeq: state.eventSeq,
           previous: {
             characterName: state.characterName,
@@ -117,9 +118,11 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
       if (!optimistic || optimistic.source !== action.source) {
         return state;
       }
+      const inputDraft = optimistic.draftEditedAfterSubmission ? state.inputDraft : optimistic.previous.inputDraft;
       return withResolvedLayers({
         ...state,
         ...optimistic.previous,
+        inputDraft,
         options: [...optimistic.previous.options],
         optimisticSubmission: undefined,
       });
@@ -130,7 +133,13 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
         historyEntries: action.historyEntries.map((entry) => ({ ...entry })),
       });
     case "setDraft":
-      return withResolvedLayers({ ...state, inputDraft: action.text });
+      return withResolvedLayers({
+        ...state,
+        inputDraft: action.text,
+        optimisticSubmission: state.optimisticSubmission
+          ? { ...state.optimisticSubmission, draftEditedAfterSubmission: true }
+          : undefined,
+      });
     case "setStatus":
       return withResolvedLayers({
         ...state,

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -1,6 +1,7 @@
 import { applyStageEvent } from "./events";
 import { clearTransientNotificationState, withResolvedLayers } from "./layers";
 import { hydrateFromSnapshot, snapshotEventSeq } from "./snapshot";
+import { normalizedUserDisplayName } from "./text";
 import type { ChatStageAction, ChatStageState } from "./types";
 
 function preserveOptimisticPresentation(state: ChatStageState, next: ChatStageState): ChatStageState {
@@ -14,6 +15,7 @@ function preserveOptimisticPresentation(state: ChatStageState, next: ChatStageSt
     options: [...state.options],
     sessionClosedReason: state.sessionClosedReason,
     status: state.status,
+    statusMessage: state.statusMessage,
     systemMessageText: state.systemMessageText,
   });
 }
@@ -27,19 +29,23 @@ function snapshotReplacesOptimisticPresentation(
   if (!optimistic) {
     return true;
   }
-  if (snapshot.sessionClosedReason || snapshot.options.length > 0 || snapshot.systemMessageText?.trim()) {
+  if (snapshot.sessionClosedReason || snapshot.options.length > 0) {
     return true;
   }
   if (authoritativeEventSeq <= optimistic.eventSeq) {
     return false;
   }
   const dialogText = snapshot.dialogText.trim();
+  const dialogHtml = snapshot.dialogHtml?.trim();
   const speaker = snapshot.characterName?.trim();
-  const userName = state.userDisplayName.trim();
-  if (speaker && speaker !== userName) {
-    return true;
+  const statusMessage = snapshot.statusMessage?.trim();
+  const userName = normalizedUserDisplayName(state.userDisplayName);
+  const hasDialogContent = Boolean(dialogHtml || dialogText);
+  const isCommandFeedback = Boolean(statusMessage && !dialogHtml && statusMessage === dialogText);
+  if (!hasDialogContent || isCommandFeedback) {
+    return false;
   }
-  return Boolean(dialogText && dialogText !== optimistic.text);
+  return Boolean(speaker && speaker !== userName);
 }
 
 export function chatStageReducer(state: ChatStageState, action: ChatStageAction): ChatStageState {
@@ -77,7 +83,7 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
     case "submitUserMessage":
       return withResolvedLayers({
         ...clearTransientNotificationState(state),
-        characterName: state.userDisplayName,
+        characterName: normalizedUserDisplayName(state.userDisplayName),
         dialogHtml: undefined,
         dialogText: action.text,
         error: undefined,
@@ -94,6 +100,7 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
             options: [...state.options],
             sessionClosedReason: state.sessionClosedReason,
             status: state.status,
+            statusMessage: state.statusMessage,
             systemMessageText: state.systemMessageText,
           },
           source: action.source ?? "send-message",
@@ -102,6 +109,7 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
         options: [],
         sessionClosedReason: undefined,
         status: "generating",
+        statusMessage: undefined,
         systemMessageText: undefined,
       });
     case "rollbackUserSubmission": {

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -33,12 +33,14 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
             options: [...state.options],
             sessionClosedReason: state.sessionClosedReason,
             status: state.status,
+            systemMessageText: state.systemMessageText,
           },
           source: action.source ?? "send-message",
         },
         options: [],
         sessionClosedReason: undefined,
         status: "generating",
+        systemMessageText: undefined,
       });
     case "rollbackUserSubmission": {
       const optimistic = state.optimisticSubmission;

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -1,19 +1,79 @@
 import { applyStageEvent } from "./events";
 import { clearTransientNotificationState, withResolvedLayers } from "./layers";
-import { hydrateFromSnapshot } from "./snapshot";
+import { hydrateFromSnapshot, snapshotEventSeq } from "./snapshot";
 import type { ChatStageAction, ChatStageState } from "./types";
+
+function preserveOptimisticPresentation(state: ChatStageState, next: ChatStageState): ChatStageState {
+  return withResolvedLayers({
+    ...next,
+    characterName: state.characterName,
+    dialogHtml: state.dialogHtml,
+    dialogText: state.dialogText,
+    inputDraft: state.inputDraft,
+    optimisticSubmission: state.optimisticSubmission,
+    options: [...state.options],
+    sessionClosedReason: state.sessionClosedReason,
+    status: state.status,
+    systemMessageText: state.systemMessageText,
+  });
+}
+
+function snapshotReplacesOptimisticPresentation(
+  state: ChatStageState,
+  snapshot: ChatStageState,
+  authoritativeEventSeq: number,
+): boolean {
+  const optimistic = state.optimisticSubmission;
+  if (!optimistic) {
+    return true;
+  }
+  if (snapshot.sessionClosedReason || snapshot.options.length > 0 || snapshot.systemMessageText?.trim()) {
+    return true;
+  }
+  if (authoritativeEventSeq <= optimistic.eventSeq) {
+    return false;
+  }
+  const dialogText = snapshot.dialogText.trim();
+  const speaker = snapshot.characterName?.trim();
+  const userName = state.userDisplayName.trim();
+  if (speaker && speaker !== userName) {
+    return true;
+  }
+  return Boolean(dialogText && dialogText !== optimistic.text);
+}
 
 export function chatStageReducer(state: ChatStageState, action: ChatStageAction): ChatStageState {
   switch (action.type) {
     case "event": {
       const next = applyStageEvent(state, action.event);
-      const authoritativeEvent =
-        (action.event.type === "snapshot" && next !== state) ||
-        (action.event.type !== "transport.state" && action.event.seq > state.eventSeq);
-      return authoritativeEvent ? { ...next, optimisticSubmission: undefined } : next;
+      if (!state.optimisticSubmission || next === state) {
+        return next;
+      }
+      if (action.event.type === "snapshot") {
+        const authoritativeEventSeq = snapshotEventSeq(action.event.snapshot);
+        if (authoritativeEventSeq <= state.eventSeq) {
+          return state;
+        }
+        return snapshotReplacesOptimisticPresentation(state, next, authoritativeEventSeq)
+          ? { ...next, optimisticSubmission: undefined }
+          : preserveOptimisticPresentation(state, next);
+      }
+      if (["dialog.end", "options.show", "session.closed"].includes(action.event.type)) {
+        return { ...next, optimisticSubmission: undefined };
+      }
+      return next;
     }
-    case "hydrate":
-      return hydrateFromSnapshot(state, action.snapshot);
+    case "hydrate": {
+      const next = hydrateFromSnapshot(state, action.snapshot);
+      if (!state.optimisticSubmission || next === state) {
+        return next;
+      }
+      // Hydration requests may have started before the user submitted. Keep the
+      // local presentation until the event stream publishes a newer response.
+      return action.snapshot.sessionClosedReason
+        ? { ...next, optimisticSubmission: undefined }
+        : preserveOptimisticPresentation(state, next);
+    }
     case "submitUserMessage":
       return withResolvedLayers({
         ...clearTransientNotificationState(state),
@@ -23,6 +83,7 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
         error: undefined,
         inputDraft: "",
         optimisticSubmission: {
+          eventSeq: state.eventSeq,
           previous: {
             characterName: state.characterName,
             dialogHtml: state.dialogHtml,
@@ -36,6 +97,7 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
             systemMessageText: state.systemMessageText,
           },
           source: action.source ?? "send-message",
+          text: action.text,
         },
         options: [],
         sessionClosedReason: undefined,
@@ -54,10 +116,6 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
         optimisticSubmission: undefined,
       });
     }
-    case "commitUserSubmission":
-      return state.optimisticSubmission?.source === action.source
-        ? { ...state, optimisticSubmission: undefined }
-        : state;
     case "setHistoryEntries":
       return withResolvedLayers({
         ...state,

--- a/frontend/src/features/chat-stage/state/types.ts
+++ b/frontend/src/features/chat-stage/state/types.ts
@@ -48,6 +48,7 @@ export interface ChatStageState extends Omit<ChatSnapshot, "sprites"> {
       options: string[];
       sessionClosedReason?: string;
       status: ChatRuntimeStatus;
+      statusMessage?: string;
       systemMessageText?: string;
     };
     source: "send-message" | "submit-option";

--- a/frontend/src/features/chat-stage/state/types.ts
+++ b/frontend/src/features/chat-stage/state/types.ts
@@ -36,6 +36,20 @@ export interface ChatStageState extends Omit<ChatSnapshot, "sprites"> {
   eventSeq: number;
   layers: ChatStageLayers;
   notificationText?: string;
+  optimisticSubmission?: {
+    previous: {
+      characterName?: string;
+      dialogHtml?: string;
+      dialogText: string;
+      error?: string;
+      inputDraft: string;
+      notificationText?: string;
+      options: string[];
+      sessionClosedReason?: string;
+      status: ChatRuntimeStatus;
+    };
+    source: "send-message" | "submit-option";
+  };
   sessionClosedReason?: string;
   sprites: ChatStageSprite[];
   transportMode: ChatTransportMode;
@@ -68,7 +82,9 @@ export interface ChatStageViewModel {
 export type ChatStageAction =
   | { type: "event"; event: ChatStageEvent }
   | { type: "hydrate"; snapshot: ChatSnapshot }
-  | { type: "submitUserMessage"; text: string }
+  | { type: "submitUserMessage"; text: string; source?: "send-message" | "submit-option" }
+  | { type: "commitUserSubmission"; source: "send-message" | "submit-option" }
+  | { type: "rollbackUserSubmission"; source: "send-message" | "submit-option" }
   | { type: "setHistoryEntries"; historyEntries: ChatHistoryEntry[] }
   | { type: "setDraft"; text: string }
   | { type: "setStatus"; status: ChatRuntimeStatus }

--- a/frontend/src/features/chat-stage/state/types.ts
+++ b/frontend/src/features/chat-stage/state/types.ts
@@ -37,6 +37,7 @@ export interface ChatStageState extends Omit<ChatSnapshot, "sprites"> {
   layers: ChatStageLayers;
   notificationText?: string;
   optimisticSubmission?: {
+    eventSeq: number;
     previous: {
       characterName?: string;
       dialogHtml?: string;
@@ -50,6 +51,7 @@ export interface ChatStageState extends Omit<ChatSnapshot, "sprites"> {
       systemMessageText?: string;
     };
     source: "send-message" | "submit-option";
+    text: string;
   };
   sessionClosedReason?: string;
   sprites: ChatStageSprite[];
@@ -84,7 +86,6 @@ export type ChatStageAction =
   | { type: "event"; event: ChatStageEvent }
   | { type: "hydrate"; snapshot: ChatSnapshot }
   | { type: "submitUserMessage"; text: string; source?: "send-message" | "submit-option" }
-  | { type: "commitUserSubmission"; source: "send-message" | "submit-option" }
   | { type: "rollbackUserSubmission"; source: "send-message" | "submit-option" }
   | { type: "setHistoryEntries"; historyEntries: ChatHistoryEntry[] }
   | { type: "setDraft"; text: string }

--- a/frontend/src/features/chat-stage/state/types.ts
+++ b/frontend/src/features/chat-stage/state/types.ts
@@ -37,6 +37,7 @@ export interface ChatStageState extends Omit<ChatSnapshot, "sprites"> {
   layers: ChatStageLayers;
   notificationText?: string;
   optimisticSubmission?: {
+    draftEditedAfterSubmission: boolean;
     eventSeq: number;
     previous: {
       characterName?: string;

--- a/frontend/src/features/chat-stage/state/types.ts
+++ b/frontend/src/features/chat-stage/state/types.ts
@@ -47,6 +47,7 @@ export interface ChatStageState extends Omit<ChatSnapshot, "sprites"> {
       options: string[];
       sessionClosedReason?: string;
       status: ChatRuntimeStatus;
+      systemMessageText?: string;
     };
     source: "send-message" | "submit-option";
   };

--- a/frontend/src/features/chat-stage/state/viewModel.ts
+++ b/frontend/src/features/chat-stage/state/viewModel.ts
@@ -15,10 +15,12 @@ export function buildChatStageViewModel(state: ChatStageState): ChatStageViewMod
   );
   const tokenUsageText = normalizeTokenUsageText(state.numericInfo, state.status);
   const systemPromptText = systemPromptTextFromState(state, dialog.dialogText);
+  const systemMessageText = state.systemMessageText?.trim();
   const layers = {
     ...state.layers,
-    dialog: state.layers.dialog && !systemPromptText && Boolean(dialog.dialogHtml || dialog.dialogText),
-    notification: Boolean(state.notificationText || systemPromptText),
+    dialog:
+      state.layers.dialog && !systemMessageText && !systemPromptText && Boolean(dialog.dialogHtml || dialog.dialogText),
+    notification: Boolean(state.notificationText || systemMessageText || systemPromptText),
   };
   return {
     backgroundPath: state.backgroundPath,
@@ -30,7 +32,7 @@ export function buildChatStageViewModel(state: ChatStageState): ChatStageViewMod
     inputDisabled: !state.layers.input || state.status === "generating" || state.status === "streaming",
     inputDraft: state.inputDraft,
     layers,
-    notificationText: state.notificationText || systemPromptText,
+    notificationText: state.notificationText || systemMessageText || systemPromptText,
     options: state.options,
     sprites: state.sprites,
     status: state.status,

--- a/frontend/src/features/chat-stage/styles/base.css
+++ b/frontend/src/features/chat-stage/styles/base.css
@@ -47,7 +47,7 @@
   --chat-dialog-body-height: auto;
   --chat-dialog-body-min-height: 64px;
   --chat-dialog-body-overflow: auto;
-  --chat-dialog-body-scrollbar-gutter: stable;
+  --chat-dialog-body-scrollbar-gutter: auto;
   --chat-dialog-border: 1px solid var(--chat-dialog-border-color);
   --chat-dialog-color: #f7f1f0;
   --chat-dialog-height: auto;

--- a/frontend/src/features/chat-stage/styles/dialog-layer.css
+++ b/frontend/src/features/chat-stage/styles/dialog-layer.css
@@ -152,8 +152,37 @@
   min-height: var(--chat-dialog-body-min-height);
   max-height: var(--chat-dialog-body-max-height);
   min-width: 0;
-  overflow: var(--chat-dialog-body-overflow);
+  overflow-x: hidden;
+  overflow-y: var(--chat-dialog-body-overflow);
+  overscroll-behavior: contain;
   scrollbar-gutter: var(--chat-dialog-body-scrollbar-gutter);
+  scrollbar-color: color-mix(in oklch, var(--stage-accent) 46%, rgba(255, 255, 255, 0.2)) transparent;
+  scrollbar-width: thin;
+}
+
+.dialog-layer__body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.dialog-layer__body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dialog-layer__body::-webkit-scrollbar-thumb {
+  min-height: 32px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--stage-accent) 46%, rgba(255, 255, 255, 0.2));
+  background-clip: padding-box;
+}
+
+.dialog-layer__body::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--stage-accent) 66%, rgba(255, 255, 255, 0.3));
+  background-clip: padding-box;
+}
+
+.dialog-layer__body::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 .dialog-layer[data-has-toolbar="true"] .dialog-layer__body {

--- a/frontend/src/features/chat-stage/styles/media-layers.css
+++ b/frontend/src/features/chat-stage/styles/media-layers.css
@@ -86,6 +86,7 @@
   --sprite-offset-y: 0px;
   --sprite-scale: 1;
   height: 90%;
+  max-width: 100%;
   min-width: 0;
   margin: 0;
   transform: translate(
@@ -118,7 +119,9 @@
 .sprite-layer__image {
   display: block;
   width: auto;
-  max-width: none;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
   object-position: bottom center;
   user-select: none;

--- a/frontend/src/features/chat-startup/initialSpriteSelection.ts
+++ b/frontend/src/features/chat-startup/initialSpriteSelection.ts
@@ -1,7 +1,7 @@
 import type { Character } from "../../shared/platform/types";
 
 function normalizedSpritePath(path: string) {
-  return path.trim().replaceAll("\\", "/").toLowerCase();
+  return path.trim().replaceAll("\\", "/");
 }
 
 export function initialSpriteOwner(path: string, characters: Array<Pick<Character, "name" | "sprites">>) {

--- a/frontend/src/features/chat-startup/initialSpriteSelection.ts
+++ b/frontend/src/features/chat-startup/initialSpriteSelection.ts
@@ -1,28 +1,48 @@
 import type { Character } from "../../shared/platform/types";
 
-function normalizedSpritePath(path: string) {
-  return path.trim().replaceAll("\\", "/");
+function browserHostPlatform() {
+  if (typeof navigator === "undefined") {
+    return "";
+  }
+  const userAgentData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  return userAgentData?.platform || navigator.platform || navigator.userAgent;
 }
 
-export function initialSpriteOwner(path: string, characters: Array<Pick<Character, "name" | "sprites">>) {
-  const normalizedPath = normalizedSpritePath(path);
+export function spritePathsAreCaseSensitive(platform = browserHostPlatform()) {
+  return !/\bwin(?:32|64|dows|ce)?\b/iu.test(platform.trim());
+}
+
+function normalizedSpritePath(path: string, caseSensitive: boolean) {
+  const normalized = path.trim().replaceAll("\\", "/");
+  return caseSensitive ? normalized : normalized.toLowerCase();
+}
+
+export function initialSpriteOwner(
+  path: string,
+  characters: Array<Pick<Character, "name" | "sprites">>,
+  { caseSensitive = spritePathsAreCaseSensitive() }: { caseSensitive?: boolean } = {},
+) {
+  const normalizedPath = normalizedSpritePath(path, caseSensitive);
   if (!normalizedPath) {
     return undefined;
   }
   return characters.find((character) =>
     (character?.sprites ?? []).some(
-      (sprite) => typeof sprite?.path === "string" && normalizedSpritePath(sprite.path) === normalizedPath,
+      (sprite) =>
+        typeof sprite?.path === "string" && normalizedSpritePath(sprite.path, caseSensitive) === normalizedPath,
     ),
   )?.name;
 }
 
 export function compatibleInitialSpritePath({
   characters,
+  caseSensitive = spritePathsAreCaseSensitive(),
   path,
   preserveUnknown = true,
   selectedCharacters,
 }: {
   characters: Array<Pick<Character, "name" | "sprites">>;
+  caseSensitive?: boolean;
   path: string;
   preserveUnknown?: boolean;
   selectedCharacters: string[];
@@ -31,7 +51,7 @@ export function compatibleInitialSpritePath({
   if (!candidate) {
     return "";
   }
-  const owner = initialSpriteOwner(candidate, characters);
+  const owner = initialSpriteOwner(candidate, characters, { caseSensitive });
   if (!owner) {
     return preserveUnknown ? candidate : "";
   }

--- a/frontend/src/shared/desktop/chatWindow.ts
+++ b/frontend/src/shared/desktop/chatWindow.ts
@@ -1,4 +1,4 @@
-import { closeDesktopWindow, isTauriDesktop, openDesktopChatWindow } from "./desktopApi";
+import { destroyDesktopChatWindow, hideDesktopWindow, isTauriDesktop, openDesktopChatWindow } from "./desktopApi";
 import type { ChatSnapshot } from "../platform/types";
 
 interface ShowChatSurfaceOptions {
@@ -61,7 +61,7 @@ function shouldCloseReactChatRuntime(
 }
 
 export async function closeChatSurface(options: CloseChatSurfaceOptions = {}) {
-  const closeRuntimePromise =
+  const closeRuntime = () =>
     options.closeRuntime && shouldCloseReactChatRuntime(options.snapshot)
       ? options.closeRuntime().catch(() => {
           // Ignore runtime close failures here and still allow the user to leave the chat surface.
@@ -69,11 +69,17 @@ export async function closeChatSurface(options: CloseChatSurfaceOptions = {}) {
       : undefined;
 
   if (isTauriDesktop()) {
-    await closeRuntimePromise;
-    await closeDesktopWindow();
+    await hideDesktopWindow().catch(() => {
+      // Continue closing the runtime even if the shell could not hide the window.
+    });
+    await closeRuntime();
+    await destroyDesktopChatWindow().catch(() => {
+      // The runtime is already closed; a shell failure must not restart the close flow.
+    });
     return;
   }
 
+  const closeRuntimePromise = closeRuntime();
   const path = options.webPath ?? "/settings/launch";
   if (options.navigate) {
     options.navigate(path);

--- a/frontend/src/shared/desktop/chatWindow.ts
+++ b/frontend/src/shared/desktop/chatWindow.ts
@@ -61,17 +61,18 @@ function shouldCloseReactChatRuntime(
 }
 
 export async function closeChatSurface(options: CloseChatSurfaceOptions = {}) {
-  if (isTauriDesktop()) {
-    await closeDesktopWindow();
-    return;
-  }
-
   const closeRuntimePromise =
     options.closeRuntime && shouldCloseReactChatRuntime(options.snapshot)
       ? options.closeRuntime().catch(() => {
           // Ignore runtime close failures here and still allow the user to leave the chat surface.
         })
       : undefined;
+
+  if (isTauriDesktop()) {
+    await closeRuntimePromise;
+    await closeDesktopWindow();
+    return;
+  }
 
   const path = options.webPath ?? "/settings/launch";
   if (options.navigate) {

--- a/frontend/src/shared/desktop/desktopApi.ts
+++ b/frontend/src/shared/desktop/desktopApi.ts
@@ -368,6 +368,14 @@ export function minimizeDesktopWindow() {
   return invokeDesktop<void>("desktop_window_minimize");
 }
 
+export function hideDesktopWindow() {
+  return invokeDesktop<void>("desktop_window_hide");
+}
+
+export function destroyDesktopChatWindow() {
+  return invokeDesktop<void>("desktop_chat_window_destroy");
+}
+
 export function toggleMaximizeDesktopWindow() {
   return invokeDesktop<void>("desktop_window_toggle_maximize");
 }

--- a/frontend/src/shared/platform/types.ts
+++ b/frontend/src/shared/platform/types.ts
@@ -829,6 +829,7 @@ export interface ChatSnapshot {
   sprites: ChatSprite[];
   status: ChatRuntimeStatus;
   statusMessage?: string;
+  systemMessageText?: string;
   userDisplayName?: string;
   voiceLanguage?: string;
   wsUrl?: string;

--- a/frontend/src/shared/theme/chatTheme.ts
+++ b/frontend/src/shared/theme/chatTheme.ts
@@ -432,7 +432,7 @@ export function resolveChatTheme(manifest: ChatThemeManifest, assetUrl: (rel: st
     style["--chat-dialog-backdrop-filter"] = "none";
     style["--chat-dialog-actions-border"] = "0 solid transparent";
     style["--chat-dialog-body-max-height"] = "none";
-    style["--chat-dialog-body-overflow"] = "visible";
+    style["--chat-dialog-body-overflow"] = "auto";
     style["--chat-dialog-body-scrollbar-gutter"] = "auto";
     style["--chat-dialog-border"] = "0 solid transparent";
     style["--chat-dialog-min-height"] = "0px";

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -264,6 +264,7 @@ describe("ChatStagePage", () => {
     await act(async () => {
       resolveCommand(snapshot({ characterName: "Aoi", dialogText: "hello from Aoi", inputDraft: "" }));
     });
+    expect(screen.getByText("hello from Aoi")).toBeInTheDocument();
   });
 
   it("shows a selected option as the user message before the command response arrives", async () => {
@@ -1354,11 +1355,12 @@ describe("ChatStagePage", () => {
 
     await waitFor(() => expect(desktopApiMocks.minimizeDesktopWindow).toHaveBeenCalledTimes(1));
     expect(desktopApiMocks.toggleMaximizeDesktopWindow).toHaveBeenCalledTimes(1);
-    expect(desktopApiMocks.closeDesktopWindow).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(chatWindowMocks.closeChatSurface).toHaveBeenCalledTimes(1));
+    expect(desktopApiMocks.closeDesktopWindow).not.toHaveBeenCalled();
     expect(desktopApiMocks.startDesktopWindowDrag).not.toHaveBeenCalled();
 
     fireEvent.mouseDown(container.querySelector(".sprite-layer__figure")!, { button: 0 });
     await waitFor(() => expect(desktopApiMocks.startDesktopWindowDrag).toHaveBeenCalledTimes(1));
-    expect(chatWindowMocks.closeChatSurface).not.toHaveBeenCalled();
+    expect(chatWindowMocks.closeChatSurface).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -291,22 +291,21 @@ describe("ChatStagePage", () => {
     });
   });
 
-  it("keeps the selected option visible as the local message when its command fails", async () => {
+  it("restores the options when an optimistic option command fails", async () => {
     mocks.getChatSnapshot.mockResolvedValue(snapshot({ options: ["Take the shortcut"] }));
     mocks.sendChatCommand.mockRejectedValueOnce(new Error("option offline"));
     renderPage();
 
     fireEvent.click(await screen.findByRole("button", { name: "Take the shortcut" }));
 
-    expect(screen.queryByRole("button", { name: "Take the shortcut" })).not.toBeInTheDocument();
-    expect(screen.getByText("Aoi")).toBeInTheDocument();
-    expect(screen.getByText("Take the shortcut")).toBeInTheDocument();
     expect(mocks.sendChatCommand).toHaveBeenCalledTimes(1);
     expect(mocks.sendChatCommand).toHaveBeenCalledWith({
       payload: "Take the shortcut",
       type: "submit-option",
     });
     expect(await screen.findByText("option offline")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Take the shortcut" })).toBeInTheDocument();
+    expect(screen.queryByText("Aoi")).not.toBeInTheDocument();
     expect(document.querySelector(".top-stage-tools__state")).toHaveTextContent("idle");
   });
 
@@ -367,6 +366,7 @@ describe("ChatStagePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(input).toHaveValue("retry me"));
+    expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(mocks.sendChatCommand).toHaveBeenCalledTimes(1);
     expect(mocks.sendChatCommand).toHaveBeenCalledWith({ payload: "retry me", type: "send-message" });
     expect(document.querySelector(".top-stage-tools__state")).toHaveTextContent("idle");

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -267,6 +267,35 @@ describe("ChatStagePage", () => {
     expect(screen.getByText("hello from Aoi")).toBeInTheDocument();
   });
 
+  it("keeps the submitted user message when a stale stream snapshot arrives", async () => {
+    let listener: ((event: ChatStageEvent) => void) | null = null;
+    mocks.getChatSnapshot.mockResolvedValue(snapshot({ eventSeq: 3 }));
+    mocks.subscribeChatEvents.mockImplementation((next) => {
+      listener = next;
+      return vi.fn();
+    });
+    renderPage();
+
+    await screen.findByText("Ready");
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "stay visible" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(screen.getByText("stay visible")).toBeInTheDocument();
+
+    act(() => {
+      listener?.({
+        seq: 3,
+        snapshot: snapshot({ characterName: "Mio", dialogText: "old reply", eventSeq: 3 }),
+        ts: Date.now(),
+        type: "snapshot",
+        v: 1,
+      });
+    });
+
+    expect(document.querySelector(".dialog-layer__name")).toHaveTextContent("Aoi");
+    expect(screen.getByText("stay visible")).toBeInTheDocument();
+    expect(screen.queryByText("old reply")).not.toBeInTheDocument();
+  });
+
   it("shows a selected option as the user message before the command response arrives", async () => {
     let resolveCommand!: (snapshot: ChatSnapshot) => void;
     mocks.getChatSnapshot.mockResolvedValue(snapshot({ options: ["Take the shortcut"] }));

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -591,6 +591,18 @@ describe("chatStageReducer", () => {
 
     expect(viewModel.layers.dialog).toBe(false);
     expect(viewModel.notificationText).toBe("等待对话开始");
+
+    const afterStatus = chatStageReducer(state, {
+      event: {
+        seq: 2,
+        status: "idle",
+        ts: 2,
+        type: "status.change",
+        v: 1,
+      },
+      type: "event",
+    });
+    expect(buildChatStageViewModel(afterStatus).notificationText).toBe("等待对话开始");
   });
 
   it("keeps named system narrators in the dialog layer", () => {

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -136,6 +136,70 @@ describe("chatStageReducer", () => {
     expect(staleSnapshot.historyEntries).toEqual([{ id: "user-1", role: "user", text: "Aoi: hello" }]);
   });
 
+  it.each(["send-message", "submit-option"] as const)(
+    "keeps the first %s submission through a newer startup feedback snapshot",
+    (source) => {
+      const submitted = chatStageReducer(
+        {
+          ...emptyChatState,
+          characterName: "",
+          dialogText: "Chat started",
+          eventSeq: 1,
+          options: source === "submit-option" ? ["Take the shortcut"] : [],
+          statusMessage: "Chat started",
+          userDisplayName: "Aoi",
+        },
+        { source, text: source === "submit-option" ? "Take the shortcut" : "hello", type: "submitUserMessage" },
+      );
+      const startupSnapshot = chatStageReducer(submitted, {
+        event: {
+          seq: 2,
+          snapshot: {
+            characterName: "Mio",
+            dialogText: "Chat started",
+            eventSeq: 2,
+            inputDraft: "",
+            options: [],
+            sprites: [],
+            status: "generating",
+            statusMessage: "Chat started",
+            userDisplayName: "Aoi",
+          },
+          ts: 2,
+          type: "snapshot",
+          v: 1,
+        },
+        type: "event",
+      });
+      const viewModel = buildChatStageViewModel(startupSnapshot);
+
+      expect(startupSnapshot.optimisticSubmission?.source).toBe(source);
+      expect(viewModel.dialogCharacterName).toBe("Aoi");
+      expect(viewModel.dialogText).toBe(source === "submit-option" ? "Take the shortcut" : "hello");
+      expect(viewModel.layers.dialog).toBe(true);
+      expect(viewModel.layers.notification).toBe(false);
+    },
+  );
+
+  it("uses the default user name and removes startup feedback from a first submission", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        dialogText: "Chat started",
+        statusMessage: "Chat started",
+        userDisplayName: "",
+      },
+      { source: "send-message", text: "hello", type: "submitUserMessage" },
+    );
+    const viewModel = buildChatStageViewModel(submitted);
+
+    expect(submitted.characterName).toBe(viewModel.userDisplayName);
+    expect(submitted.statusMessage).toBeUndefined();
+    expect(viewModel.dialogText).toBe("hello");
+    expect(viewModel.layers.dialog).toBe(true);
+    expect(viewModel.layers.notification).toBe(false);
+  });
+
   it("keeps an optimistic user message when a late initial hydration resolves", () => {
     const submitted = chatStageReducer(
       { ...emptyChatState, eventSeq: 3, inputDraft: "hello", userDisplayName: "Aoi" },

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -24,6 +24,64 @@ describe("chatStageReducer", () => {
     expect(state.status).toBe("generating");
   });
 
+  it("rolls an optimistic option submission back to the previous presentation", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Mio",
+        dialogText: "Choose",
+        options: ["Left", "Right"],
+      },
+      { source: "submit-option", text: "Left", type: "submitUserMessage" },
+    );
+
+    const restored = chatStageReducer(submitted, {
+      source: "submit-option",
+      type: "rollbackUserSubmission",
+    });
+
+    expect(restored.characterName).toBe("Mio");
+    expect(restored.dialogText).toBe("Choose");
+    expect(restored.options).toEqual(["Left", "Right"]);
+    expect(restored.status).toBe("idle");
+    expect(restored.optimisticSubmission).toBeUndefined();
+  });
+
+  it("does not roll back a submission after a newer authoritative event", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        dialogText: "Choose",
+        eventSeq: 1,
+        options: ["Left", "Right"],
+      },
+      { source: "submit-option", text: "Left", type: "submitUserMessage" },
+    );
+    const replied = chatStageReducer(submitted, {
+      event: {
+        color: "#fff",
+        fullHtml: "<p>Accepted</p>",
+        isSystem: false,
+        seq: 2,
+        speaker: "Mio",
+        ts: 2,
+        type: "dialog.end",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    const lateRollback = chatStageReducer(replied, {
+      source: "submit-option",
+      type: "rollbackUserSubmission",
+    });
+
+    expect(lateRollback.characterName).toBe("Mio");
+    expect(lateRollback.dialogText).toBe("Accepted");
+    expect(lateRollback.options).toEqual([]);
+    expect(lateRollback.optimisticSubmission).toBeUndefined();
+  });
+
   it("hydrates runtime snapshots from platform events", () => {
     const state = chatStageReducer(emptyChatState, {
       snapshot: {

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -47,6 +47,32 @@ describe("chatStageReducer", () => {
     expect(restored.optimisticSubmission).toBeUndefined();
   });
 
+  it("preserves a new draft when an earlier submission fails late", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Mio",
+        dialogText: "Previous reply",
+        inputDraft: "first message",
+        options: ["Left", "Right"],
+        userDisplayName: "Aoi",
+      },
+      { source: "send-message", text: "first message", type: "submitUserMessage" },
+    );
+    const withNextDraft = chatStageReducer(submitted, { text: "next message", type: "setDraft" });
+    const restored = chatStageReducer(withNextDraft, {
+      source: "send-message",
+      type: "rollbackUserSubmission",
+    });
+
+    expect(restored.characterName).toBe("Mio");
+    expect(restored.dialogText).toBe("Previous reply");
+    expect(restored.options).toEqual(["Left", "Right"]);
+    expect(restored.status).toBe("idle");
+    expect(restored.inputDraft).toBe("next message");
+    expect(restored.optimisticSubmission).toBeUndefined();
+  });
+
   it("does not roll back a submission after a newer authoritative event", () => {
     const submitted = chatStageReducer(
       {
@@ -745,6 +771,51 @@ describe("chatStageReducer", () => {
       type: "event",
     });
     expect(buildChatStageViewModel(afterStatus).notificationText).toBe("等待对话开始");
+  });
+
+  it("hydrates folded system messages and clears them after dialogue or session close", () => {
+    const hydrated = chatStageReducer(emptyChatState, {
+      snapshot: {
+        characterName: "",
+        dialogHtml: "<p>Waiting for chat</p>",
+        dialogText: "Waiting for chat",
+        eventSeq: 1,
+        inputDraft: "",
+        options: [],
+        sprites: [],
+        status: "idle",
+        systemMessageText: "Waiting for chat",
+      },
+      type: "hydrate",
+    });
+    const systemView = buildChatStageViewModel(hydrated);
+
+    expect(systemView.notificationText).toBe("Waiting for chat");
+    expect(systemView.layers.notification).toBe(true);
+    expect(systemView.layers.dialog).toBe(false);
+
+    const withDialogue = chatStageReducer(hydrated, {
+      event: {
+        color: "#fff",
+        fullHtml: "<p>Ready now</p>",
+        isSystem: false,
+        seq: 2,
+        speaker: "Mio",
+        ts: 2,
+        type: "dialog.end",
+        v: 1,
+      },
+      type: "event",
+    });
+    expect(withDialogue.systemMessageText).toBeUndefined();
+    expect(buildChatStageViewModel(withDialogue).layers.dialog).toBe(true);
+
+    const closed = chatStageReducer(hydrated, {
+      event: { reason: "Closed", seq: 2, ts: 2, type: "session.closed", v: 1 },
+      type: "event",
+    });
+    expect(closed.systemMessageText).toBeUndefined();
+    expect(buildChatStageViewModel(closed).notificationText).toBe("Closed");
   });
 
   it("keeps named system narrators in the dialog layer", () => {

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -82,6 +82,84 @@ describe("chatStageReducer", () => {
     expect(lateRollback.optimisticSubmission).toBeUndefined();
   });
 
+  it("keeps an optimistic user message through unrelated runtime events and stale snapshots", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Mio",
+        dialogText: "old reply",
+        eventSeq: 3,
+        inputDraft: "hello",
+        sprites: [],
+        userDisplayName: "Aoi",
+      },
+      { source: "send-message", text: "hello", type: "submitUserMessage" },
+    );
+    const withStatus = chatStageReducer(submitted, {
+      event: { seq: 4, status: "generating", ts: 4, type: "status.change", v: 1 },
+      type: "event",
+    });
+    const withHistory = chatStageReducer(withStatus, {
+      event: {
+        entries: [{ id: "user-1", role: "user", text: "Aoi: hello" }],
+        seq: 5,
+        ts: 5,
+        type: "history.replace",
+        v: 1,
+      },
+      type: "event",
+    });
+    const staleSnapshot = chatStageReducer(withHistory, {
+      event: {
+        seq: 5,
+        snapshot: {
+          characterName: "Mio",
+          dialogText: "old reply",
+          eventSeq: 3,
+          inputDraft: "",
+          options: [],
+          sessionId: "session-1",
+          sprites: [],
+          status: "idle",
+        },
+        ts: 5,
+        type: "snapshot",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(staleSnapshot.characterName).toBe("Aoi");
+    expect(staleSnapshot.dialogText).toBe("hello");
+    expect(staleSnapshot.status).toBe("generating");
+    expect(staleSnapshot.optimisticSubmission?.text).toBe("hello");
+    expect(staleSnapshot.historyEntries).toEqual([{ id: "user-1", role: "user", text: "Aoi: hello" }]);
+  });
+
+  it("keeps an optimistic user message when a late initial hydration resolves", () => {
+    const submitted = chatStageReducer(
+      { ...emptyChatState, eventSeq: 3, inputDraft: "hello", userDisplayName: "Aoi" },
+      { source: "send-message", text: "hello", type: "submitUserMessage" },
+    );
+    const hydrated = chatStageReducer(submitted, {
+      snapshot: {
+        characterName: "Mio",
+        dialogText: "old reply",
+        eventSeq: 4,
+        inputDraft: "",
+        options: [],
+        sessionId: "session-1",
+        sprites: [],
+        status: "idle",
+      },
+      type: "hydrate",
+    });
+
+    expect(hydrated.characterName).toBe("Aoi");
+    expect(hydrated.dialogText).toBe("hello");
+    expect(hydrated.optimisticSubmission?.text).toBe("hello");
+  });
+
   it("hydrates runtime snapshots from platform events", () => {
     const state = chatStageReducer(emptyChatState, {
       snapshot: {

--- a/frontend/src/test/features/chat-stage/chatTheme.test.tsx
+++ b/frontend/src/test/features/chat-stage/chatTheme.test.tsx
@@ -199,6 +199,8 @@ describe("chat theme runtime", () => {
     expect(resolved.style["--chat-dialog-border"]).toBe("0 solid transparent");
     expect(resolved.style["--chat-dialog-body-height"]).toBe("100%");
     expect(resolved.style["--chat-dialog-body-min-height"]).toBe("0px");
+    expect(resolved.style["--chat-dialog-body-overflow"]).toBe("auto");
+    expect(resolved.style["--chat-dialog-body-scrollbar-gutter"]).toBe("auto");
     expect(resolved.style["--chat-dialog-frame"]).toBe('url("asset://assets/dialog-border.svg") 28 fill / 28px round');
     expect(resolved.style["--chat-dialog-height"]).toBe("166px");
     expect(resolved.style["--chat-dialog-padding"]).toBe("40px");

--- a/frontend/src/test/features/chat-startup/initialSpriteSelection.test.ts
+++ b/frontend/src/test/features/chat-startup/initialSpriteSelection.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { compatibleInitialSpritePath, initialSpriteOwner } from "../../../features/chat-startup/initialSpriteSelection";
+import {
+  compatibleInitialSpritePath,
+  initialSpriteOwner,
+  spritePathsAreCaseSensitive,
+} from "../../../features/chat-startup/initialSpriteSelection";
 
 const characters = [
   { name: "Nanami", sprites: [{ path: "C:/Sprites/Nanami/Idle.PNG" }] },
@@ -50,10 +54,11 @@ describe("initial sprite selection", () => {
       { name: "Lower", sprites: [{ path: "sprites/hero.png" }] },
     ];
 
-    expect(initialSpriteOwner("sprites/Hero.png", caseDistinctCharacters)).toBe("Upper");
-    expect(initialSpriteOwner("sprites/hero.png", caseDistinctCharacters)).toBe("Lower");
+    expect(initialSpriteOwner("sprites/Hero.png", caseDistinctCharacters, { caseSensitive: true })).toBe("Upper");
+    expect(initialSpriteOwner("sprites/hero.png", caseDistinctCharacters, { caseSensitive: true })).toBe("Lower");
     expect(
       compatibleInitialSpritePath({
+        caseSensitive: true,
         characters: caseDistinctCharacters,
         path: "sprites/hero.png",
         selectedCharacters: ["Lower"],
@@ -61,11 +66,43 @@ describe("initial sprite selection", () => {
     ).toBe("sprites/hero.png");
     expect(
       compatibleInitialSpritePath({
+        caseSensitive: true,
         characters: caseDistinctCharacters,
         path: "sprites/hero.png",
         selectedCharacters: ["Upper"],
       }),
     ).toBe("");
+  });
+
+  it("matches Windows path casing with the same semantics as os.path.normcase", () => {
+    expect(initialSpriteOwner("c:\\sprites\\nanami\\idle.png", characters, { caseSensitive: false })).toBe("Nanami");
+    expect(
+      compatibleInitialSpritePath({
+        caseSensitive: false,
+        characters,
+        path: "c:\\sprites\\nanami\\idle.png",
+        preserveUnknown: false,
+        selectedCharacters: ["Nanami"],
+      }),
+    ).toBe("c:\\sprites\\nanami\\idle.png");
+    expect(
+      compatibleInitialSpritePath({
+        caseSensitive: false,
+        characters,
+        path: "c:\\sprites\\nanami\\idle.png",
+        preserveUnknown: false,
+        selectedCharacters: ["Junko"],
+      }),
+    ).toBe("");
+  });
+
+  it.each([
+    ["Win32", false],
+    ["Windows", false],
+    ["Linux x86_64", true],
+    ["MacIntel", true],
+  ])("derives host path casing for %s", (platform, expected) => {
+    expect(spritePathsAreCaseSensitive(platform)).toBe(expected);
   });
 
   it("handles empty and malformed character collections without matching an owner", () => {

--- a/frontend/src/test/features/chat-startup/initialSpriteSelection.test.ts
+++ b/frontend/src/test/features/chat-startup/initialSpriteSelection.test.ts
@@ -10,8 +10,8 @@ const characters = [
 describe("initial sprite selection", () => {
   it.each([
     {
-      expected: "c:\\sprites\\nanami\\idle.png",
-      path: " c:\\sprites\\nanami\\idle.png ",
+      expected: "C:\\Sprites\\Nanami\\Idle.PNG",
+      path: " C:\\Sprites\\Nanami\\Idle.PNG ",
       preserveUnknown: true,
       selectedCharacters: ["Nanami"],
     },
@@ -42,6 +42,30 @@ describe("initial sprite selection", () => {
     { expected: "", path: "   ", preserveUnknown: true, selectedCharacters: ["Nanami"] },
   ])("normalizes compatible paths without changing the retained value", (testCase) => {
     expect(compatibleInitialSpritePath({ characters, ...testCase })).toBe(testCase.expected);
+  });
+
+  it("keeps case-distinct sprite paths assigned to their exact owners", () => {
+    const caseDistinctCharacters = [
+      { name: "Upper", sprites: [{ path: "sprites/Hero.png" }] },
+      { name: "Lower", sprites: [{ path: "sprites/hero.png" }] },
+    ];
+
+    expect(initialSpriteOwner("sprites/Hero.png", caseDistinctCharacters)).toBe("Upper");
+    expect(initialSpriteOwner("sprites/hero.png", caseDistinctCharacters)).toBe("Lower");
+    expect(
+      compatibleInitialSpritePath({
+        characters: caseDistinctCharacters,
+        path: "sprites/hero.png",
+        selectedCharacters: ["Lower"],
+      }),
+    ).toBe("sprites/hero.png");
+    expect(
+      compatibleInitialSpritePath({
+        characters: caseDistinctCharacters,
+        path: "sprites/hero.png",
+        selectedCharacters: ["Upper"],
+      }),
+    ).toBe("");
   });
 
   it("handles empty and malformed character collections without matching an owner", () => {

--- a/frontend/src/test/shared/desktop/chatWindow.test.ts
+++ b/frontend/src/test/shared/desktop/chatWindow.test.ts
@@ -62,14 +62,26 @@ describe("showChatSurface", () => {
     expect(window.location.hash).toBe("");
   });
 
-  it("closes the dedicated desktop chat window in Tauri", async () => {
+  it("closes the React runtime before the dedicated desktop chat window", async () => {
     desktopMocks.isTauriDesktop.mockReturnValue(true);
-    desktopMocks.closeDesktopWindow.mockResolvedValue(undefined);
+    const order: string[] = [];
+    const closeRuntime = vi.fn().mockImplementation(async () => {
+      order.push("runtime");
+    });
+    desktopMocks.closeDesktopWindow.mockImplementation(async () => {
+      order.push("window");
+    });
     const navigate = vi.fn();
 
-    await closeChatSurface({ navigate });
+    await closeChatSurface({
+      closeRuntime,
+      navigate,
+      snapshot: { runtimeMode: "react", sessionId: "session-1", wsUrl: "ws://127.0.0.1:8788/ws" },
+    });
 
+    expect(closeRuntime).toHaveBeenCalledTimes(1);
     expect(desktopMocks.closeDesktopWindow).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["runtime", "window"]);
     expect(navigate).not.toHaveBeenCalled();
     expect(window.location.hash).toBe("");
   });

--- a/frontend/src/test/shared/desktop/chatWindow.test.ts
+++ b/frontend/src/test/shared/desktop/chatWindow.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const desktopMocks = vi.hoisted(() => ({
-  closeDesktopWindow: vi.fn(),
+  destroyDesktopChatWindow: vi.fn(),
+  hideDesktopWindow: vi.fn(),
   isTauriDesktop: vi.fn(),
   openDesktopChatWindow: vi.fn(),
 }));
 
 vi.mock("../../../shared/desktop/desktopApi", () => ({
-  closeDesktopWindow: desktopMocks.closeDesktopWindow,
+  destroyDesktopChatWindow: desktopMocks.destroyDesktopChatWindow,
+  hideDesktopWindow: desktopMocks.hideDesktopWindow,
   isTauriDesktop: desktopMocks.isTauriDesktop,
   openDesktopChatWindow: desktopMocks.openDesktopChatWindow,
 }));
@@ -62,26 +64,39 @@ describe("showChatSurface", () => {
     expect(window.location.hash).toBe("");
   });
 
-  it("closes the React runtime before the dedicated desktop chat window", async () => {
+  it("hides the dedicated desktop chat window before closing the runtime, then destroys it", async () => {
     desktopMocks.isTauriDesktop.mockReturnValue(true);
     const order: string[] = [];
-    const closeRuntime = vi.fn().mockImplementation(async () => {
-      order.push("runtime");
+    let resolveClose: () => void = () => {};
+    const closeRuntime = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          order.push("runtime-started");
+          resolveClose = resolve;
+        }),
+    );
+    desktopMocks.hideDesktopWindow.mockImplementation(async () => {
+      order.push("window-hidden");
     });
-    desktopMocks.closeDesktopWindow.mockImplementation(async () => {
-      order.push("window");
+    desktopMocks.destroyDesktopChatWindow.mockImplementation(async () => {
+      order.push("window-destroyed");
     });
     const navigate = vi.fn();
 
-    await closeChatSurface({
+    const closePromise = closeChatSurface({
       closeRuntime,
       navigate,
       snapshot: { runtimeMode: "react", sessionId: "session-1", wsUrl: "ws://127.0.0.1:8788/ws" },
     });
 
-    expect(closeRuntime).toHaveBeenCalledTimes(1);
-    expect(desktopMocks.closeDesktopWindow).toHaveBeenCalledTimes(1);
-    expect(order).toEqual(["runtime", "window"]);
+    await vi.waitFor(() => expect(closeRuntime).toHaveBeenCalledTimes(1));
+    expect(desktopMocks.hideDesktopWindow).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["window-hidden", "runtime-started"]);
+    expect(desktopMocks.destroyDesktopChatWindow).not.toHaveBeenCalled();
+    resolveClose();
+    await closePromise;
+    expect(desktopMocks.destroyDesktopChatWindow).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["window-hidden", "runtime-started", "window-destroyed"]);
     expect(navigate).not.toHaveBeenCalled();
     expect(window.location.hash).toBe("");
   });

--- a/frontend/src/test/shared/desktop/desktopApi.test.ts
+++ b/frontend/src/test/shared/desktop/desktopApi.test.ts
@@ -19,6 +19,8 @@ import {
   checkDesktopUpdate,
   getDesktopProjectRootStatus,
   getDesktopRuntimeState,
+  hideDesktopWindow,
+  destroyDesktopChatWindow,
   installDesktopRuntimeProfile,
   installDesktopUpdate,
   isTauriDesktop,
@@ -115,6 +117,8 @@ describe("desktop API environment detection", () => {
     await repairDesktopRuntime("install-runtime", "installRuntimeDeps");
     await installDesktopRuntimeProfile("local-ai");
     await browseDesktopFiles({ path: "/tmp", showHidden: true });
+    await hideDesktopWindow();
+    await destroyDesktopChatWindow();
     await minimizeDesktopWindow();
     await toggleMaximizeDesktopWindow();
     await startDesktopWindowDrag();
@@ -129,6 +133,8 @@ describe("desktop API environment detection", () => {
     });
     expect(mockInvoke).toHaveBeenCalledWith("desktop_runtime_install_profile", { profile: "local-ai" });
     expect(mockInvoke).toHaveBeenCalledWith("desktop_files_browse", { path: "/tmp", showHidden: true });
+    expect(mockInvoke).toHaveBeenCalledWith("desktop_window_hide", undefined);
+    expect(mockInvoke).toHaveBeenCalledWith("desktop_chat_window_destroy", undefined);
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_minimize", undefined);
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_toggle_maximize", undefined);
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_start_drag", undefined);

--- a/frontend_bridge_core/chat.py
+++ b/frontend_bridge_core/chat.py
@@ -244,8 +244,9 @@ def _stop_chat_process(process: subprocess.Popen[bytes], *, wait_timeout: float)
         return
 
     deadline = time.monotonic() + max(wait_timeout, 0.15)
+    graceful_timeout = max(0.45, wait_timeout - 0.7)
     steps: list[tuple[int | str, float]] = [
-        (signal.SIGINT, 0.45),
+        (signal.SIGINT, graceful_timeout),
         (signal.SIGTERM, 0.35),
         ("kill", 0.35),
     ]
@@ -273,7 +274,7 @@ def _stop_chat_process(process: subprocess.Popen[bytes], *, wait_timeout: float)
             return
 
 
-def shutdown_active_chat_process(*, wait_timeout: float = 1.2) -> None:
+def shutdown_active_chat_process(*, wait_timeout: float = 1.2, wait_before_signal: float = 0.0) -> None:
     """Stop the active chat child without needing bridge request state.
 
     The bridge may be asked to exit from watchdog/signal paths where there is no
@@ -293,7 +294,14 @@ def shutdown_active_chat_process(*, wait_timeout: float = 1.2) -> None:
 
     if process is not None and process.poll() is None:
         try:
-            _stop_chat_process(process, wait_timeout=wait_timeout)
+            started = time.monotonic()
+            exited_gracefully = wait_before_signal > 0 and _wait_process_exit(
+                process,
+                min(wait_before_signal, wait_timeout),
+            )
+            if not exited_gracefully:
+                remaining = max(0.15, wait_timeout - (time.monotonic() - started))
+                _stop_chat_process(process, wait_timeout=remaining)
         finally:
             with _main_chat_process_lock:
                 if _main_chat_process is process:
@@ -470,7 +478,7 @@ def _close_chat(
     state: BridgeState,
     *,
     reason: str = "聊天会话已结束。",
-    wait_timeout: float = 1.2,
+    wait_timeout: float = 4.0,
 ) -> dict[str, Any]:
     global _main_chat_process
 
@@ -478,12 +486,25 @@ def _close_chat(
     chat_stream = getattr(state, "chat_stream", None)
     _set_chat_runtime_closing(state, True)
     try:
+        graceful_shutdown_requested = False
+        if session_id and chat_stream is not None:
+            try:
+                graceful_shutdown_requested = bool(
+                    chat_stream.send_command(
+                        session_id,
+                        {"cmdId": uuid.uuid4().hex, "type": "close-session"},
+                    )
+                )
+            except Exception:
+                graceful_shutdown_requested = False
+        shutdown_active_chat_process(
+            wait_timeout=wait_timeout,
+            wait_before_signal=max(0.0, wait_timeout - 0.7) if graceful_shutdown_requested else 0.0,
+        )
         if session_id and chat_stream is not None:
             snapshot = chat_stream.get_snapshot(session_id)
             if not isinstance(snapshot, dict) or not str(snapshot.get("sessionClosedReason") or "").strip():
                 chat_stream.close_session(session_id, reason=reason)
-
-        shutdown_active_chat_process(wait_timeout=wait_timeout)
     finally:
         _set_chat_runtime_closing(state, False)
     closed_snapshot = _chat_snapshot(state, "idle", "")

--- a/frontend_bridge_core/chat.py
+++ b/frontend_bridge_core/chat.py
@@ -43,6 +43,7 @@ from .runtime_dependencies import runtime_dependency_error_from_text
 from .security import reject_control_chars, safe_project_path
 from .templates import (
     TEMP_SPLIT_META,
+    _compose_runtime_template,
     _effective_user_scenario,
     _history_id_from_scenario,
     _scenario_from_template_like,
@@ -377,9 +378,7 @@ def _launch_chat(
 
         # 把用户情景放在系统模板末尾（紧跟 closing 提示后）
         effective_user_scenario = _effective_user_scenario(user_scenario)
-        template = system_template.rstrip()
-        if effective_user_scenario:
-            template = template + "\n" + effective_user_scenario + "\n"
+        template = _compose_runtime_template(system_template, effective_user_scenario)
         template_dir = _template_dir(state)
         (template_dir / "_temp.txt").write_text(template, encoding="utf-8")
         (template_dir / TEMP_SPLIT_META).write_text(
@@ -475,10 +474,10 @@ def _close_chat(
 ) -> dict[str, Any]:
     global _main_chat_process
 
+    session_id = str(state.chat_session.get("sessionId") or "").strip()
+    chat_stream = getattr(state, "chat_stream", None)
     _set_chat_runtime_closing(state, True)
     try:
-        session_id = str(state.chat_session.get("sessionId") or "").strip()
-        chat_stream = getattr(state, "chat_stream", None)
         if session_id and chat_stream is not None:
             snapshot = chat_stream.get_snapshot(session_id)
             if not isinstance(snapshot, dict) or not str(snapshot.get("sessionClosedReason") or "").strip():
@@ -487,7 +486,15 @@ def _close_chat(
         shutdown_active_chat_process(wait_timeout=wait_timeout)
     finally:
         _set_chat_runtime_closing(state, False)
-    return _chat_snapshot(state, "idle", "")
+    closed_snapshot = _chat_snapshot(state, "idle", "")
+    if session_id:
+        if chat_stream is not None:
+            delete_session = getattr(chat_stream, "delete_session", None)
+            if callable(delete_session):
+                delete_session(session_id)
+        if str(state.chat_session.get("sessionId") or "").strip() == session_id:
+            state.chat_session = {**state.chat_session, "sessionId": ""}
+    return closed_snapshot
 
 
 def _resolve_project_file(raw_path: str | Path) -> Path:

--- a/frontend_bridge_core/templates.py
+++ b/frontend_bridge_core/templates.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from core.sprite.chat_branch_storage import ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME
+from llm.template_generator import json_format_reminder
 
 from .state import BridgeState
 from .security import safe_child_path, safe_filename
@@ -55,6 +56,15 @@ def _compose_for_llm(scenario: str, system: str) -> str:
 
 def _effective_user_scenario(user_scenario: str) -> str:
     return (user_scenario or "").strip() or DEFAULT_EMPTY_SCENARIO
+
+
+def _compose_runtime_template(system_template: str, user_scenario: str) -> str:
+    parts = [
+        (system_template or "").rstrip(),
+        _effective_user_scenario(user_scenario),
+        json_format_reminder(),
+    ]
+    return "\n".join(part for part in parts if part) + "\n"
 
 
 def _normalize_hash_character_names(character_names: Any = None) -> list[str]:

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -704,6 +704,7 @@
     "tools_item": "- **{name}**: {description}",
     "tools_param_summary": " (parameters: {summary}; * = required)",
     "closing": "\nBegin the scene: describe the situation and what the user is doing; {extra}then continue:\n",
+    "closing_json_reminder": "You must reply using the required JSON format.\n",
     "closing_extra_bgm": "set initial scene and BGM, "
   }
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -701,6 +701,7 @@
     "tools_item": "- **{name}**：{description}",
     "tools_param_summary": "（引数：{summary}；* は必須）",
     "closing": "\n会話を開始。状況とユーザーの行動を説明し{extra}続けてください：\n",
+    "closing_json_reminder": "必ず指定された JSON 形式で応答してください。\n",
     "closing_extra_bgm": "初期のシーンと BGM を設定し、"
   }
 }

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -701,6 +701,7 @@
     "tools_item": "- **{name}**：{description}",
     "tools_param_summary": "（参数：{summary}；带 * 者为必填）",
     "closing": "\n请开始对话, 开始时介绍下用户所处的情境和背景, {extra} 以及在做什么事情: \n",
+    "closing_json_reminder": "必须以规定的 JSON 格式回复。\n",
     "closing_extra_bgm": "设置初始的场景和bgm, "
   }
 }

--- a/llm/template_generator.py
+++ b/llm/template_generator.py
@@ -46,6 +46,11 @@ def _T(key: str, **kwargs) -> str:
     return tr_i18n(f"template_gen.{key}", **kwargs)
 
 
+def json_format_reminder() -> str:
+    """Return the localized reminder that must close every runtime system prompt."""
+    return _T("closing_json_reminder").strip()
+
+
 def _json_string_content(value: Any) -> str:
     return json.dumps(str(value), ensure_ascii=False)[1:-1]
 
@@ -510,4 +515,5 @@ class TemplateGenerator:
             template += f"- {item.text}\n"
         extra = _T("closing_extra_bgm") if (bg_name and not is_transparent_background(bg_name)) else ""
         template += _T("closing", extra=extra)
+        template += f"{json_format_reminder()}\n"
         return template, ""

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 import signal
 import sys
+import threading
 import time
 
 _PROCESS_STARTED_AT = time.perf_counter()
@@ -106,6 +107,7 @@ from core.paths import resource_path
 from core.sprite.chat_branch_storage import (
     chat_history_active_path,
     load_branch_state,
+    reconcile_active_branch_state,
     remove_chat_history_storage,
     save_branch_state,
 )
@@ -675,14 +677,10 @@ def main():
             restored = load_branch_state(args.history) if args.history else None
             if restored is None:
                 return _default_branch_state()
-            active_branch = restored.get("branches", {}).get(restored.get("active"))  # type: ignore[union-attr]
-            if isinstance(active_branch, dict):
-                if isinstance(active_branch.get("history"), list):
-                    chat_history[:] = list(active_branch.get("history") or [])
-                if isinstance(active_branch.get("messages"), list):
-                    restored_messages = copy.deepcopy(active_branch.get("messages") or [])
-                    messages[:] = restored_messages
-                    llm_manager.set_messages(restored_messages)
+            restored_messages, restored_history = reconcile_active_branch_state(restored, messages, chat_history)
+            messages[:] = restored_messages
+            chat_history[:] = restored_history
+            llm_manager.set_messages(restored_messages)
             return restored
 
         branch_state: dict[str, object] = _load_initial_branch_state()
@@ -870,6 +868,10 @@ def main():
                 ack_sent = True
 
             try:
+                if command_type == "close-session":
+                    emit_ack(ok=True)
+                    shutdown_requested.set()
+                    return
                 if command_type == "send-message":
                     submit_runtime_text(str(payload or ""), notify_key=None)
                     emit_ack(ok=True)
@@ -988,6 +990,7 @@ def main():
                 ui_updates.post_notification(str(exc))
                 emit_ack(ok=False, error=str(exc))
 
+        shutdown_requested = threading.Event()
         stream_sink.set_command_handler(handle_stream_command)
 
         with _startup_phase("workflow.start"):
@@ -1065,8 +1068,8 @@ def main():
         )
         try:
             restore_interrupt_handlers = _install_interrupt_handlers()
-            while True:
-                time.sleep(1)
+            while not shutdown_requested.wait(1):
+                pass
         except KeyboardInterrupt:
             pass
         finally:

--- a/test/unit/core/test_chat_branch_storage.py
+++ b/test/unit/core/test_chat_branch_storage.py
@@ -10,6 +10,7 @@ from core.sprite.chat_branch_storage import (
     chat_history_active_path,
     chat_history_branch_tree_path,
     load_branch_state,
+    reconcile_active_branch_state,
     remove_chat_history_storage,
     save_branch_state,
 )
@@ -18,6 +19,52 @@ from frontend_bridge_core.templates import _latest_history_json
 
 
 class ChatBranchStorageTests(unittest.TestCase):
+    def test_reconcile_prefers_recovered_active_history_over_stale_branch_payload(self):
+        branch_state = {
+            "active": "main",
+            "branches": {
+                "main": {
+                    "id": "main",
+                    "history": ["Mio: stale"],
+                    "messages": [{"role": "assistant", "content": "stale"}],
+                }
+            },
+        }
+        recovered_messages = [
+            {"role": "user", "content": "latest question"},
+            {"role": "assistant", "content": "latest answer"},
+        ]
+        recovered_history = ["Aoi: latest question", "Mio: latest answer"]
+
+        messages, history = reconcile_active_branch_state(
+            branch_state,
+            recovered_messages,
+            recovered_history,
+        )
+
+        self.assertEqual(messages, recovered_messages)
+        self.assertEqual(history, recovered_history)
+        self.assertEqual(branch_state["branches"]["main"]["messages"], recovered_messages)
+        self.assertEqual(branch_state["branches"]["main"]["history"], recovered_history)
+
+    def test_reconcile_uses_branch_payload_when_active_history_is_empty(self):
+        branch_messages = [{"role": "assistant", "content": "restored"}]
+        branch_history = ["Mio: restored"]
+        branch_state = {
+            "active": "branch-2",
+            "branches": {
+                "branch-2": {
+                    "id": "branch-2",
+                    "history": branch_history,
+                    "messages": branch_messages,
+                }
+            },
+        }
+
+        messages, history = reconcile_active_branch_state(branch_state, [], [])
+
+        self.assertEqual(messages, branch_messages)
+        self.assertEqual(history, branch_history)
     def test_non_existing_json_path_maps_to_session_folder(self):
         path = Path("data/chat_history/session.json")
 

--- a/test/unit/core/test_chat_initial_sprite.py
+++ b/test/unit/core/test_chat_initial_sprite.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from queue import Queue
 from types import SimpleNamespace
@@ -47,17 +48,31 @@ def test_find_character_sprite_by_path_matches_relative_and_absolute(tmp_path, m
     ) == ("七海千秋", 0)
 
 
-def test_find_character_sprite_by_path_normalizes_case_and_slashes(tmp_path, monkeypatch):
+def test_find_character_sprite_by_path_uses_host_case_semantics_and_normalizes_slashes(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     character = SimpleNamespace(
         name="Nanami",
         sprites=[SimpleNamespace(path="C:/Sprites/Nanami/Idle.PNG")],
     )
 
-    assert find_character_sprite_by_path(
+    matched = find_character_sprite_by_path(
         _config(characters=[character]),
         "c:\\sprites\\nanami\\idle.png",
-    ) == ("Nanami", 0)
+    )
+    expected = ("Nanami", 0) if os.path.normcase("A") == os.path.normcase("a") else None
+    assert matched == expected
+
+
+def test_find_character_sprite_by_path_preserves_case_distinct_files_on_sensitive_hosts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    characters = [
+        SimpleNamespace(name="Upper", sprites=[SimpleNamespace(path="sprites/Face.png")]),
+        SimpleNamespace(name="Lower", sprites=[SimpleNamespace(path="sprites/face.png")]),
+    ]
+
+    matched = find_character_sprite_by_path(_config(characters=characters), "sprites/face.png")
+    expected = ("Upper", 0) if os.path.normcase("A") == os.path.normcase("a") else ("Lower", 0)
+    assert matched == expected
 
 
 def test_display_initial_sprite_prefers_character_sprite_index(tmp_path, monkeypatch):
@@ -132,7 +147,13 @@ def test_initial_sprite_path_preserves_selected_or_custom_sprite(tmp_path, monke
     [
         ("", ["Nanami"], "C:/Sprites/Nanami/Idle.PNG"),
         ("c:\\sprites\\nanami\\idle.png", ["Nanami"], "c:\\sprites\\nanami\\idle.png"),
-        ("C:/SPRITES/JUNKO/IDLE.png", ["Nanami"], "C:/Sprites/Nanami/Idle.PNG"),
+        (
+            "C:/SPRITES/JUNKO/IDLE.png",
+            ["Nanami"],
+            "C:/Sprites/Nanami/Idle.PNG"
+            if os.path.normcase("A") == os.path.normcase("a")
+            else "C:/SPRITES/JUNKO/IDLE.png",
+        ),
         ("C:/Sprites/Junko/Idle.PNG", ["Junko"], "C:/Sprites/Junko/Idle.PNG"),
         ("D:/external/custom.png", ["Nanami"], "D:/external/custom.png"),
         ("C:/Sprites/Nanami/Idle.PNG", [], ""),

--- a/test/unit/core/test_event_sink.py
+++ b/test/unit/core/test_event_sink.py
@@ -110,6 +110,27 @@ class EventSinkSnapshotTests(unittest.TestCase):
         self.assertEqual(next_snapshot["dialogText"], "旁白：新的系统消息")
         self.assertEqual(next_snapshot.get("characterName"), "")
 
+    def test_speakerless_system_dialog_survives_status_updates_for_reconnect(self):
+        snapshot = fold_event_into_snapshot(
+            make_empty_chat_snapshot(),
+            {
+                "seq": 1,
+                "ts": 1,
+                "type": "dialog.end",
+                "speaker": "",
+                "color": "#84C2D5",
+                "isSystem": True,
+                "fullHtml": "<p>Waiting for chat</p>",
+                "v": 1,
+            },
+        )
+        next_snapshot = fold_event_into_snapshot(
+            snapshot,
+            {"seq": 2, "ts": 2, "type": "status.change", "status": "idle", "v": 1},
+        )
+
+        self.assertEqual(next_snapshot.get("systemMessageText"), "Waiting for chat")
+
     def test_session_closed_clears_busy_overlay_fields_in_snapshot(self):
         snapshot = make_empty_chat_snapshot()
         snapshot["busyText"] = "Loading"

--- a/test/unit/core/test_runtime_shutdown.py
+++ b/test/unit/core/test_runtime_shutdown.py
@@ -36,10 +36,10 @@ class RuntimeShutdownTests(unittest.TestCase):
             [
                 "emit_session_closed",
                 "workflow_stop",
+                "save_history",
                 "memory_shutdown",
                 "plugin_shutdown",
                 "tts_shutdown",
-                "save_history",
                 "save_background",
                 "close_stream_sink",
             ],
@@ -71,10 +71,10 @@ class RuntimeShutdownTests(unittest.TestCase):
             [
                 "emit_session_closed",
                 "workflow_stop",
+                "save_history",
                 "memory_shutdown",
                 "plugin_shutdown",
                 "tts_shutdown",
-                "save_history",
                 "save_background",
                 "close_stream_sink",
             ],

--- a/test/unit/frontend_bridge_core/test_frontend_bridge_shutdown.py
+++ b/test/unit/frontend_bridge_core/test_frontend_bridge_shutdown.py
@@ -21,8 +21,8 @@ def test_shutdown_bridge_runtime_stops_active_chat_and_stream(monkeypatch):
     stream = _ChatStreamStub()
     state = SimpleNamespace(chat_stream=stream)
 
-    def fake_shutdown_active_chat_process(*, wait_timeout):
-        calls.append(wait_timeout)
+    def fake_shutdown_active_chat_process(*, wait_timeout, wait_before_signal=0.0):
+        calls.append((wait_timeout, wait_before_signal))
 
     monkeypatch.setattr(chat, "shutdown_active_chat_process", fake_shutdown_active_chat_process)
     frontend_bridge._set_bridge_state(state)
@@ -31,7 +31,7 @@ def test_shutdown_bridge_runtime_stops_active_chat_and_stream(monkeypatch):
     finally:
         frontend_bridge._set_bridge_state(None)
 
-    assert calls == [1.5]
+    assert calls == [(1.5, 0.0)]
     assert stream.stopped is True
 
 

--- a/test/unit/frontend_bridge_core/test_frontend_chat_launch_paths.py
+++ b/test/unit/frontend_bridge_core/test_frontend_chat_launch_paths.py
@@ -71,6 +71,7 @@ class _DummyClosableProcess:
 class _ChatStreamForClose:
     def __init__(self):
         self.closed = []
+        self.deleted = []
         self.snapshot = {
             "dialogText": "",
             "eventSeq": 3,
@@ -93,6 +94,9 @@ class _ChatStreamForClose:
         self.snapshot["notificationText"] = reason
         self.snapshot["sessionClosedReason"] = reason
         self.snapshot["status"] = "idle"
+
+    def delete_session(self, session_id: str):
+        self.deleted.append(session_id)
 
 
 def test_launch_chat_uses_source_main_py_with_project_root_cwd(tmp_path, monkeypatch):
@@ -314,6 +318,8 @@ def test_close_chat_sends_sigint_and_marks_runtime_session_closed(monkeypatch):
 
     assert process.signals == [signal.SIGINT]
     assert chat_stream.closed == [("session-1", "聊天会话已结束。")]
+    assert chat_stream.deleted == ["session-1"]
+    assert state.chat_session["sessionId"] == ""
     assert snapshot["sessionClosedReason"] == "聊天会话已结束。"
     assert snapshot["runtimeMode"] == "react"
 

--- a/test/unit/frontend_bridge_core/test_frontend_chat_launch_paths.py
+++ b/test/unit/frontend_bridge_core/test_frontend_chat_launch_paths.py
@@ -69,9 +69,11 @@ class _DummyClosableProcess:
 
 
 class _ChatStreamForClose:
-    def __init__(self):
+    def __init__(self, process=None):
         self.closed = []
+        self.commands = []
         self.deleted = []
+        self.process = process
         self.snapshot = {
             "dialogText": "",
             "eventSeq": 3,
@@ -94,6 +96,12 @@ class _ChatStreamForClose:
         self.snapshot["notificationText"] = reason
         self.snapshot["sessionClosedReason"] = reason
         self.snapshot["status"] = "idle"
+
+    def send_command(self, session_id: str, command: dict):
+        self.commands.append((session_id, command))
+        if self.process is not None and command.get("type") == "close-session":
+            self.process.running = False
+        return True
 
     def delete_session(self, session_id: str):
         self.deleted.append(session_id)
@@ -303,9 +311,9 @@ def test_runtime_dependency_error_maps_opencc_package():
     }
 
 
-def test_close_chat_sends_sigint_and_marks_runtime_session_closed(monkeypatch):
+def test_close_chat_requests_graceful_runtime_shutdown_and_marks_session_closed(monkeypatch):
     process = _DummyClosableProcess()
-    chat_stream = _ChatStreamForClose()
+    chat_stream = _ChatStreamForClose(process)
     monkeypatch.setattr(chat, "_main_chat_process", process)
 
     state = SimpleNamespace(
@@ -316,7 +324,10 @@ def test_close_chat_sends_sigint_and_marks_runtime_session_closed(monkeypatch):
 
     snapshot = chat._close_chat(state)
 
-    assert process.signals == [signal.SIGINT]
+    assert process.signals == []
+    assert chat_stream.commands[0][0] == "session-1"
+    assert chat_stream.commands[0][1]["type"] == "close-session"
+    assert isinstance(chat_stream.commands[0][1]["cmdId"], str)
     assert chat_stream.closed == [("session-1", "聊天会话已结束。")]
     assert chat_stream.deleted == ["session-1"]
     assert state.chat_session["sessionId"] == ""

--- a/test/unit/frontend_bridge_core/test_frontend_templates.py
+++ b/test/unit/frontend_bridge_core/test_frontend_templates.py
@@ -1,6 +1,7 @@
 from frontend_bridge_core.templates import (
     MARK_SCENARIO,
     MARK_SYSTEM,
+    _compose_runtime_template,
     _compose_stored_template,
     _has_untranslated_template_keys,
     _history_id_from_scenario,
@@ -30,6 +31,28 @@ def test_history_id_uses_effective_scenario_and_selected_characters():
     assert scenario_id != _history_id_from_scenario("another scenario", ["Alice", "Bob"])
     assert _history_id_from_scenario("") == _history_id_from_scenario(
         "你扮演一个RPG系统。",
+    )
+
+
+def test_runtime_template_places_json_reminder_after_user_scenario(monkeypatch):
+    monkeypatch.setattr(
+        "frontend_bridge_core.templates.json_format_reminder",
+        lambda: "必须以规定的 JSON 格式回复。",
+    )
+
+    assert _compose_runtime_template("system rules", "user scenario") == (
+        "system rules\nuser scenario\n必须以规定的 JSON 格式回复。\n"
+    )
+
+
+def test_runtime_template_places_json_reminder_after_default_scenario(monkeypatch):
+    monkeypatch.setattr(
+        "frontend_bridge_core.templates.json_format_reminder",
+        lambda: "必须以规定的 JSON 格式回复。",
+    )
+
+    assert _compose_runtime_template("system rules", "") == (
+        "system rules\n你扮演一个RPG系统。\n必须以规定的 JSON 格式回复。\n"
     )
 
 

--- a/test/unit/sdk/test_output_contracts.py
+++ b/test/unit/sdk/test_output_contracts.py
@@ -134,6 +134,40 @@ def test_template_generator_renders_added_field_aliases(monkeypatch) -> None:
     assert "camera (string, optional): Camera framing for this line. Aliases: shot, framing." in template
 
 
+def test_template_generator_ends_with_json_format_reminder(monkeypatch) -> None:
+    character = SimpleNamespace(
+        sprites=[object()],
+        emotion_tags="happy: 01",
+        character_setting="A test character.",
+    )
+
+    monkeypatch.setattr(
+        "llm.template_generator.config_manager",
+        SimpleNamespace(get_character_by_name=lambda name: character),
+    )
+    monkeypatch.setattr("llm.template_generator._format_llm_tools_block", lambda: "")
+
+    def fake_translation(key: str, **kwargs) -> str:
+        if key == "closing":
+            return "Begin the scene.\n"
+        if key == "closing_json_reminder":
+            return "MUST_USE_REQUIRED_JSON_FORMAT\n"
+        return f"{key}\n"
+
+    monkeypatch.setattr("llm.template_generator._T", fake_translation)
+
+    template, warning = TemplateGenerator(output_contract_patches=[]).generate_chat_template(
+        selected_characters=["Alice"],
+        bg_name=None,
+        use_effect=False,
+        use_cg=False,
+        use_llm_translation=False,
+    )
+
+    assert warning == ""
+    assert template.endswith("Begin the scene.\nMUST_USE_REQUIRED_JSON_FORMAT\n")
+
+
 def test_template_generator_omits_scene_and_bgm_for_transparent_background(monkeypatch) -> None:
     character = SimpleNamespace(
         sprites=[object()],


### PR DESCRIPTION
<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把重点收拢一下，方便你轻松看完。

本 PR 完善了聊天舞台的消息状态、乐观提交、关闭生命周期、运行时提示词、立绘路径和视觉布局。

### New Features
- 在后端快照、共享 `ChatSnapshot` 协议和前端状态中新增 `systemMessageText`，用于独立表示无说话人的系统对话，并接入事件折叠、hydration、会话清理、视图模型和通知显示。
- 为文本消息和选项提交增加带来源标记的乐观展示与失败回滚，并通过事件序号和权威事件避免迟到失败或陈旧快照覆盖当前状态。
- 为 `useDialogTypewriter` 增加 `showDialogImmediately`，允许提交前立即完成正在播放的逐字动画。

### Enhancements
- 新增 `_compose_runtime_template()` 和 `json_format_reminder()`，按照“系统模板 → 有效用户场景 → 本地化 JSON 格式提醒”的顺序组合运行时提示词，并统一空场景回退、片段空白和末尾换行。
- 调整桌面关闭生命周期，使符合条件的 React 会话先关闭运行时再关闭桌面窗口；后端关闭流程同时处理聊天子进程、最终快照、流会话删除及持久状态清理。
- 调整通知显示优先级为“普通通知 → 系统消息 → 系统提示”，并在系统消息可见时隐藏普通对话层。
- 将无边框对话框的纵向滚动移入正文区域，增加滚动边界隔离、横向裁剪及 Firefox/WebKit 滚动条样式。
- 收紧立绘容器和图片尺寸约束，减少窄窗口、多立绘及超大素材造成的溢出。
- Python 初始立绘路径匹配改用 `os.path.normcase()` 遵循运行平台的大小写语义；前端初始立绘归属比较保留路径大小写。

### Tests
- 扩展聊天页面、reducer 和视图模型测试，覆盖乐观消息、来源匹配回滚、陈旧快照、迟到 hydration、权威事件、系统消息恢复、等待提示和桌面关闭委托。
- 增加运行时模板与模板生成器测试，覆盖显式及默认场景、片段顺序、本地化提醒、错误路径和末尾换行。
- 扩展聊天关闭测试，验证子进程 `SIGINT`、流会话关闭与删除、关闭元数据保留以及持久会话 ID 清理。
- 更新初始立绘路径大小写语义、主题 CSS 变量和布局契约测试。

### Chores
- 在英语、日语和简体中文 locale 中同步新增 `template_gen.closing_json_reminder`。

<details><summary>Original in English</summary>

This PR refines chat-stage message state, optimistic submissions, shutdown lifecycle, runtime prompts, sprite paths, and visual layout.

### New Features
- Adds `systemMessageText` to backend snapshots, the shared `ChatSnapshot` protocol, and frontend state for speakerless system dialogue, integrating it with event folding, hydration, session cleanup, view-model projection, and notifications.
- Adds source-aware optimistic presentation and failure rollback for text and option submissions, using event sequencing and authoritative events to prevent late failures or stale snapshots from replacing current state.
- Adds `showDialogImmediately` to `useDialogTypewriter`, allowing an active typewriter animation to finish immediately before submission.

### Enhancements
- Adds `_compose_runtime_template()` and `json_format_reminder()` to compose runtime prompts as “system template → effective user scenario → localized JSON-format reminder,” with consistent empty-scenario fallback, fragment trimming, and trailing-newline handling.
- Refines desktop shutdown so eligible React sessions close their runtime before the desktop window. Backend shutdown also handles the chat subprocess, final snapshot, stream-session deletion, and persisted-state cleanup.
- Applies the notification precedence “regular notification → system message → system prompt,” hiding normal dialogue while a system message is visible.
- Moves borderless-dialog vertical scrolling into the body and adds scroll containment, horizontal clipping, and Firefox/WebKit scrollbar styling.
- Tightens sprite container and image bounds to reduce overflow with narrow windows, multiple sprites, and oversized assets.
- Changes Python initial-sprite matching to use `os.path.normcase()` and follow platform casing semantics, while frontend ownership comparison preserves path casing.

### Tests
- Expands page, reducer, and view-model coverage for optimistic messages, source-matched rollback, stale snapshots, late hydration, authoritative events, system-message restoration, waiting notifications, and desktop-close delegation.
- Adds runtime-template and template-generator tests for explicit and default scenarios, fragment ordering, localized reminders, error paths, and trailing newlines.
- Extends shutdown tests for subprocess `SIGINT`, stream-session closure and deletion, retained close metadata, and persisted session-ID cleanup.
- Updates tests for initial-sprite path casing, theme CSS variables, and layout contracts.

### Chores
- Synchronizes `template_gen.closing_json_reminder` across the English, Japanese, and Simplified Chinese locales.

</details>

<!-- astrbot-review:end:summary -->