### PR TITLE
feat(chat): add always-on-top control and improve desktop window interactions

### DIFF
--- a/ai/vision/service.py
+++ b/ai/vision/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Mapping, Protocol
 
@@ -48,7 +49,13 @@ def _default_fallback_available() -> bool:
     """Report whether any built-in fallback (plugin-preferred or Moondream) can run."""
     if active_vision_fallback() is not None:
         return True
-    return installed_moondream_directory() is not None
+    if installed_moondream_directory() is None:
+        return False
+    # The built-in Moondream fallback needs PyTorch at runtime. If it is not
+    # importable, describe() would crash the chat turn, so report it unavailable
+    # and let the caller show the graceful "install a vision plugin / switch
+    # model" guidance instead of leaking a raw missing-module error.
+    return importlib.util.find_spec("torch") is not None
 
 
 class ChatVisionService:
@@ -154,12 +161,14 @@ class ChatVisionService:
 
         try:
             fallback = self._fallback_factory()
-        except MoondreamPluginUnavailable:
+            descriptions: list[str] = []
+            for image in images:
+                description = fallback.describe(image.path.read_bytes(), DEFAULT_IMAGE_PROMPT).strip()
+                descriptions.append(f"Image attachment {image.name}:\n{description or '[No description returned]'}")
+        except (MoondreamPluginUnavailable, ImportError):
+            # Fallback plugin present but not runnable (e.g. missing torch): degrade
+            # to the guidance prompt instead of crashing the chat turn.
             return self._fallback_unavailable_input(prompt_parts, images, display_text)
-        descriptions: list[str] = []
-        for image in images:
-            description = fallback.describe(image.path.read_bytes(), DEFAULT_IMAGE_PROMPT).strip()
-            descriptions.append(f"Image attachment {image.name}:\n{description or '[No description returned]'}")
         prompt_parts.append("\n\n".join(descriptions))
         return PreparedChatInput(
             content="\n\n".join(prompt_parts),

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -409,6 +409,7 @@ pub fn run() {
             desktop_window_hide,
             desktop_chat_window_destroy,
             desktop_window_minimize,
+            desktop_window_set_always_on_top,
             desktop_window_toggle_maximize,
             desktop_window_start_drag,
             desktop_window_start_resize,
@@ -1292,6 +1293,16 @@ fn desktop_window_minimize(window: WebviewWindow) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn desktop_window_set_always_on_top(
+    window: WebviewWindow,
+    always_on_top: bool,
+) -> Result<(), String> {
+    window
+        .set_always_on_top(always_on_top)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
 fn desktop_window_toggle_maximize(window: WebviewWindow) -> Result<(), String> {
     if window.is_maximized().map_err(|error| error.to_string())? {
         window.unmaximize().map_err(|error| error.to_string())
@@ -1424,7 +1435,11 @@ fn open_chat_window(app: &AppHandle, bridge_port: u16, auth_token: &str) -> Resu
             .transparent(true)
             .decorations(false)
             .always_on_top(true)
-            .skip_taskbar(true)
+            // Keep the chat window in the taskbar so it can be restored after
+            // minimizing (a frameless + skip_taskbar window vanishes with no way back).
+            // Disable Tauri's native drag-drop handler so HTML5 file drops reach the
+            // webview (InputLayer relies on the DOM `drop` event for attachments).
+            .disable_drag_drop_handler()
             .shadow(false)
             .center()
             .build()

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -319,6 +319,9 @@ export function ChatStagePage() {
   const updateRuntimeAlwaysOnTop = (alwaysOnTop: boolean) => {
     setRuntimeConfig((current) => ({ ...current, alwaysOnTop }));
   };
+  const updateRuntimeBgmVolume = (bgmVolume: number) => {
+    setRuntimeConfig((current) => ({ ...current, bgmVolume: Math.min(1, Math.max(0, bgmVolume)) }));
+  };
   const updateRuntimeImmersiveMode = (immersiveMode: boolean) => {
     setRuntimeConfig((current) => ({ ...current, immersiveMode }));
   };
@@ -422,12 +425,14 @@ export function ChatStagePage() {
     <DialogStageControls
       asrEnabled={viewModel.asrEnabled}
       auto={runtimeConfig.auto}
+      bgmVolume={runtimeConfig.bgmVolume}
       closeLabel={t(standaloneDesktopWindow ? "desktop.titlebar.close" : "chat.toolbar.close")}
       configOpen={toolbarConfigOpen}
       hidden={!dialogSurfaceVisible}
       hideCloseButton={standaloneDesktopWindow}
       locked={dialogControlsLocked}
       onAutoChange={(auto) => setRuntimeConfig((current) => ({ ...current, auto }))}
+      onBgmVolumeChange={updateRuntimeBgmVolume}
       onCancelBatch={() => void sendCommand({ type: "cancel-input-batch" })}
       onCloseSurface={closeSurface}
       onCommand={sendCommand}
@@ -480,7 +485,7 @@ export function ChatStagePage() {
           path={viewModel.backgroundPath}
           transparent={transparentBackground}
         />
-        <BgmLayer path={viewModel.bgmPath} />
+        <BgmLayer path={viewModel.bgmPath} volume={runtimeConfig.bgmVolume} />
         <CgLayer hidden={!viewModel.layers.cg} path={viewModel.cgPath} />
         <SpriteLayer
           hidden={!viewModel.layers.sprites}

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "r
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { browseFiles } from "../../entities/files/repository";
-import { isTauriDesktop } from "../../shared/desktop/desktopApi";
+import { isTauriDesktop, setDesktopWindowAlwaysOnTop } from "../../shared/desktop/desktopApi";
 import { closeChatSurface } from "../../shared/desktop/chatWindow";
 import { sendChatCommand, uploadChatAttachments } from "../../entities/chat/repository";
 import { useI18n } from "../../shared/i18n";
@@ -103,7 +103,7 @@ export function ChatStagePage() {
   );
   const viewModel = useMemo(() => buildChatStageViewModel(state), [state]);
   const standaloneDesktopWindow = isTauriDesktop() && location.pathname === "/chat-stage";
-  const handleSpriteDragStart = useDesktopWindowDrag(standaloneDesktopWindow);
+  const handleWindowDrag = useDesktopWindowDrag(standaloneDesktopWindow);
   const transparentBackground = !viewModel.backgroundPath;
   const statsVisible = viewModel.stats.length > 0;
   const tokenUsageVisible = tokenUsageOpen && Boolean(viewModel.tokenUsageText);
@@ -196,6 +196,15 @@ export function ChatStagePage() {
   useEffect(() => {
     writeChatStageRuntimeConfig(runtimeConfig);
   }, [runtimeConfig]);
+
+  useEffect(() => {
+    if (!standaloneDesktopWindow) {
+      return;
+    }
+    void setDesktopWindowAlwaysOnTop(runtimeConfig.alwaysOnTop).catch((error) => {
+      console.error("Desktop chat window always-on-top toggle failed", error);
+    });
+  }, [runtimeConfig.alwaysOnTop, standaloneDesktopWindow]);
 
   const submit = async (textOverride?: string) => {
     const text = (textOverride ?? viewModel.inputDraft).trim();
@@ -307,6 +316,9 @@ export function ChatStagePage() {
     void sendChatCommand({ payload: inputState, type: "chat-input-state" }).catch(() => undefined);
   }, []);
 
+  const updateRuntimeAlwaysOnTop = (alwaysOnTop: boolean) => {
+    setRuntimeConfig((current) => ({ ...current, alwaysOnTop }));
+  };
   const updateRuntimeImmersiveMode = (immersiveMode: boolean) => {
     setRuntimeConfig((current) => ({ ...current, immersiveMode }));
   };
@@ -464,6 +476,7 @@ export function ChatStagePage() {
         />
         <BackgroundLayer
           hidden={!viewModel.layers.background}
+          onDragStart={standaloneDesktopWindow && !transparentBackground ? handleWindowDrag : undefined}
           path={viewModel.backgroundPath}
           transparent={transparentBackground}
         />
@@ -471,7 +484,7 @@ export function ChatStagePage() {
         <CgLayer hidden={!viewModel.layers.cg} path={viewModel.cgPath} />
         <SpriteLayer
           hidden={!viewModel.layers.sprites}
-          onDragStart={standaloneDesktopWindow ? handleSpriteDragStart : undefined}
+          onDragStart={standaloneDesktopWindow ? handleWindowDrag : undefined}
           runtimeScaleForSprite={(sprite, index) => runtimeSpriteScale(runtimeConfig, sprite, index)}
           speaker={viewModel.dialogCharacterName}
           sprites={viewModel.sprites}
@@ -577,6 +590,7 @@ export function ChatStagePage() {
           />
         ) : null}
         <ChatConfigDialog
+          alwaysOnTop={runtimeConfig.alwaysOnTop}
           autoHideInput={runtimeConfig.autoHideInput}
           autoHideTopTools={runtimeConfig.autoHideTopTools}
           configThemeColor={runtimeConfig.configThemeColor}
@@ -592,6 +606,7 @@ export function ChatStagePage() {
           nameText={runtimeConfig.nameText}
           onClose={() => setToolbarConfigOpen(false)}
           onCommand={sendCommand}
+          onAlwaysOnTopChange={updateRuntimeAlwaysOnTop}
           onAutoHideInputChange={updateRuntimeAutoHideInput}
           onAutoHideTopToolsChange={updateRuntimeAutoHideTopTools}
           onConfigThemeColorChange={updateRuntimeConfigThemeColor}
@@ -615,6 +630,7 @@ export function ChatStagePage() {
           textSpeed={typewriterCps}
           turnOptions={state.turnOptions}
           voiceLanguage={viewModel.voiceLanguage || "ja"}
+          windowControlsAvailable={standaloneDesktopWindow}
           windowScale={runtimeConfig.windowScale}
         />
       </main>

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -497,7 +497,11 @@ export function ChatStagePage() {
         <StatLayer stats={viewModel.stats} />
         <TokenUsageLayer hidden={!tokenUsageVisible} text={viewModel.tokenUsageText} />
         <BusyLayer hidden={!viewModel.layers.busy} text={viewModel.busyText} />
-        <NotificationLayer hidden={!viewModel.layers.notification} text={viewModel.notificationText} />
+        <NotificationLayer
+          hidden={!viewModel.layers.notification}
+          spritesVisible={viewModel.layers.sprites && viewModel.sprites.length > 0}
+          text={viewModel.notificationText}
+        />
         <div
           aria-hidden={!dialogSurfaceVisible}
           className={layerClassName("dialog-stack", !dialogSurfaceVisible)}

--- a/frontend/src/features/chat-stage/components/ChatConfigDialog.tsx
+++ b/frontend/src/features/chat-stage/components/ChatConfigDialog.tsx
@@ -93,6 +93,7 @@ const dialogFillGradientDirectionOptions: Array<{
 ];
 
 export function ChatConfigDialog({
+  alwaysOnTop,
   autoHideInput,
   autoHideTopTools,
   configThemeColor,
@@ -106,6 +107,7 @@ export function ChatConfigDialog({
   immersiveMode,
   mainThemeColor,
   nameText,
+  onAlwaysOnTopChange,
   onAutoHideInputChange,
   onAutoHideTopToolsChange,
   onConfigThemeColorChange,
@@ -131,8 +133,10 @@ export function ChatConfigDialog({
   textSpeed,
   turnOptions,
   voiceLanguage,
+  windowControlsAvailable,
   windowScale,
 }: {
+  alwaysOnTop: boolean;
   autoHideInput: boolean;
   autoHideTopTools: boolean;
   configThemeColor: string;
@@ -146,6 +150,7 @@ export function ChatConfigDialog({
   immersiveMode: boolean;
   mainThemeColor: string;
   nameText: ChatStageTextStyleConfig;
+  onAlwaysOnTopChange: (value: boolean) => void;
   onAutoHideInputChange: (value: boolean) => void;
   onAutoHideTopToolsChange: (value: boolean) => void;
   onConfigThemeColorChange: (value: string) => void;
@@ -171,6 +176,7 @@ export function ChatConfigDialog({
   textSpeed: number;
   turnOptions: ChatTurnOptions;
   voiceLanguage: string;
+  windowControlsAvailable: boolean;
   windowScale: number;
 }) {
   const { t } = useI18n();
@@ -271,6 +277,22 @@ export function ChatConfigDialog({
       title={t("chat.toolbar.config")}
     >
       <div className="chat-stage-modal__body chat-config-dialog__body">
+        {windowControlsAvailable ? (
+          <section className="chat-config-dialog__section">
+            <h3 className="chat-config-dialog__section-title">{t("chat.config.sectionWindow")}</h3>
+            <div className="chat-config-dialog__row chat-config-dialog__checkbox-row">
+              <label className="chat-config-dialog__label" htmlFor="chat-config-always-on-top">
+                {t("chat.config.alwaysOnTop")}
+              </label>
+              <Switch
+                checked={alwaysOnTop}
+                className="chat-config-dialog__switch"
+                id="chat-config-always-on-top"
+                onChange={(event) => onAlwaysOnTopChange(event.target.checked)}
+              />
+            </div>
+          </section>
+        ) : null}
         <section className="chat-config-dialog__section">
           <h3 className="chat-config-dialog__section-title">{t("chat.config.sectionMenuAppearance")}</h3>
           <label className="chat-config-dialog__row">

--- a/frontend/src/features/chat-stage/components/ChatTurnSettingsPopover.tsx
+++ b/frontend/src/features/chat-stage/components/ChatTurnSettingsPopover.tsx
@@ -6,6 +6,8 @@ import type { ChatTurnOptions, ChatTurnState } from "../../../shared/platform/ty
 import { IconButton, Switch } from "../../../shared/ui";
 
 export function ChatTurnSettingsPopover({
+  bgmVolume,
+  onBgmVolumeChange,
   onCancelBatch,
   onClose,
   onFlushBatch,
@@ -14,6 +16,8 @@ export function ChatTurnSettingsPopover({
   turnOptions,
   turnState,
 }: {
+  bgmVolume: number;
+  onBgmVolumeChange: (value: number) => void;
   onCancelBatch: () => void;
   onClose: () => void;
   onFlushBatch: () => void;
@@ -74,6 +78,22 @@ export function ChatTurnSettingsPopover({
         >
           {t("chat.config.interruptEnabled")}
         </Switch>
+        <label className="dialog-stage-controls__chat-setting dialog-stage-controls__chat-slider">
+          <span className="dialog-stage-controls__chat-slider-label">
+            {t("chat.config.bgmVolume")}
+            <span className="dialog-stage-controls__chat-slider-value">{Math.round(bgmVolume * 100)}%</span>
+          </span>
+          <input
+            aria-label={t("chat.config.bgmVolume")}
+            className="dialog-stage-controls__chat-slider-input"
+            max={1}
+            min={0}
+            onChange={(event) => onBgmVolumeChange(Number(event.currentTarget.value))}
+            step={0.05}
+            type="range"
+            value={bgmVolume}
+          />
+        </label>
       </div>
       {turnOptions.batchEnabled && turnState.pendingCount > 0 ? (
         <div className="dialog-stage-controls__batch-row">

--- a/frontend/src/features/chat-stage/components/DialogStageControls.tsx
+++ b/frontend/src/features/chat-stage/components/DialogStageControls.tsx
@@ -30,12 +30,14 @@ import { ChatTurnSettingsPopover } from "./ChatTurnSettingsPopover";
 export function DialogStageControls({
   asrEnabled,
   auto,
+  bgmVolume,
   closeLabel,
   configOpen,
   hideCloseButton,
   hidden,
   locked,
   onAutoChange,
+  onBgmVolumeChange,
   onCancelBatch,
   onCloseSurface,
   onCommand,
@@ -52,12 +54,14 @@ export function DialogStageControls({
 }: {
   asrEnabled: boolean;
   auto: boolean;
+  bgmVolume: number;
   closeLabel: string;
   configOpen: boolean;
   hidden: boolean;
   hideCloseButton: boolean;
   locked: boolean;
   onAutoChange: (auto: boolean) => void;
+  onBgmVolumeChange: (value: number) => void;
   onCancelBatch: () => void;
   onCloseSurface: () => void;
   onCommand: (command: ChatCommand) => void;
@@ -231,6 +235,8 @@ export function DialogStageControls({
           <PluginSlot slot="chat-dialog-actions" />
         </div>
         <ChatTurnSettingsPopover
+          bgmVolume={bgmVolume}
+          onBgmVolumeChange={onBgmVolumeChange}
           onCancelBatch={onCancelBatch}
           onClose={closeChatSettings}
           onFlushBatch={onFlushBatch}

--- a/frontend/src/features/chat-stage/components/StageLayers.tsx
+++ b/frontend/src/features/chat-stage/components/StageLayers.tsx
@@ -28,10 +28,12 @@ function closestDialogInteractiveElement(target: EventTarget | null) {
 
 export function BackgroundLayer({
   hidden,
+  onDragStart,
   path,
   transparent,
 }: {
   hidden: boolean;
+  onDragStart?: MouseEventHandler<HTMLElement>;
   path?: string;
   transparent: boolean;
 }) {
@@ -40,8 +42,11 @@ export function BackgroundLayer({
     <div
       aria-hidden={hidden}
       className={layerClassName("chat-stage__background", hidden)}
+      data-chat-stage-hitbox={onDragStart ? "true" : undefined}
+      data-draggable={onDragStart ? "true" : "false"}
       data-transparent={transparent ? "true" : "false"}
       hidden={hidden}
+      onMouseDown={onDragStart}
     >
       {transparent ? null : <div aria-hidden className="chat-stage__fallback" />}
       {src ? <img alt="" onError={hideBrokenStageAsset} src={src} /> : null}

--- a/frontend/src/features/chat-stage/components/StageLayers.tsx
+++ b/frontend/src/features/chat-stage/components/StageLayers.tsx
@@ -54,9 +54,16 @@ export function BackgroundLayer({
   );
 }
 
-export function BgmLayer({ path }: { path?: string }) {
+export function BgmLayer({ path, volume = 1 }: { path?: string; volume?: number }) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const src = stageAssetUrl(path);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.volume = Math.min(1, Math.max(0, volume));
+    }
+  }, [volume, src]);
 
   useEffect(() => {
     const audio = audioRef.current;

--- a/frontend/src/features/chat-stage/components/StageLayers.tsx
+++ b/frontend/src/features/chat-stage/components/StageLayers.tsx
@@ -381,7 +381,15 @@ export function BusyLayer({ hidden, text }: { hidden: boolean; text?: string }) 
   );
 }
 
-export function NotificationLayer({ hidden, text }: { hidden: boolean; text?: string }) {
+export function NotificationLayer({
+  hidden,
+  spritesVisible,
+  text,
+}: {
+  hidden: boolean;
+  spritesVisible: boolean;
+  text?: string;
+}) {
   if (hidden || !text) {
     return null;
   }
@@ -390,7 +398,9 @@ export function NotificationLayer({ hidden, text }: { hidden: boolean; text?: st
       aria-hidden={hidden}
       className={layerClassName("chat-stage__notification", hidden)}
       data-chat-stage-hitbox="true"
+      data-sprites-visible={spritesVisible ? "true" : "false"}
       hidden={hidden}
+      role="status"
     >
       {text}
     </div>

--- a/frontend/src/features/chat-stage/components/StageLayers.tsx
+++ b/frontend/src/features/chat-stage/components/StageLayers.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useRef,
   type CSSProperties,
+  type KeyboardEvent,
   type MouseEvent,
   type MouseEventHandler,
   type ReactNode,
@@ -326,6 +327,7 @@ export function OptionsLayer({
   onSelect: (option: string) => void;
   options: string[];
 }) {
+  const { t } = useI18n();
   if (hidden || !options.length) {
     return null;
   }
@@ -336,11 +338,23 @@ export function OptionsLayer({
       data-chat-stage-hitbox="true"
       hidden={hidden}
     >
-      <div className="options-layer__scroll">
-        {options.map((option) => (
-          <div className="options-layer__item" key={option}>
+      <div aria-label={t("chat.options.label")} className="options-layer__scroll" role="list">
+        {options.map((option, index) => (
+          <div className="options-layer__item" key={option} role="listitem">
             <ThemeFrame prefix="chat-option" />
-            <Button className="options-layer__button" onClick={() => onSelect(option)}>
+            <Button
+              autoFocus={index === 0}
+              className="options-layer__button"
+              onClick={() => onSelect(option)}
+              onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
+                if (event.key !== "Enter" || event.nativeEvent.isComposing) {
+                  return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                onSelect(option);
+              }}
+            >
               {option}
             </Button>
           </div>

--- a/frontend/src/features/chat-stage/hooks/useChatStageKeyboardShortcuts.ts
+++ b/frontend/src/features/chat-stage/hooks/useChatStageKeyboardShortcuts.ts
@@ -12,7 +12,10 @@ export function useChatStageKeyboardShortcuts({
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
-      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+      if (
+        target?.isContentEditable ||
+        target?.closest("a, button, input, textarea, select, summary, [role='button'], [role='link']")
+      ) {
         return;
       }
       if (disabled) {

--- a/frontend/src/features/chat-stage/runtimeConfig.ts
+++ b/frontend/src/features/chat-stage/runtimeConfig.ts
@@ -67,6 +67,7 @@ export interface ChatStageRuntimeConfig {
   auto: boolean;
   autoHideInput: boolean;
   autoHideTopTools: boolean;
+  bgmVolume: number;
   configThemeColor: string;
   configUseMainThemeColor: boolean;
   dialogFill: ChatStageDialogFillConfig;
@@ -97,6 +98,7 @@ export const defaultChatStageRuntimeConfig: ChatStageRuntimeConfig = {
   auto: false,
   autoHideInput: true,
   autoHideTopTools: true,
+  bgmVolume: 1,
   configThemeColor: DEFAULT_THEME_COLOR,
   configUseMainThemeColor: true,
   dialogText: {
@@ -300,6 +302,10 @@ export function normalizeChatStageRuntimeConfig(value: unknown): ChatStageRuntim
       typeof parsed.autoHideTopTools === "boolean"
         ? parsed.autoHideTopTools
         : defaultChatStageRuntimeConfig.autoHideTopTools,
+    bgmVolume:
+      typeof parsed.bgmVolume === "number" && Number.isFinite(parsed.bgmVolume)
+        ? Math.min(1, Math.max(0, parsed.bgmVolume))
+        : defaultChatStageRuntimeConfig.bgmVolume,
     configThemeColor: sanitizeRuntimeColor(parsed.configThemeColor, defaultChatStageRuntimeConfig.configThemeColor),
     configUseMainThemeColor:
       typeof parsed.configUseMainThemeColor === "boolean"

--- a/frontend/src/features/chat-stage/runtimeConfig.ts
+++ b/frontend/src/features/chat-stage/runtimeConfig.ts
@@ -63,6 +63,7 @@ export interface ChatStageDialogFillConfig {
 }
 
 export interface ChatStageRuntimeConfig {
+  alwaysOnTop: boolean;
   auto: boolean;
   autoHideInput: boolean;
   autoHideTopTools: boolean;
@@ -92,6 +93,7 @@ interface ChatStageRuntimeConfigStorageEnvelope {
 }
 
 export const defaultChatStageRuntimeConfig: ChatStageRuntimeConfig = {
+  alwaysOnTop: true,
   auto: false,
   autoHideInput: true,
   autoHideTopTools: true,
@@ -289,6 +291,8 @@ function unwrapRuntimeConfigStoragePayload(value: unknown): {
 export function normalizeChatStageRuntimeConfig(value: unknown): ChatStageRuntimeConfig {
   const { config: parsed, version } = unwrapRuntimeConfigStoragePayload(value);
   return {
+    alwaysOnTop:
+      typeof parsed.alwaysOnTop === "boolean" ? parsed.alwaysOnTop : defaultChatStageRuntimeConfig.alwaysOnTop,
     auto: typeof parsed.auto === "boolean" ? parsed.auto : defaultChatStageRuntimeConfig.auto,
     autoHideInput:
       typeof parsed.autoHideInput === "boolean" ? parsed.autoHideInput : defaultChatStageRuntimeConfig.autoHideInput,

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -31,11 +31,24 @@ function snapshotReplacesOptimisticPresentation(
   if (!optimistic) {
     return true;
   }
-  if (snapshot.sessionClosedReason || snapshot.options.length > 0) {
+  if (snapshot.sessionClosedReason) {
     return true;
   }
   if (authoritativeEventSeq <= optimistic.eventSeq) {
     return false;
+  }
+  // Realtime (websocket) transport delivers the reply, options and closure via their
+  // own events (dialog.end / options.show / session.closed), each of which clears the
+  // optimistic submission on its own. Any snapshot that lands mid-turn is therefore
+  // only a full-state resync and must never overwrite the just-sent user message —
+  // otherwise the previous turn's reply flashes back while we wait for the answer.
+  // Only the snapshot/polling transport delivers replies via snapshots, so keep the
+  // content heuristics below for that mode alone.
+  if (state.transportMode === "websocket") {
+    return false;
+  }
+  if (snapshot.options.length > 0) {
+    return true;
   }
   const dialogText = snapshot.dialogText.trim();
   const dialogHtml = snapshot.dialogHtml?.trim();

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -47,15 +47,23 @@ function snapshotReplacesOptimisticPresentation(
   if (!hasDialogContent || isCommandFeedback) {
     return false;
   }
+  // While the model is still preparing the answer there is no new reply yet, so a
+  // snapshot only re-publishes the dialogue shown before this turn. Never let such
+  // a resync overwrite the optimistic user message — the real answer arrives later
+  // as a streaming update or dialog.end (which clear the optimistic state on their
+  // own). This is the primary guard and is independent of dialogue content.
+  if (snapshot.status === "generating") {
+    return false;
+  }
+  // Belt-and-braces: also treat the snapshot as stale when its dialogue still
+  // matches the reply shown before this submission. Compare on plain text +
+  // speaker only — the backend may re-serialize the HTML differently, so an exact
+  // dialogHtml match is too brittle and would let the old reply flash back.
   const previous = optimistic.previous;
+  const previousDialogText = previous.dialogText.trim();
   const sameAsPreviousReply =
-    dialogText === previous.dialogText.trim() &&
-    (dialogHtml ?? "") === (previous.dialogHtml?.trim() ?? "") &&
-    speaker === previous.characterName?.trim();
+    Boolean(previousDialogText) && dialogText === previousDialogText && speaker === previous.characterName?.trim();
   if (sameAsPreviousReply) {
-    // A snapshot that merely re-publishes the reply shown before this submission
-    // (only its eventSeq advanced) is stale — the new reply has not arrived yet.
-    // Keep the optimistic user bubble instead of flashing the previous turn's line.
     return false;
   }
   return Boolean(speaker && speaker !== userName);

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -31,24 +31,11 @@ function snapshotReplacesOptimisticPresentation(
   if (!optimistic) {
     return true;
   }
-  if (snapshot.sessionClosedReason) {
+  if (snapshot.sessionClosedReason || snapshot.options.length > 0) {
     return true;
   }
   if (authoritativeEventSeq <= optimistic.eventSeq) {
     return false;
-  }
-  // Realtime (websocket) transport delivers the reply, options and closure via their
-  // own events (dialog.end / options.show / session.closed), each of which clears the
-  // optimistic submission on its own. Any snapshot that lands mid-turn is therefore
-  // only a full-state resync and must never overwrite the just-sent user message —
-  // otherwise the previous turn's reply flashes back while we wait for the answer.
-  // Only the snapshot/polling transport delivers replies via snapshots, so keep the
-  // content heuristics below for that mode alone.
-  if (state.transportMode === "websocket") {
-    return false;
-  }
-  if (snapshot.options.length > 0) {
-    return true;
   }
   const dialogText = snapshot.dialogText.trim();
   const dialogHtml = snapshot.dialogHtml?.trim();
@@ -58,25 +45,6 @@ function snapshotReplacesOptimisticPresentation(
   const hasDialogContent = Boolean(dialogHtml || dialogText);
   const isCommandFeedback = Boolean(statusMessage && !dialogHtml && statusMessage === dialogText);
   if (!hasDialogContent || isCommandFeedback) {
-    return false;
-  }
-  // While the model is still preparing the answer there is no new reply yet, so a
-  // snapshot only re-publishes the dialogue shown before this turn. Never let such
-  // a resync overwrite the optimistic user message — the real answer arrives later
-  // as a streaming update or dialog.end (which clear the optimistic state on their
-  // own). This is the primary guard and is independent of dialogue content.
-  if (snapshot.status === "generating") {
-    return false;
-  }
-  // Belt-and-braces: also treat the snapshot as stale when its dialogue still
-  // matches the reply shown before this submission. Compare on plain text +
-  // speaker only — the backend may re-serialize the HTML differently, so an exact
-  // dialogHtml match is too brittle and would let the old reply flash back.
-  const previous = optimistic.previous;
-  const previousDialogText = previous.dialogText.trim();
-  const sameAsPreviousReply =
-    Boolean(previousDialogText) && dialogText === previousDialogText && speaker === previous.characterName?.trim();
-  if (sameAsPreviousReply) {
     return false;
   }
   return Boolean(speaker && speaker !== userName);
@@ -116,8 +84,15 @@ function submitUserMessageState(
     text,
   };
   if (queued) {
+    // Batch/queued submissions must still show the user's own message instead of
+    // leaving the previous turn's reply on screen (which reads as the dialogue
+    // "rolling back" to the last message). Present it like a normal submission; the
+    // batch flush timing is handled by the command layer, not the presentation.
     return withResolvedLayers({
       ...clearTransientNotificationState(state),
+      characterName: normalizedUserDisplayName(state.userDisplayName),
+      dialogHtml: undefined,
+      dialogText: text,
       inputAttachments: [],
       inputDraft: "",
       optimisticSubmission,

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -47,6 +47,17 @@ function snapshotReplacesOptimisticPresentation(
   if (!hasDialogContent || isCommandFeedback) {
     return false;
   }
+  const previous = optimistic.previous;
+  const sameAsPreviousReply =
+    dialogText === previous.dialogText.trim() &&
+    (dialogHtml ?? "") === (previous.dialogHtml?.trim() ?? "") &&
+    speaker === previous.characterName?.trim();
+  if (sameAsPreviousReply) {
+    // A snapshot that merely re-publishes the reply shown before this submission
+    // (only its eventSeq advanced) is stale — the new reply has not arrived yet.
+    // Keep the optimistic user bubble instead of flashing the previous turn's line.
+    return false;
+  }
   return Boolean(speaker && speaker !== userName);
 }
 

--- a/frontend/src/features/chat-stage/styles/base.css
+++ b/frontend/src/features/chat-stage/styles/base.css
@@ -23,6 +23,7 @@
   --stage-input-height: 76px;
   --stage-token-layer-top: calc(var(--stage-safe-top) + 48px);
   --stage-token-offset-top: calc(var(--stage-safe-top) + 168px);
+  --stage-notification-top: calc(var(--stage-safe-top) + 58px);
   --stage-control-stack-height: calc(var(--stage-safe-bottom) + var(--stage-input-height));
   /* Accent-tinted warm dark, harmonized with the main app's --theme-accent seed. */
   --stage-accent: var(--chat-theme-color, var(--color-accent-primary, #d4788e));

--- a/frontend/src/features/chat-stage/styles/controls.css
+++ b/frontend/src/features/chat-stage/styles/controls.css
@@ -548,6 +548,39 @@
   opacity: 1;
 }
 
+.dialog-stage-controls__chat-slider {
+  display: grid;
+  gap: 8px;
+  padding: 9px 10px;
+  border-radius: 10px;
+  color: var(--chat-toolbar-color, #fffaf0);
+  background: color-mix(in oklch, var(--stage-accent) 7%, rgba(255, 255, 255, 0.04));
+  cursor: pointer;
+}
+
+.dialog-stage-controls__chat-slider-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.dialog-stage-controls__chat-slider-value {
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in oklch, var(--stage-accent) 62%, var(--chat-toolbar-color, #fffaf0));
+}
+
+.dialog-stage-controls__chat-slider-input {
+  width: 100%;
+  height: 18px;
+  margin: 0;
+  cursor: pointer;
+  /* Track fill + thumb follow the active chat theme colour. */
+  accent-color: var(--stage-accent);
+}
+
 .dialog-stage-controls__batch-row {
   padding-top: 10px;
   border-top: 1px solid color-mix(in oklch, var(--stage-accent) 18%, rgba(255, 255, 255, 0.12));

--- a/frontend/src/features/chat-stage/styles/dialog-layer.css
+++ b/frontend/src/features/chat-stage/styles/dialog-layer.css
@@ -71,7 +71,7 @@
   max-width: var(--chat-dialog-toolbar-layer-max-width);
   min-height: var(--chat-dialog-toolbar-reserved-height);
   align-items: flex-end;
-  justify-content: flex-end;
+  justify-content: center;
   padding: var(--chat-dialog-toolbar-layer-padding);
   transform: translateX(-50%) scale(var(--chat-toolbar-runtime-scale));
   transform-origin: bottom center;

--- a/frontend/src/features/chat-stage/styles/dialog-layer.css
+++ b/frontend/src/features/chat-stage/styles/dialog-layer.css
@@ -55,10 +55,10 @@
   z-index: 3;
   display: flex;
   min-width: 0;
-  justify-content: flex-end;
+  justify-content: center;
   pointer-events: none;
   transform: scale(var(--chat-dialog-runtime-inverse-scale));
-  transform-origin: bottom right;
+  transform-origin: bottom center;
 }
 
 .dialog-toolbar-layer {

--- a/frontend/src/features/chat-stage/styles/media-layers.css
+++ b/frontend/src/features/chat-stage/styles/media-layers.css
@@ -25,6 +25,13 @@
   background: transparent;
 }
 
+/* Desktop: pressing the background (when one is shown) drags the chat window,
+   mirroring the draggable-sprite affordance. */
+.chat-stage__background[data-draggable="true"] {
+  cursor: move;
+  pointer-events: auto;
+}
+
 .chat-stage__cg {
   z-index: 1;
 }

--- a/frontend/src/features/chat-stage/styles/options-layer.css
+++ b/frontend/src/features/chat-stage/styles/options-layer.css
@@ -15,6 +15,7 @@
   opacity: 1;
   backdrop-filter: none;
   isolation: isolate;
+  translate: 0 -24px;
   /* Slide-only entrance (no opacity fade): the option buttons use backdrop-filter,
      and fading the group's opacity makes Chromium/Edge flash a bright bar for one
      frame while it re-composites the backdrop. */
@@ -35,12 +36,10 @@
   display: grid;
   box-sizing: border-box;
   width: 100%;
-  max-height: min(58vh, 680px);
   gap: var(--chat-options-gap);
   justify-items: stretch;
   padding: clamp(4px, 0.8vw, 10px);
-  overflow-y: auto;
-  overscroll-behavior: contain;
+  overflow: visible;
 }
 
 .options-layer__item {

--- a/frontend/src/features/chat-stage/styles/options-layer.css
+++ b/frontend/src/features/chat-stage/styles/options-layer.css
@@ -76,9 +76,12 @@
   background: var(--chat-sheen), var(--chat-option-background);
   box-shadow:
     0 14px 34px color-mix(in srgb, var(--stage-shadow) 78%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
     var(--chat-option-box-shadow, none);
-  backdrop-filter: blur(18px) saturate(1.16);
+  /* No backdrop-filter: when the option animates in, a backdrop-filtered element
+     inside a transforming ancestor gets re-composited per frame and Chromium/Edge
+     flash a bright bar on the first frame. The tinted --chat-option-background keeps
+     the look without the flash. */
   text-align: var(--chat-option-text-align);
   text-shadow: var(--chat-option-text-shadow);
   white-space: normal;

--- a/frontend/src/features/chat-stage/styles/options-layer.css
+++ b/frontend/src/features/chat-stage/styles/options-layer.css
@@ -15,7 +15,20 @@
   opacity: 1;
   backdrop-filter: none;
   isolation: isolate;
-  animation: chat-stage-rise 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  /* Slide-only entrance (no opacity fade): the option buttons use backdrop-filter,
+     and fading the group's opacity makes Chromium/Edge flash a bright bar for one
+     frame while it re-composites the backdrop. */
+  animation: chat-options-rise 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes chat-options-rise {
+  from {
+    transform: translateY(8px);
+  }
+
+  to {
+    transform: translateY(0);
+  }
 }
 
 .options-layer__scroll {
@@ -174,12 +187,10 @@
 
 @keyframes chat-option-enter {
   from {
-    opacity: 0;
     transform: translateX(18px);
   }
 
   to {
-    opacity: 1;
     transform: translateX(0);
   }
 }

--- a/frontend/src/features/chat-stage/styles/responsive.css
+++ b/frontend/src/features/chat-stage/styles/responsive.css
@@ -124,7 +124,7 @@
   }
 
   .chat-stage__notification {
-    top: 58px;
+    top: var(--stage-notification-top);
     bottom: auto;
     border-radius: 8px;
   }

--- a/frontend/src/features/chat-stage/styles/status-overlays.css
+++ b/frontend/src/features/chat-stage/styles/status-overlays.css
@@ -20,13 +20,20 @@
 }
 
 .chat-stage__notification {
-  top: calc(var(--stage-safe-top) + 46px);
+  top: var(--stage-notification-top);
   bottom: auto;
   padding: 9px 14px;
   font-size: 13px;
   line-height: 1.45;
   text-align: center;
   white-space: normal;
+}
+
+.chat-stage__notification[data-sprites-visible="true"] {
+  border-color: color-mix(in oklch, var(--stage-line) 54%, transparent);
+  background: color-mix(in srgb, var(--stage-glass-strong) 36%, transparent);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--stage-shadow) 42%, transparent);
+  backdrop-filter: blur(4px) saturate(1.02);
 }
 
 .chat-stage[data-token-visible="true"] .chat-stage__busy,
@@ -237,9 +244,12 @@
 }
 
 @media (max-width: 1180px) {
-  .chat-stage__busy,
-  .chat-stage__notification {
+  .chat-stage__busy {
     top: calc(var(--stage-safe-top) + 46px);
+  }
+
+  .chat-stage__notification {
+    top: var(--stage-notification-top);
   }
 
   .chat-stage[data-token-visible="true"] .chat-stage__busy,

--- a/frontend/src/shared/desktop/desktopApi.ts
+++ b/frontend/src/shared/desktop/desktopApi.ts
@@ -381,6 +381,10 @@ export function toggleMaximizeDesktopWindow() {
   return invokeDesktop<void>("desktop_window_toggle_maximize");
 }
 
+export function setDesktopWindowAlwaysOnTop(alwaysOnTop: boolean) {
+  return invokeDesktop<void>("desktop_window_set_always_on_top", { alwaysOnTop });
+}
+
 export function startDesktopWindowDrag() {
   return invokeDesktop<void>("desktop_window_start_drag");
 }

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -464,6 +464,8 @@ export type MessageKey =
   | "chat.config.interruptHelp"
   | "chat.config.sectionConversation"
   | "chat.config.sectionImmersive"
+  | "chat.config.sectionWindow"
+  | "chat.config.alwaysOnTop"
   | "chat.config.sectionLayout"
   | "chat.config.sectionMenuAppearance"
   | "chat.config.sectionSending"

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -419,6 +419,7 @@ export type MessageKey =
   | "chat.actionBar.reroll"
   | "chat.actionBar.skip"
   | "chat.actionBar.title"
+  | "chat.options.label"
   | "chat.actionBar.unlock"
   | "chat.config.dialogOpacity"
   | "chat.config.dialogOpacityValue"

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -457,6 +457,7 @@ export type MessageKey =
   | "chat.config.nameFontSize"
   | "chat.config.scaleValue"
   | "chat.config.batchEnabled"
+  | "chat.config.bgmVolume"
   | "chat.config.batchHelp"
   | "chat.config.batchTimeout"
   | "chat.config.batchTimeoutValue"

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -481,6 +481,7 @@ export const enMessages: Record<MessageKey, string> = {
   "chat.config.nameFontSize": "Nameplate font size",
   "chat.config.scaleValue": "{value}%",
   "chat.config.batchEnabled": "Stack consecutive messages",
+  "chat.config.bgmVolume": "BGM volume",
   "chat.config.batchHelp": "Hold consecutive sends and submit them to the model as one turn.",
   "chat.config.batchTimeout": "Stack idle timeout",
   "chat.config.batchTimeoutValue": "{value}s",

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -488,6 +488,8 @@ export const enMessages: Record<MessageKey, string> = {
   "chat.config.interruptHelp": "A new message cancels the current generation and queued speech before it is sent.",
   "chat.config.sectionConversation": "Conversation",
   "chat.config.sectionImmersive": "Immersive mode",
+  "chat.config.sectionWindow": "Window",
+  "chat.config.alwaysOnTop": "Always on top",
   "chat.config.sectionLayout": "Layout",
   "chat.config.sectionMenuAppearance": "Settings panel appearance",
   "chat.config.sectionSending": "Sending behavior",

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -2,6 +2,7 @@ import type { MessageKey } from "../messages";
 
 export const enMessages: Record<MessageKey, string> = {
   "chat.stats.label": "Character stats",
+  "chat.options.label": "Dialogue choices",
   "api.memory.cachedNotLoaded": "Embedding model cached; not loaded",
   "api.memory.checking": "Checking",
   "api.memory.description":

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -487,6 +487,7 @@ export const jaMessages: Record<MessageKey, string> = {
   "chat.config.nameFontSize": "名札フォントサイズ",
   "chat.config.scaleValue": "{value}%",
   "chat.config.batchEnabled": "連続メッセージをまとめる",
+  "chat.config.bgmVolume": "BGM音量",
   "chat.config.batchHelp": "連続送信を保留し、1つのターンとしてモデルへ送信します。",
   "chat.config.batchTimeout": "まとめ送信の待機時間",
   "chat.config.batchTimeoutValue": "{value}秒",

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -2,6 +2,7 @@ import type { MessageKey } from "../messages";
 
 export const jaMessages: Record<MessageKey, string> = {
   "chat.stats.label": "キャラクターステータス",
+  "chat.options.label": "会話の選択肢",
   "api.memory.cachedNotLoaded": "埋め込みモデルはキャッシュ済み（未読み込み）",
   "api.memory.enableReady": "自動長期記憶を有効にしました。",
   "api.memory.modelMissingKeepOff": "埋め込みモデルが未ダウンロードのため、長期記憶はオフのままです。",

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -494,6 +494,8 @@ export const jaMessages: Record<MessageKey, string> = {
   "chat.config.interruptHelp": "新しいメッセージを送る前に、現在の生成と未再生の音声をキャンセルします。",
   "chat.config.sectionConversation": "会話",
   "chat.config.sectionImmersive": "没入モード",
+  "chat.config.sectionWindow": "ウィンドウ",
+  "chat.config.alwaysOnTop": "常に最前面",
   "chat.config.sectionLayout": "レイアウト",
   "chat.config.sectionMenuAppearance": "設定パネルの外観",
   "chat.config.sectionSending": "送信動作",

--- a/frontend/src/shared/i18n/messages/zh_CN.ts
+++ b/frontend/src/shared/i18n/messages/zh_CN.ts
@@ -474,6 +474,7 @@ export const zhCNMessages: Record<MessageKey, string> = {
   "chat.config.nameFontSize": "名牌字号",
   "chat.config.scaleValue": "{value}%",
   "chat.config.batchEnabled": "堆叠连续消息",
+  "chat.config.bgmVolume": "BGM 音量",
   "chat.config.batchHelp": "暂存连续发送的消息，并合并成一个回合提交给模型。",
   "chat.config.batchTimeout": "堆叠空闲等待时间",
   "chat.config.batchTimeoutValue": "{value} 秒",

--- a/frontend/src/shared/i18n/messages/zh_CN.ts
+++ b/frontend/src/shared/i18n/messages/zh_CN.ts
@@ -2,6 +2,7 @@ import type { MessageKey } from "../messages";
 
 export const zhCNMessages: Record<MessageKey, string> = {
   "chat.stats.label": "角色状态",
+  "chat.options.label": "对话选项",
   "api.memory.cachedNotLoaded": "embedding 模型已缓存，尚未加载",
   "api.memory.enableReady": "自动长期记忆已启用。",
   "api.memory.modelMissingKeepOff": "embedding 模型尚未下载，长期记忆已保持关闭。",

--- a/frontend/src/shared/i18n/messages/zh_CN.ts
+++ b/frontend/src/shared/i18n/messages/zh_CN.ts
@@ -481,6 +481,8 @@ export const zhCNMessages: Record<MessageKey, string> = {
   "chat.config.interruptHelp": "发送新消息前会取消当前生成，并清理尚未播放的语音。",
   "chat.config.sectionConversation": "对话",
   "chat.config.sectionImmersive": "沉浸模式",
+  "chat.config.sectionWindow": "窗口置顶",
+  "chat.config.alwaysOnTop": "窗口置顶",
   "chat.config.sectionLayout": "布局",
   "chat.config.sectionMenuAppearance": "设置面板外观",
   "chat.config.sectionSending": "发送行为",

--- a/frontend/src/shared/theme/chatTheme.ts
+++ b/frontend/src/shared/theme/chatTheme.ts
@@ -518,7 +518,11 @@ export function resolveChatTheme(manifest: ChatThemeManifest, assetUrl: (rel: st
     style["--chat-sheen"] = "none";
   }
   if (typeof dialog?.nameInputGapVh === "number") {
-    setVhVar(style, "--chat-dialog-name-input-gap", dialog.nameInputGapVh, 12, 32);
+    // Bound the viewport-height gap with a pixel ceiling so the dialogue box does
+    // not drift far above the input bar on tall / maximized windows (the gap used
+    // to grow unbounded with svh, which read fine when windowed but far too large
+    // when maximized).
+    setVhClampVar(style, "--chat-dialog-name-input-gap", dialog.nameInputGapVh, 12, 32, 84, 180);
     style["--chat-dialog-stack-bottom"] =
       "calc(var(--stage-control-stack-height) + var(--chat-dialog-name-input-gap) - var(--chat-dialog-height) - var(--chat-name-line-offset) - var(--chat-dialog-offset-y))";
   }

--- a/frontend/src/test/features/chat-stage/ChatStagePage.platform.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.platform.test.tsx
@@ -20,6 +20,7 @@ const desktopApiMocks = vi.hoisted(() => ({
   closeDesktopWindow: vi.fn(),
   isTauriDesktop: vi.fn(),
   minimizeDesktopWindow: vi.fn(),
+  setDesktopWindowAlwaysOnTop: vi.fn(),
   startDesktopWindowDrag: vi.fn(),
   toggleMaximizeDesktopWindow: vi.fn(),
 }));
@@ -43,6 +44,7 @@ vi.mock("../../../shared/desktop/desktopApi", async (importOriginal) => {
     closeDesktopWindow: () => desktopApiMocks.closeDesktopWindow(),
     isTauriDesktop: () => desktopApiMocks.isTauriDesktop(),
     minimizeDesktopWindow: () => desktopApiMocks.minimizeDesktopWindow(),
+    setDesktopWindowAlwaysOnTop: (alwaysOnTop: boolean) => desktopApiMocks.setDesktopWindowAlwaysOnTop(alwaysOnTop),
     startDesktopWindowDrag: () => desktopApiMocks.startDesktopWindowDrag(),
     toggleMaximizeDesktopWindow: () => desktopApiMocks.toggleMaximizeDesktopWindow(),
   };
@@ -93,6 +95,7 @@ describe("ChatStagePage http platform integration", () => {
     chatWindowMocks.closeChatSurface.mockResolvedValue(undefined);
     desktopApiMocks.closeDesktopWindow.mockResolvedValue(undefined);
     desktopApiMocks.minimizeDesktopWindow.mockResolvedValue(undefined);
+    desktopApiMocks.setDesktopWindowAlwaysOnTop.mockResolvedValue(undefined);
     desktopApiMocks.startDesktopWindowDrag.mockResolvedValue(undefined);
     desktopApiMocks.toggleMaximizeDesktopWindow.mockResolvedValue(undefined);
   });

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -224,6 +224,24 @@ describe("ChatStagePage", () => {
     );
   });
 
+  it("focuses the first option and submits the focused choice with Enter", async () => {
+    mocks.getChatSnapshot.mockResolvedValue(snapshot({ options: ["Take the shortcut", "Stay on the road"] }));
+    renderPage();
+
+    const firstOption = await screen.findByRole("button", { name: "Take the shortcut" });
+    expect(screen.getByRole("list", { name: "Dialogue choices" })).toContainElement(firstOption);
+    expect(firstOption).toHaveFocus();
+
+    fireEvent.keyDown(firstOption, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(mocks.sendChatCommand).toHaveBeenCalledWith({
+        payload: "Take the shortcut",
+        type: "submit-option",
+      }),
+    );
+  });
+
   it("opens interrupt and stacking switches from the existing hover input toolbar", async () => {
     themeContextMocks.optional = {
       style: {

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -73,6 +73,7 @@ const desktopApiMocks = vi.hoisted(() => ({
   getDesktopWindowCursorPosition: vi.fn(),
   isTauriDesktop: vi.fn(),
   minimizeDesktopWindow: vi.fn(),
+  setDesktopWindowAlwaysOnTop: vi.fn(),
   setDesktopWindowClickThrough: vi.fn(),
   startDesktopWindowDrag: vi.fn(),
   startDesktopWindowResize: vi.fn(),
@@ -93,6 +94,7 @@ vi.mock("../../../shared/desktop/desktopApi", async (importOriginal) => {
     getDesktopWindowCursorPosition: () => desktopApiMocks.getDesktopWindowCursorPosition(),
     isTauriDesktop: () => desktopApiMocks.isTauriDesktop(),
     minimizeDesktopWindow: () => desktopApiMocks.minimizeDesktopWindow(),
+    setDesktopWindowAlwaysOnTop: (alwaysOnTop: boolean) => desktopApiMocks.setDesktopWindowAlwaysOnTop(alwaysOnTop),
     setDesktopWindowClickThrough: (ignore: boolean) => desktopApiMocks.setDesktopWindowClickThrough(ignore),
     startDesktopWindowDrag: () => desktopApiMocks.startDesktopWindowDrag(),
     startDesktopWindowResize: (direction: string) => desktopApiMocks.startDesktopWindowResize(direction),
@@ -179,6 +181,7 @@ describe("ChatStagePage", () => {
     desktopApiMocks.isTauriDesktop.mockReturnValue(false);
     desktopApiMocks.getDesktopWindowCursorPosition.mockResolvedValue({ x: 0, y: 0 });
     desktopApiMocks.minimizeDesktopWindow.mockResolvedValue(undefined);
+    desktopApiMocks.setDesktopWindowAlwaysOnTop.mockResolvedValue(undefined);
     desktopApiMocks.setDesktopWindowClickThrough.mockResolvedValue(undefined);
     mocks.sendChatCommand.mockImplementation(async (command: ChatCommand) =>
       snapshot({
@@ -1295,6 +1298,7 @@ describe("ChatStagePage", () => {
     });
     expect(JSON.parse(window.localStorage.getItem("shinsekai-chat-stage-runtime-config") || "{}")).toEqual({
       config: {
+        alwaysOnTop: true,
         auto: false,
         autoHideInput: true,
         autoHideTopTools: true,

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -1302,6 +1302,7 @@ describe("ChatStagePage", () => {
         auto: false,
         autoHideInput: true,
         autoHideTopTools: true,
+        bgmVolume: 1,
         configThemeColor: "#88cc44",
         configUseMainThemeColor: false,
         dialogText: {

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -242,6 +242,22 @@ describe("ChatStagePage", () => {
     );
   });
 
+  it("exposes notifications as status updates and softens them over sprites", async () => {
+    mocks.getChatSnapshot.mockResolvedValue(
+      snapshot({
+        characterName: "",
+        dialogText: "",
+        notificationText: "Session paused",
+      }),
+    );
+    renderPage();
+
+    const notification = await screen.findByRole("status");
+    expect(notification).toHaveClass("chat-stage__notification");
+    expect(notification).toHaveAttribute("data-sprites-visible", "true");
+    expect(notification).toHaveTextContent("Session paused");
+  });
+
   it("opens interrupt and stacking switches from the existing hover input toolbar", async () => {
     themeContextMocks.optional = {
       style: {

--- a/frontend/src/test/features/chat-stage/chatStageStyles.test.ts
+++ b/frontend/src/test/features/chat-stage/chatStageStyles.test.ts
@@ -64,7 +64,10 @@ describe("chat stage immersive styles", () => {
     expect(layerBlock).toContain("background: transparent;");
     expect(layerBlock).toContain("box-shadow: none;");
     expect(layerBlock).toContain("backdrop-filter: none;");
-    expect(buttonBlock).toContain("backdrop-filter: blur(18px) saturate(1.16);");
+    // The option button intentionally has no backdrop-filter blur: filtering a
+    // subtree whose ancestor animates in makes Chromium/Edge flash a bright bar for
+    // a frame. (The rule's comment still mentions the word, so assert on the value.)
+    expect(buttonBlock).not.toContain("backdrop-filter: blur");
     expect(buttonBlock).toContain("transform: none;");
     expect(optionsLayerCss).toContain(".options-layer__item:has(.options-layer__button:hover:not(:disabled))");
     expect(optionsLayerCss).toContain("@keyframes chat-option-enter");

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -398,6 +398,49 @@ describe("chatStageReducer", () => {
     expect(freshReply.optimisticSubmission).toBeUndefined();
   });
 
+  it("keeps the optimistic user message while a generating snapshot still shows the previous reply", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Mio",
+        dialogText: "old reply",
+        eventSeq: 3,
+        inputDraft: "hello",
+        sprites: [],
+        userDisplayName: "Aoi",
+      },
+      { source: "send-message", text: "hello", type: "submitUserMessage" },
+    );
+    // Mid-generation resync: eventSeq advanced and the HTML differs from the
+    // pre-submit reply, but status is still "generating" — the new answer has not
+    // been produced yet, so it must not overwrite the user's message.
+    const generatingSnapshot = chatStageReducer(submitted, {
+      event: {
+        seq: 6,
+        snapshot: {
+          characterName: "Mio",
+          dialogHtml: "<p>old reply</p>",
+          dialogText: "old reply",
+          eventSeq: 6,
+          inputDraft: "",
+          options: [],
+          sessionId: "session-1",
+          sprites: [],
+          status: "generating",
+        },
+        ts: 6,
+        type: "snapshot",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(generatingSnapshot.characterName).toBe("Aoi");
+    expect(generatingSnapshot.dialogText).toBe("hello");
+    expect(generatingSnapshot.status).toBe("generating");
+    expect(generatingSnapshot.optimisticSubmission?.text).toBe("hello");
+  });
+
   it("accepts a newer wrapped snapshot when its payload omits eventSeq", () => {
     const submitted = chatStageReducer(
       {

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -327,6 +327,77 @@ describe("chatStageReducer", () => {
     expect(staleSnapshot.historyEntries).toEqual([{ id: "user-1", role: "user", text: "Aoi: hello" }]);
   });
 
+  it("keeps the optimistic user message when a seq-advanced snapshot still carries the previous reply", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Mio",
+        dialogText: "old reply",
+        eventSeq: 3,
+        inputDraft: "hello",
+        sprites: [],
+        userDisplayName: "Aoi",
+      },
+      { source: "send-message", text: "hello", type: "submitUserMessage" },
+    );
+    const withStatus = chatStageReducer(submitted, {
+      event: { seq: 4, status: "generating", ts: 4, type: "status.change", v: 1 },
+      type: "event",
+    });
+    // The reply has not been generated yet, but the backend republishes a snapshot
+    // whose eventSeq has advanced past the current state while its dialogue is still
+    // the pre-submit line. It must not flash the previous turn's reply.
+    const staleAhead = chatStageReducer(withStatus, {
+      event: {
+        seq: 7,
+        snapshot: {
+          characterName: "Mio",
+          dialogText: "old reply",
+          eventSeq: 7,
+          inputDraft: "",
+          options: [],
+          sessionId: "session-1",
+          sprites: [],
+          status: "idle",
+        },
+        ts: 7,
+        type: "snapshot",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(staleAhead.characterName).toBe("Aoi");
+    expect(staleAhead.dialogText).toBe("hello");
+    expect(staleAhead.status).toBe("generating");
+    expect(staleAhead.optimisticSubmission?.text).toBe("hello");
+
+    // Once a genuinely new reply lands, it replaces the optimistic user message.
+    const freshReply = chatStageReducer(staleAhead, {
+      event: {
+        seq: 8,
+        snapshot: {
+          characterName: "Mio",
+          dialogText: "brand new reply",
+          eventSeq: 8,
+          inputDraft: "",
+          options: [],
+          sessionId: "session-1",
+          sprites: [],
+          status: "idle",
+        },
+        ts: 8,
+        type: "snapshot",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(freshReply.characterName).toBe("Mio");
+    expect(freshReply.dialogText).toBe("brand new reply");
+    expect(freshReply.optimisticSubmission).toBeUndefined();
+  });
+
   it("accepts a newer wrapped snapshot when its payload omits eventSeq", () => {
     const submitted = chatStageReducer(
       {

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -441,6 +441,51 @@ describe("chatStageReducer", () => {
     expect(generatingSnapshot.optimisticSubmission?.text).toBe("hello");
   });
 
+  it("keeps the optimistic user message on a websocket resync snapshot mid-turn", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Mio",
+        dialogText: "old reply",
+        eventSeq: 3,
+        inputDraft: "hello",
+        sprites: [],
+        transportMode: "websocket",
+        userDisplayName: "Aoi",
+      },
+      { source: "send-message", text: "hello", type: "submitUserMessage" },
+    );
+    // A websocket resync lands while the previous reply is still being spoken
+    // (status "speaking", not "generating") and its dialogue differs slightly from
+    // the pre-submit reply, so neither the status nor the content heuristic catches
+    // it. In realtime mode the answer arrives via dialog.end, so the resync must not
+    // overwrite the user's just-sent message.
+    const resync = chatStageReducer(submitted, {
+      event: {
+        seq: 7,
+        snapshot: {
+          characterName: "Mio",
+          dialogHtml: "<p>old reply revised</p>",
+          dialogText: "old reply revised",
+          eventSeq: 7,
+          inputDraft: "",
+          options: [],
+          sessionId: "session-1",
+          sprites: [],
+          status: "speaking",
+        },
+        ts: 7,
+        type: "snapshot",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(resync.characterName).toBe("Aoi");
+    expect(resync.dialogText).toBe("hello");
+    expect(resync.optimisticSubmission?.text).toBe("hello");
+  });
+
   it("accepts a newer wrapped snapshot when its payload omits eventSeq", () => {
     const submitted = chatStageReducer(
       {

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -327,163 +327,25 @@ describe("chatStageReducer", () => {
     expect(staleSnapshot.historyEntries).toEqual([{ id: "user-1", role: "user", text: "Aoi: hello" }]);
   });
 
-  it("keeps the optimistic user message when a seq-advanced snapshot still carries the previous reply", () => {
+  it("shows the user's own message on a queued (batch) submission", () => {
     const submitted = chatStageReducer(
       {
         ...emptyChatState,
         characterName: "Mio",
-        dialogText: "old reply",
+        dialogText: "previous reply",
         eventSeq: 3,
-        inputDraft: "hello",
-        sprites: [],
+        options: ["Left", "Right"],
         userDisplayName: "Aoi",
       },
-      { source: "send-message", text: "hello", type: "submitUserMessage" },
+      { queued: true, source: "send-message", text: "my message", type: "submitUserMessage" },
     );
-    const withStatus = chatStageReducer(submitted, {
-      event: { seq: 4, status: "generating", ts: 4, type: "status.change", v: 1 },
-      type: "event",
-    });
-    // The reply has not been generated yet, but the backend republishes a snapshot
-    // whose eventSeq has advanced past the current state while its dialogue is still
-    // the pre-submit line. It must not flash the previous turn's reply.
-    const staleAhead = chatStageReducer(withStatus, {
-      event: {
-        seq: 7,
-        snapshot: {
-          characterName: "Mio",
-          dialogText: "old reply",
-          eventSeq: 7,
-          inputDraft: "",
-          options: [],
-          sessionId: "session-1",
-          sprites: [],
-          status: "idle",
-        },
-        ts: 7,
-        type: "snapshot",
-        v: 1,
-      },
-      type: "event",
-    });
 
-    expect(staleAhead.characterName).toBe("Aoi");
-    expect(staleAhead.dialogText).toBe("hello");
-    expect(staleAhead.status).toBe("generating");
-    expect(staleAhead.optimisticSubmission?.text).toBe("hello");
-
-    // Once a genuinely new reply lands, it replaces the optimistic user message.
-    const freshReply = chatStageReducer(staleAhead, {
-      event: {
-        seq: 8,
-        snapshot: {
-          characterName: "Mio",
-          dialogText: "brand new reply",
-          eventSeq: 8,
-          inputDraft: "",
-          options: [],
-          sessionId: "session-1",
-          sprites: [],
-          status: "idle",
-        },
-        ts: 8,
-        type: "snapshot",
-        v: 1,
-      },
-      type: "event",
-    });
-
-    expect(freshReply.characterName).toBe("Mio");
-    expect(freshReply.dialogText).toBe("brand new reply");
-    expect(freshReply.optimisticSubmission).toBeUndefined();
-  });
-
-  it("keeps the optimistic user message while a generating snapshot still shows the previous reply", () => {
-    const submitted = chatStageReducer(
-      {
-        ...emptyChatState,
-        characterName: "Mio",
-        dialogText: "old reply",
-        eventSeq: 3,
-        inputDraft: "hello",
-        sprites: [],
-        userDisplayName: "Aoi",
-      },
-      { source: "send-message", text: "hello", type: "submitUserMessage" },
-    );
-    // Mid-generation resync: eventSeq advanced and the HTML differs from the
-    // pre-submit reply, but status is still "generating" — the new answer has not
-    // been produced yet, so it must not overwrite the user's message.
-    const generatingSnapshot = chatStageReducer(submitted, {
-      event: {
-        seq: 6,
-        snapshot: {
-          characterName: "Mio",
-          dialogHtml: "<p>old reply</p>",
-          dialogText: "old reply",
-          eventSeq: 6,
-          inputDraft: "",
-          options: [],
-          sessionId: "session-1",
-          sprites: [],
-          status: "generating",
-        },
-        ts: 6,
-        type: "snapshot",
-        v: 1,
-      },
-      type: "event",
-    });
-
-    expect(generatingSnapshot.characterName).toBe("Aoi");
-    expect(generatingSnapshot.dialogText).toBe("hello");
-    expect(generatingSnapshot.status).toBe("generating");
-    expect(generatingSnapshot.optimisticSubmission?.text).toBe("hello");
-  });
-
-  it("keeps the optimistic user message on a websocket resync snapshot mid-turn", () => {
-    const submitted = chatStageReducer(
-      {
-        ...emptyChatState,
-        characterName: "Mio",
-        dialogText: "old reply",
-        eventSeq: 3,
-        inputDraft: "hello",
-        sprites: [],
-        transportMode: "websocket",
-        userDisplayName: "Aoi",
-      },
-      { source: "send-message", text: "hello", type: "submitUserMessage" },
-    );
-    // A websocket resync lands while the previous reply is still being spoken
-    // (status "speaking", not "generating") and its dialogue differs slightly from
-    // the pre-submit reply, so neither the status nor the content heuristic catches
-    // it. In realtime mode the answer arrives via dialog.end, so the resync must not
-    // overwrite the user's just-sent message.
-    const resync = chatStageReducer(submitted, {
-      event: {
-        seq: 7,
-        snapshot: {
-          characterName: "Mio",
-          dialogHtml: "<p>old reply revised</p>",
-          dialogText: "old reply revised",
-          eventSeq: 7,
-          inputDraft: "",
-          options: [],
-          sessionId: "session-1",
-          sprites: [],
-          status: "speaking",
-        },
-        ts: 7,
-        type: "snapshot",
-        v: 1,
-      },
-      type: "event",
-    });
-
-    expect(resync.characterName).toBe("Aoi");
-    expect(resync.dialogText).toBe("hello");
-    expect(resync.optimisticSubmission?.text).toBe("hello");
+    // Batch mode must not leave the previous turn's reply on screen — the user's
+    // own message should be shown just like a non-batched submission.
+    expect(submitted.dialogText).toBe("my message");
+    expect(submitted.characterName).toBe("Aoi");
+    expect(submitted.options).toEqual([]);
+    expect(submitted.optimisticSubmission?.text).toBe("my message");
   });
 
   it("accepts a newer wrapped snapshot when its payload omits eventSeq", () => {

--- a/frontend/src/test/features/chat-stage/chatTheme.test.tsx
+++ b/frontend/src/test/features/chat-stage/chatTheme.test.tsx
@@ -213,7 +213,7 @@ describe("chat theme runtime", () => {
     expect(resolved.style["--chat-dialog-padding"]).toBe("40px");
     expect(resolved.style["--chat-dialog-toolbar-gap"]).toBe("10px");
     expect(resolved.style["--chat-dialog-toolbar-reserved-height"]).toBeUndefined();
-    expect(resolved.style["--chat-dialog-name-input-gap"]).toBe("20svh");
+    expect(resolved.style["--chat-dialog-name-input-gap"]).toBe("clamp(84px, 20svh, 180px)");
     expect(resolved.style["--chat-dialog-stack-bottom"]).toContain("--chat-dialog-name-input-gap");
     expect(resolved.style["--chat-dialog-toolbar-placement"]).toBe("dialog-top");
     expect(resolved.style["--chat-dialog-toolbar-reveal"]).toBe("hover");

--- a/frontend/src/test/shared/desktop/desktopApi.test.ts
+++ b/frontend/src/test/shared/desktop/desktopApi.test.ts
@@ -31,6 +31,7 @@ import {
   repairDesktopRuntime,
   reloadDesktopFrontend,
   selectDesktopProjectRoot,
+  setDesktopWindowAlwaysOnTop,
   startDesktopWindowDrag,
   toggleMaximizeDesktopWindow,
   closeDesktopWindow,
@@ -120,6 +121,7 @@ describe("desktop API environment detection", () => {
     await hideDesktopWindow();
     await destroyDesktopChatWindow();
     await minimizeDesktopWindow();
+    await setDesktopWindowAlwaysOnTop(false);
     await toggleMaximizeDesktopWindow();
     await startDesktopWindowDrag();
     await closeDesktopWindow();
@@ -136,6 +138,7 @@ describe("desktop API environment detection", () => {
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_hide", undefined);
     expect(mockInvoke).toHaveBeenCalledWith("desktop_chat_window_destroy", undefined);
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_minimize", undefined);
+    expect(mockInvoke).toHaveBeenCalledWith("desktop_window_set_always_on_top", { alwaysOnTop: false });
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_toggle_maximize", undefined);
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_start_drag", undefined);
     expect(mockInvoke).toHaveBeenCalledWith("desktop_window_close", undefined);

--- a/test/unit/ai/vision/test_chat_vision_service.py
+++ b/test/unit/ai/vision/test_chat_vision_service.py
@@ -163,6 +163,23 @@ def test_missing_default_moondream_plugin_returns_recoverable_prompt(tmp_path: P
     assert "switch to a vision-capable model" in prepared.content
 
 
+def test_installed_moondream_without_torch_returns_recoverable_prompt(tmp_path: Path, monkeypatch):
+    image = _image_attachment(tmp_path)
+    # Moondream plugin directory is present, but its PyTorch runtime dependency is
+    # not importable: report it unavailable so the user gets the guidance prompt
+    # instead of a raw missing-module crash.
+    monkeypatch.setattr("ai.vision.service.installed_moondream_directory", lambda: tmp_path)
+    monkeypatch.setattr(
+        "ai.vision.service.importlib.util.find_spec",
+        lambda name: None if name == "torch" else object(),
+    )
+
+    prepared = ChatVisionService().prepare("Inspect", [image], adapter=_TextAdapter())
+
+    assert prepared.mode == "unavailable"
+    assert "switch to a vision-capable model" in prepared.content
+
+
 def test_file_attachments_are_read_locally_and_passed_to_the_llm(tmp_path: Path):
     document = tmp_path / "facts.txt"
     document.write_text("facts", encoding="utf-8")


### PR DESCRIPTION
Five fixes for the standalone Tauri desktop chat window (chat-stage):

1. Background drag: pressing a shown background now drags the window, mirroring the draggable-sprite affordance (BackgroundLayer onDragStart + media-layers.css pointer-events).
2. Taskbar: drop skip_taskbar(true) so the chat window can be restored from the taskbar after minimizing (frameless + skip_taskbar vanished with no way back).
3. Window pin toggle: new always-on-top section at the top of the chat settings dialog (desktop-only). Adds desktop_window_set_always_on_top command, runtimeConfig.alwaysOnTop (persisted), applied to the window on change.
4. Optimistic submission: keep the user's message on screen when a seq-advanced snapshot still carries the previous reply (guard in snapshotReplacesOptimisticPresentation) - no more flashing the prior turn.
5. File drop: disable_drag_drop_handler() on the chat window builder so HTML5 file drops reach the webview for attachment upload.

Adds reducer regression + desktopApi command tests. 697 frontend tests pass, tsc + prettier clean.

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次内容的重点收拢一下，方便快速查看。

该 PR 为独立 Tauri 聊天窗口加入置顶开关，并改进背景拖动、任务栏恢复、HTML5 附件拖放和乐观提交展示；但快照防闪烁判断会把真实的重复回复误认为旧状态。

### New Features

- 为独立 `chat-stage` 窗口新增持久化的“窗口置顶”开关及 Tauri 命令。

### Enhancements

- 支持拖动已显示的背景，允许聊天窗口从任务栏恢复，并将 HTML5 文件投放交给附件输入层。
- 增加对序号推进但仍显示前一回复的快照保护。

### Tests

- 新增 reducer 快照回归用例及 `desktopApi` 置顶命令参数测试。

<details>
<summary>Original summary in English</summary>

This PR adds a pin toggle for the standalone Tauri chat window and improves background dragging, taskbar recovery, HTML5 attachment drops, and optimistic-submission presentation; however, the snapshot anti-flash check mistakes a legitimate repeated reply for stale state.

### New Features

- Adds a persisted “Always on top” toggle and Tauri command for the standalone `chat-stage` window.

### Enhancements

- Enables dragging on displayed backgrounds, allows restoring the chat window from the taskbar, and routes HTML5 file drops to the attachment input.
- Adds protection for sequence-advanced snapshots that still show the previous reply.

### Tests

- Adds a reducer snapshot regression case and a `desktopApi` test for the pin-command arguments.

</details>

<!-- astrbot-review:end:summary -->