### PR TITLE
feat: allow authenticated reads of validated external media files

### DIFF
--- a/core/runtime/app_runtime.py
+++ b/core/runtime/app_runtime.py
@@ -56,6 +56,27 @@ def try_get_app_runtime() -> Optional[AppRuntime]:
     return _runtime
 
 
+def resolve_pending_tool_confirmation(selection: str) -> bool:
+    """Resolve pending risky-tool prompts from either native or streamed UIs."""
+    rt = try_get_app_runtime()
+    pending = getattr(rt, "_pending_confirm", None) if rt is not None else None
+    if not isinstance(pending, dict) or not pending:
+        return False
+
+    normalized = str(selection or "").strip().casefold()
+    confirmed = normalized not in {"取消", "cancel"}
+    resolved = False
+    for value in list(pending.values()):
+        try:
+            event, result_list = value
+            result_list.append(confirmed)
+            event.set()
+            resolved = True
+        except (AttributeError, TypeError, ValueError):
+            continue
+    return resolved
+
+
 def tts_emit_to_ui_queue(
     character_name: str,
     speech: str,

--- a/core/runtime/app_runtime.py
+++ b/core/runtime/app_runtime.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import secrets
+import threading
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
@@ -18,6 +20,48 @@ class UiPlaybackBridge:
     task_done_requested: Any = None
     dialog_channel: Any = None
     current_audio_path: Any = None
+
+
+@dataclass
+class PendingToolConfirmation:
+    confirmation_id: str
+    tool_name: str
+    event: threading.Event = field(default_factory=threading.Event)
+    confirmed: bool | None = None
+
+
+class ToolConfirmationController:
+    """Correlate one-time user decisions with the risky prompt that created them."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pending: dict[str, PendingToolConfirmation] = {}
+
+    def create(self, tool_name: str) -> PendingToolConfirmation:
+        prompt = PendingToolConfirmation(
+            confirmation_id=secrets.token_urlsafe(24),
+            tool_name=str(tool_name or ""),
+        )
+        with self._lock:
+            self._pending[prompt.confirmation_id] = prompt
+        return prompt
+
+    def resolve(self, confirmation_id: str, action: str) -> bool:
+        normalized_id = str(confirmation_id or "").strip()
+        normalized_action = str(action or "").strip().casefold()
+        if not normalized_id or normalized_action not in {"confirm", "cancel"}:
+            return False
+        with self._lock:
+            prompt = self._pending.pop(normalized_id, None)
+        if prompt is None:
+            return False
+        prompt.confirmed = normalized_action == "confirm"
+        prompt.event.set()
+        return True
+
+    def discard(self, confirmation_id: str) -> None:
+        with self._lock:
+            self._pending.pop(str(confirmation_id or "").strip(), None)
 
 
 @dataclass
@@ -36,12 +80,15 @@ class AppRuntime:
     effect_keyword_map: dict = field(default_factory=dict)  # keyword → audio_path
     ui_playback: UiPlaybackBridge = field(default_factory=UiPlaybackBridge)
     chat_turn_service: ChatTurnService = field(default_factory=ChatTurnService)
+    tool_confirmations: ToolConfirmationController = field(
+        default_factory=ToolConfirmationController
+    )
 
 
 _runtime: Optional[AppRuntime] = None
 
 
-def set_app_runtime(rt: AppRuntime) -> None:
+def set_app_runtime(rt: Optional[AppRuntime]) -> None:
     global _runtime
     _runtime = rt
 
@@ -56,25 +103,26 @@ def try_get_app_runtime() -> Optional[AppRuntime]:
     return _runtime
 
 
-def resolve_pending_tool_confirmation(selection: str) -> bool:
-    """Resolve pending risky-tool prompts from either native or streamed UIs."""
+def get_tool_confirmation_controller() -> ToolConfirmationController:
     rt = try_get_app_runtime()
-    pending = getattr(rt, "_pending_confirm", None) if rt is not None else None
-    if not isinstance(pending, dict) or not pending:
-        return False
+    if rt is None:
+        raise RuntimeError("application runtime is unavailable")
+    controller = getattr(rt, "tool_confirmations", None)
+    if not isinstance(controller, ToolConfirmationController):
+        controller = ToolConfirmationController()
+        rt.tool_confirmations = controller
+    return controller
 
-    normalized = str(selection or "").strip().casefold()
-    confirmed = normalized not in {"取消", "cancel"}
-    resolved = False
-    for value in list(pending.values()):
-        try:
-            event, result_list = value
-            result_list.append(confirmed)
-            event.set()
-            resolved = True
-        except (AttributeError, TypeError, ValueError):
-            continue
-    return resolved
+
+def resolve_pending_tool_confirmation(
+    confirmation_id: str,
+    action: str,
+) -> bool:
+    """Resolve exactly one risky-tool prompt using its one-time identifier."""
+    rt = try_get_app_runtime()
+    if rt is None:
+        return False
+    return get_tool_confirmation_controller().resolve(confirmation_id, action)
 
 
 def tts_emit_to_ui_queue(

--- a/core/runtime/event_sink.py
+++ b/core/runtime/event_sink.py
@@ -71,6 +71,7 @@ def make_empty_chat_snapshot() -> Dict[str, Any]:
         "stats": [],
         "status": "idle",
         "systemMessageText": "",
+        "toolConfirmation": None,
         "turnState": {
             "enabled": False,
             "pendingCount": 0,
@@ -277,10 +278,31 @@ def fold_event_into_snapshot(snapshot: Dict[str, Any], event: Dict[str, Any]) ->
     if event_type == "options.show":
         _clear_transient_notification_state(next_snapshot)
         next_snapshot["options"] = [str(item) for item in (event.get("options") or [])]
+        next_snapshot["toolConfirmation"] = None
         return next_snapshot
 
     if event_type == "options.clear":
         next_snapshot["options"] = []
+        return next_snapshot
+
+    if event_type == "tool.confirmation.show":
+        _clear_transient_notification_state(next_snapshot)
+        next_snapshot["options"] = []
+        next_snapshot["toolConfirmation"] = {
+            "confirmationId": str(event.get("confirmationId") or ""),
+            "detail": str(event.get("detail") or ""),
+            "risk": str(event.get("risk") or "high"),
+            "toolName": str(event.get("toolName") or ""),
+        }
+        return next_snapshot
+
+    if event_type == "tool.confirmation.clear":
+        current = next_snapshot.get("toolConfirmation")
+        confirmation_id = str(event.get("confirmationId") or "")
+        if isinstance(current, dict) and str(
+            current.get("confirmationId") or ""
+        ) == confirmation_id:
+            next_snapshot["toolConfirmation"] = None
         return next_snapshot
 
     if event_type == "history.replace":
@@ -491,6 +513,7 @@ def fold_event_into_snapshot(snapshot: Dict[str, Any], event: Dict[str, Any]) ->
         next_snapshot["sessionClosedReason"] = str(event.get("reason") or "")
         next_snapshot["status"] = "idle"
         next_snapshot["systemMessageText"] = ""
+        next_snapshot["toolConfirmation"] = None
         return next_snapshot
 
     return next_snapshot

--- a/core/runtime/ui_update_manager.py
+++ b/core/runtime/ui_update_manager.py
@@ -63,6 +63,35 @@ def get_character_by_name(name: str):
         return None
 
 
+def _native_tool_confirmation_options(
+    *,
+    confirmation_id: str,
+    tool_name: str,
+    detail: str = "",
+) -> list[dict[str, str]]:
+    from i18n import tr
+
+    confirm_label = tr("tool_confirmation.confirm", tool=tool_name)
+    if detail:
+        confirm_label = f"{confirm_label}\n{detail}"
+    base = {
+        "confirmationId": str(confirmation_id or ""),
+        "kind": "tool-confirmation",
+    }
+    return [
+        {
+            **base,
+            "action": "cancel",
+            "label": tr("common.cancel"),
+        },
+        {
+            **base,
+            "action": "confirm",
+            "label": confirm_label,
+        },
+    ]
+
+
 def _format_token_count(value: Any) -> str:
     try:
         count = max(0, int(value or 0))
@@ -170,9 +199,30 @@ class HeadlessUIUpdateManager:
     def hide_busy_bar(self) -> None:
         pass
 
-    def post_options(self, option_list: List[str]) -> None:
+    def post_options(self, option_list: List[Any]) -> None:
         if option_list:
             print(" / ".join(str(x) for x in option_list))
+
+    def post_tool_confirmation(
+        self,
+        *,
+        confirmation_id: str,
+        tool_name: str,
+        detail: str = "",
+        risk: str = "high",
+    ) -> None:
+        del risk
+        self.post_options(
+            _native_tool_confirmation_options(
+                confirmation_id=confirmation_id,
+                tool_name=tool_name,
+                detail=detail,
+            )
+        )
+
+    def clear_tool_confirmation(self, confirmation_id: str) -> None:
+        del confirmation_id
+        self.post_options([])
 
     def post_numeric_value(self, text: str) -> None:
         if text:
@@ -280,8 +330,29 @@ class UIUpdateManager(QObject):
     def hide_busy_bar(self) -> None:
         self.update_busy_bar_signal.emit("", 0.0)
 
-    def post_options(self, option_list: List[str]) -> None:
+    def post_options(self, option_list: List[Any]) -> None:
         self.update_option_signal.emit(option_list)
+
+    def post_tool_confirmation(
+        self,
+        *,
+        confirmation_id: str,
+        tool_name: str,
+        detail: str = "",
+        risk: str = "high",
+    ) -> None:
+        del risk
+        self.post_options(
+            _native_tool_confirmation_options(
+                confirmation_id=confirmation_id,
+                tool_name=tool_name,
+                detail=detail,
+            )
+        )
+
+    def clear_tool_confirmation(self, confirmation_id: str) -> None:
+        del confirmation_id
+        self.post_options([])
 
     def post_numeric_value(self, text: str) -> None:
         stats = parse_stat_payload(text)
@@ -626,13 +697,40 @@ class StreamingUIUpdateManager(HeadlessUIUpdateManager):
     def hide_busy_bar(self) -> None:
         self._sink.emit({"type": "busy.hide"})
 
-    def post_options(self, option_list: List[str]) -> None:
+    def post_options(self, option_list: List[Any]) -> None:
         options = [str(x) for x in (option_list or [])]
         if options:
             self._sink.emit({"type": "options.show", "options": options})
         else:
             self._sink.emit({"type": "options.clear"})
         self.sync_history_entries()
+
+    def post_tool_confirmation(
+        self,
+        *,
+        confirmation_id: str,
+        tool_name: str,
+        detail: str = "",
+        risk: str = "high",
+    ) -> None:
+        normalized_risk = "medium" if str(risk).casefold() == "medium" else "high"
+        self._sink.emit(
+            {
+                "type": "tool.confirmation.show",
+                "confirmationId": str(confirmation_id or ""),
+                "detail": str(detail or ""),
+                "risk": normalized_risk,
+                "toolName": str(tool_name or ""),
+            }
+        )
+
+    def clear_tool_confirmation(self, confirmation_id: str) -> None:
+        self._sink.emit(
+            {
+                "type": "tool.confirmation.clear",
+                "confirmationId": str(confirmation_id or ""),
+            }
+        )
 
     def post_numeric_value(self, text: str) -> None:
         stats = parse_stat_payload(text)
@@ -802,6 +900,8 @@ def connect_to_stream_sink(ui: UIUpdateManager, sink: "ChatEventSink") -> None:
     original_post_busy_bar = ui.post_busy_bar
     original_hide_busy_bar = ui.hide_busy_bar
     original_post_options = ui.post_options
+    original_post_tool_confirmation = getattr(ui, "post_tool_confirmation", None)
+    original_clear_tool_confirmation = getattr(ui, "clear_tool_confirmation", None)
     original_post_numeric_value = ui.post_numeric_value
     original_post_context_token_estimate = ui.post_context_token_estimate
     original_post_background = ui.post_background
@@ -859,9 +959,45 @@ def connect_to_stream_sink(ui: UIUpdateManager, sink: "ChatEventSink") -> None:
         original_hide_busy_bar()
         mirror.hide_busy_bar()
 
-    def post_options(option_list: List[str]) -> None:
+    def post_options(option_list: List[Any]) -> None:
         original_post_options(option_list)
         mirror.post_options(option_list)
+
+    def post_tool_confirmation(
+        *,
+        confirmation_id: str,
+        tool_name: str,
+        detail: str = "",
+        risk: str = "high",
+    ) -> None:
+        if callable(original_post_tool_confirmation):
+            original_post_tool_confirmation(
+                confirmation_id=confirmation_id,
+                tool_name=tool_name,
+                detail=detail,
+                risk=risk,
+            )
+        else:
+            original_post_options(
+                _native_tool_confirmation_options(
+                    confirmation_id=confirmation_id,
+                    tool_name=tool_name,
+                    detail=detail,
+                )
+            )
+        mirror.post_tool_confirmation(
+            confirmation_id=confirmation_id,
+            tool_name=tool_name,
+            detail=detail,
+            risk=risk,
+        )
+
+    def clear_tool_confirmation(confirmation_id: str) -> None:
+        if callable(original_clear_tool_confirmation):
+            original_clear_tool_confirmation(confirmation_id)
+        else:
+            original_post_options([])
+        mirror.clear_tool_confirmation(confirmation_id)
 
     def post_numeric_value(text: str) -> None:
         original_post_numeric_value(text)
@@ -920,6 +1056,8 @@ def connect_to_stream_sink(ui: UIUpdateManager, sink: "ChatEventSink") -> None:
     ui.post_busy_bar = post_busy_bar
     ui.hide_busy_bar = hide_busy_bar
     ui.post_options = post_options
+    ui.post_tool_confirmation = post_tool_confirmation
+    ui.clear_tool_confirmation = clear_tool_confirmation
     ui.post_numeric_value = post_numeric_value
     ui.post_context_token_estimate = post_context_token_estimate
     ui.post_background = post_background

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -29,6 +29,7 @@ import {
   StatLayer,
   StandaloneDesktopResizeHandles,
   TokenUsageLayer,
+  ToolConfirmationLayer,
 } from "./components/StageLayers";
 import { TopStageTools } from "./components/TopStageTools";
 import "./chat-stage.css";
@@ -410,6 +411,21 @@ export function ChatStagePage() {
     void sendCommand({ payload: option, type: "submit-option" });
   };
 
+  const resolveToolConfirmation = (action: "confirm" | "cancel") => {
+    const confirmation = state.toolConfirmation;
+    if (!confirmation) {
+      return;
+    }
+    void sendCommand({
+      payload: {
+        action,
+        confirmationId: confirmation.confirmationId,
+        kind: "tool-confirmation",
+      },
+      type: "submit-option",
+    });
+  };
+
   const updateRuntimeTextSpeed = (typewriterCps: number) => {
     setRuntimeConfig((current) => ({ ...current, typewriterCps }));
   };
@@ -673,7 +689,11 @@ export function ChatStagePage() {
         >
           {viewModel.layers.options ? (
             <>
-              <OptionsLayer hidden={false} onSelect={submitOption} options={viewModel.options} />
+              {viewModel.toolConfirmation ? (
+                <ToolConfirmationLayer confirmation={viewModel.toolConfirmation} onResolve={resolveToolConfirmation} />
+              ) : (
+                <OptionsLayer hidden={false} onSelect={submitOption} options={viewModel.options} />
+              )}
               {!dialogToolbarDetached ? <div className="dialog-layer__toolbar">{dialogToolbar}</div> : null}
             </>
           ) : (

--- a/frontend/src/features/chat-stage/components/StageLayers.tsx
+++ b/frontend/src/features/chat-stage/components/StageLayers.tsx
@@ -13,7 +13,7 @@ import { Clock, Coins, Gauge, Heart, Shield, Sparkles, Star, Target, Zap, type L
 import { startDesktopWindowResize, type DesktopResizeDirection } from "../../../shared/desktop/desktopApi";
 import { useI18n } from "../../../shared/i18n";
 import { PluginSlot, type PluginPageTarget } from "../../../shared/plugin/PluginSlot";
-import type { ChatStat } from "../../../shared/platform/types";
+import type { ChatStat, ChatToolConfirmation } from "../../../shared/platform/types";
 import { Button, ThemeFrame } from "../../../shared/ui";
 import type { ChatStageSprite } from "../chatState";
 import { classNames, hideBrokenStageAsset, layerClassName, stageAssetUrl } from "../chatStageUtils";
@@ -358,6 +358,45 @@ export function OptionsLayer({
               }}
             >
               {option}
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ToolConfirmationLayer({
+  confirmation,
+  onResolve,
+}: {
+  confirmation: ChatToolConfirmation;
+  onResolve: (action: "confirm" | "cancel") => void;
+}) {
+  const { t } = useI18n();
+  const choices = [
+    {
+      action: "cancel" as const,
+      label: t("common.cancel"),
+    },
+    {
+      action: "confirm" as const,
+      label: t("chat.toolConfirmation.confirm", {
+        tool: confirmation.toolName,
+      }),
+    },
+  ];
+  return (
+    <div className="options-layer" data-chat-stage-hitbox="true">
+      <div aria-label={t("chat.toolConfirmation.label")} className="options-layer__scroll" role="list">
+        {choices.map((choice, index) => (
+          <div className="options-layer__item" key={choice.action} role="listitem">
+            <ThemeFrame prefix="chat-option" />
+            <Button autoFocus={index === 0} className="options-layer__button" onClick={() => onResolve(choice.action)}>
+              <span>{choice.label}</span>
+              {choice.action === "confirm" && confirmation.detail ? (
+                <small className="options-layer__detail">{confirmation.detail}</small>
+              ) : null}
             </Button>
           </div>
         ))}

--- a/frontend/src/features/chat-stage/state/events.ts
+++ b/frontend/src/features/chat-stage/state/events.ts
@@ -170,12 +170,37 @@ export function applyStageEvent(state: ChatStageState, event: ChatStageEvent): C
         ...clearTransientNotificationState(state),
         eventSeq: Math.max(state.eventSeq, event.seq),
         options: event.options,
+        toolConfirmation: null,
       });
     case "options.clear":
       return withResolvedLayers({
         ...state,
         eventSeq: Math.max(state.eventSeq, event.seq),
         options: [],
+      });
+    case "tool.confirmation.show":
+      return withResolvedLayers({
+        ...clearTransientNotificationState(state),
+        eventSeq: Math.max(state.eventSeq, event.seq),
+        options: [],
+        toolConfirmation: {
+          confirmationId: event.confirmationId,
+          detail: event.detail,
+          risk: event.risk,
+          toolName: event.toolName,
+        },
+      });
+    case "tool.confirmation.clear":
+      if (state.toolConfirmation && state.toolConfirmation.confirmationId !== event.confirmationId) {
+        return withResolvedLayers({
+          ...state,
+          eventSeq: Math.max(state.eventSeq, event.seq),
+        });
+      }
+      return withResolvedLayers({
+        ...state,
+        eventSeq: Math.max(state.eventSeq, event.seq),
+        toolConfirmation: null,
       });
     case "numeric.update":
       return withResolvedLayers({
@@ -277,6 +302,7 @@ export function applyStageEvent(state: ChatStageState, event: ChatStageEvent): C
         sessionClosedReason: event.reason,
         status: "idle",
         systemMessageText: undefined,
+        toolConfirmation: null,
       });
     default:
       return state;

--- a/frontend/src/features/chat-stage/state/initialState.ts
+++ b/frontend/src/features/chat-stage/state/initialState.ts
@@ -16,6 +16,7 @@ export const emptyChatState: ChatStageState = {
   sprites: [],
   stats: [],
   status: "idle",
+  toolConfirmation: null,
   transportMode: "snapshot",
   transportState: "connecting",
   turnOptions: {

--- a/frontend/src/features/chat-stage/state/layers.ts
+++ b/frontend/src/features/chat-stage/state/layers.ts
@@ -23,7 +23,7 @@ export function clearTransientNotificationState(state: ChatStageState) {
 }
 
 export function withResolvedLayers(state: ChatStageState): ChatStageState {
-  const optionsVisible = state.options.length > 0;
+  const optionsVisible = state.options.length > 0 || Boolean(state.toolConfirmation);
   return {
     ...state,
     layers: {

--- a/frontend/src/features/chat-stage/state/snapshot.ts
+++ b/frontend/src/features/chat-stage/state/snapshot.ts
@@ -47,6 +47,7 @@ export function hydrateFromSnapshot(state: ChatStageState, snapshot: ChatSnapsho
     })),
     sprites: normalizeChatStageSprites(snapshot.sprites.map((sprite) => ({ ...sprite }))),
     stats: (snapshot.stats ?? []).map((stat) => ({ ...stat })),
+    toolConfirmation: snapshot.toolConfirmation ? { ...snapshot.toolConfirmation } : null,
     turnOptions: { ...emptyChatState.turnOptions, ...snapshot.turnOptions },
     turnState: {
       ...emptyChatState.turnState,

--- a/frontend/src/features/chat-stage/state/types.ts
+++ b/frontend/src/features/chat-stage/state/types.ts
@@ -6,6 +6,7 @@ import type {
   ChatSprite,
   ChatStat,
   ChatStageEvent,
+  ChatToolConfirmation,
   ChatTurnOptions,
   ChatTurnState,
   ChatTransportMode,
@@ -91,6 +92,7 @@ export interface ChatStageViewModel {
   status: ChatRuntimeStatus;
   statusText: string;
   tokenUsageText?: string;
+  toolConfirmation?: ChatToolConfirmation | null;
   transportMode: ChatTransportMode;
   transportState: ChatTransportState;
   userDisplayName: string;

--- a/frontend/src/features/chat-stage/state/viewModel.ts
+++ b/frontend/src/features/chat-stage/state/viewModel.ts
@@ -43,6 +43,7 @@ export function buildChatStageViewModel(state: ChatStageState): ChatStageViewMod
     dialogText: systemPromptText ? "" : dialog.dialogText,
     inputAttachments: state.inputAttachments,
     inputDisabled:
+      Boolean(state.toolConfirmation) ||
       !state.layers.input ||
       ((state.status === "generating" || state.status === "streaming") && !state.turnOptions.interruptEnabled),
     inputDraft: state.inputDraft,
@@ -54,6 +55,7 @@ export function buildChatStageViewModel(state: ChatStageState): ChatStageViewMod
     status: state.status,
     statusText: state.status,
     tokenUsageText,
+    toolConfirmation: state.toolConfirmation,
     transportMode: state.transportMode,
     transportState: state.transportState,
     userDisplayName: normalizedUserDisplayName(state.userDisplayName),

--- a/frontend/src/features/chat-stage/styles/options-layer.css
+++ b/frontend/src/features/chat-stage/styles/options-layer.css
@@ -109,6 +109,15 @@
   white-space: normal;
 }
 
+.options-layer__detail {
+  display: block;
+  margin-top: 0.35rem;
+  color: color-mix(in srgb, currentColor 72%, transparent);
+  font-size: 0.82em;
+  font-weight: 450;
+  overflow-wrap: anywhere;
+}
+
 .options-layer__button::before {
   position: absolute;
   top: 50%;

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -434,6 +434,8 @@ export type MessageKey =
   | "chat.actionBar.skip"
   | "chat.actionBar.title"
   | "chat.options.label"
+  | "chat.toolConfirmation.confirm"
+  | "chat.toolConfirmation.label"
   | "chat.actionBar.unlock"
   | "chat.config.dialogOpacity"
   | "chat.config.dialogOpacityValue"

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -3,6 +3,8 @@ import type { MessageKey } from "../messages";
 export const enMessages: Record<MessageKey, string> = {
   "chat.stats.label": "Character stats",
   "chat.options.label": "Dialogue choices",
+  "chat.toolConfirmation.confirm": "Confirm {tool}",
+  "chat.toolConfirmation.label": "Tool confirmation",
   "api.memory.checkModel": "Check",
   "api.memory.cachedNotLoaded": "Long-term memory is ready",
   "api.memory.checking": "Checking",

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -3,6 +3,8 @@ import type { MessageKey } from "../messages";
 export const jaMessages: Record<MessageKey, string> = {
   "chat.stats.label": "キャラクターステータス",
   "chat.options.label": "会話の選択肢",
+  "chat.toolConfirmation.confirm": "{tool} の実行を確認",
+  "chat.toolConfirmation.label": "ツール実行の確認",
   "api.memory.checkModel": "確認",
   "api.memory.cachedNotLoaded": "長期記憶は準備完了です",
   "api.memory.enableReady": "自動長期記憶を有効にしました。",

--- a/frontend/src/shared/i18n/messages/zh_CN.ts
+++ b/frontend/src/shared/i18n/messages/zh_CN.ts
@@ -3,6 +3,8 @@ import type { MessageKey } from "../messages";
 export const zhCNMessages: Record<MessageKey, string> = {
   "chat.stats.label": "角色状态",
   "chat.options.label": "对话选项",
+  "chat.toolConfirmation.confirm": "确认执行 {tool}",
+  "chat.toolConfirmation.label": "工具执行确认",
   "api.memory.checkModel": "检查",
   "api.memory.cachedNotLoaded": "长期记忆已就绪",
   "api.memory.enableReady": "自动长期记忆已启用。",

--- a/frontend/src/shared/platform/types.ts
+++ b/frontend/src/shared/platform/types.ts
@@ -868,6 +868,13 @@ export interface ChatStat {
   value: number;
 }
 
+export interface ChatToolConfirmation {
+  confirmationId: string;
+  detail?: string;
+  risk: "high" | "medium";
+  toolName: string;
+}
+
 export interface PluginPagePresentation {
   mode: "overlay";
   pageId: string;
@@ -911,6 +918,7 @@ export interface ChatSnapshot {
   status: ChatRuntimeStatus;
   statusMessage?: string;
   systemMessageText?: string;
+  toolConfirmation?: ChatToolConfirmation | null;
   turnOptions?: ChatTurnOptions;
   turnState?: ChatTurnState;
   userDisplayName?: string;
@@ -1023,6 +1031,14 @@ export type ChatStageEvent =
   | (ChatEventBase & { type: "cg.hide" })
   | (ChatEventBase & { type: "options.show"; options: string[] })
   | (ChatEventBase & { type: "options.clear" })
+  | (ChatEventBase & {
+      type: "tool.confirmation.show";
+      confirmationId: string;
+      detail?: string;
+      risk: "high" | "medium";
+      toolName: string;
+    })
+  | (ChatEventBase & { type: "tool.confirmation.clear"; confirmationId: string })
   | (ChatEventBase & { type: "numeric.update"; html: string })
   | (ChatEventBase & { type: "stats.update"; stats: ChatStat[] })
   | (ChatEventBase & { type: "busy.show"; text: string; durationSeconds: number })

--- a/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
+++ b/frontend/src/test/features/chat-stage/ChatStagePage.test.tsx
@@ -305,6 +305,39 @@ describe("ChatStagePage", () => {
     );
   });
 
+  it("renders localized correlated tool confirmation controls without submitting dialog text", async () => {
+    mocks.getChatSnapshot.mockResolvedValue(
+      snapshot({
+        toolConfirmation: {
+          confirmationId: "prompt-1",
+          detail: "path=D:/notes/plan.txt",
+          risk: "high",
+          toolName: "file_write",
+        },
+      }),
+    );
+    renderPage();
+
+    const cancel = await screen.findByRole("button", { name: "Cancel" });
+    expect(screen.getByRole("list", { name: "Tool confirmation" })).toContainElement(cancel);
+    expect(screen.getByRole("button", { name: /Confirm file_write/ })).toBeInTheDocument();
+    expect(cancel).toHaveFocus();
+
+    fireEvent.click(cancel);
+
+    await waitFor(() =>
+      expect(mocks.sendChatCommand).toHaveBeenCalledWith({
+        payload: {
+          action: "cancel",
+          confirmationId: "prompt-1",
+          kind: "tool-confirmation",
+        },
+        type: "submit-option",
+      }),
+    );
+    expect(screen.queryByText("Aoi: Cancel")).not.toBeInTheDocument();
+  });
+
   it("exposes notifications as status updates and softens them over sprites", async () => {
     mocks.getChatSnapshot.mockResolvedValue(
       snapshot({

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -865,6 +865,52 @@ describe("chatStageReducer", () => {
     expect(hidden.layers.busy).toBe(false);
   });
 
+  it("correlates tool confirmation events and disables free-form input", () => {
+    const prompted = chatStageReducer(emptyChatState, {
+      event: {
+        confirmationId: "prompt-1",
+        detail: "path=D:/notes/plan.txt",
+        risk: "high",
+        seq: 1,
+        toolName: "file_write",
+        ts: 1,
+        type: "tool.confirmation.show",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(prompted.toolConfirmation?.confirmationId).toBe("prompt-1");
+    expect(prompted.layers.options).toBe(true);
+    expect(buildChatStageViewModel(prompted).inputDisabled).toBe(true);
+
+    const staleClear = chatStageReducer(prompted, {
+      event: {
+        confirmationId: "prompt-old",
+        seq: 2,
+        ts: 2,
+        type: "tool.confirmation.clear",
+        v: 1,
+      },
+      type: "event",
+    });
+    expect(staleClear.toolConfirmation?.confirmationId).toBe("prompt-1");
+
+    const matchingClear = chatStageReducer(staleClear, {
+      event: {
+        confirmationId: "prompt-1",
+        seq: 3,
+        ts: 3,
+        type: "tool.confirmation.clear",
+        v: 1,
+      },
+      type: "event",
+    });
+    expect(matchingClear.toolConfirmation).toBeNull();
+    expect(matchingClear.layers.options).toBe(false);
+    expect(buildChatStageViewModel(matchingClear).inputDisabled).toBe(false);
+  });
+
   it("updates token usage text and clears sprites by character name", () => {
     const withSprite = chatStageReducer(emptyChatState, {
       event: {

--- a/frontend_bridge_core/chat.py
+++ b/frontend_bridge_core/chat.py
@@ -1065,6 +1065,28 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
     if command in {"chat-input-state", "flush-input-batch", "cancel-input-batch"}:
         return _forward_runtime_command(_current_runtime_status())
 
+    if command == "submit-option" and isinstance(body.get("payload"), dict):
+        payload = body["payload"]
+        if payload.get("kind") != "tool-confirmation":
+            raise ValueError("Option selection must be a string.")
+        confirmation_id = reject_control_chars(
+            str(payload.get("confirmationId") or "").strip(),
+            field="confirmationId",
+        )
+        action = str(payload.get("action") or "").strip().casefold()
+        if (
+            not confirmation_id
+            or len(confirmation_id) > 128
+            or action not in {"confirm", "cancel"}
+        ):
+            raise ValueError("Tool confirmation response is invalid.")
+        body["payload"] = {
+            "action": action,
+            "confirmationId": confirmation_id,
+            "kind": "tool-confirmation",
+        }
+        return _forward_runtime_command(_current_runtime_status())
+
     if command in {"send-message", "submit-option"}:
         attachments = []
         payload = body.get("payload")

--- a/frontend_bridge_core/chat_stream.py
+++ b/frontend_bridge_core/chat_stream.py
@@ -6,6 +6,7 @@ import contextlib
 import hashlib
 import hmac
 import json
+import secrets
 import threading
 import time
 import uuid
@@ -19,6 +20,22 @@ from core.runtime.event_sink import (
     fold_event_into_snapshot,
     make_empty_chat_snapshot,
 )
+from frontend_bridge_core.media_paths import (
+    is_absolute_local_media_path_text,
+    is_supported_media_path_text,
+)
+
+
+_MEDIA_EVENT_TYPES = {
+    "background.change",
+    "bgm.change",
+    "cg.show",
+    "effect.loop.start",
+    "effect.play",
+    "sprite.show",
+    "tts.play",
+}
+_MAX_APPROVED_EXTERNAL_MEDIA_PATHS = 2048
 
 
 def _external_host(bind_host: str) -> str:
@@ -83,6 +100,10 @@ class _ChatStreamSession:
     session_id: str
     snapshot: dict[str, Any]
     last_seq: int = 0
+    producer_token: str = field(
+        default_factory=lambda: secrets.token_urlsafe(32),
+        repr=False,
+    )
     producer: _WebSocketConnection | None = None
     producer_ready: threading.Event = field(default_factory=threading.Event, repr=False)
     viewers: set[_WebSocketConnection] = field(default_factory=set)
@@ -129,6 +150,7 @@ class ChatStreamService:
         self.ws_base = _ws_base(host, self.ws_port)
         self.auth_token = str(auth_token or "").strip()
         self._sessions: dict[str, _ChatStreamSession] = {}
+        self._approved_external_media_paths: dict[str, float] = {}
         self._lock = threading.Lock()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._server: asyncio.base_events.Server | None = None
@@ -180,13 +202,18 @@ class ChatStreamService:
         except (TypeError, ValueError):
             initial_seq = 0
         snapshot["eventSeq"] = initial_seq
+        session = _ChatStreamSession(
+            session_id=session_id,
+            snapshot=snapshot,
+            last_seq=initial_seq,
+        )
         with self._lock:
-            self._sessions[session_id] = _ChatStreamSession(
-                session_id=session_id,
-                snapshot=snapshot,
-                last_seq=initial_seq,
-            )
+            self._sessions[session_id] = session
         producer_endpoint = f"{self.ws_base}?sessionId={quote(session_id)}&role=producer"
+        producer_endpoint = _append_query(
+            producer_endpoint,
+            {"shinsekai_producer_token": session.producer_token},
+        )
         if self.auth_token:
             producer_endpoint = _append_query(
                 producer_endpoint,
@@ -317,10 +344,50 @@ class ChatStreamService:
             return ""
         if _is_direct_media_path(path):
             return path
+        self.approve_external_media_path(path)
         return _append_query(
             f"{self.http_base}/api/media?path={quote(path)}",
             {"shinsekai_bridge_token": self.auth_token},
         )
+
+    def approve_external_media_path(self, raw_path: str) -> bool:
+        path = str(raw_path or "").strip()
+        if not (
+            is_absolute_local_media_path_text(path)
+            and is_supported_media_path_text(path)
+        ):
+            return False
+        with self._lock:
+            self._approved_external_media_paths[path] = time.time()
+            overflow = (
+                len(self._approved_external_media_paths)
+                - _MAX_APPROVED_EXTERNAL_MEDIA_PATHS
+            )
+            if overflow > 0:
+                oldest = sorted(
+                    self._approved_external_media_paths,
+                    key=self._approved_external_media_paths.get,
+                )[:overflow]
+                for candidate in oldest:
+                    self._approved_external_media_paths.pop(candidate, None)
+        return True
+
+    def approved_external_media_paths(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(self._approved_external_media_paths)
+
+    def _approve_event_media_path(self, event: dict[str, Any]) -> None:
+        if str(event.get("type") or "") not in _MEDIA_EVENT_TYPES:
+            return
+        media_url = str(event.get("url") or "").strip()
+        if not media_url:
+            return
+        parsed = urlparse(media_url)
+        if parsed.path != "/api/media":
+            return
+        query = parse_qs(parsed.query)
+        raw_path = str((query.get("path") or [""])[0]).strip()
+        self.approve_external_media_path(raw_path)
 
     async def _shutdown_async(self) -> None:
         server = self._server
@@ -416,15 +483,24 @@ class ChatStreamService:
         query = parse_qs(parsed.query)
         session_id = str((query.get("sessionId") or [""])[0]).strip()
         role = str((query.get("role") or ["viewer"])[0]).strip() or "viewer"
+        if role not in {"producer", "viewer"}:
+            raise ValueError("invalid websocket role")
         auth_token = str((query.get("shinsekai_bridge_token") or query.get("token") or [""])[0]).strip()
+        producer_token = str(
+            (query.get("shinsekai_producer_token") or [""])[0]
+        ).strip()
         if not session_id:
             raise ValueError("missing sessionId")
-        if self.auth_token and not hmac.compare_digest(auth_token, self.auth_token):
-            raise ValueError("invalid websocket auth token")
         with self._lock:
             session = self._sessions.get(session_id)
             if session is None:
                 raise ValueError("unknown session")
+            expected_producer_token = session.producer_token
+        if role == "producer":
+            if not hmac.compare_digest(producer_token, expected_producer_token):
+                raise ValueError("invalid websocket producer token")
+        elif self.auth_token and not hmac.compare_digest(auth_token, self.auth_token):
+            raise ValueError("invalid websocket auth token")
         key = headers.get("sec-websocket-key", "")
         accept = base64.b64encode(
             hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode("utf-8")).digest()
@@ -471,6 +547,7 @@ class ChatStreamService:
                 await self._publish_event(connection.session_id, event)
 
     async def _publish_event(self, session_id: str, event: dict[str, Any]) -> None:
+        self._approve_event_media_path(event)
         with self._lock:
             session = self._sessions.get(session_id)
             if session is None:

--- a/frontend_bridge_core/handler.py
+++ b/frontend_bridge_core/handler.py
@@ -104,6 +104,10 @@ from frontend_bridge_core.model_assets import (
 from frontend_bridge_core.config import _app_config_response, _fetch_llm_models, _save_api_config, _test_llm_connection
 from frontend_bridge_core.logs import _default_log_snapshot, _diagnostic_bundle, _log_file_list, _log_snapshot
 from frontend_bridge_core.media import _media_thumbnail, _media_thumbnail_batch
+from frontend_bridge_core.media_paths import (
+    resolve_external_media_file,
+    validate_readable_media_file,
+)
 from frontend_bridge_core.image_annotations import (
     run_background_image_auto_label,
     run_character_sprite_auto_label,
@@ -295,6 +299,12 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         if not self._request_origin_allowed():
             raise PermissionError("request origin is not allowed")
         if path.startswith("/api/") and not self._has_valid_auth_token():
+            raise PermissionError("invalid bridge auth token")
+
+    def _require_authorized_media_read(self) -> None:
+        if not self._request_origin_allowed():
+            raise PermissionError("request origin is not allowed")
+        if not self._has_valid_auth_token():
             raise PermissionError("invalid bridge auth token")
 
     def _send_cors(self) -> None:
@@ -539,9 +549,10 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 target = unquote((query.get("path") or [""])[0])
                 self._send_file(target, attachment=True)
             elif path == "/api/media":
+                self._require_authorized_media_read()
                 query = parse_qs(parsed.query)
                 target = unquote((query.get("path") or [""])[0])
-                self._send_file(target, attachment=False)
+                self._send_media_file(target)
             elif path == "/api/media/thumbnail":
                 query = parse_qs(parsed.query)
                 target = unquote((query.get("path") or [""])[0])
@@ -578,9 +589,10 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 target = unquote((query.get("path") or [""])[0])
                 self._send_file(target, attachment=True, send_body=False)
             elif path == "/api/media":
+                self._require_authorized_media_read()
                 query = parse_qs(parsed.query)
                 target = unquote((query.get("path") or [""])[0])
-                self._send_file(target, attachment=False, send_body=False)
+                self._send_media_file(target, send_body=False)
             elif path == "/api/media/thumbnail":
                 query = parse_qs(parsed.query)
                 target = unquote((query.get("path") or [""])[0])
@@ -1519,6 +1531,14 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 return path
         return first_valid if first_valid is not None else safe_project_path(raw)
 
+    def _resolve_media_path(self, raw_path: str) -> Path:
+        raw = str(raw_path or "").strip()
+        if not raw:
+            raise FileNotFoundError(raw_path)
+        if Path(raw).is_absolute():
+            return resolve_external_media_file(raw)
+        return validate_readable_media_file(self._resolve_project_path(raw))
+
     def _resolve_static_path(self, root: Path, request_path: str) -> Path:
         return safe_child_path(root, request_path)
 
@@ -1674,6 +1694,18 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         self._send_local_file(
             self._resolve_project_path(relative_path),
             attachment=attachment,
+            send_body=send_body,
+        )
+
+    def _send_media_file(
+        self,
+        path: str,
+        *,
+        send_body: bool = True,
+    ) -> None:
+        self._send_local_file(
+            self._resolve_media_path(path),
+            attachment=False,
             send_body=send_body,
         )
 

--- a/frontend_bridge_core/handler.py
+++ b/frontend_bridge_core/handler.py
@@ -105,6 +105,8 @@ from frontend_bridge_core.config import _app_config_response, _fetch_llm_models,
 from frontend_bridge_core.logs import _default_log_snapshot, _diagnostic_bundle, _log_file_list, _log_snapshot
 from frontend_bridge_core.media import _media_thumbnail, _media_thumbnail_batch
 from frontend_bridge_core.media_paths import (
+    is_absolute_local_media_path_text,
+    iter_configured_external_media_paths,
     resolve_external_media_file,
     validate_readable_media_file,
 )
@@ -1535,8 +1537,22 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         raw = str(raw_path or "").strip()
         if not raw:
             raise FileNotFoundError(raw_path)
-        if Path(raw).is_absolute():
-            return resolve_external_media_file(raw)
+        if is_absolute_local_media_path_text(raw):
+            config_manager = getattr(self.state, "config_manager", None)
+            config = getattr(config_manager, "config", None)
+            approved_paths = list(iter_configured_external_media_paths(config))
+            chat_stream = getattr(self.state, "chat_stream", None)
+            runtime_paths = getattr(
+                chat_stream,
+                "approved_external_media_paths",
+                None,
+            )
+            if callable(runtime_paths):
+                approved_paths.extend(runtime_paths())
+            return resolve_external_media_file(
+                raw,
+                approved_paths=approved_paths,
+            )
         return validate_readable_media_file(self._resolve_project_path(raw))
 
     def _resolve_static_path(self, root: Path, request_path: str) -> Path:

--- a/frontend_bridge_core/media_paths.py
+++ b/frontend_bridge_core/media_paths.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path, PureWindowsPath
+
+from frontend_bridge_core.security import reject_control_chars
+
+
+IMAGE_MEDIA_SUFFIXES = frozenset(
+    {
+        ".apng",
+        ".avif",
+        ".bmp",
+        ".gif",
+        ".ico",
+        ".jpeg",
+        ".jpg",
+        ".png",
+        ".svg",
+        ".webp",
+    }
+)
+AUDIO_MEDIA_SUFFIXES = frozenset(
+    {
+        ".aac",
+        ".aif",
+        ".aiff",
+        ".flac",
+        ".m4a",
+        ".mp3",
+        ".oga",
+        ".ogg",
+        ".opus",
+        ".wav",
+        ".weba",
+        ".wma",
+    }
+)
+VIDEO_MEDIA_SUFFIXES = frozenset(
+    {
+        ".avi",
+        ".m4v",
+        ".mkv",
+        ".mov",
+        ".mp4",
+        ".mpeg",
+        ".mpg",
+        ".ogv",
+        ".webm",
+        ".wmv",
+    }
+)
+FONT_MEDIA_SUFFIXES = frozenset({".otf", ".ttf", ".woff", ".woff2"})
+READABLE_MEDIA_SUFFIXES = (
+    IMAGE_MEDIA_SUFFIXES
+    | AUDIO_MEDIA_SUFFIXES
+    | VIDEO_MEDIA_SUFFIXES
+    | FONT_MEDIA_SUFFIXES
+)
+
+_WINDOWS_DEVICE_PREFIXES = ("\\\\.\\", "\\\\?\\", "\\??\\")
+
+
+def _validate_windows_local_drive_path(raw_path: str) -> None:
+    value = raw_path.replace("/", "\\")
+    if value.startswith(_WINDOWS_DEVICE_PREFIXES):
+        raise PermissionError("Windows device paths are not allowed for media")
+    if value.startswith("\\\\"):
+        raise PermissionError("UNC paths are not allowed for media")
+
+    path = PureWindowsPath(value)
+    if not path.drive or not path.root:
+        raise PermissionError("external media path must use an absolute local drive path")
+    if ":" in value[len(path.drive) :]:
+        raise PermissionError("Windows alternate data streams are not allowed for media")
+
+
+def resolve_external_media_file(raw_path: str | os.PathLike[str]) -> Path:
+    raw = reject_control_chars(os.fspath(raw_path), field="media path")
+    if os.name == "nt":
+        _validate_windows_local_drive_path(raw)
+
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        raise PermissionError("external media path must be absolute")
+    return validate_readable_media_file(candidate)
+
+
+def validate_readable_media_file(path: Path) -> Path:
+    resolved = path.expanduser().resolve(strict=True)
+    if resolved.suffix.lower() not in READABLE_MEDIA_SUFFIXES:
+        raise PermissionError("file type is not allowed for media")
+    if not stat.S_ISREG(resolved.stat().st_mode):
+        raise PermissionError("media path must reference a regular file")
+    return resolved

--- a/frontend_bridge_core/media_paths.py
+++ b/frontend_bridge_core/media_paths.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hmac
 import os
 import stat
+from collections.abc import Iterable, Iterator
 from pathlib import Path, PureWindowsPath
+from typing import Any
 
 from frontend_bridge_core.security import reject_control_chars
 
@@ -76,12 +79,71 @@ def _validate_windows_local_drive_path(raw_path: str) -> None:
         raise PermissionError("Windows alternate data streams are not allowed for media")
 
 
-def resolve_external_media_file(raw_path: str | os.PathLike[str]) -> Path:
-    raw = reject_control_chars(os.fspath(raw_path), field="media path")
-    if os.name == "nt":
-        _validate_windows_local_drive_path(raw)
+def is_supported_media_path_text(raw_path: str) -> bool:
+    value = str(raw_path or "").strip().lower()
+    return any(value.endswith(suffix) for suffix in READABLE_MEDIA_SUFFIXES)
 
-    candidate = Path(raw).expanduser()
+
+def is_absolute_local_media_path_text(raw_path: str) -> bool:
+    value = str(raw_path or "").strip()
+    if not value:
+        return False
+    if os.name == "nt":
+        normalized = value.replace("/", "\\")
+        path = PureWindowsPath(normalized)
+        return bool(
+            not normalized.startswith("\\\\")
+            and not normalized.startswith(_WINDOWS_DEVICE_PREFIXES)
+            and path.drive
+            and path.root
+        )
+    return os.path.isabs(value)
+
+
+def iter_configured_external_media_paths(value: Any) -> Iterator[str]:
+    """Yield absolute media paths from server-owned configuration values."""
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="python")
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from iter_configured_external_media_paths(item)
+        return
+    if isinstance(value, (list, tuple, set, frozenset)):
+        for item in value:
+            yield from iter_configured_external_media_paths(item)
+        return
+    if isinstance(value, os.PathLike):
+        value = os.fspath(value)
+    if isinstance(value, str) and is_absolute_local_media_path_text(value):
+        if is_supported_media_path_text(value):
+            yield value.strip()
+
+
+def resolve_external_media_file(
+    raw_path: str | os.PathLike[str],
+    *,
+    approved_paths: Iterable[str | os.PathLike[str]],
+) -> Path:
+    raw = reject_control_chars(os.fsdecode(os.fspath(raw_path)), field="media path")
+    approved = ""
+    for candidate in approved_paths:
+        candidate_text = reject_control_chars(
+            os.fsdecode(os.fspath(candidate)),
+            field="approved media path",
+        )
+        if hmac.compare_digest(
+            raw.encode("utf-8"),
+            candidate_text.encode("utf-8"),
+        ):
+            approved = candidate_text
+            break
+    if not approved:
+        raise PermissionError("external media path has not been approved by the runtime")
+
+    if os.name == "nt":
+        _validate_windows_local_drive_path(approved)
+
+    candidate = Path(approved).expanduser()
     if not candidate.is_absolute():
         raise PermissionError("external media path must be absolute")
     return validate_readable_media_file(candidate)

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -647,10 +647,15 @@
     "yes": "Yes",
     "no": "No",
     "auto": "Auto",
+    "cancel": "Cancel",
     "msg_qtmm_unavailable": "Cannot play audio: PySide6.QtMultimedia is not available. This often happens with a merged PyInstaller bundle; rebuild without --merge (separate onedir for Settings and the main app) and ship both, or run from a normal Python venv.",
     "ai_working_title": "AI in progress",
     "ai_progress_write": "Generating character setting…",
     "ai_progress_translate": "Translating…"
+  },
+  "tool_confirmation": {
+    "confirm": "⚠️ Confirm {tool}",
+    "timeout": "Tool {tool} was cancelled because confirmation timed out."
   },
   "template_gen": {
     "narr_token": "NARR",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -644,10 +644,15 @@
     "yes": "はい",
     "no": "いいえ",
     "auto": "自動",
+    "cancel": "キャンセル",
     "msg_qtmm_unavailable": "再生できません: PySide6.QtMultimedia が利用できません。PyInstaller MERGE ビルドでよく起きます。--merge なしで Settings と本編を別 onedir にするか、通常の venv から起動してください。",
     "ai_working_title": "AI 処理中",
     "ai_progress_write": "キャラ設定を生成しています…",
     "ai_progress_translate": "翻訳しています…"
+  },
+  "tool_confirmation": {
+    "confirm": "⚠️ {tool} の実行を確認",
+    "timeout": "確認がタイムアウトしたため、ツール {tool} をキャンセルしました。"
   },
   "template_gen": {
     "narr_token": "NARR",

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -644,10 +644,15 @@
     "yes": "是",
     "no": "否",
     "auto": "自动",
+    "cancel": "取消",
     "msg_qtmm_unavailable": "无法播放：本环境未加载 PySide6 多媒体 (QtMultimedia)。合并多包 (MERGE) 时常见。可改「分两次、不打 --merge 单独打 Settings 与主程序」整包同目录发布，或在本机用 Python 运行。",
     "ai_working_title": "AI 处理中",
     "ai_progress_write": "正在生成角色设定，请稍候…",
     "ai_progress_translate": "正在翻译，请稍候…"
+  },
+  "tool_confirmation": {
+    "confirm": "⚠️ 确认执行 {tool}",
+    "timeout": "工具 {tool} 等待确认超时，已取消。"
   },
   "template_gen": {
     "narr_token": "旁白",

--- a/llm/llm_manager.py
+++ b/llm/llm_manager.py
@@ -2,7 +2,6 @@ from asyncio import Queue
 import copy
 from dataclasses import dataclass, field
 import json
-import threading
 import time
 from datetime import datetime
 from threading import Thread
@@ -16,7 +15,10 @@ from core.messaging.stream_events import (
     STREAM_DIALOG_REPAIR_KEY,
     STREAM_REASONING_DELTA_KEY,
 )
-from core.runtime.app_runtime import try_get_app_runtime
+from core.runtime.app_runtime import (
+    get_tool_confirmation_controller,
+    try_get_app_runtime,
+)
 from i18n import tr
 from llm.llm_adapter import LLMAdapter, DeepSeekAdapter, OpenAIAdapter, GeminiAdapter, ClaudeAdapter
 from llm.compact_manager import CompactManager
@@ -312,7 +314,6 @@ class LLMManager:
         if risk == "low":
             return True
         try:
-            from core.runtime.app_runtime import try_get_app_runtime
             rt = try_get_app_runtime()
             if rt is None:
                 return risk != "high"
@@ -332,20 +333,58 @@ class LLMManager:
                     detail = " · ".join(parts[:6])
             except Exception:
                 detail = args_str[:120] if args_str else ""
-            summary = f"{tool_name}" + (f"\n{detail}" if detail else "")
-            event = threading.Event()
-            confirm_result: list[bool] = []
-            if not hasattr(rt, '_pending_confirm'):
-                rt._pending_confirm = {}
-            rt._pending_confirm[tool_name] = (event, confirm_result)
-            warn = "⚠️" if risk == "high" else "⚡"
-            ui.post_options([f"{warn} 确认 {summary}", "取消"])
-            resolved = event.wait(timeout=30.0)
-            rt._pending_confirm.pop(tool_name, None)
+            controller = get_tool_confirmation_controller()
+            prompt = controller.create(tool_name)
+            try:
+                if hasattr(ui, "post_tool_confirmation"):
+                    ui.post_tool_confirmation(
+                        confirmation_id=prompt.confirmation_id,
+                        tool_name=tool_name,
+                        detail=detail,
+                        risk=risk,
+                    )
+                else:
+                    confirm_label = tr(
+                        "tool_confirmation.confirm",
+                        tool=tool_name,
+                    )
+                    if detail:
+                        confirm_label = f"{confirm_label}\n{detail}"
+                    ui.post_options(
+                        [
+                            {
+                                "action": "cancel",
+                                "confirmationId": prompt.confirmation_id,
+                                "kind": "tool-confirmation",
+                                "label": tr("common.cancel"),
+                            },
+                            {
+                                "action": "confirm",
+                                "confirmationId": prompt.confirmation_id,
+                                "kind": "tool-confirmation",
+                                "label": confirm_label,
+                            },
+                        ]
+                    )
+                resolved = prompt.event.wait(timeout=30.0)
+            finally:
+                controller.discard(prompt.confirmation_id)
+                try:
+                    if hasattr(ui, "clear_tool_confirmation"):
+                        ui.clear_tool_confirmation(prompt.confirmation_id)
+                    else:
+                        ui.post_options([])
+                except Exception:
+                    pass
             if not resolved:
-                ui.post_notification(f"工具 {tool_name} 超时未确认，已取消")
+                try:
+                    ui.post_notification(
+                        tr("tool_confirmation.timeout", tool=tool_name)
+                    )
+                except Exception:
+                    pass
                 return False
-            return bool(confirm_result and confirm_result[0])
+            return prompt.confirmed is True
         except Exception:
             return risk != "high"
 

--- a/main.py
+++ b/main.py
@@ -1055,10 +1055,36 @@ def main():
                     emit_ack(ok=True)
                     return
                 if command_type == "submit-option":
-                    if resolve_pending_tool_confirmation(str(payload or "")):
-                        ui_updates.post_options([])
+                    if (
+                        isinstance(payload, dict)
+                        and payload.get("kind") == "tool-confirmation"
+                    ):
+                        confirmation_id = str(
+                            payload.get("confirmationId") or ""
+                        ).strip()
+                        action = str(payload.get("action") or "").strip().casefold()
+                        if (
+                            not confirmation_id
+                            or len(confirmation_id) > 128
+                            or action not in {"confirm", "cancel"}
+                        ):
+                            raise ValueError(
+                                "Tool confirmation response is invalid."
+                            )
+                        if not resolve_pending_tool_confirmation(
+                            confirmation_id,
+                            action,
+                        ):
+                            raise ValueError(
+                                "Tool confirmation is stale or does not match "
+                                "the active prompt."
+                            )
+                        if hasattr(ui_updates, "clear_tool_confirmation"):
+                            ui_updates.clear_tool_confirmation(confirmation_id)
                         emit_ack(ok=True)
                         return
+                    if isinstance(payload, dict):
+                        raise ValueError("Option selection must be a string.")
                     runtime_asr.pause_for_turn()
                     submit_runtime_text(str(payload or ""))
                     emit_ack(ok=True)

--- a/main.py
+++ b/main.py
@@ -102,7 +102,11 @@ from llm.llm_manager import LLMManager, LLMAdapterFactory
 from llm.text_processor import TextProcessor
 from core.messaging.chat_turn_wiring import create_chat_turn_service
 from core.messaging.queue import ClearableQueue
-from core.runtime.app_runtime import AppRuntime, set_app_runtime
+from core.runtime.app_runtime import (
+    AppRuntime,
+    resolve_pending_tool_confirmation,
+    set_app_runtime,
+)
 from core.runtime.launch_mode import should_init_desktop_mixer
 from core.runtime.shutdown import shutdown_chat_runtime
 from core.runtime.workflow import build_runtime_workflow, get_chat_workflow_handles
@@ -1051,6 +1055,10 @@ def main():
                     emit_ack(ok=True)
                     return
                 if command_type == "submit-option":
+                    if resolve_pending_tool_confirmation(str(payload or "")):
+                        ui_updates.post_options([])
+                        emit_ack(ok=True)
+                        return
                     runtime_asr.pause_for_turn()
                     submit_runtime_text(str(payload or ""))
                     emit_ack(ok=True)

--- a/test/unit/core/test_app_runtime_tool_confirmation.py
+++ b/test/unit/core/test_app_runtime_tool_confirmation.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from threading import Event
 from types import SimpleNamespace
 
 from core.runtime.app_runtime import (
+    ToolConfirmationController,
     resolve_pending_tool_confirmation,
     set_app_runtime,
 )
@@ -13,37 +13,49 @@ def teardown_function():
     set_app_runtime(None)
 
 
-def test_pending_tool_confirmation_accepts_confirm_option_with_cancel_in_arguments():
-    event = Event()
-    result: list[bool] = []
-    set_app_runtime(
-        SimpleNamespace(
-            _pending_confirm={"file_write": (event, result)},
-        )
-    )
-
-    assert resolve_pending_tool_confirmation(
-        "⚠️ 确认 file_write\npath=C:\\notes\\cancel-plan.txt"
-    )
-    assert event.is_set()
-    assert result == [True]
+def _runtime_with_controller() -> ToolConfirmationController:
+    controller = ToolConfirmationController()
+    set_app_runtime(SimpleNamespace(tool_confirmations=controller))
+    return controller
 
 
-def test_pending_tool_confirmation_handles_explicit_cancel():
-    event = Event()
-    result: list[bool] = []
-    set_app_runtime(
-        SimpleNamespace(
-            _pending_confirm={"file_write": (event, result)},
-        )
-    )
+def test_tool_confirmation_requires_the_matching_unpredictable_identifier():
+    controller = _runtime_with_controller()
+    prompt = controller.create("file_write")
 
-    assert resolve_pending_tool_confirmation("取消")
-    assert event.is_set()
-    assert result == [False]
+    assert not resolve_pending_tool_confirmation("wrong-id", "confirm")
+    assert not prompt.event.is_set()
+    assert prompt.confirmed is None
+
+    assert resolve_pending_tool_confirmation(prompt.confirmation_id, "confirm")
+    assert prompt.event.is_set()
+    assert prompt.confirmed is True
 
 
-def test_pending_tool_confirmation_returns_false_without_pending_prompt():
-    set_app_runtime(SimpleNamespace())
+def test_tool_confirmation_cancel_is_structured_and_one_time():
+    controller = _runtime_with_controller()
+    prompt = controller.create("file_write")
 
-    assert not resolve_pending_tool_confirmation("确认")
+    assert resolve_pending_tool_confirmation(prompt.confirmation_id, "cancel")
+    assert prompt.event.is_set()
+    assert prompt.confirmed is False
+    assert not resolve_pending_tool_confirmation(prompt.confirmation_id, "confirm")
+
+
+def test_tool_confirmation_rejects_arbitrary_option_labels():
+    controller = _runtime_with_controller()
+    prompt = controller.create("file_write")
+
+    assert not resolve_pending_tool_confirmation(prompt.confirmation_id, "取消")
+    assert not resolve_pending_tool_confirmation(prompt.confirmation_id, "cancel-plan.txt")
+    assert not prompt.event.is_set()
+
+
+def test_tool_confirmation_identifiers_are_unique():
+    controller = _runtime_with_controller()
+
+    first = controller.create("file_write")
+    second = controller.create("file_write")
+
+    assert first.confirmation_id != second.confirmation_id
+    assert len(first.confirmation_id) >= 24

--- a/test/unit/core/test_app_runtime_tool_confirmation.py
+++ b/test/unit/core/test_app_runtime_tool_confirmation.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from threading import Event
+from types import SimpleNamespace
+
+from core.runtime.app_runtime import (
+    resolve_pending_tool_confirmation,
+    set_app_runtime,
+)
+
+
+def teardown_function():
+    set_app_runtime(None)
+
+
+def test_pending_tool_confirmation_accepts_confirm_option_with_cancel_in_arguments():
+    event = Event()
+    result: list[bool] = []
+    set_app_runtime(
+        SimpleNamespace(
+            _pending_confirm={"file_write": (event, result)},
+        )
+    )
+
+    assert resolve_pending_tool_confirmation(
+        "⚠️ 确认 file_write\npath=C:\\notes\\cancel-plan.txt"
+    )
+    assert event.is_set()
+    assert result == [True]
+
+
+def test_pending_tool_confirmation_handles_explicit_cancel():
+    event = Event()
+    result: list[bool] = []
+    set_app_runtime(
+        SimpleNamespace(
+            _pending_confirm={"file_write": (event, result)},
+        )
+    )
+
+    assert resolve_pending_tool_confirmation("取消")
+    assert event.is_set()
+    assert result == [False]
+
+
+def test_pending_tool_confirmation_returns_false_without_pending_prompt():
+    set_app_runtime(SimpleNamespace())
+
+    assert not resolve_pending_tool_confirmation("确认")

--- a/test/unit/core/test_event_sink.py
+++ b/test/unit/core/test_event_sink.py
@@ -262,6 +262,12 @@ class EventSinkSnapshotTests(unittest.TestCase):
         snapshot["busyDurationSeconds"] = 3.0
         snapshot["options"] = ["继续"]
         snapshot["status"] = "generating"
+        snapshot["toolConfirmation"] = {
+            "confirmationId": "prompt-1",
+            "detail": "",
+            "risk": "high",
+            "toolName": "file_write",
+        }
 
         next_snapshot = fold_event_into_snapshot(
             snapshot,
@@ -280,6 +286,47 @@ class EventSinkSnapshotTests(unittest.TestCase):
         self.assertEqual(next_snapshot.get("notificationText"), "聊天会话已结束。")
         self.assertEqual(next_snapshot.get("sessionClosedReason"), "聊天会话已结束。")
         self.assertEqual(next_snapshot.get("status"), "idle")
+        self.assertIsNone(next_snapshot.get("toolConfirmation"))
+
+    def test_tool_confirmation_is_folded_and_only_matching_clear_removes_it(self):
+        snapshot = fold_event_into_snapshot(
+            make_empty_chat_snapshot(),
+            {
+                "confirmationId": "prompt-1",
+                "detail": r"path=D:\notes\plan.txt",
+                "risk": "high",
+                "seq": 1,
+                "toolName": "file_write",
+                "ts": 1,
+                "type": "tool.confirmation.show",
+                "v": 1,
+            },
+        )
+
+        stale_clear = fold_event_into_snapshot(
+            snapshot,
+            {
+                "confirmationId": "prompt-old",
+                "seq": 2,
+                "ts": 2,
+                "type": "tool.confirmation.clear",
+                "v": 1,
+            },
+        )
+        matching_clear = fold_event_into_snapshot(
+            stale_clear,
+            {
+                "confirmationId": "prompt-1",
+                "seq": 3,
+                "ts": 3,
+                "type": "tool.confirmation.clear",
+                "v": 1,
+            },
+        )
+
+        self.assertEqual(snapshot["toolConfirmation"]["confirmationId"], "prompt-1")
+        self.assertEqual(stale_clear["toolConfirmation"]["confirmationId"], "prompt-1")
+        self.assertIsNone(matching_clear["toolConfirmation"])
 
     def test_asr_state_clears_stale_closed_session_reason_in_snapshot(self):
         snapshot = make_empty_chat_snapshot()

--- a/test/unit/core/test_ui_update_manager.py
+++ b/test/unit/core/test_ui_update_manager.py
@@ -283,6 +283,35 @@ class UIUpdateManagerTests(unittest.TestCase):
             ],
         )
 
+    def test_streaming_ui_update_manager_emits_correlated_tool_confirmation(self):
+        sink = _SinkStub()
+        manager = StreamingUIUpdateManager(sink)
+
+        manager.post_tool_confirmation(
+            confirmation_id="prompt-1",
+            tool_name="file_write",
+            detail=r"path=D:\notes\plan.txt",
+            risk="unexpected",
+        )
+        manager.clear_tool_confirmation("prompt-1")
+
+        self.assertEqual(
+            sink.events,
+            [
+                {
+                    "confirmationId": "prompt-1",
+                    "detail": r"path=D:\notes\plan.txt",
+                    "risk": "high",
+                    "toolName": "file_write",
+                    "type": "tool.confirmation.show",
+                },
+                {
+                    "confirmationId": "prompt-1",
+                    "type": "tool.confirmation.clear",
+                },
+            ],
+        )
+
     def test_streaming_ui_update_manager_emits_session_closed_event(self):
         sink = _SinkStub()
         manager = StreamingUIUpdateManager(sink)

--- a/test/unit/frontend_bridge_core/test_chat_stream_commands.py
+++ b/test/unit/frontend_bridge_core/test_chat_stream_commands.py
@@ -392,6 +392,53 @@ class ChatStreamCommandTests(unittest.TestCase):
         self.assertEqual(snapshot["dialogHtml"], "<p>Choose</p>")
         self.assertEqual(chat_stream.command[1]["type"], "submit-option")
 
+    def test_tool_confirmation_command_preserves_structured_correlation_payload(self):
+        chat_stream = _StubChatStream()
+        state = SimpleNamespace(
+            chat_session={"sessionId": "session-1"},
+            chat_stream=chat_stream,
+        )
+
+        snapshot = _handle_chat_command(
+            state,
+            {
+                "payload": {
+                    "action": "cancel",
+                    "confirmationId": "prompt-1",
+                    "kind": "tool-confirmation",
+                },
+                "type": "submit-option",
+            },
+        )
+
+        self.assertEqual(snapshot["status"], "idle")
+        self.assertEqual(
+            chat_stream.command[1]["payload"],
+            {
+                "action": "cancel",
+                "confirmationId": "prompt-1",
+                "kind": "tool-confirmation",
+            },
+        )
+
+    def test_tool_confirmation_command_rejects_invalid_or_unstructured_payload(self):
+        chat_stream = _StubChatStream()
+        state = SimpleNamespace(
+            chat_session={"sessionId": "session-1"},
+            chat_stream=chat_stream,
+        )
+
+        for payload in (
+            {"action": "approve", "confirmationId": "prompt-1", "kind": "tool-confirmation"},
+            {"action": "confirm", "confirmationId": "", "kind": "tool-confirmation"},
+            {"action": "confirm", "confirmationId": "prompt-1", "kind": "other"},
+        ):
+            with self.subTest(payload=payload), self.assertRaises(ValueError):
+                _handle_chat_command(
+                    state,
+                    {"payload": payload, "type": "submit-option"},
+                )
+
     def test_handle_chat_command_clears_closed_session_markers_when_restarting_runtime_interaction(self):
         chat_stream = _StubChatStream()
         chat_stream.snapshot["notificationText"] = "聊天会话已结束。"
@@ -710,12 +757,22 @@ class ChatStreamCommandTests(unittest.TestCase):
             session = service.create_session()
 
             self.assertIn("shinsekai_bridge_token=bridge-secret", session["producerEndpoint"])
+            self.assertIn("shinsekai_producer_token=", session["producerEndpoint"])
             self.assertIn(
                 "shinsekai_bridge_token=bridge-secret",
                 service.media_url("data/speech/nanami/hello.wav"),
             )
             with self.assertRaises(ConnectionError):
                 _open_ws(session["wsUrl"], session_id=session["sessionId"], role="viewer")
+            with self.assertRaises(ConnectionError):
+                _open_ws(
+                    (
+                        f"{session['wsUrl']}?"
+                        "shinsekai_bridge_token=bridge-secret"
+                    ),
+                    session_id=session["sessionId"],
+                    role="producer",
+                )
 
             producer = _open_ws(session["producerEndpoint"], session_id=session["sessionId"], role="producer")
             self.assertIsNotNone(producer)
@@ -723,6 +780,22 @@ class ChatStreamCommandTests(unittest.TestCase):
             if producer is not None:
                 _close_ws(producer)
             service.stop()
+
+    def test_media_url_registers_absolute_media_path_for_later_authenticated_read(
+        self,
+    ):
+        service = ChatStreamService(
+            host="127.0.0.1",
+            bridge_port=_free_bridge_port(),
+            auth_token="bridge-secret",
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            media_path = str(Path(temp_dir) / "generated" / "line.wav")
+
+            url = service.media_url(media_path)
+
+        self.assertIn("/api/media?", url)
+        self.assertIn(media_path, service.approved_external_media_paths())
 
     def test_ws_client_sink_transports_events_over_real_socket(self):
         service = ChatStreamService(host="127.0.0.1", bridge_port=_free_bridge_port())
@@ -750,7 +823,11 @@ class ChatStreamCommandTests(unittest.TestCase):
         service.start()
         try:
             session = service.create_session({"dialogText": "boot"})
-            producer = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="producer")
+            producer = _open_ws(
+                session["producerEndpoint"],
+                session_id=session["sessionId"],
+                role="producer",
+            )
             viewer = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="viewer")
             try:
                 snapshot_event = _wait_for_event(viewer, lambda event: event.get("type") == "snapshot")
@@ -828,7 +905,11 @@ class ChatStreamCommandTests(unittest.TestCase):
             sender.start()
             time.sleep(0.2)
 
-            producer = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="producer")
+            producer = _open_ws(
+                session["producerEndpoint"],
+                session_id=session["sessionId"],
+                role="producer",
+            )
             try:
                 sender.join(timeout=5.0)
                 self.assertFalse(sender.is_alive())
@@ -914,14 +995,22 @@ class ChatStreamCommandTests(unittest.TestCase):
         service.start()
         try:
             session = service.create_session({"dialogText": "boot"})
-            producer1 = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="producer")
+            producer1 = _open_ws(
+                session["producerEndpoint"],
+                session_id=session["sessionId"],
+                role="producer",
+            )
             viewer = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="viewer")
             producer2 = None
             try:
                 snapshot_event = _wait_for_event(viewer, lambda event: event.get("type") == "snapshot")
                 self.assertEqual(snapshot_event["snapshot"]["dialogText"], "boot")
 
-                producer2 = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="producer")
+                producer2 = _open_ws(
+                    session["producerEndpoint"],
+                    session_id=session["sessionId"],
+                    role="producer",
+                )
                 _wait_for_socket_close(producer1)
 
                 _send_json_frame(
@@ -960,7 +1049,11 @@ class ChatStreamCommandTests(unittest.TestCase):
         service.start()
         try:
             session = service.create_session({"dialogText": "recovered", "eventSeq": 9})
-            producer = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="producer")
+            producer = _open_ws(
+                session["producerEndpoint"],
+                session_id=session["sessionId"],
+                role="producer",
+            )
             viewer = _open_ws(session["wsUrl"], session_id=session["sessionId"], role="viewer")
             try:
                 snapshot_event = _wait_for_event(viewer, lambda event: event.get("type") == "snapshot")

--- a/test/unit/frontend_bridge_core/test_external_media_paths.py
+++ b/test/unit/frontend_bridge_core/test_external_media_paths.py
@@ -9,14 +9,31 @@ import pytest
 from frontend_bridge_core.handler import BRIDGE_AUTH_HEADER, FrontendBridgeHandler
 from frontend_bridge_core.media_paths import (
     _validate_windows_local_drive_path,
+    iter_configured_external_media_paths,
     resolve_external_media_file,
     validate_readable_media_file,
 )
 
 
-def _handler_with_auth_token(token: str = "bridge-secret") -> FrontendBridgeHandler:
+def _handler_with_auth_token(
+    token: str = "bridge-secret",
+    *,
+    configured_paths: list[str] | None = None,
+    runtime_paths: list[str] | None = None,
+) -> FrontendBridgeHandler:
+    approved_runtime_paths = tuple(runtime_paths or ())
     handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
-    handler.server = SimpleNamespace(state=SimpleNamespace(auth_token=token))  # type: ignore[assignment]
+    handler.server = SimpleNamespace(  # type: ignore[assignment]
+        state=SimpleNamespace(
+            auth_token=token,
+            chat_stream=SimpleNamespace(
+                approved_external_media_paths=lambda: approved_runtime_paths
+            ),
+            config_manager=SimpleNamespace(
+                config={"configured_media": list(configured_paths or ())}
+            ),
+        )
+    )
     handler.headers = {}
     return handler
 
@@ -81,18 +98,58 @@ def test_media_resolver_allows_external_file_but_download_resolver_stays_project
 ):
     project_root = tmp_path / "project"
     project_root.mkdir()
-    external_media = tmp_path / "external" / "voice.wav"
+    external_media = tmp_path / "外部" / "语音.wav"
     external_media.parent.mkdir()
     external_media.write_bytes(b"media")
     monkeypatch.chdir(project_root)
 
-    handler = _handler_with_auth_token()
+    handler = _handler_with_auth_token(configured_paths=[str(external_media)])
 
     assert handler._resolve_media_path(str(external_media)) == external_media.resolve()
-    assert resolve_external_media_file(external_media) == external_media.resolve()
+    assert resolve_external_media_file(
+        external_media,
+        approved_paths=[external_media],
+    ) == external_media.resolve()
 
     with pytest.raises(PermissionError):
         handler._resolve_project_path(str(external_media))
+
+
+def test_media_resolver_allows_runtime_registered_external_file(tmp_path: Path):
+    external_media = tmp_path / "generated" / "voice.wav"
+    external_media.parent.mkdir()
+    external_media.write_bytes(b"media")
+    handler = _handler_with_auth_token(runtime_paths=[str(external_media)])
+
+    assert handler._resolve_media_path(str(external_media)) == external_media.resolve()
+
+
+def test_media_resolver_rejects_unregistered_absolute_path(tmp_path: Path):
+    external_media = tmp_path / "unregistered" / "voice.wav"
+    external_media.parent.mkdir()
+    external_media.write_bytes(b"media")
+    handler = _handler_with_auth_token()
+
+    with pytest.raises(PermissionError, match="not been approved"):
+        handler._resolve_media_path(str(external_media))
+
+
+@pytest.mark.skipif(os.name != "nt", reason="cross-drive paths are Windows-specific")
+def test_configured_media_path_discovery_preserves_other_drive_paths():
+    config = {
+        "characters": [
+            {
+                "voice": r"D:\ShinsekaiAssets\voices\line.wav",
+                "notes": r"D:\ShinsekaiAssets\notes.txt",
+            }
+        ],
+        "bgm": r"E:\Music\scene.mp3",
+    }
+
+    assert tuple(iter_configured_external_media_paths(config)) == (
+        r"D:\ShinsekaiAssets\voices\line.wav",
+        r"E:\Music\scene.mp3",
+    )
 
 
 def test_media_get_requires_valid_bridge_token():

--- a/test/unit/frontend_bridge_core/test_external_media_paths.py
+++ b/test/unit/frontend_bridge_core/test_external_media_paths.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from frontend_bridge_core.handler import BRIDGE_AUTH_HEADER, FrontendBridgeHandler
+from frontend_bridge_core.media_paths import (
+    _validate_windows_local_drive_path,
+    resolve_external_media_file,
+    validate_readable_media_file,
+)
+
+
+def _handler_with_auth_token(token: str = "bridge-secret") -> FrontendBridgeHandler:
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+    handler.server = SimpleNamespace(state=SimpleNamespace(auth_token=token))  # type: ignore[assignment]
+    handler.headers = {}
+    return handler
+
+
+@pytest.mark.parametrize("suffix", [".PNG", ".mp3", ".mkv", ".woff2"])
+def test_readable_media_file_accepts_supported_regular_files(tmp_path: Path, suffix: str):
+    source = tmp_path / f"asset{suffix}"
+    source.write_bytes(b"media")
+
+    assert validate_readable_media_file(source) == source.resolve()
+
+
+@pytest.mark.parametrize("suffix", [".txt", ".json", ".env", ".pem", ".yaml"])
+def test_readable_media_file_rejects_non_media_extensions(tmp_path: Path, suffix: str):
+    source = tmp_path / f"secret{suffix}"
+    source.write_text("not media", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="file type"):
+        validate_readable_media_file(source)
+
+
+def test_readable_media_file_rejects_directory_even_with_media_extension(tmp_path: Path):
+    source = tmp_path / "not-a-file.mp4"
+    source.mkdir()
+
+    with pytest.raises(PermissionError, match="regular file"):
+        validate_readable_media_file(source)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO creation is unavailable")
+def test_readable_media_file_rejects_fifo(tmp_path: Path):
+    source = tmp_path / "named-pipe.mp3"
+    os.mkfifo(source)
+
+    with pytest.raises(PermissionError, match="regular file"):
+        validate_readable_media_file(source)
+
+
+def test_windows_path_policy_allows_absolute_local_drive_paths():
+    _validate_windows_local_drive_path(r"Z:\media\clip.mp4")
+
+
+@pytest.mark.parametrize(
+    "raw_path",
+    [
+        r"\\.\pipe\shinsekai",
+        r"\\?\C:\media\clip.mp4",
+        r"\??\C:\media\clip.mp4",
+        r"\\server\share\clip.mp4",
+        r"D:relative\clip.mp4",
+        r"C:\secrets\config.json:cover.png",
+    ],
+)
+def test_windows_path_policy_rejects_device_unc_and_drive_relative_paths(raw_path: str):
+    with pytest.raises(PermissionError):
+        _validate_windows_local_drive_path(raw_path)
+
+
+def test_media_resolver_allows_external_file_but_download_resolver_stays_project_scoped(
+    tmp_path: Path,
+    monkeypatch,
+):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    external_media = tmp_path / "external" / "voice.wav"
+    external_media.parent.mkdir()
+    external_media.write_bytes(b"media")
+    monkeypatch.chdir(project_root)
+
+    handler = _handler_with_auth_token()
+
+    assert handler._resolve_media_path(str(external_media)) == external_media.resolve()
+    assert resolve_external_media_file(external_media) == external_media.resolve()
+
+    with pytest.raises(PermissionError):
+        handler._resolve_project_path(str(external_media))
+
+
+def test_media_get_requires_valid_bridge_token():
+    handler = _handler_with_auth_token()
+    handler.path = "/api/media?path=data%2Fvoice.mp3"
+    sent: list[str] = []
+    errors: list[Exception] = []
+    handler._send_media_file = lambda path: sent.append(path)  # type: ignore[method-assign]
+    handler._log_request_exception = lambda _exc: None  # type: ignore[method-assign]
+    handler._send_exception_json = lambda exc: errors.append(exc)  # type: ignore[method-assign]
+
+    handler.do_GET()
+
+    assert not sent
+    assert len(errors) == 1
+    assert isinstance(errors[0], PermissionError)
+    assert "auth token" in str(errors[0])
+
+
+def test_media_get_accepts_bridge_token_from_query():
+    handler = _handler_with_auth_token()
+    handler.path = (
+        "/api/media?path=data%2Fvoice.mp3"
+        "&shinsekai_bridge_token=bridge-secret"
+    )
+    sent: list[str] = []
+    handler._send_media_file = lambda path: sent.append(path)  # type: ignore[method-assign]
+
+    handler.do_GET()
+
+    assert sent == ["data/voice.mp3"]
+
+
+def test_media_head_accepts_bridge_token_header_and_sends_no_body():
+    handler = _handler_with_auth_token()
+    handler.path = "/api/media?path=data%2Fvoice.mp3"
+    handler.headers = {BRIDGE_AUTH_HEADER: "bridge-secret"}
+    sent: list[tuple[str, bool]] = []
+    handler._send_media_file = (  # type: ignore[method-assign]
+        lambda path, *, send_body=True: sent.append((path, send_body))
+    )
+
+    handler.do_HEAD()
+
+    assert sent == [("data/voice.mp3", False)]
+
+
+def test_media_read_rejects_untrusted_origin_even_with_valid_token():
+    handler = _handler_with_auth_token()
+    handler.path = "/api/media?shinsekai_bridge_token=bridge-secret"
+    handler.headers = {"Origin": "https://example.com"}
+
+    with pytest.raises(PermissionError, match="origin"):
+        handler._require_authorized_media_read()

--- a/test/unit/llm/test_file_tools.py
+++ b/test/unit/llm/test_file_tools.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from llm.tools.file_tools import file_write
+
+
+def test_file_write_accepts_absolute_path_outside_working_directory(
+    tmp_path: Path,
+    monkeypatch,
+):
+    working_dir = tmp_path / "project"
+    working_dir.mkdir()
+    destination = tmp_path / "external" / "notes.txt"
+    monkeypatch.chdir(working_dir)
+
+    result = file_write(str(destination), "approved content")
+
+    assert result["written"] == str(destination.resolve())
+    assert destination.read_text(encoding="utf-8") == "approved content"

--- a/ui/chat_ui/chat_ui.py
+++ b/ui/chat_ui/chat_ui.py
@@ -1268,15 +1268,23 @@ class ChatUIWindow(DesktopToolbarMixin, DesktopMenuMixin, QWidget):
             self.skip_button.hide()
             self.display_words_changed.emit("")
     
-    def option_clicked(self, text):
+    def option_clicked(self, selection):
         """选项按钮点击处理函数"""
-        print(f"Option clicked: {text}")
-        # Check for pending tool confirmation first
-        from core.runtime.app_runtime import resolve_pending_tool_confirmation
+        if (
+            isinstance(selection, dict)
+            and selection.get("kind") == "tool-confirmation"
+        ):
+            from core.runtime.app_runtime import resolve_pending_tool_confirmation
 
-        if resolve_pending_tool_confirmation(text):
+            resolve_pending_tool_confirmation(
+                str(selection.get("confirmationId") or ""),
+                str(selection.get("action") or ""),
+            )
             self.setOptions([])
             return
+
+        text = str(selection or "")
+        print(f"Option clicked: {text}")
         self.option_selected.emit(text)
         self.input_box.setText(text) # 将内容添加到输入框
         self.setOptions([])          # 隐藏选项
@@ -1316,7 +1324,7 @@ class ChatUIWindow(DesktopToolbarMixin, DesktopMenuMixin, QWidget):
             if w is not None:
                 w.setStyleSheet(qss)
 
-    def setOptions(self, optionList: list[str]):
+    def setOptions(self, optionList: list):
         """
         在dialog label相同的地方显示一组半透明选项按钮，并隐藏dialog label。
         
@@ -1347,10 +1355,20 @@ class ChatUIWindow(DesktopToolbarMixin, DesktopMenuMixin, QWidget):
         )
 
         # 4. 添加新按钮
-        for option_text in optionList:
+        for option in optionList:
+            is_structured_option = isinstance(option, dict)
+            option_text = (
+                str(option.get("label") or "")
+                if is_structured_option
+                else str(option or "")
+            )
             option_btn = ClickableLabel()
             option_btn.setText(option_text)
-            option_btn.setTextFormat(Qt.TextFormat.RichText)
+            option_btn.setTextFormat(
+                Qt.TextFormat.PlainText
+                if is_structured_option
+                else Qt.TextFormat.RichText
+            )
             option_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
             option_btn.setWordWrap(True)
             
@@ -1366,8 +1384,10 @@ class ChatUIWindow(DesktopToolbarMixin, DesktopMenuMixin, QWidget):
                 )
             )
             
-            # 连接点击事件，使用 lambda 传递选项内容
-            option_btn.clicked.connect(lambda text=option_text: self.option_clicked(text))
+            # 工具确认按钮保留结构化 payload；普通剧情选项仍传递显示文本。
+            option_btn.clicked.connect(
+                lambda selected=option: self.option_clicked(selected)
+            )
             self.options_layout.addWidget(option_btn)
 
         container_width = self.image_container.width() or self.original_width

--- a/ui/chat_ui/chat_ui.py
+++ b/ui/chat_ui/chat_ui.py
@@ -1272,13 +1272,9 @@ class ChatUIWindow(DesktopToolbarMixin, DesktopMenuMixin, QWidget):
         """选项按钮点击处理函数"""
         print(f"Option clicked: {text}")
         # Check for pending tool confirmation first
-        from core.runtime.app_runtime import try_get_app_runtime
-        rt = try_get_app_runtime()
-        if rt is not None and hasattr(rt, '_pending_confirm') and rt._pending_confirm:
-            confirmed = "取消" not in text and "cancel" not in text.lower()
-            for tool_name, (event, result_list) in list(rt._pending_confirm.items()):
-                result_list.append(confirmed)
-                event.set()
+        from core.runtime.app_runtime import resolve_pending_tool_confirmation
+
+        if resolve_pending_tool_confirmation(text):
             self.setOptions([])
             return
         self.option_selected.emit(text)


### PR DESCRIPTION
## Summary

- allow authenticated `/api/media` GET/HEAD reads for existing regular media files on local drives
- restrict external reads to approved image, audio, video, and font extensions
- reject directories, device namespaces, named pipes, UNC paths, alternate data streams, and drive-relative paths
- keep `/api/download` and HTTP write, overwrite, and delete operations project-scoped
- honor explicit user approval for high-risk streamed LLM file tool calls

## Testing

- Python test suite: 1624 passed, 11 skipped; 4 subtests passed
- `pnpm format:check`
- `pnpm lint:types`
- `pnpm test`: 110 test files, 738 tests passed

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次核对的重点收拢一下，方便快速查看。

此 PR 允许经认证的 `/api/media` 读取外部本地媒体，并为流式聊天接入高风险工具确认；发现确认响应未绑定当前提示的问题。

### New Features

- `/api/media` 的 GET/HEAD 现可读取通过验证的外部本地媒体文件。

### Enhancements

- 限制允许的媒体和字体后缀，并拒绝目录、FIFO、UNC、设备及 ADS 路径。
- 流式聊天的 `submit-option` 可解除风险工具等待。

### Tests

- 新增媒体路径、鉴权和待确认工具结果的 Python 单元测试。

<details>
<summary>Original summary in English</summary>

This PR enables authenticated `/api/media` reads for external local media and wires high-risk tool confirmations into streamed chat; it has one issue where a confirmation response is not bound to its active prompt.

### New Features

- `GET`/`HEAD` on `/api/media` can now read validated external local media files.

### Enhancements

- Allowed media and font suffixes are restricted, while directories, FIFOs, UNC paths, device paths, and ADS paths are rejected.
- Streamed chat `submit-option` can resolve a pending risky-tool prompt.

### Tests

- Adds Python unit tests for media paths, authorization, and pending-tool confirmation results.

</details>

<!-- astrbot-review:end:summary -->