### PR TITLE
fix(onboarding): align downloaded TTS defaults and compact navigation

### DIFF
--- a/frontend/src/features/api-settings/ApiSettingsPage.tsx
+++ b/frontend/src/features/api-settings/ApiSettingsPage.tsx
@@ -50,6 +50,7 @@ import { TtsBundleSection } from "./TtsBundleSection";
 import {
   activeMapValue,
   adapterSchema,
+  applyDownloadedTtsBundle,
   applyTtsProviderDefaults,
   apiSchemaWithAdapterOptions,
   asrComputeOptions,
@@ -358,15 +359,7 @@ export function ApiSettingsPage() {
     onSuccess(result) {
       setTtsBundleDialogOpen(false);
       setTtsBundleError(null);
-      setDraft((current) =>
-        current
-          ? {
-              ...current,
-              gpt_sovits_api_path: result.path,
-              tts_provider: result.provider,
-            }
-          : current,
-      );
+      setDraft((current) => (current ? applyDownloadedTtsBundle(current, result) : current));
       showToast({
         kind: "success",
         message: t("api.tts.bundleDone", { path: result.path }),

--- a/frontend/src/features/api-settings/apiSettingsUtils.ts
+++ b/frontend/src/features/api-settings/apiSettingsUtils.ts
@@ -364,6 +364,17 @@ export function applyTtsProviderDefaults(config: ApiConfig, installedTtsBundlePa
   };
 }
 
+export function applyDownloadedTtsBundle(config: ApiConfig, result: { path: string; provider: string }): ApiConfig {
+  return applyTtsProviderDefaults(
+    {
+      ...config,
+      gpt_sovits_api_path: result.path,
+      tts_provider: result.provider,
+    },
+    result.path,
+  );
+}
+
 export function normalizeApiConfigForUi(config: ApiConfig, installedTtsBundlePath = ""): ApiConfig {
   const provider = (config.llm_provider || "Deepseek").trim() || "Deepseek";
   return applyTtsProviderDefaults(

--- a/frontend/src/features/onboarding/OnboardingPage.tsx
+++ b/frontend/src/features/onboarding/OnboardingPage.tsx
@@ -63,7 +63,6 @@ export function OnboardingPage() {
       {
         accent: "accent" as const,
         content: <ApiSetupPanel copy={copy} onSaved={() => setApiSaved(true)} />,
-        description: copy.api.description,
         icon: <Settings aria-hidden size={18} />,
         id: "api",
         title: copy.api.title,
@@ -71,7 +70,6 @@ export function OnboardingPage() {
       {
         accent: "info" as const,
         content: <PluginSetupPanel copy={copy} onInstalled={() => setPluginsInstalled(true)} />,
-        description: copy.plugins.description,
         icon: <Plug aria-hidden size={18} />,
         id: "plugins",
         optional: true,
@@ -80,7 +78,6 @@ export function OnboardingPage() {
       {
         accent: "success" as const,
         content: <CharacterSetupPanel copy={copy} />,
-        description: copy.characters.description,
         icon: <Gamepad2 aria-hidden size={18} />,
         id: "characters",
         title: copy.characters.title,
@@ -88,7 +85,6 @@ export function OnboardingPage() {
       {
         accent: "warning" as const,
         content: <BackgroundSetupPanel copy={copy} />,
-        description: copy.backgrounds.description,
         icon: <FileImage aria-hidden size={18} />,
         id: "backgrounds",
         optional: true,
@@ -97,7 +93,6 @@ export function OnboardingPage() {
       {
         accent: "accent" as const,
         content: <CompletionSetupPanel copy={copy} />,
-        description: copy.complete.description,
         icon: <CheckCircle2 aria-hidden size={18} />,
         id: "complete",
         title: copy.complete.title,

--- a/frontend/src/features/onboarding/steps/ApiSetupPanel.tsx
+++ b/frontend/src/features/onboarding/steps/ApiSetupPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../../entities/config/repository";
 import type { ApiConfig } from "../../../entities/config/types";
 import type { TaskSnapshot, TtsBundleDownloadResult, TtsBundleKind } from "../../../shared/platform/types";
+import { applyDownloadedTtsBundle } from "../../api-settings/apiSettingsUtils";
 import {
   AsyncButton,
   Button,
@@ -100,12 +101,7 @@ export function ApiSetupPanel({ copy, onSaved }: ApiSetupPanelProps) {
     },
     onSuccess(result) {
       if (draft) {
-        const next = {
-          ...draft,
-          gpt_sovits_api_path: result.path,
-          gpt_sovits_url: result.path,
-          tts_provider: result.provider,
-        };
+        const next = applyDownloadedTtsBundle(draft, result);
         setDraft(next);
         saveMutation.mutate(next);
       }

--- a/frontend/src/shared/ui/GuidedFlow.css
+++ b/frontend/src/shared/ui/GuidedFlow.css
@@ -48,21 +48,22 @@
 }
 
 .guided-flow__steps {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  display: flex;
+  min-width: 0;
   gap: var(--space-2);
 }
 
 .guided-flow__step {
   display: grid;
   min-width: 0;
-  min-height: 76px;
-  grid-template-columns: 34px minmax(0, 1fr);
+  min-height: 52px;
+  flex: 1 1 0;
+  grid-template-columns: 30px minmax(0, 1fr);
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-control);
-  padding: 10px;
+  padding: 8px;
   color: var(--color-text-muted);
   background: var(--color-surface);
   cursor: pointer;
@@ -98,8 +99,8 @@
 
 .guided-flow__step-icon {
   display: grid;
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   place-items: center;
   border: 1px solid var(--color-accent-border);
   border-radius: var(--radius-control);
@@ -129,9 +130,8 @@
 }
 
 .guided-flow__step-copy {
-  display: grid;
+  display: block;
   min-width: 0;
-  gap: 4px;
 }
 
 .guided-flow__step-title-row {
@@ -142,8 +142,7 @@
   gap: 8px;
 }
 
-.guided-flow__step-title,
-.guided-flow__step-description {
+.guided-flow__step-title {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -184,12 +183,6 @@
   background: var(--color-bg-input);
 }
 
-.guided-flow__step-description {
-  color: var(--color-text-muted);
-  font-size: 12px;
-  line-height: 1.25;
-}
-
 .guided-flow__body {
   min-width: 0;
   min-height: 0;
@@ -221,10 +214,6 @@
     grid-template-columns: 1fr;
     align-items: start;
   }
-
-  .guided-flow__steps {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 620px) {
@@ -245,7 +234,7 @@
   }
 
   .guided-flow__step {
-    flex: 0 0 178px;
+    flex: 0 0 150px;
   }
 
   .guided-flow__footer {

--- a/frontend/src/shared/ui/GuidedFlow.tsx
+++ b/frontend/src/shared/ui/GuidedFlow.tsx
@@ -8,7 +8,6 @@ import "./GuidedFlow.css";
 export interface GuidedFlowStep {
   accent?: "accent" | "info" | "success" | "warning";
   content: ReactNode;
-  description: string;
   icon?: ReactNode;
   id: string;
   optional?: boolean;
@@ -109,7 +108,6 @@ export function GuidedFlow({
                       {step.optional ? optionalLabel : requiredLabel}
                     </span>
                   </span>
-                  <span className="guided-flow__step-description">{step.description}</span>
                 </span>
               </button>
             );

--- a/frontend/src/test/features/api-settings/apiSettingsUtils.config.test.ts
+++ b/frontend/src/test/features/api-settings/apiSettingsUtils.config.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   activeMapValue,
+  applyDownloadedTtsBundle,
   applyTtsProviderDefaults,
   apiSchemaWithAdapterOptions,
   catalogOptions,
   containsPathQuotes,
   DEFAULT_TTS_SERVER_URL,
+  HTTPS_DEFAULT_TTS_SERVER_URL,
   isTaskCancelledError,
   isTaskRunning,
   llmModelFetchKey,
@@ -208,6 +210,25 @@ describe("API settings utilities", () => {
         tts_provider: "gpt-sovits",
       }).gpt_sovits_url,
     ).toBe(DEFAULT_TTS_SERVER_URL);
+
+    expect(
+      applyDownloadedTtsBundle(
+        {
+          ...sampleConfig.api_config,
+          gpt_sovits_api_path: "",
+          gpt_sovits_url: HTTPS_DEFAULT_TTS_SERVER_URL,
+          tts_provider: "",
+        },
+        {
+          path: "/project/data/tts_bundles/installed/gpt_sovits_v2pro/GPT-SoVITS-v2pro",
+          provider: "gpt-sovits",
+        },
+      ),
+    ).toMatchObject({
+      gpt_sovits_api_path: "/project/data/tts_bundles/installed/gpt_sovits_v2pro/GPT-SoVITS-v2pro",
+      gpt_sovits_url: DEFAULT_TTS_SERVER_URL,
+      tts_provider: "gpt-sovits",
+    });
   });
 
   it("deduplicates model options and derives request keys", () => {

--- a/frontend/src/test/features/onboarding/ApiSetupPanel.test.tsx
+++ b/frontend/src/test/features/onboarding/ApiSetupPanel.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+import { DEFAULT_TTS_SERVER_URL, HTTPS_DEFAULT_TTS_SERVER_URL } from "../../../features/api-settings/apiSettingsUtils";
 import { onboardingCopy } from "../../../features/onboarding/onboardingCopy";
 import { ApiSetupPanel } from "../../../features/onboarding/steps/ApiSetupPanel";
 import { I18nProvider } from "../../../shared/i18n";
@@ -96,8 +97,13 @@ describe("ApiSetupPanel TTS bundle flow", () => {
     expect(firstArg).toEqual({ kind: "gptso" });
   });
 
-  it("auto-fills TTS provider, URL, and path after successful bundle download", async () => {
+  it("uses API settings defaults for TTS provider, URL, and path after bundle download", async () => {
     mocks.saveApiConfig.mockImplementation(async (config: Record<string, unknown>) => config);
+    mocks.getAppConfig.mockResolvedValue(
+      appConfigForOnboarding({
+        gpt_sovits_url: HTTPS_DEFAULT_TTS_SERVER_URL,
+      }),
+    );
 
     renderPanel();
     expect(await screen.findByLabelText("基础地址")).toBeInTheDocument();
@@ -112,7 +118,7 @@ describe("ApiSetupPanel TTS bundle flow", () => {
 
     const saved = mocks.saveApiConfig.mock.calls[0][0] as Record<string, unknown>;
     expect(saved.tts_provider).toBe("gpt-sovits");
-    expect(saved.gpt_sovits_url).toBe("/project/data/tts_bundles/installed/gpt_sovits_v2pro/GPT-SoVITS-v2pro");
+    expect(saved.gpt_sovits_url).toBe(DEFAULT_TTS_SERVER_URL);
     expect(saved.gpt_sovits_api_path).toBe("/project/data/tts_bundles/installed/gpt_sovits_v2pro/GPT-SoVITS-v2pro");
   });
 
@@ -120,7 +126,7 @@ describe("ApiSetupPanel TTS bundle flow", () => {
     mocks.saveApiConfig.mockResolvedValue({
       ...appConfigForOnboarding().api_config,
       tts_provider: "gpt-sovits",
-      gpt_sovits_url: "/project/data/tts_bundles/installed/gpt_sovits_v2pro/GPT-SoVITS-v2pro",
+      gpt_sovits_url: DEFAULT_TTS_SERVER_URL,
       gpt_sovits_api_path: "/project/data/tts_bundles/installed/gpt_sovits_v2pro/GPT-SoVITS-v2pro",
     });
 

--- a/frontend/src/test/features/onboarding/OnboardingFlow.test.tsx
+++ b/frontend/src/test/features/onboarding/OnboardingFlow.test.tsx
@@ -188,6 +188,9 @@ describe("onboarding flow", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "First run guide" })).toBeInTheDocument();
+    const stepNavigation = screen.getByRole("navigation", { name: "First run guide" });
+    expect(within(stepNavigation).getAllByRole("button")).toHaveLength(5);
+    expect(within(stepNavigation).queryByText(onboardingCopy.en.api.description)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open next step" }));
 
     const apiDialog = await screen.findByRole("dialog", { name: "Confirm" });


### PR DESCRIPTION
## Summary

- share downloaded TTS bundle defaults between onboarding and API settings
- normalize the built-in local TTS URL to `http://127.0.0.1:9880` instead of persisting the legacy HTTPS value
- keep the TTS installation path separate from the API URL
- remove step descriptions and compact the onboarding navigation into a single row

## Testing

- Python test suite: 1598 passed, 10 skipped; 4 subtests passed
- `pnpm format:check`
- `pnpm lint:types`
- `pnpm test`: 110 test files, 738 tests passed

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次核对的重点轻轻理顺，方便接着看。

本 PR 统一了首次引导与 API 设置页在下载 TTS 整合包后的默认配置，并压缩了引导步骤导航；但在受支持的窄桌面主窗口中，新的单行导航会使步骤标题不可读。

### Enhancements

- 通过 `applyDownloadedTtsBundle` 统一下载后的 TTS 服务 URL、安装路径和提供商默认值。
- 移除步骤导航中的描述并缩小导航项尺寸。

### Tests

- 更新了 TTS 默认 URL/路径及引导下载保存行为的测试，并覆盖了紧凑导航的结构。

<details>
<summary>Original summary in English</summary>

This PR aligns the post-download TTS defaults between onboarding and API settings and compacts the onboarding navigation; however, the new single-row navigation makes step titles unreadable in supported narrow desktop main windows.

### Enhancements

- Uses `applyDownloadedTtsBundle` to align the downloaded TTS server URL, installation path, and provider defaults.
- Removes step descriptions from the navigation and reduces the navigation item size.

### Tests

- Updates coverage for TTS default URL/path handling, onboarding download persistence, and the compact navigation structure.

</details>

<!-- astrbot-review:end:summary -->