### PR TITLE
refactor: centralize PyTorch stack and improve download diagnostics

### DIFF
--- a/config/mirror_env.py
+++ b/config/mirror_env.py
@@ -36,22 +36,11 @@ _DEFAULT_IP_REGION_URLS = (
     "https://ipapi.co/country/",
     "https://api.country.is/",
 )
-_NETWORK_PROXY_ENV_NAMES = (
-    "HTTPS_PROXY",
-    "https_proxy",
-    "HTTP_PROXY",
-    "http_proxy",
-    "ALL_PROXY",
-    "all_proxy",
-    "SOCKS_PROXY",
-    "socks_proxy",
-)
 
 _MANAGED_ENV_NAMES = (
     "HF_ENDPOINT",
     "HF_HOME",
     "HF_HUB_CACHE",
-    "HF_HUB_DISABLE_XET",
     "HUGGINGFACE_HUB_ENDPOINT",
     "HUGGINGFACE_HUB_CACHE",
     "TRANSFORMERS_CACHE",
@@ -191,18 +180,9 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     huggingface_source = _redact_url(values.huggingface or OFFICIAL_HUGGINGFACE_URL)
     github_source = _redact_url(values.github or OFFICIAL_GITHUB_URL)
     pypi_source = _redact_url(values.pypi or OFFICIAL_PYPI_INDEX_URL)
-    disable_xet_for_proxy = (
-        _uses_official_huggingface_source(values.huggingface)
-        and _has_active_network_proxy()
-    )
-    huggingface_transport = "http" if disable_xet_for_proxy else "auto"
     _set_or_restore_env("HF_ENDPOINT", values.huggingface)
     _set_or_restore_env("HUGGINGFACE_HUB_ENDPOINT", values.huggingface)
     _set_or_restore_env("SHINSEKAI_HUGGINGFACE_MIRROR_URL", values.huggingface)
-    _set_or_restore_env(
-        "HF_HUB_DISABLE_XET",
-        "1" if disable_xet_for_proxy else "",
-    )
     hf_home = _resolved_cache_path(values.huggingface_cache_dir)
     hf_hub_cache = (Path(hf_home) / "hub").as_posix()
     transformers_cache = (Path(hf_home) / "transformers").as_posix()
@@ -218,11 +198,10 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     _set_or_restore_env("SHINSEKAI_MIRROR_REGION", values.region)
     logger.info(
         "Mirror environment applied "
-        "(region=%s, mode=%s, huggingface=%s, huggingface_transport=%s, github=%s, pypi=%s)",
+        "(region=%s, mode=%s, huggingface=%s, github=%s, pypi=%s)",
         values.region,
         detection_mode,
         huggingface_source,
-        huggingface_transport,
         github_source,
         pypi_source,
         extra={
@@ -230,8 +209,6 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
             "region": values.region,
             "detection_mode": detection_mode,
             "huggingface_source": huggingface_source,
-            "huggingface_transport": huggingface_transport,
-            "huggingface_xet_disabled_for_proxy": disable_xet_for_proxy,
             "github_source": github_source,
             "pypi_source": pypi_source,
             "huggingface_mirror": _redact_url(values.huggingface),
@@ -367,15 +344,6 @@ def _set_or_restore_env(name: str, value: str) -> None:
         os.environ.pop(name, None)
     else:
         os.environ[name] = original
-
-
-def _uses_official_huggingface_source(url: str) -> bool:
-    normalized = str(url or OFFICIAL_HUGGINGFACE_URL).strip().rstrip("/").casefold()
-    return normalized == OFFICIAL_HUGGINGFACE_URL.casefold()
-
-
-def _has_active_network_proxy() -> bool:
-    return any(str(os.environ.get(name, "") or "").strip() for name in _NETWORK_PROXY_ENV_NAMES)
 
 
 class _FallbackMirrorConfig:

--- a/config/mirror_env.py
+++ b/config/mirror_env.py
@@ -19,6 +19,8 @@ DEFAULT_HUGGINGFACE_MIRROR_URL = "https://hf-mirror.com"
 DEFAULT_GITHUB_MIRROR_URL = "https://gh-proxy.com/"
 DEFAULT_PYPI_MIRROR_URL = "https://pypi.tuna.tsinghua.edu.cn/simple/"
 DEFAULT_HUGGINGFACE_CACHE_DIR = "./data/cache/huggingface"
+OFFICIAL_HUGGINGFACE_URL = "https://huggingface.co"
+OFFICIAL_GITHUB_URL = "https://github.com"
 OFFICIAL_PYPI_INDEX_URL = "https://pypi.org/simple/"
 
 REGION_AUTO = "auto"
@@ -174,6 +176,10 @@ def system_config_payload_with_resolved_mirrors(config: Any) -> dict[str, Any]:
 
 def apply_mirror_environment(config: Any) -> MirrorValues:
     values = resolved_mirror_values(config)
+    detection_mode = "auto" if bool(getattr(config, "mirror_auto_detect_china", True)) else "manual"
+    huggingface_source = _redact_url(values.huggingface or OFFICIAL_HUGGINGFACE_URL)
+    github_source = _redact_url(values.github or OFFICIAL_GITHUB_URL)
+    pypi_source = _redact_url(values.pypi or OFFICIAL_PYPI_INDEX_URL)
     _set_or_restore_env("HF_ENDPOINT", values.huggingface)
     _set_or_restore_env("HUGGINGFACE_HUB_ENDPOINT", values.huggingface)
     _set_or_restore_env("SHINSEKAI_HUGGINGFACE_MIRROR_URL", values.huggingface)
@@ -191,10 +197,20 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     _set_or_restore_env("SHINSEKAI_PIP_INDEX_URL", values.pypi)
     _set_or_restore_env("SHINSEKAI_MIRROR_REGION", values.region)
     logger.info(
-        "Mirror environment applied",
+        "Mirror environment applied "
+        "(region=%s, mode=%s, huggingface=%s, github=%s, pypi=%s)",
+        values.region,
+        detection_mode,
+        huggingface_source,
+        github_source,
+        pypi_source,
         extra={
             "event": "mirror.env.applied",
             "region": values.region,
+            "detection_mode": detection_mode,
+            "huggingface_source": huggingface_source,
+            "github_source": github_source,
+            "pypi_source": pypi_source,
             "huggingface_mirror": _redact_url(values.huggingface),
             "huggingface_cache_dir": hf_home,
             "github_mirror": _redact_url(values.github),

--- a/config/mirror_env.py
+++ b/config/mirror_env.py
@@ -36,11 +36,22 @@ _DEFAULT_IP_REGION_URLS = (
     "https://ipapi.co/country/",
     "https://api.country.is/",
 )
+_NETWORK_PROXY_ENV_NAMES = (
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "SOCKS_PROXY",
+    "socks_proxy",
+)
 
 _MANAGED_ENV_NAMES = (
     "HF_ENDPOINT",
     "HF_HOME",
     "HF_HUB_CACHE",
+    "HF_HUB_DISABLE_XET",
     "HUGGINGFACE_HUB_ENDPOINT",
     "HUGGINGFACE_HUB_CACHE",
     "TRANSFORMERS_CACHE",
@@ -180,9 +191,18 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     huggingface_source = _redact_url(values.huggingface or OFFICIAL_HUGGINGFACE_URL)
     github_source = _redact_url(values.github or OFFICIAL_GITHUB_URL)
     pypi_source = _redact_url(values.pypi or OFFICIAL_PYPI_INDEX_URL)
+    disable_xet_for_proxy = (
+        _uses_official_huggingface_source(values.huggingface)
+        and _has_active_network_proxy()
+    )
+    huggingface_transport = "http" if disable_xet_for_proxy else "auto"
     _set_or_restore_env("HF_ENDPOINT", values.huggingface)
     _set_or_restore_env("HUGGINGFACE_HUB_ENDPOINT", values.huggingface)
     _set_or_restore_env("SHINSEKAI_HUGGINGFACE_MIRROR_URL", values.huggingface)
+    _set_or_restore_env(
+        "HF_HUB_DISABLE_XET",
+        "1" if disable_xet_for_proxy else "",
+    )
     hf_home = _resolved_cache_path(values.huggingface_cache_dir)
     hf_hub_cache = (Path(hf_home) / "hub").as_posix()
     transformers_cache = (Path(hf_home) / "transformers").as_posix()
@@ -198,10 +218,11 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     _set_or_restore_env("SHINSEKAI_MIRROR_REGION", values.region)
     logger.info(
         "Mirror environment applied "
-        "(region=%s, mode=%s, huggingface=%s, github=%s, pypi=%s)",
+        "(region=%s, mode=%s, huggingface=%s, huggingface_transport=%s, github=%s, pypi=%s)",
         values.region,
         detection_mode,
         huggingface_source,
+        huggingface_transport,
         github_source,
         pypi_source,
         extra={
@@ -209,6 +230,8 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
             "region": values.region,
             "detection_mode": detection_mode,
             "huggingface_source": huggingface_source,
+            "huggingface_transport": huggingface_transport,
+            "huggingface_xet_disabled_for_proxy": disable_xet_for_proxy,
             "github_source": github_source,
             "pypi_source": pypi_source,
             "huggingface_mirror": _redact_url(values.huggingface),
@@ -344,6 +367,15 @@ def _set_or_restore_env(name: str, value: str) -> None:
         os.environ.pop(name, None)
     else:
         os.environ[name] = original
+
+
+def _uses_official_huggingface_source(url: str) -> bool:
+    normalized = str(url or OFFICIAL_HUGGINGFACE_URL).strip().rstrip("/").casefold()
+    return normalized == OFFICIAL_HUGGINGFACE_URL.casefold()
+
+
+def _has_active_network_proxy() -> bool:
+    return any(str(os.environ.get(name, "") or "").strip() for name in _NETWORK_PROXY_ENV_NAMES)
 
 
 class _FallbackMirrorConfig:

--- a/config/mirror_env.py
+++ b/config/mirror_env.py
@@ -36,6 +36,17 @@ _DEFAULT_IP_REGION_URLS = (
     "https://ipapi.co/country/",
     "https://api.country.is/",
 )
+_NETWORK_PROXY_ENV_NAMES = (
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "SOCKS_PROXY",
+    "socks_proxy",
+)
+
 _MANAGED_ENV_NAMES = (
     "HF_ENDPOINT",
     "HF_HOME",
@@ -180,14 +191,17 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     huggingface_source = _redact_url(values.huggingface or OFFICIAL_HUGGINGFACE_URL)
     github_source = _redact_url(values.github or OFFICIAL_GITHUB_URL)
     pypi_source = _redact_url(values.pypi or OFFICIAL_PYPI_INDEX_URL)
-    disable_xet = _uses_official_huggingface_source(values.huggingface)
-    huggingface_transport = "http" if disable_xet else "auto"
+    disable_xet_for_proxy = (
+        _uses_official_huggingface_source(values.huggingface)
+        and _has_active_network_proxy()
+    )
+    huggingface_transport = "http" if disable_xet_for_proxy else "auto"
     _set_or_restore_env("HF_ENDPOINT", values.huggingface)
     _set_or_restore_env("HUGGINGFACE_HUB_ENDPOINT", values.huggingface)
     _set_or_restore_env("SHINSEKAI_HUGGINGFACE_MIRROR_URL", values.huggingface)
     _set_or_restore_env(
         "HF_HUB_DISABLE_XET",
-        "1" if disable_xet else "",
+        "1" if disable_xet_for_proxy else "",
     )
     hf_home = _resolved_cache_path(values.huggingface_cache_dir)
     hf_hub_cache = (Path(hf_home) / "hub").as_posix()
@@ -217,7 +231,7 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
             "detection_mode": detection_mode,
             "huggingface_source": huggingface_source,
             "huggingface_transport": huggingface_transport,
-            "huggingface_xet_disabled": disable_xet,
+            "huggingface_xet_disabled_for_proxy": disable_xet_for_proxy,
             "github_source": github_source,
             "pypi_source": pypi_source,
             "huggingface_mirror": _redact_url(values.huggingface),
@@ -358,6 +372,10 @@ def _set_or_restore_env(name: str, value: str) -> None:
 def _uses_official_huggingface_source(url: str) -> bool:
     normalized = str(url or OFFICIAL_HUGGINGFACE_URL).strip().rstrip("/").casefold()
     return normalized == OFFICIAL_HUGGINGFACE_URL.casefold()
+
+
+def _has_active_network_proxy() -> bool:
+    return any(str(os.environ.get(name, "") or "").strip() for name in _NETWORK_PROXY_ENV_NAMES)
 
 
 class _FallbackMirrorConfig:

--- a/config/mirror_env.py
+++ b/config/mirror_env.py
@@ -36,17 +36,6 @@ _DEFAULT_IP_REGION_URLS = (
     "https://ipapi.co/country/",
     "https://api.country.is/",
 )
-_NETWORK_PROXY_ENV_NAMES = (
-    "HTTPS_PROXY",
-    "https_proxy",
-    "HTTP_PROXY",
-    "http_proxy",
-    "ALL_PROXY",
-    "all_proxy",
-    "SOCKS_PROXY",
-    "socks_proxy",
-)
-
 _MANAGED_ENV_NAMES = (
     "HF_ENDPOINT",
     "HF_HOME",
@@ -191,17 +180,14 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     huggingface_source = _redact_url(values.huggingface or OFFICIAL_HUGGINGFACE_URL)
     github_source = _redact_url(values.github or OFFICIAL_GITHUB_URL)
     pypi_source = _redact_url(values.pypi or OFFICIAL_PYPI_INDEX_URL)
-    disable_xet_for_proxy = (
-        _uses_official_huggingface_source(values.huggingface)
-        and _has_active_network_proxy()
-    )
-    huggingface_transport = "http" if disable_xet_for_proxy else "auto"
+    disable_xet = _uses_official_huggingface_source(values.huggingface)
+    huggingface_transport = "http" if disable_xet else "auto"
     _set_or_restore_env("HF_ENDPOINT", values.huggingface)
     _set_or_restore_env("HUGGINGFACE_HUB_ENDPOINT", values.huggingface)
     _set_or_restore_env("SHINSEKAI_HUGGINGFACE_MIRROR_URL", values.huggingface)
     _set_or_restore_env(
         "HF_HUB_DISABLE_XET",
-        "1" if disable_xet_for_proxy else "",
+        "1" if disable_xet else "",
     )
     hf_home = _resolved_cache_path(values.huggingface_cache_dir)
     hf_hub_cache = (Path(hf_home) / "hub").as_posix()
@@ -231,7 +217,7 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
             "detection_mode": detection_mode,
             "huggingface_source": huggingface_source,
             "huggingface_transport": huggingface_transport,
-            "huggingface_xet_disabled_for_proxy": disable_xet_for_proxy,
+            "huggingface_xet_disabled": disable_xet,
             "github_source": github_source,
             "pypi_source": pypi_source,
             "huggingface_mirror": _redact_url(values.huggingface),
@@ -372,10 +358,6 @@ def _set_or_restore_env(name: str, value: str) -> None:
 def _uses_official_huggingface_source(url: str) -> bool:
     normalized = str(url or OFFICIAL_HUGGINGFACE_URL).strip().rstrip("/").casefold()
     return normalized == OFFICIAL_HUGGINGFACE_URL.casefold()
-
-
-def _has_active_network_proxy() -> bool:
-    return any(str(os.environ.get(name, "") or "").strip() for name in _NETWORK_PROXY_ENV_NAMES)
 
 
 class _FallbackMirrorConfig:

--- a/core/plugins/plugin_requirements_install.py
+++ b/core/plugins/plugin_requirements_install.py
@@ -8,7 +8,6 @@ import importlib.metadata as importlib_metadata
 import logging
 import os
 import re
-import subprocess
 import sys
 import tempfile
 import time
@@ -19,8 +18,11 @@ from core.plugins.pip_index_config import (
 )
 from core.plugins.pip_runner import (
     apply_pip_index_and_extra_args as _apply_pip_index_and_extra_args,
-    pip_win_creationflags as _pip_win_creationflags,
     run_pip_install as _run_pip_install,
+)
+from core.plugins.pytorch_runtime import (
+    build_pytorch_install_plan as _build_pytorch_install_plan,
+    partition_pytorch_requirement_lines as _partition_torch_requirement_lines,
 )
 
 try:
@@ -30,10 +32,6 @@ except Exception:  # pragma: no cover - fallback for minimal embedded runtimes.
     Requirement = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
-
-_TORCH_PROJECT_NAMES = frozenset({"torch", "torchvision", "torchaudio"})
-_CUDA_VER_LINE_RE = re.compile(r"CUDA Version:\s*(\d+)\.(\d+)")
-
 
 def frozen_release_root() -> Path | None:
     """打包运行时返回发行根目录；开发模式返回 ``None``。"""
@@ -115,53 +113,6 @@ def ensure_plugins_namespace_on_syspath() -> None:
             logger.info("Prepended cwd for plugins namespace: %s", s)
 
 
-def _nvidia_smi_cuda_driver_version() -> tuple[int, int] | None:
-    """Parse ``CUDA Version: major.minor`` from ``nvidia-smi`` stdout; None if unavailable."""
-    pop_kw: dict[str, object] = {
-        "args": ["nvidia-smi"],
-        "capture_output": True,
-        "text": True,
-        "timeout": 20,
-    }
-    if sys.platform == "win32":
-        flags = _pip_win_creationflags()
-        if flags:
-            pop_kw["creationflags"] = flags
-    try:
-        proc = subprocess.run(**pop_kw)
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if proc.returncode != 0 or not proc.stdout:
-        return None
-    match = _CUDA_VER_LINE_RE.search(proc.stdout)
-    if not match:
-        return None
-    return int(match.group(1)), int(match.group(2))
-
-
-def _pytorch_wheel_index_url_for_this_machine() -> tuple[str, str]:
-    """
-    Choose ``pip install --index-url`` for PyTorch official wheels (CUDA vs CPU).
-
-    Only used on Windows/Linux after splitting ``torch`` / ``torchvision`` / ``torchaudio`` lines out
-    of a plugin ``requirements.txt``.
-    """
-    ver = _nvidia_smi_cuda_driver_version()
-    if ver is None:
-        return "https://download.pytorch.org/whl/cpu", "no_usable_nvidia_smi_cpu"
-    major, minor = ver
-    if (major, minor) >= (12, 4):
-        tag = "cu124"
-    elif major >= 12:
-        tag = "cu121"
-    elif (major, minor) >= (11, 8):
-        tag = "cu118"
-    else:
-        tag = "cu118"
-    url = f"https://download.pytorch.org/whl/{tag}"
-    return url, f"nvidia_driver_cuda_{major}.{minor}_{tag}"
-
-
 def _requirement_line_project_name(line: str) -> str | None:
     """PEP 508-ish name from a single ``requirements.txt`` line, or None if not a plain package."""
     segment = line.split("#", 1)[0].strip()
@@ -180,18 +131,6 @@ def _requirement_line_project_name(line: str) -> str | None:
     if not match:
         return None
     return match.group(1).lower().replace("_", "-")
-
-
-def _partition_torch_requirement_lines(lines: list[str]) -> tuple[list[str], list[str]]:
-    torch_only: list[str] = []
-    rest: list[str] = []
-    for line in lines:
-        name = _requirement_line_project_name(line)
-        if name is not None and name in _TORCH_PROJECT_NAMES:
-            torch_only.append(line.rstrip("\r\n"))
-        else:
-            rest.append(line.rstrip("\r\n"))
-    return torch_only, rest
 
 
 def _has_non_comment_requirement(lines: list[str]) -> bool:
@@ -354,8 +293,9 @@ def install_plugin_requirements_txt(
     Run ``python -m pip install -r requirements_file`` if it exists under ``plugin_root``.
 
     冻结版使用 :func:`pip_python_executable`（默认 ``<发行根>/runtime/python.exe``）执行
-    ``pip install --target <发行根>/data/plugin_site_packages``；宿主须在启动时调用
-    :func:`ensure_plugin_site_packages_on_syspath`。
+    普通依赖使用 ``pip install --target <发行根>/data/plugin_site_packages``；PyTorch
+    二进制栈是例外，会统一安装进 bundled runtime，避免两套 ``torch`` 同时出现在
+    ``sys.path``。宿主须在启动时调用 :func:`ensure_plugin_site_packages_on_syspath`。
 
     On Windows/Linux, if the file lists ``torch``, ``torchvision``, or ``torchaudio``, those lines are
     installed first from PyTorch's wheel index (CUDA channel derived from ``nvidia-smi``, otherwise CPU).
@@ -401,10 +341,13 @@ def install_plugin_requirements_txt(
         logger.warning("Could not read %s: %s", req, exc)
         return ("pip_exception", str(exc))
 
-    # 先在本地分发信息里做预检，普通包只把“缺失或版本不满足”的行交给 pip。
-    # 这样已安装依赖不会反复下载，国内用户装插件时能少等很多。
-    can_prune, install_lines = _install_lines_after_precheck(lines)
-    if can_prune and not install_lines:
+    # PyTorch 栈始终单独检查。普通包仍只把“缺失或版本不满足”的行交给 pip；
+    # PyTorch 还会核对 CPU/CUDA wheel 标签，不能被普通的 ``>=`` 预检提前裁掉。
+    torch_lines, source_other_lines = _partition_torch_requirement_lines(lines)
+    split_torch = bool(torch_lines) and sys.platform != "darwin"
+    precheck_source_lines = source_other_lines if split_torch else lines
+    can_prune, install_lines = _install_lines_after_precheck(precheck_source_lines)
+    if can_prune and not install_lines and not split_torch:
         logger.info("Plugin pip: all requirements already satisfied, skipping install.")
         return ("pip_ok", "")
 
@@ -421,41 +364,47 @@ def install_plugin_requirements_txt(
             active_req = precheck_tf
             active_lines = install_lines
 
-        torch_lines, other_lines = _partition_torch_requirement_lines(active_lines)
-        split_torch = bool(torch_lines) and sys.platform != "darwin"
-
         if split_torch:
-            # torch/torchvision/torchaudio 不走普通 PyPI 镜像。
-            # 这里先按本机 CUDA/CPU 选择 PyTorch 官方 wheel index，再安装剩余依赖。
-            idx_url, idx_reason = _pytorch_wheel_index_url_for_this_machine()
-            logger.info(
-                "Plugin pip: PyTorch packages use index %s (%s)",
-                idx_url,
-                idx_reason,
+            # torch/torchvision/torchaudio 不走普通 PyPI 镜像，也不装进插件
+            # --target：整套二进制运行时必须由 bundled/runtime Python 统一持有。
+            installed_versions = _installed_distribution_versions()
+            plan = _build_pytorch_install_plan(
+                torch_lines,
+                installed_versions,
+                requirement_is_satisfied=_requirement_line_is_satisfied,
             )
-            torch_tf = _write_temp_requirements("easyai_torch_req_", torch_lines)
-
-            cmd_torch = [
-                *base_cmd,
-                "--index-url",
-                idx_url,
-                "--extra-index-url",
-                "https://pypi.org/simple",
-                "-r",
-                str(torch_tf),
-            ]
-            code1, detail1 = _finish_install_result(
-                _run_pip_install(
+            logger.info(
+                "Plugin pip: PyTorch plan index=%s (%s), install=%s, "
+                "force_reinstall=%s: %s",
+                plan.index_url,
+                plan.index_reason,
+                plan.install_required,
+                plan.force_reinstall,
+                plan.detail,
+            )
+            if plan.install_required:
+                torch_tf = _write_temp_requirements("easyai_torch_req_", torch_lines)
+                # Intentionally omit plugin ``--target`` for the PyTorch stack.
+                cmd_torch = [
+                    *_pip_base_install_cmd(py, None),
+                    "--index-url",
+                    plan.index_url,
+                    "--extra-index-url",
+                    "https://pypi.org/simple",
+                ]
+                if plan.force_reinstall:
+                    cmd_torch.extend(["--upgrade", "--force-reinstall"])
+                cmd_torch.extend(["-r", str(torch_tf)])
+                code1, detail1 = _run_pip_install(
                     _apply_pip_index_and_extra_args(cmd_torch, torch_lines),
                     cwd=root,
                     timeout_sec=remaining_budget(),
                     on_output_line=on_output_line,
-                ),
-                pip_target,
-            )
-            if code1 != "pip_ok":
-                return (code1, detail1)
+                )
+                if code1 != "pip_ok":
+                    return (code1, detail1)
 
+            other_lines = install_lines if can_prune else source_other_lines
             if not _has_non_comment_requirement(other_lines):
                 return _finish_install_result(("pip_ok", ""), pip_target)
 

--- a/core/plugins/plugin_requirements_install.py
+++ b/core/plugins/plugin_requirements_install.py
@@ -382,8 +382,15 @@ def install_plugin_requirements_txt(
                 plan.force_reinstall,
                 plan.detail,
             )
+            managed_torch_lines = list(plan.requirement_lines)
+            if managed_torch_lines:
+                torch_tf = _write_temp_requirements(
+                    "easyai_torch_req_",
+                    managed_torch_lines,
+                )
             if plan.install_required:
-                torch_tf = _write_temp_requirements("easyai_torch_req_", torch_lines)
+                if torch_tf is None:
+                    return ("pip_exception", "host PyTorch requirements are unavailable")
                 # Intentionally omit plugin ``--target`` for the PyTorch stack.
                 cmd_torch = [
                     *_pip_base_install_cmd(py, None),
@@ -401,7 +408,7 @@ def install_plugin_requirements_txt(
                     cmd_torch.extend(["--upgrade", "--force-reinstall", "--no-deps"])
                 cmd_torch.extend(["-r", str(torch_tf)])
                 code1, detail1 = _run_pip_install(
-                    _apply_pip_index_and_extra_args(cmd_torch, torch_lines),
+                    _apply_pip_index_and_extra_args(cmd_torch, managed_torch_lines),
                     cwd=root,
                     timeout_sec=remaining_budget(),
                     on_output_line=on_output_line,
@@ -419,7 +426,10 @@ def install_plugin_requirements_txt(
                         str(torch_tf),
                     ]
                     code2, detail2 = _run_pip_install(
-                        _apply_pip_index_and_extra_args(cmd_torch_deps, torch_lines),
+                        _apply_pip_index_and_extra_args(
+                            cmd_torch_deps,
+                            managed_torch_lines,
+                        ),
                         cwd=root,
                         timeout_sec=remaining_budget(),
                         on_output_line=on_output_line,
@@ -432,9 +442,17 @@ def install_plugin_requirements_txt(
                 return _finish_install_result(("pip_ok", ""), pip_target)
 
             other_tf = _write_temp_requirements("easyai_other_req_", other_lines)
-
+            # Keep PyTorch-enabled plugins in the bundled runtime environment.
+            # pip's ``--target`` resolver ignores distributions already
+            # installed in the runtime and would otherwise download a second
+            # transitive torch for packages such as accelerate. The host stack
+            # also acts as a constraint so incompatible transitive requirements
+            # fail clearly instead of silently replacing it.
+            cmd_other_base = _pip_base_install_cmd(py, None)
+            if torch_tf is not None:
+                cmd_other_base.extend(["-c", str(torch_tf)])
             cmd_other = _apply_pip_index_and_extra_args(
-                [*base_cmd, "-r", str(other_tf)],
+                [*cmd_other_base, "-r", str(other_tf)],
                 other_lines,
             )
             return _finish_install_result(
@@ -444,7 +462,7 @@ def install_plugin_requirements_txt(
                     timeout_sec=remaining_budget(),
                     on_output_line=on_output_line,
                 ),
-                pip_target,
+                None,
             )
 
         cmd = _apply_pip_index_and_extra_args(

--- a/core/plugins/plugin_requirements_install.py
+++ b/core/plugins/plugin_requirements_install.py
@@ -393,7 +393,12 @@ def install_plugin_requirements_txt(
                     "https://pypi.org/simple",
                 ]
                 if plan.force_reinstall:
-                    cmd_torch.extend(["--upgrade", "--force-reinstall"])
+                    # ``--force-reinstall`` also applies to resolved transitive
+                    # dependencies unless dependency resolution is disabled.
+                    # Replace only the requested PyTorch binary stack first;
+                    # the follow-up plain install repairs missing dependencies
+                    # without forcing already-satisfied packages to reinstall.
+                    cmd_torch.extend(["--upgrade", "--force-reinstall", "--no-deps"])
                 cmd_torch.extend(["-r", str(torch_tf)])
                 code1, detail1 = _run_pip_install(
                     _apply_pip_index_and_extra_args(cmd_torch, torch_lines),
@@ -403,6 +408,24 @@ def install_plugin_requirements_txt(
                 )
                 if code1 != "pip_ok":
                     return (code1, detail1)
+                if plan.force_reinstall:
+                    cmd_torch_deps = [
+                        *_pip_base_install_cmd(py, None),
+                        "--index-url",
+                        plan.index_url,
+                        "--extra-index-url",
+                        "https://pypi.org/simple",
+                        "-r",
+                        str(torch_tf),
+                    ]
+                    code2, detail2 = _run_pip_install(
+                        _apply_pip_index_and_extra_args(cmd_torch_deps, torch_lines),
+                        cwd=root,
+                        timeout_sec=remaining_budget(),
+                        on_output_line=on_output_line,
+                    )
+                    if code2 != "pip_ok":
+                        return (code2, detail2)
 
             other_lines = install_lines if can_prune else source_other_lines
             if not _has_non_comment_requirement(other_lines):

--- a/core/plugins/pytorch_runtime.py
+++ b/core/plugins/pytorch_runtime.py
@@ -4,8 +4,9 @@ PyTorch packages need stricter handling than ordinary plugin dependencies:
 
 * the wheel channel (``cpu`` / ``cuXXX``) is part of runtime compatibility;
 * ``torch``, ``torchvision`` and ``torchaudio`` must be kept as one stack;
-* a broad requirement such as ``torch>=2`` must not accept an installed CPU
-  wheel when the current machine should use a CUDA wheel.
+* plugin-authored PyTorch versions are ignored so a broad requirement such as
+  ``torch>=2`` cannot silently upgrade the shared runtime to an untested stack;
+* the host-owned versions and the detected GPU channel are checked together.
 
 This module deliberately owns the policy and the pure planning logic.  The
 caller remains responsible for executing pip so its existing progress,
@@ -32,6 +33,11 @@ except Exception:  # pragma: no cover - minimal embedded runtime fallback.
 
 
 PYTORCH_PROJECT_NAMES = ("torch", "torchvision", "torchaudio")
+HOST_PYTORCH_REQUIREMENTS = (
+    "torch==2.7.1",
+    "torchvision==0.22.1",
+    "torchaudio==2.7.1",
+)
 _PYTORCH_PROJECT_NAME_SET = frozenset(PYTORCH_PROJECT_NAMES)
 _CUDA_VER_LINE_RE = re.compile(r"CUDA Version:\s*(\d+)\.(\d+)")
 _LOCAL_BUILD_RE = re.compile(r"(?:^|[.+-])(cpu|cu\d+)(?:$|[.+-])", re.IGNORECASE)
@@ -52,6 +58,7 @@ _GLOBAL_REGION_NAMES = frozenset(
 
 @dataclass(frozen=True)
 class PytorchInstallPlan:
+    requirement_lines: tuple[str, ...]
     index_url: str
     index_reason: str
     expected_build: str
@@ -181,16 +188,17 @@ def pytorch_wheel_index_url_for_cuda_version(
     if version is None:
         return f"{base}/cpu", "no_usable_nvidia_smi_cpu"
     major, minor = version
+    # The host-owned 2.7.1 stack is officially published for cu118, cu126,
+    # cu128 and CPU. Do not cross-fallback between CUDA channels: when the
+    # detected driver falls in a gap such as CUDA 12.1/12.4, use CPU wheels.
     if (major, minor) >= (12, 8):
         tag = "cu128"
     elif (major, minor) >= (12, 6):
         tag = "cu126"
-    elif (major, minor) >= (12, 4):
-        tag = "cu124"
-    elif major >= 12:
-        tag = "cu121"
-    else:
+    elif major == 11 and minor >= 8:
         tag = "cu118"
+    else:
+        return f"{base}/cpu", f"nvidia_driver_cuda_{major}.{minor}_cpu_fallback"
     return f"{base}/{tag}", f"nvidia_driver_cuda_{major}.{minor}_{tag}"
 
 
@@ -250,12 +258,13 @@ def build_pytorch_install_plan(
     index_url: str | None = None,
     index_reason: str | None = None,
 ) -> PytorchInstallPlan:
-    """Decide whether the requested PyTorch stack can be reused.
+    """Decide whether the host-owned PyTorch stack can be reused.
 
-    A missing package needs a normal install.  A version or wheel-channel
-    mismatch needs ``--force-reinstall`` so pip replaces the complete stack
-    instead of accepting a semantically compatible wheel from the wrong
-    channel.
+    Plugin-authored versions only opt into the shared stack; they never select
+    its versions. A missing package needs a normal install. A host-version or
+    wheel-channel mismatch needs ``--force-reinstall`` so pip replaces the
+    complete stack instead of accepting a semantically compatible wheel from
+    the wrong channel.
     """
     if index_url is None:
         index_url, detected_reason = pytorch_wheel_index_url_for_this_machine()
@@ -268,23 +277,23 @@ def build_pytorch_install_plan(
         canonical_distribution_name(name): version for name, version in installed_versions.items()
     }
 
-    active_lines: list[str] = []
-    requested_names: list[str] = []
+    has_active_pytorch_requirement = False
     for line in requirement_lines:
         active = _active_requirement(line)
         if active is None:
             continue
-        active_lines.append(line)
         name = (
             canonical_distribution_name(active.name)
             if Requirement is not None and hasattr(active, "name")
             else requirement_line_project_name(str(active))
         )
-        if name in _PYTORCH_PROJECT_NAME_SET and name not in requested_names:
-            requested_names.append(name)
+        if name in _PYTORCH_PROJECT_NAME_SET:
+            has_active_pytorch_requirement = True
+            break
 
-    if not active_lines:
+    if not has_active_pytorch_requirement:
         return PytorchInstallPlan(
+            requirement_lines=(),
             index_url=index_url,
             index_reason=index_reason,
             expected_build=expected_build,
@@ -293,6 +302,8 @@ def build_pytorch_install_plan(
             detail="no active PyTorch requirements",
         )
 
+    active_lines = list(HOST_PYTORCH_REQUIREMENTS)
+    requested_names = list(PYTORCH_PROJECT_NAMES)
     missing = [name for name in requested_names if name not in normalized_versions]
     unsatisfied = [
         line
@@ -304,15 +315,16 @@ def build_pytorch_install_plan(
         detail = (
             f"missing packages: {', '.join(missing)}"
             if missing and not installed_stack
-            else "installed PyTorch versions do not match current requirements"
+            else "installed PyTorch versions do not match the host stack"
         )
         return PytorchInstallPlan(
+            requirement_lines=HOST_PYTORCH_REQUIREMENTS,
             index_url=index_url,
             index_reason=index_reason,
             expected_build=expected_build,
             install_required=True,
             force_reinstall=bool(installed_stack),
-            detail=detail,
+            detail=f"{detail}; plugin versions ignored in favor of host stack",
         )
 
     wrong_build = [
@@ -323,6 +335,7 @@ def build_pytorch_install_plan(
     ]
     if wrong_build:
         return PytorchInstallPlan(
+            requirement_lines=HOST_PYTORCH_REQUIREMENTS,
             index_url=index_url,
             index_reason=index_reason,
             expected_build=expected_build,
@@ -335,10 +348,11 @@ def build_pytorch_install_plan(
         )
 
     return PytorchInstallPlan(
+        requirement_lines=HOST_PYTORCH_REQUIREMENTS,
         index_url=index_url,
         index_reason=index_reason,
         expected_build=expected_build,
         install_required=False,
         force_reinstall=False,
-        detail="installed PyTorch stack matches requirements and wheel channel",
+        detail="installed PyTorch stack matches host versions and wheel channel",
     )

--- a/core/plugins/pytorch_runtime.py
+++ b/core/plugins/pytorch_runtime.py
@@ -1,0 +1,344 @@
+"""Shared PyTorch wheel selection and reinstall planning.
+
+PyTorch packages need stricter handling than ordinary plugin dependencies:
+
+* the wheel channel (``cpu`` / ``cuXXX``) is part of runtime compatibility;
+* ``torch``, ``torchvision`` and ``torchaudio`` must be kept as one stack;
+* a broad requirement such as ``torch>=2`` must not accept an installed CPU
+  wheel when the current machine should use a CUDA wheel.
+
+This module deliberately owns the policy and the pure planning logic.  The
+caller remains responsible for executing pip so its existing progress,
+timeout, mirror and error-reporting behavior stays intact.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from core.plugins.pip_index_config import pip_index_urls as _pip_index_urls
+from core.plugins.pip_runner import pip_win_creationflags
+
+try:
+    from packaging.requirements import InvalidRequirement, Requirement
+except Exception:  # pragma: no cover - minimal embedded runtime fallback.
+    InvalidRequirement = ValueError  # type: ignore[assignment]
+    Requirement = None  # type: ignore[assignment]
+
+
+PYTORCH_PROJECT_NAMES = ("torch", "torchvision", "torchaudio")
+_PYTORCH_PROJECT_NAME_SET = frozenset(PYTORCH_PROJECT_NAMES)
+_CUDA_VER_LINE_RE = re.compile(r"CUDA Version:\s*(\d+)\.(\d+)")
+_LOCAL_BUILD_RE = re.compile(r"(?:^|[.+-])(cpu|cu\d+)(?:$|[.+-])", re.IGNORECASE)
+_OFFICIAL_PYTORCH_WHEEL_BASE = "https://download.pytorch.org/whl"
+_CHINA_PYTORCH_WHEEL_BASE = "https://mirrors.aliyun.com/pytorch-wheels"
+_CHINA_INDEX_DOMAINS = (
+    "pypi.tuna.tsinghua.edu.cn",
+    "mirrors.ustc.edu.cn",
+    "mirrors.hit.edu.cn",
+    "mirrors.aliyun.com",
+    "mirror.sjtu.edu.cn",
+)
+_CHINA_REGION_NAMES = frozenset({"china", "cn", "mainland", "mainland_china"})
+_GLOBAL_REGION_NAMES = frozenset(
+    {"official", "global", "intl", "international", "overseas", "us"}
+)
+
+
+@dataclass(frozen=True)
+class PytorchInstallPlan:
+    index_url: str
+    index_reason: str
+    expected_build: str
+    install_required: bool
+    force_reinstall: bool
+    detail: str
+
+
+def canonical_distribution_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).strip("-").lower()
+
+
+def requirement_line_project_name(line: str) -> str | None:
+    """Return the normalized project name for a plain requirement line."""
+    segment = line.split("#", 1)[0].strip()
+    if not segment:
+        return None
+    lower = segment.lower()
+    if lower.startswith(("--", "-r ", "-c ")):
+        return None
+    if lower.startswith("-e "):
+        segment = segment[2:].strip()
+    first = segment.split()[0]
+    if "://" in first or first.startswith("git+"):
+        return None
+    match = re.match(r"([A-Za-z0-9][A-Za-z0-9._-]*)", segment)
+    if not match:
+        return None
+    return canonical_distribution_name(match.group(1))
+
+
+def partition_pytorch_requirement_lines(lines: list[str]) -> tuple[list[str], list[str]]:
+    pytorch: list[str] = []
+    rest: list[str] = []
+    for line in lines:
+        name = requirement_line_project_name(line)
+        target = pytorch if name in _PYTORCH_PROJECT_NAME_SET else rest
+        target.append(line.rstrip("\r\n"))
+    return pytorch, rest
+
+
+def nvidia_smi_cuda_driver_version() -> tuple[int, int] | None:
+    """Parse the maximum CUDA version reported by ``nvidia-smi``."""
+    pop_kw: dict[str, object] = {
+        "args": ["nvidia-smi"],
+        "capture_output": True,
+        "text": True,
+        "timeout": 20,
+    }
+    if sys.platform == "win32":
+        flags = pip_win_creationflags()
+        if flags:
+            pop_kw["creationflags"] = flags
+    try:
+        proc = subprocess.run(**pop_kw)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    match = _CUDA_VER_LINE_RE.search(proc.stdout)
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _explicit_pytorch_region() -> str:
+    runtime_source = os.environ.get("SHINSEKAI_RUNTIME_SOURCE", "").strip().lower()
+    if runtime_source in _CHINA_REGION_NAMES:
+        return "china"
+    if runtime_source in _GLOBAL_REGION_NAMES:
+        return "global"
+    mirror_region = os.environ.get("SHINSEKAI_MIRROR_REGION", "").strip().lower()
+    if mirror_region in _CHINA_REGION_NAMES:
+        return "china"
+    if mirror_region in _GLOBAL_REGION_NAMES:
+        return "global"
+    return ""
+
+
+def _configured_index_urls() -> list[str]:
+    urls = list(_pip_index_urls())
+    if urls:
+        return urls
+    # ``pip_index_urls`` deliberately returns [] when pip itself was explicitly
+    # configured. Inspect those values only to choose a compatible PyTorch
+    # mirror; they are never reused as PyTorch wheel URLs.
+    for name in (
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+        "SHINSEKAI_PIP_INDEX_URL",
+        "SHINSEKAI_PIP_INDEX_URLS",
+    ):
+        raw = os.environ.get(name, "")
+        for line in raw.splitlines():
+            urls.extend(part.strip() for part in line.split(",") if part.strip())
+    return urls
+
+
+def _indexes_prefer_china(index_urls: list[str]) -> bool:
+    if not index_urls:
+        return False
+    primary = index_urls[0].lower()
+    return any(domain in primary for domain in _CHINA_INDEX_DOMAINS)
+
+
+def pytorch_wheel_base_url(index_urls: list[str] | None = None) -> str:
+    override = os.environ.get("SHINSEKAI_PYTORCH_WHEEL_BASE", "").strip().rstrip("/")
+    if override:
+        return override
+    region = _explicit_pytorch_region()
+    if region == "china":
+        return _CHINA_PYTORCH_WHEEL_BASE
+    if region == "global":
+        return _OFFICIAL_PYTORCH_WHEEL_BASE
+    selected_indexes = _configured_index_urls() if index_urls is None else index_urls
+    if _indexes_prefer_china(selected_indexes):
+        return _CHINA_PYTORCH_WHEEL_BASE
+    return _OFFICIAL_PYTORCH_WHEEL_BASE
+
+
+def pytorch_wheel_index_url_for_cuda_version(
+    version: tuple[int, int] | None,
+    *,
+    base_url: str | None = None,
+) -> tuple[str, str]:
+    base = (base_url or pytorch_wheel_base_url()).rstrip("/")
+    if version is None:
+        return f"{base}/cpu", "no_usable_nvidia_smi_cpu"
+    major, minor = version
+    if (major, minor) >= (12, 8):
+        tag = "cu128"
+    elif (major, minor) >= (12, 6):
+        tag = "cu126"
+    elif (major, minor) >= (12, 4):
+        tag = "cu124"
+    elif major >= 12:
+        tag = "cu121"
+    else:
+        tag = "cu118"
+    return f"{base}/{tag}", f"nvidia_driver_cuda_{major}.{minor}_{tag}"
+
+
+def pytorch_wheel_index_url_for_this_machine() -> tuple[str, str]:
+    return pytorch_wheel_index_url_for_cuda_version(nvidia_smi_cuda_driver_version())
+
+
+def pytorch_index_build(index_url: str) -> str:
+    candidate = index_url.rstrip("/").rsplit("/", 1)[-1].lower()
+    if candidate == "cpu" or re.fullmatch(r"cu\d+", candidate):
+        return candidate
+    return ""
+
+
+def installed_pytorch_project_names(installed_versions: Mapping[str, str]) -> list[str]:
+    normalized = {
+        canonical_distribution_name(name): version for name, version in installed_versions.items()
+    }
+    return [name for name in PYTORCH_PROJECT_NAMES if name in normalized]
+
+
+def _active_requirement(line: str):
+    stripped = line.split("#", 1)[0].strip()
+    if not stripped:
+        return None
+    if Requirement is None:
+        return stripped
+    try:
+        requirement = Requirement(stripped)
+    except InvalidRequirement:
+        return stripped
+    if requirement.marker and not requirement.marker.evaluate():
+        return None
+    return requirement
+
+
+def _installed_build(version: str) -> str:
+    match = _LOCAL_BUILD_RE.search(version or "")
+    return match.group(1).lower() if match else ""
+
+
+def _build_matches(version: str, expected_build: str) -> bool:
+    if not expected_build:
+        return True
+    installed_build = _installed_build(version)
+    if expected_build == "cpu":
+        # Some CPU-only PyPI wheels have no local ``+cpu`` suffix.
+        return installed_build in {"", "cpu"}
+    return installed_build == expected_build
+
+
+def build_pytorch_install_plan(
+    requirement_lines: list[str],
+    installed_versions: Mapping[str, str],
+    *,
+    requirement_is_satisfied: Callable[[str, Mapping[str, str]], bool],
+    index_url: str | None = None,
+    index_reason: str | None = None,
+) -> PytorchInstallPlan:
+    """Decide whether the requested PyTorch stack can be reused.
+
+    A missing package needs a normal install.  A version or wheel-channel
+    mismatch needs ``--force-reinstall`` so pip replaces the complete stack
+    instead of accepting a semantically compatible wheel from the wrong
+    channel.
+    """
+    if index_url is None:
+        index_url, detected_reason = pytorch_wheel_index_url_for_this_machine()
+        if index_reason is None:
+            index_reason = detected_reason
+    if index_reason is None:
+        index_reason = "configured"
+    expected_build = pytorch_index_build(index_url)
+    normalized_versions = {
+        canonical_distribution_name(name): version for name, version in installed_versions.items()
+    }
+
+    active_lines: list[str] = []
+    requested_names: list[str] = []
+    for line in requirement_lines:
+        active = _active_requirement(line)
+        if active is None:
+            continue
+        active_lines.append(line)
+        name = (
+            canonical_distribution_name(active.name)
+            if Requirement is not None and hasattr(active, "name")
+            else requirement_line_project_name(str(active))
+        )
+        if name in _PYTORCH_PROJECT_NAME_SET and name not in requested_names:
+            requested_names.append(name)
+
+    if not active_lines:
+        return PytorchInstallPlan(
+            index_url=index_url,
+            index_reason=index_reason,
+            expected_build=expected_build,
+            install_required=False,
+            force_reinstall=False,
+            detail="no active PyTorch requirements",
+        )
+
+    missing = [name for name in requested_names if name not in normalized_versions]
+    unsatisfied = [
+        line
+        for line in active_lines
+        if not requirement_is_satisfied(line, normalized_versions)
+    ]
+    if unsatisfied:
+        installed_stack = installed_pytorch_project_names(normalized_versions)
+        detail = (
+            f"missing packages: {', '.join(missing)}"
+            if missing and not installed_stack
+            else "installed PyTorch versions do not match current requirements"
+        )
+        return PytorchInstallPlan(
+            index_url=index_url,
+            index_reason=index_reason,
+            expected_build=expected_build,
+            install_required=True,
+            force_reinstall=bool(installed_stack),
+            detail=detail,
+        )
+
+    wrong_build = [
+        f"{name}=={normalized_versions[name]}"
+        for name in PYTORCH_PROJECT_NAMES
+        if name in normalized_versions
+        and not _build_matches(normalized_versions[name], expected_build)
+    ]
+    if wrong_build:
+        return PytorchInstallPlan(
+            index_url=index_url,
+            index_reason=index_reason,
+            expected_build=expected_build,
+            install_required=True,
+            force_reinstall=True,
+            detail=(
+                f"expected {expected_build or 'selected'} wheels, found "
+                + ", ".join(wrong_build)
+            ),
+        )
+
+    return PytorchInstallPlan(
+        index_url=index_url,
+        index_reason=index_reason,
+        expected_build=expected_build,
+        install_required=False,
+        force_reinstall=False,
+        detail="installed PyTorch stack matches requirements and wheel channel",
+    )

--- a/docs/PLUGIN_DEVELOPER_GUIDE.md
+++ b/docs/PLUGIN_DEVELOPER_GUIDE.md
@@ -1233,9 +1233,15 @@ fields.
 
 Ship a `requirements.txt` next to your plugin. It is installed when the user **installs
 or updates** the plugin (not on every launch): already-satisfied lines are skipped,
-`torch`/`torchvision`/`torchaudio` are routed to the PyTorch wheel index with automatic
-CUDA/CPU channel selection, and frozen (packaged) installs go to
-`data/plugin_site_packages` via the bundled runtime. Mirror selection honours
+`torch`/`torchvision`/`torchaudio` are treated as one binary stack and routed to the
+PyTorch wheel index with automatic CUDA/CPU channel selection. The host checks both
+the requirement versions and the installed wheel build (`cpu` / `cuXXX`) on every
+plugin install or update; a mismatch triggers a full `--force-reinstall` of the
+requested stack. In frozen builds the PyTorch stack is installed into the bundled
+runtime itself, while ordinary plugin dependencies go to `data/plugin_site_packages`.
+China-region or China-pip-index installs use the Aliyun PyTorch wheel mirror; global
+installs use the official PyTorch index. `SHINSEKAI_PYTORCH_WHEEL_BASE` can override
+that mapping explicitly. General mirror selection honours
 `PIP_INDEX_URL` (and friends), `SHINSEKAI_PIP_INDEX_URL(S)`, `SHINSEKAI_RUNTIME_SOURCE`,
 and `SHINSEKAI_MIRROR_REGION`; a requirements file that sets its own `-i` /
 `--index-url` is left untouched. Document download size, model caches, and hardware

--- a/docs/PLUGIN_DEVELOPER_GUIDE.md
+++ b/docs/PLUGIN_DEVELOPER_GUIDE.md
@@ -1234,13 +1234,20 @@ fields.
 Ship a `requirements.txt` next to your plugin. It is installed when the user **installs
 or updates** the plugin (not on every launch): already-satisfied lines are skipped,
 `torch`/`torchvision`/`torchaudio` are treated as one binary stack and routed to the
-PyTorch wheel index with automatic CUDA/CPU channel selection. The host checks both
-the requirement versions and the installed wheel build (`cpu` / `cuXXX`) on every
-plugin install or update; a mismatch triggers `--force-reinstall --no-deps` for the
-requested stack. A following normal pip pass repairs only missing or incompatible
-transitive dependencies instead of forcing every already-satisfied library to
-reinstall. In frozen builds the PyTorch stack is installed into the bundled runtime
-itself, while ordinary plugin dependencies go to `data/plugin_site_packages`.
+PyTorch wheel index with automatic CUDA/CPU channel selection. Plugin-authored
+PyTorch versions are ignored: declaring any member opts into the host-owned
+`torch==2.7.1` / `torchvision==0.22.1` / `torchaudio==2.7.1` stack. The host checks
+both those versions and the installed wheel build (`cpu` / `cuXXX`) on every plugin
+install or update. The supported GPU channels are `cu118`, `cu126`, and `cu128`;
+driver versions without a matching published channel use CPU wheels. A mismatch
+triggers `--force-reinstall --no-deps` for the host stack. A following normal pip
+pass repairs only missing or incompatible transitive dependencies instead of forcing
+every already-satisfied library to reinstall.
+
+In frozen builds, PyTorch-enabled plugin dependencies are installed into the bundled
+runtime and constrained to the host stack. This prevents packages such as `accelerate`
+from resolving a second, newer Torch into `data/plugin_site_packages`. Ordinary
+plugins without PyTorch continue to use `data/plugin_site_packages`.
 China-region or China-pip-index installs use the Aliyun PyTorch wheel mirror; global
 installs use the official PyTorch index. `SHINSEKAI_PYTORCH_WHEEL_BASE` can override
 that mapping explicitly. General mirror selection honours

--- a/docs/PLUGIN_DEVELOPER_GUIDE.md
+++ b/docs/PLUGIN_DEVELOPER_GUIDE.md
@@ -1236,9 +1236,11 @@ or updates** the plugin (not on every launch): already-satisfied lines are skipp
 `torch`/`torchvision`/`torchaudio` are treated as one binary stack and routed to the
 PyTorch wheel index with automatic CUDA/CPU channel selection. The host checks both
 the requirement versions and the installed wheel build (`cpu` / `cuXXX`) on every
-plugin install or update; a mismatch triggers a full `--force-reinstall` of the
-requested stack. In frozen builds the PyTorch stack is installed into the bundled
-runtime itself, while ordinary plugin dependencies go to `data/plugin_site_packages`.
+plugin install or update; a mismatch triggers `--force-reinstall --no-deps` for the
+requested stack. A following normal pip pass repairs only missing or incompatible
+transitive dependencies instead of forcing every already-satisfied library to
+reinstall. In frozen builds the PyTorch stack is installed into the bundled runtime
+itself, while ordinary plugin dependencies go to `data/plugin_site_packages`.
 China-region or China-pip-index installs use the Aliyun PyTorch wheel mirror; global
 installs use the official PyTorch index. `SHINSEKAI_PYTORCH_WHEEL_BASE` can override
 that mapping explicitly. General mirror selection honours

--- a/frontend/src-tauri/src/runtime.rs
+++ b/frontend/src-tauri/src/runtime.rs
@@ -6,6 +6,7 @@ mod managed;
 mod manifest;
 mod python_env;
 mod python_probe;
+mod pytorch;
 mod resolver;
 
 pub use resolver::{RuntimeCandidateView, RuntimeRepairActionKind, RuntimeScanView};

--- a/frontend/src-tauri/src/runtime/managed.rs
+++ b/frontend/src-tauri/src/runtime/managed.rs
@@ -104,20 +104,30 @@ where
             write_temp_requirements(requirements_path, "shinsekai-runtime", &other_lines)?;
         let result = (|| {
             if plan.install_required {
-                let mut install_torch = pip_install_command(python, &torch_requirements, None);
-                install_torch
-                    .arg("--index-url")
-                    .arg(&plan.index_url)
-                    .arg("--extra-index-url")
-                    .arg("https://pypi.org/simple");
-                if plan.force_reinstall {
-                    install_torch.arg("--upgrade").arg("--force-reinstall");
-                }
+                let mut install_torch = pytorch_install_command(
+                    python,
+                    &torch_requirements,
+                    &plan.index_url,
+                    plan.force_reinstall,
+                );
                 run_command_with_live_log(
                     &mut install_torch,
                     "install Shinsekai PyTorch runtime dependencies",
                     &mut on_log_line,
                 )?;
+                if plan.force_reinstall {
+                    let mut repair_dependencies = pytorch_install_command(
+                        python,
+                        &torch_requirements,
+                        &plan.index_url,
+                        false,
+                    );
+                    run_command_with_live_log(
+                        &mut repair_dependencies,
+                        "repair Shinsekai PyTorch runtime dependencies",
+                        &mut on_log_line,
+                    )?;
+                }
             }
             if !has_non_comment_requirement(&other_lines) {
                 return Ok(());
@@ -217,6 +227,30 @@ fn pip_install_command(
     install.arg("-m").arg("pip").arg("install");
     configure_pip_install_command(&mut install, python, pip_index_url);
     install.arg("-r").arg(requirements_path);
+    install
+}
+
+fn pytorch_install_command(
+    python: &Path,
+    requirements_path: &Path,
+    index_url: &str,
+    force_stack_only: bool,
+) -> Command {
+    let mut install = pip_install_command(python, requirements_path, None);
+    install
+        .arg("--index-url")
+        .arg(index_url)
+        .arg("--extra-index-url")
+        .arg("https://pypi.org/simple");
+    if force_stack_only {
+        // Without --no-deps, pip applies --force-reinstall to every resolved
+        // transitive dependency. A following plain install repairs only
+        // dependencies that are missing or genuinely incompatible.
+        install
+            .arg("--upgrade")
+            .arg("--force-reinstall")
+            .arg("--no-deps");
+    }
     install
 }
 

--- a/frontend/src-tauri/src/runtime/managed.rs
+++ b/frontend/src-tauri/src/runtime/managed.rs
@@ -98,8 +98,11 @@ where
             plan.force_reinstall,
             plan.detail,
         ));
-        let torch_requirements =
-            write_temp_requirements(requirements_path, "shinsekai-torch", &torch_lines)?;
+        let torch_requirements = write_temp_requirements(
+            requirements_path,
+            "shinsekai-torch",
+            &plan.requirement_lines,
+        )?;
         let other_requirements =
             write_temp_requirements(requirements_path, "shinsekai-runtime", &other_lines)?;
         let result = (|| {
@@ -136,6 +139,7 @@ where
                 python,
                 &other_requirements,
                 pip_index_urls,
+                Some(&torch_requirements),
                 &mut on_log_line,
             )
         })();
@@ -148,6 +152,7 @@ where
         python,
         requirements_path,
         pip_index_urls,
+        None,
         &mut on_log_line,
     )
 }
@@ -156,6 +161,7 @@ fn install_runtime_requirements_file_with_indexes<F>(
     python: &Path,
     requirements_path: &Path,
     pip_index_urls: &[String],
+    constraints_path: Option<&Path>,
     mut on_log_line: F,
 ) -> RuntimeResult<()>
 where
@@ -165,6 +171,7 @@ where
 
     if pip_index_urls.is_empty() {
         let mut install = pip_install_command(python, requirements_path, None);
+        apply_pip_constraints(&mut install, constraints_path);
         return run_command_with_live_log(
             &mut install,
             "install Shinsekai runtime dependencies",
@@ -174,6 +181,7 @@ where
 
     for pip_index_url in pip_index_urls {
         let mut install = pip_install_command(python, requirements_path, Some(pip_index_url));
+        apply_pip_constraints(&mut install, constraints_path);
         on_log_line(&format!("Using pip index: {}", pip_index_url.trim()));
         match run_command_with_live_log(
             &mut install,
@@ -228,6 +236,12 @@ fn pip_install_command(
     configure_pip_install_command(&mut install, python, pip_index_url);
     install.arg("-r").arg(requirements_path);
     install
+}
+
+fn apply_pip_constraints(command: &mut Command, constraints_path: Option<&Path>) {
+    if let Some(path) = constraints_path {
+        command.arg("-c").arg(path);
+    }
 }
 
 fn pytorch_install_command(

--- a/frontend/src-tauri/src/runtime/managed.rs
+++ b/frontend/src-tauri/src/runtime/managed.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     error::Error,
     fs::{self, OpenOptions},
     io::{BufRead, BufReader, Read, Write},
@@ -13,11 +12,10 @@ use std::{
 use serde::Serialize;
 use tauri::{Emitter, Manager, Runtime};
 
-use super::{manifest::RuntimeRequirements, python_env};
+use super::{manifest::RuntimeRequirements, python_env, pytorch};
 
 type RuntimeResult<T> = Result<T, Box<dyn Error>>;
 const RUNTIME_PROGRESS_EVENT: &str = "shinsekai:runtime-progress";
-const TORCH_PROJECT_NAMES: &[&str] = &["torch", "torchvision", "torchaudio"];
 
 fn configure_pip_install_command(
     command: &mut Command,
@@ -87,30 +85,40 @@ where
         .lines()
         .map(ToString::to_string)
         .collect::<Vec<_>>();
-    let (torch_lines, other_lines) = partition_torch_requirement_lines(&requirement_lines);
+    let (torch_lines, other_lines) = pytorch::partition_requirement_lines(&requirement_lines);
     let split_torch = !torch_lines.is_empty() && !cfg!(target_os = "macos");
 
     if split_torch {
-        let (torch_index, reason) = pytorch_wheel_index_url_for_this_machine(pip_index_urls);
+        let plan = pytorch::install_plan(python, &torch_lines, pip_index_urls);
         on_log_line(&format!(
-            "Installing PyTorch packages first from {torch_index} ({reason})"
+            "PyTorch plan: index={} ({}), install={}, force_reinstall={}: {}",
+            plan.index_url,
+            plan.index_reason,
+            plan.install_required,
+            plan.force_reinstall,
+            plan.detail,
         ));
         let torch_requirements =
             write_temp_requirements(requirements_path, "shinsekai-torch", &torch_lines)?;
         let other_requirements =
             write_temp_requirements(requirements_path, "shinsekai-runtime", &other_lines)?;
         let result = (|| {
-            let mut install_torch = pip_install_command(python, &torch_requirements, None);
-            install_torch
-                .arg("--index-url")
-                .arg(&torch_index)
-                .arg("--extra-index-url")
-                .arg("https://pypi.org/simple");
-            run_command_with_live_log(
-                &mut install_torch,
-                "install Shinsekai PyTorch runtime dependencies",
-                &mut on_log_line,
-            )?;
+            if plan.install_required {
+                let mut install_torch = pip_install_command(python, &torch_requirements, None);
+                install_torch
+                    .arg("--index-url")
+                    .arg(&plan.index_url)
+                    .arg("--extra-index-url")
+                    .arg("https://pypi.org/simple");
+                if plan.force_reinstall {
+                    install_torch.arg("--upgrade").arg("--force-reinstall");
+                }
+                run_command_with_live_log(
+                    &mut install_torch,
+                    "install Shinsekai PyTorch runtime dependencies",
+                    &mut on_log_line,
+                )?;
+            }
             if !has_non_comment_requirement(&other_lines) {
                 return Ok(());
             }
@@ -198,130 +206,6 @@ fn has_non_comment_requirement(lines: &[String]) -> bool {
         let trimmed = line.split('#').next().unwrap_or("").trim();
         !trimmed.is_empty() && !trimmed.starts_with('#')
     })
-}
-
-fn partition_torch_requirement_lines(lines: &[String]) -> (Vec<String>, Vec<String>) {
-    let mut torch_lines = Vec::new();
-    let mut other_lines = Vec::new();
-    for line in lines {
-        let project_name = requirement_line_project_name(line);
-        if project_name
-            .as_deref()
-            .is_some_and(|name| TORCH_PROJECT_NAMES.contains(&name))
-        {
-            torch_lines.push(line.trim_end_matches(['\r', '\n']).to_string());
-        } else {
-            other_lines.push(line.trim_end_matches(['\r', '\n']).to_string());
-        }
-    }
-    (torch_lines, other_lines)
-}
-
-fn requirement_line_project_name(line: &str) -> Option<String> {
-    let mut segment = line.split('#').next()?.trim();
-    if segment.is_empty() {
-        return None;
-    }
-    let lower = segment.to_ascii_lowercase();
-    if lower.starts_with("--") || lower.starts_with("-r ") || lower.starts_with("-c ") {
-        return None;
-    }
-    if lower.starts_with("-e ") {
-        segment = segment.get(3..)?.trim();
-    }
-    let first = segment.split_whitespace().next().unwrap_or(segment);
-    if first.contains("://") || first.starts_with("git+") {
-        return None;
-    }
-    let name = first
-        .chars()
-        .take_while(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
-        .collect::<String>();
-    if name.is_empty() {
-        None
-    } else {
-        Some(name.to_ascii_lowercase().replace('_', "-"))
-    }
-}
-
-fn pytorch_wheel_index_url_for_this_machine(pip_index_urls: &[String]) -> (String, String) {
-    pytorch_wheel_index_url_for_cuda_version(
-        nvidia_smi_cuda_driver_version(),
-        pytorch_wheel_base_url(pip_index_urls),
-    )
-}
-
-fn pytorch_wheel_base_url(pip_index_urls: &[String]) -> String {
-    if let Ok(value) = env::var("SHINSEKAI_PYTORCH_WHEEL_BASE") {
-        let trimmed = value.trim().trim_end_matches('/');
-        if !trimmed.is_empty() {
-            return trimmed.to_string();
-        }
-    }
-    if pip_indexes_prefer_china(pip_index_urls) {
-        "https://mirror.sjtu.edu.cn/pytorch-wheels".to_string()
-    } else {
-        "https://download.pytorch.org/whl".to_string()
-    }
-}
-
-fn pip_indexes_prefer_china(pip_index_urls: &[String]) -> bool {
-    let Some(primary) = pip_index_urls.first() else {
-        return false;
-    };
-    let primary = primary.to_ascii_lowercase();
-    [
-        "pypi.tuna.tsinghua.edu.cn",
-        "mirrors.ustc.edu.cn",
-        "mirrors.hit.edu.cn",
-        "mirrors.aliyun.com",
-        "mirror.sjtu.edu.cn",
-    ]
-    .iter()
-    .any(|domain| primary.contains(domain))
-}
-
-fn pytorch_wheel_index_url_for_cuda_version(
-    version: Option<(u32, u32)>,
-    base_url: String,
-) -> (String, String) {
-    let Some((major, minor)) = version else {
-        return (
-            format!("{base_url}/cpu"),
-            "no_usable_nvidia_smi_cpu".to_string(),
-        );
-    };
-    let tag = if (major, minor) >= (12, 4) {
-        "cu124"
-    } else if major >= 12 {
-        "cu121"
-    } else {
-        "cu118"
-    };
-    (
-        format!("{base_url}/{tag}"),
-        format!("nvidia_driver_cuda_{major}.{minor}_{tag}"),
-    )
-}
-
-fn nvidia_smi_cuda_driver_version() -> Option<(u32, u32)> {
-    let output = Command::new("nvidia-smi").output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_nvidia_smi_cuda_version(&stdout)
-}
-
-fn parse_nvidia_smi_cuda_version(output: &str) -> Option<(u32, u32)> {
-    let (_, tail) = output.split_once("CUDA Version:")?;
-    let version_text = tail
-        .trim_start()
-        .chars()
-        .take_while(|ch| ch.is_ascii_digit() || *ch == '.')
-        .collect::<String>();
-    let (major, minor) = version_text.split_once('.')?;
-    Some((major.parse().ok()?, minor.parse().ok()?))
 }
 
 fn pip_install_command(

--- a/frontend/src-tauri/src/runtime/managed/tests.rs
+++ b/frontend/src-tauri/src/runtime/managed/tests.rs
@@ -108,6 +108,24 @@ fn pytorch_dependency_repair_command_does_not_force_reinstall() {
     assert!(!args.iter().any(|arg| arg == "--no-deps"));
 }
 
+#[test]
+fn ordinary_runtime_install_is_constrained_to_the_host_pytorch_stack() {
+    let mut command = pip_install_command(
+        Path::new("python"),
+        Path::new("plugin-requirements.txt"),
+        None,
+    );
+    apply_pip_constraints(&mut command, Some(Path::new("host-pytorch.txt")));
+    let args = command
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+    assert!(args
+        .windows(2)
+        .any(|pair| pair == ["-c", "host-pytorch.txt"]));
+}
+
 #[cfg(unix)]
 #[test]
 fn ensure_python_pip_available_bootstraps_with_ensurepip() {
@@ -303,7 +321,7 @@ fn pytorch_wheel_index_url_matches_cuda_driver_version() {
             "https://download.pytorch.org/whl".to_string()
         )
         .0,
-        "https://download.pytorch.org/whl/cu124"
+        "https://download.pytorch.org/whl/cpu"
     );
     assert_eq!(
         pytorch::wheel_index_url_for_cuda_version(
@@ -311,7 +329,7 @@ fn pytorch_wheel_index_url_matches_cuda_driver_version() {
             "https://download.pytorch.org/whl".to_string()
         )
         .0,
-        "https://download.pytorch.org/whl/cu121"
+        "https://download.pytorch.org/whl/cpu"
     );
     assert_eq!(
         pytorch::wheel_index_url_for_cuda_version(
@@ -401,11 +419,7 @@ fn parse_nvidia_smi_cuda_version_reads_driver_report() {
 
 #[test]
 fn pytorch_install_plan_skips_matching_exact_cuda_stack() {
-    let lines = vec![
-        "torch==2.7.1".to_string(),
-        "torchvision==0.22.1".to_string(),
-        "torchaudio==2.7.1".to_string(),
-    ];
+    let lines = vec!["torch==99.0.0".to_string()];
     let installed = HashMap::from([
         ("torch".to_string(), "2.7.1+cu128".to_string()),
         ("torchvision".to_string(), "0.22.1+cu128".to_string()),
@@ -421,6 +435,14 @@ fn pytorch_install_plan_skips_matching_exact_cuda_stack() {
 
     assert!(!plan.install_required);
     assert!(!plan.force_reinstall);
+    assert_eq!(
+        plan.requirement_lines,
+        vec![
+            "torch==2.7.1".to_string(),
+            "torchvision==0.22.1".to_string(),
+            "torchaudio==2.7.1".to_string(),
+        ]
+    );
 }
 
 #[test]

--- a/frontend/src-tauri/src/runtime/managed/tests.rs
+++ b/frontend/src-tauri/src/runtime/managed/tests.rs
@@ -72,6 +72,42 @@ fn configure_pip_install_command_adds_selected_index_url_argument() {
     );
 }
 
+#[test]
+fn pytorch_force_reinstall_command_limits_replacement_to_the_stack() {
+    let command = pytorch_install_command(
+        Path::new("python"),
+        Path::new("torch-requirements.txt"),
+        "https://download.pytorch.org/whl/cu128",
+        true,
+    );
+    let args = command
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+    assert!(args.iter().any(|arg| arg == "--force-reinstall"));
+    assert!(args.iter().any(|arg| arg == "--upgrade"));
+    assert!(args.iter().any(|arg| arg == "--no-deps"));
+}
+
+#[test]
+fn pytorch_dependency_repair_command_does_not_force_reinstall() {
+    let command = pytorch_install_command(
+        Path::new("python"),
+        Path::new("torch-requirements.txt"),
+        "https://download.pytorch.org/whl/cu128",
+        false,
+    );
+    let args = command
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+    assert!(!args.iter().any(|arg| arg == "--force-reinstall"));
+    assert!(!args.iter().any(|arg| arg == "--upgrade"));
+    assert!(!args.iter().any(|arg| arg == "--no-deps"));
+}
+
 #[cfg(unix)]
 #[test]
 fn ensure_python_pip_available_bootstraps_with_ensurepip() {

--- a/frontend/src-tauri/src/runtime/managed/tests.rs
+++ b/frontend/src-tauri/src/runtime/managed/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use std::collections::HashMap;
+use std::env;
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -213,7 +215,7 @@ fn partition_torch_requirement_lines_splits_pytorch_packages() {
         "git+https://example.invalid/package.git".to_string(),
     ];
 
-    let (torch_lines, other_lines) = partition_torch_requirement_lines(&lines);
+    let (torch_lines, other_lines) = pytorch::partition_requirement_lines(&lines);
 
     assert_eq!(
         torch_lines,
@@ -236,7 +238,23 @@ fn partition_torch_requirement_lines_splits_pytorch_packages() {
 #[test]
 fn pytorch_wheel_index_url_matches_cuda_driver_version() {
     assert_eq!(
-        pytorch_wheel_index_url_for_cuda_version(
+        pytorch::wheel_index_url_for_cuda_version(
+            Some((13, 2)),
+            "https://download.pytorch.org/whl".to_string()
+        )
+        .0,
+        "https://download.pytorch.org/whl/cu128"
+    );
+    assert_eq!(
+        pytorch::wheel_index_url_for_cuda_version(
+            Some((12, 8)),
+            "https://download.pytorch.org/whl".to_string()
+        )
+        .0,
+        "https://download.pytorch.org/whl/cu128"
+    );
+    assert_eq!(
+        pytorch::wheel_index_url_for_cuda_version(
             None,
             "https://download.pytorch.org/whl".to_string()
         )
@@ -244,7 +262,7 @@ fn pytorch_wheel_index_url_matches_cuda_driver_version() {
         "https://download.pytorch.org/whl/cpu"
     );
     assert_eq!(
-        pytorch_wheel_index_url_for_cuda_version(
+        pytorch::wheel_index_url_for_cuda_version(
             Some((12, 4)),
             "https://download.pytorch.org/whl".to_string()
         )
@@ -252,7 +270,7 @@ fn pytorch_wheel_index_url_matches_cuda_driver_version() {
         "https://download.pytorch.org/whl/cu124"
     );
     assert_eq!(
-        pytorch_wheel_index_url_for_cuda_version(
+        pytorch::wheel_index_url_for_cuda_version(
             Some((12, 1)),
             "https://download.pytorch.org/whl".to_string()
         )
@@ -260,7 +278,7 @@ fn pytorch_wheel_index_url_matches_cuda_driver_version() {
         "https://download.pytorch.org/whl/cu121"
     );
     assert_eq!(
-        pytorch_wheel_index_url_for_cuda_version(
+        pytorch::wheel_index_url_for_cuda_version(
             Some((11, 8)),
             "https://download.pytorch.org/whl".to_string()
         )
@@ -273,14 +291,18 @@ fn pytorch_wheel_index_url_matches_cuda_driver_version() {
 fn pytorch_wheel_base_url_follows_runtime_pip_region() {
     let _guard = PYTORCH_WHEEL_ENV_LOCK.lock().unwrap();
     let _restore = EnvRestore::capture("SHINSEKAI_PYTORCH_WHEEL_BASE");
+    let _runtime_source = EnvRestore::capture("SHINSEKAI_RUNTIME_SOURCE");
+    let _mirror_region = EnvRestore::capture("SHINSEKAI_MIRROR_REGION");
     env::remove_var("SHINSEKAI_PYTORCH_WHEEL_BASE");
+    env::remove_var("SHINSEKAI_RUNTIME_SOURCE");
+    env::remove_var("SHINSEKAI_MIRROR_REGION");
 
     assert_eq!(
-        pytorch_wheel_base_url(&["https://pypi.tuna.tsinghua.edu.cn/simple/".to_string()]),
-        "https://mirror.sjtu.edu.cn/pytorch-wheels"
+        pytorch::wheel_base_url(&["https://pypi.tuna.tsinghua.edu.cn/simple/".to_string()]),
+        "https://mirrors.aliyun.com/pytorch-wheels"
     );
     assert_eq!(
-        pytorch_wheel_base_url(&["https://pypi.org/simple/".to_string()]),
+        pytorch::wheel_base_url(&["https://pypi.org/simple/".to_string()]),
         "https://download.pytorch.org/whl"
     );
 }
@@ -289,14 +311,40 @@ fn pytorch_wheel_base_url_follows_runtime_pip_region() {
 fn pytorch_wheel_base_url_can_be_overridden() {
     let _guard = PYTORCH_WHEEL_ENV_LOCK.lock().unwrap();
     let _restore = EnvRestore::capture("SHINSEKAI_PYTORCH_WHEEL_BASE");
+    let _runtime_source = EnvRestore::capture("SHINSEKAI_RUNTIME_SOURCE");
+    let _mirror_region = EnvRestore::capture("SHINSEKAI_MIRROR_REGION");
     env::set_var(
         "SHINSEKAI_PYTORCH_WHEEL_BASE",
         "https://example.invalid/pytorch-wheels/",
     );
+    env::set_var("SHINSEKAI_RUNTIME_SOURCE", "official");
+    env::set_var("SHINSEKAI_MIRROR_REGION", "global");
 
     assert_eq!(
-        pytorch_wheel_base_url(&["https://pypi.org/simple/".to_string()]),
+        pytorch::wheel_base_url(&["https://pypi.org/simple/".to_string()]),
         "https://example.invalid/pytorch-wheels"
+    );
+}
+
+#[test]
+fn pytorch_wheel_base_explicit_region_overrides_generic_pip_index() {
+    let _guard = PYTORCH_WHEEL_ENV_LOCK.lock().unwrap();
+    let _wheel_base = EnvRestore::capture("SHINSEKAI_PYTORCH_WHEEL_BASE");
+    let _runtime_source = EnvRestore::capture("SHINSEKAI_RUNTIME_SOURCE");
+    let _mirror_region = EnvRestore::capture("SHINSEKAI_MIRROR_REGION");
+    env::remove_var("SHINSEKAI_PYTORCH_WHEEL_BASE");
+    env::remove_var("SHINSEKAI_RUNTIME_SOURCE");
+
+    env::set_var("SHINSEKAI_MIRROR_REGION", "china");
+    assert_eq!(
+        pytorch::wheel_base_url(&["https://pypi.org/simple/".to_string()]),
+        "https://mirrors.aliyun.com/pytorch-wheels"
+    );
+
+    env::set_var("SHINSEKAI_MIRROR_REGION", "global");
+    assert_eq!(
+        pytorch::wheel_base_url(&["https://pypi.tuna.tsinghua.edu.cn/simple/".to_string()]),
+        "https://download.pytorch.org/whl"
     );
 }
 
@@ -308,8 +356,60 @@ fn parse_nvidia_smi_cuda_version_reads_driver_report() {
 +-----------------------------------------------------------------------------+
 "#;
 
-    assert_eq!(parse_nvidia_smi_cuda_version(output), Some((12, 4)));
-    assert_eq!(parse_nvidia_smi_cuda_version("no cuda here"), None);
+    assert_eq!(
+        pytorch::parse_nvidia_smi_cuda_version(output),
+        Some((12, 4))
+    );
+    assert_eq!(pytorch::parse_nvidia_smi_cuda_version("no cuda here"), None);
+}
+
+#[test]
+fn pytorch_install_plan_skips_matching_exact_cuda_stack() {
+    let lines = vec![
+        "torch==2.7.1".to_string(),
+        "torchvision==0.22.1".to_string(),
+        "torchaudio==2.7.1".to_string(),
+    ];
+    let installed = HashMap::from([
+        ("torch".to_string(), "2.7.1+cu128".to_string()),
+        ("torchvision".to_string(), "0.22.1+cu128".to_string()),
+        ("torchaudio".to_string(), "2.7.1+cu128".to_string()),
+    ]);
+
+    let plan = pytorch::build_install_plan(
+        &lines,
+        &installed,
+        "https://download.pytorch.org/whl/cu128".to_string(),
+        "test".to_string(),
+    );
+
+    assert!(!plan.install_required);
+    assert!(!plan.force_reinstall);
+}
+
+#[test]
+fn pytorch_install_plan_forces_reinstall_for_cpu_or_version_mismatch() {
+    let lines = vec![
+        "torch==2.7.1".to_string(),
+        "torchvision==0.22.1".to_string(),
+        "torchaudio==2.7.1".to_string(),
+    ];
+    let installed = HashMap::from([
+        ("torch".to_string(), "2.12.1+cpu".to_string()),
+        ("torchaudio".to_string(), "2.11.0+cpu".to_string()),
+    ]);
+
+    let plan = pytorch::build_install_plan(
+        &lines,
+        &installed,
+        "https://download.pytorch.org/whl/cu128".to_string(),
+        "test".to_string(),
+    );
+
+    assert!(plan.install_required);
+    assert!(plan.force_reinstall);
+    assert!(plan.detail.contains("version mismatch"));
+    assert!(plan.detail.contains("expected cu128 wheels"));
 }
 
 #[test]

--- a/frontend/src-tauri/src/runtime/pytorch.rs
+++ b/frontend/src-tauri/src/runtime/pytorch.rs
@@ -3,9 +3,15 @@ use std::{collections::HashMap, env, path::Path, process::Command};
 use super::python_env;
 
 const PYTORCH_PROJECT_NAMES: &[&str] = &["torch", "torchvision", "torchaudio"];
+const HOST_PYTORCH_STACK: &[(&str, &str)] = &[
+    ("torch", "2.7.1"),
+    ("torchvision", "0.22.1"),
+    ("torchaudio", "2.7.1"),
+];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct PytorchInstallPlan {
+    pub requirement_lines: Vec<String>,
     pub index_url: String,
     pub index_reason: String,
     pub expected_build: String,
@@ -53,30 +59,43 @@ pub(super) fn build_install_plan(
     index_reason: String,
 ) -> PytorchInstallPlan {
     let expected_build = index_build(&index_url);
-    let requested = requirement_lines
+    let has_pytorch_requirement = requirement_lines
         .iter()
-        .filter_map(|line| {
-            requirement_line_project_name(line).map(|name| {
-                let exact_version = exact_requirement_version(line);
-                (name, exact_version)
-            })
-        })
+        .filter_map(|line| requirement_line_project_name(line))
+        .any(|name| PYTORCH_PROJECT_NAMES.contains(&name.as_str()));
+    if !has_pytorch_requirement {
+        return PytorchInstallPlan {
+            requirement_lines: Vec::new(),
+            index_url,
+            index_reason,
+            expected_build,
+            install_required: false,
+            force_reinstall: false,
+            detail: "no active PyTorch requirements".to_string(),
+        };
+    }
+
+    // Plugin/runtime requirement files only opt into PyTorch. The host owns
+    // the exact shared binary stack so a broad plugin constraint cannot select
+    // an untested latest release from the wheel index.
+    let managed_requirement_lines = HOST_PYTORCH_STACK
+        .iter()
+        .map(|(name, version)| format!("{name}=={version}"))
         .collect::<Vec<_>>();
     let installed_stack = PYTORCH_PROJECT_NAMES
         .iter()
         .filter(|name| installed_versions.contains_key(**name))
         .count();
-    let missing = requested
+    let missing = HOST_PYTORCH_STACK
         .iter()
-        .filter(|(name, _)| !installed_versions.contains_key(name))
-        .map(|(name, _)| name.clone())
+        .filter(|(name, _)| !installed_versions.contains_key(*name))
+        .map(|(name, _)| (*name).to_string())
         .collect::<Vec<_>>();
-    let version_mismatches = requested
+    let version_mismatches = HOST_PYTORCH_STACK
         .iter()
-        .filter_map(|(name, exact)| {
-            let expected = exact.as_ref()?;
-            let installed = installed_versions.get(name)?;
-            (public_version(installed) != expected)
+        .filter_map(|(name, expected)| {
+            let installed = installed_versions.get(*name)?;
+            (public_version(installed) != *expected)
                 .then(|| format!("{name}=={installed} (expected {expected})"))
         })
         .collect::<Vec<_>>();
@@ -104,6 +123,7 @@ pub(super) fn build_install_plan(
             ));
         }
         return PytorchInstallPlan {
+            requirement_lines: managed_requirement_lines,
             index_url,
             index_reason,
             expected_build,
@@ -115,6 +135,7 @@ pub(super) fn build_install_plan(
 
     if !missing.is_empty() {
         return PytorchInstallPlan {
+            requirement_lines: managed_requirement_lines,
             index_url,
             index_reason,
             expected_build,
@@ -124,21 +145,14 @@ pub(super) fn build_install_plan(
         };
     }
 
-    // Unpinned/ranged requirements are still handed to pip so pip remains the
-    // source of truth for PEP 440 range evaluation. It will not download when
-    // the installed package already satisfies the range.
-    let has_unpinned = requested.iter().any(|(_, exact)| exact.is_none());
     PytorchInstallPlan {
+        requirement_lines: managed_requirement_lines,
         index_url,
         index_reason,
         expected_build,
-        install_required: has_unpinned,
+        install_required: false,
         force_reinstall: false,
-        detail: if has_unpinned {
-            "PyTorch range requirements need pip validation".to_string()
-        } else {
-            "installed PyTorch stack matches requirements and wheel channel".to_string()
-        },
+        detail: "installed PyTorch stack matches host versions and wheel channel".to_string(),
     }
 }
 
@@ -192,22 +206,6 @@ fn requirement_line_project_name(line: &str) -> Option<String> {
 
 fn canonical_project_name(name: &str) -> String {
     name.to_ascii_lowercase().replace(['_', '.'], "-")
-}
-
-fn exact_requirement_version(line: &str) -> Option<String> {
-    let segment = line.split('#').next()?.split(';').next()?.trim();
-    let (_, version) = segment.split_once("==")?;
-    if segment.contains("===") {
-        return None;
-    }
-    let version = version
-        .split(',')
-        .next()
-        .unwrap_or(version)
-        .trim()
-        .trim_matches('"')
-        .trim_matches('\'');
-    (!version.is_empty() && !version.contains('*')).then(|| public_version(version).to_string())
 }
 
 fn public_version(version: &str) -> &str {
@@ -381,15 +379,19 @@ pub(super) fn wheel_index_url_for_cuda_version(
         );
     };
     let tag = if (major, minor) >= (12, 8) {
-        "cu128"
+        Some("cu128")
     } else if (major, minor) >= (12, 6) {
-        "cu126"
-    } else if (major, minor) >= (12, 4) {
-        "cu124"
-    } else if major >= 12 {
-        "cu121"
+        Some("cu126")
+    } else if major == 11 && minor >= 8 {
+        Some("cu118")
     } else {
-        "cu118"
+        None
+    };
+    let Some(tag) = tag else {
+        return (
+            format!("{base_url}/cpu"),
+            format!("nvidia_driver_cuda_{major}.{minor}_cpu_fallback"),
+        );
     };
     (
         format!("{base_url}/{tag}"),

--- a/frontend/src-tauri/src/runtime/pytorch.rs
+++ b/frontend/src-tauri/src/runtime/pytorch.rs
@@ -1,0 +1,418 @@
+use std::{collections::HashMap, env, path::Path, process::Command};
+
+use super::python_env;
+
+const PYTORCH_PROJECT_NAMES: &[&str] = &["torch", "torchvision", "torchaudio"];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct PytorchInstallPlan {
+    pub index_url: String,
+    pub index_reason: String,
+    pub expected_build: String,
+    pub install_required: bool,
+    pub force_reinstall: bool,
+    pub detail: String,
+}
+
+pub(super) fn partition_requirement_lines(lines: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut pytorch_lines = Vec::new();
+    let mut other_lines = Vec::new();
+    for line in lines {
+        let project_name = requirement_line_project_name(line);
+        if project_name
+            .as_deref()
+            .is_some_and(|name| PYTORCH_PROJECT_NAMES.contains(&name))
+        {
+            pytorch_lines.push(line.trim_end_matches(['\r', '\n']).to_string());
+        } else {
+            other_lines.push(line.trim_end_matches(['\r', '\n']).to_string());
+        }
+    }
+    (pytorch_lines, other_lines)
+}
+
+pub(super) fn install_plan(
+    python: &Path,
+    requirement_lines: &[String],
+    pip_index_urls: &[String],
+) -> PytorchInstallPlan {
+    let (index_url, index_reason) = wheel_index_url_for_this_machine(pip_index_urls);
+    let installed_versions = installed_versions(python);
+    build_install_plan(
+        requirement_lines,
+        &installed_versions,
+        index_url,
+        index_reason,
+    )
+}
+
+pub(super) fn build_install_plan(
+    requirement_lines: &[String],
+    installed_versions: &HashMap<String, String>,
+    index_url: String,
+    index_reason: String,
+) -> PytorchInstallPlan {
+    let expected_build = index_build(&index_url);
+    let requested = requirement_lines
+        .iter()
+        .filter_map(|line| {
+            requirement_line_project_name(line).map(|name| {
+                let exact_version = exact_requirement_version(line);
+                (name, exact_version)
+            })
+        })
+        .collect::<Vec<_>>();
+    let installed_stack = PYTORCH_PROJECT_NAMES
+        .iter()
+        .filter(|name| installed_versions.contains_key(**name))
+        .count();
+    let missing = requested
+        .iter()
+        .filter(|(name, _)| !installed_versions.contains_key(name))
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let version_mismatches = requested
+        .iter()
+        .filter_map(|(name, exact)| {
+            let expected = exact.as_ref()?;
+            let installed = installed_versions.get(name)?;
+            (public_version(installed) != expected)
+                .then(|| format!("{name}=={installed} (expected {expected})"))
+        })
+        .collect::<Vec<_>>();
+    let build_mismatches = PYTORCH_PROJECT_NAMES
+        .iter()
+        .filter_map(|name| {
+            let installed = installed_versions.get(*name)?;
+            (!build_matches(installed, &expected_build)).then(|| format!("{name}=={installed}"))
+        })
+        .collect::<Vec<_>>();
+
+    if !version_mismatches.is_empty() || !build_mismatches.is_empty() {
+        let mut reasons = Vec::new();
+        if !version_mismatches.is_empty() {
+            reasons.push(format!(
+                "version mismatch: {}",
+                version_mismatches.join(", ")
+            ));
+        }
+        if !build_mismatches.is_empty() {
+            reasons.push(format!(
+                "expected {} wheels, found {}",
+                expected_build,
+                build_mismatches.join(", ")
+            ));
+        }
+        return PytorchInstallPlan {
+            index_url,
+            index_reason,
+            expected_build,
+            install_required: true,
+            force_reinstall: true,
+            detail: reasons.join("; "),
+        };
+    }
+
+    if !missing.is_empty() {
+        return PytorchInstallPlan {
+            index_url,
+            index_reason,
+            expected_build,
+            install_required: true,
+            force_reinstall: installed_stack > 0,
+            detail: format!("missing packages: {}", missing.join(", ")),
+        };
+    }
+
+    // Unpinned/ranged requirements are still handed to pip so pip remains the
+    // source of truth for PEP 440 range evaluation. It will not download when
+    // the installed package already satisfies the range.
+    let has_unpinned = requested.iter().any(|(_, exact)| exact.is_none());
+    PytorchInstallPlan {
+        index_url,
+        index_reason,
+        expected_build,
+        install_required: has_unpinned,
+        force_reinstall: false,
+        detail: if has_unpinned {
+            "PyTorch range requirements need pip validation".to_string()
+        } else {
+            "installed PyTorch stack matches requirements and wheel channel".to_string()
+        },
+    }
+}
+
+fn installed_versions(python: &Path) -> HashMap<String, String> {
+    let script = r#"
+import importlib.metadata as metadata
+for name in ("torch", "torchvision", "torchaudio"):
+    try:
+        print(name + "\t" + metadata.version(name))
+    except metadata.PackageNotFoundError:
+        pass
+"#;
+    let mut command = Command::new(python);
+    command.arg("-c").arg(script);
+    python_env::configure_python_command(&mut command, python);
+    let Ok(output) = command.output() else {
+        return HashMap::new();
+    };
+    if !output.status.success() {
+        return HashMap::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .map(|(name, version)| (canonical_project_name(name), version.trim().to_string()))
+        .collect()
+}
+
+fn requirement_line_project_name(line: &str) -> Option<String> {
+    let mut segment = line.split('#').next()?.trim();
+    if segment.is_empty() {
+        return None;
+    }
+    let lower = segment.to_ascii_lowercase();
+    if lower.starts_with("--") || lower.starts_with("-r ") || lower.starts_with("-c ") {
+        return None;
+    }
+    if lower.starts_with("-e ") {
+        segment = segment.get(3..)?.trim();
+    }
+    let first = segment.split_whitespace().next().unwrap_or(segment);
+    if first.contains("://") || first.starts_with("git+") {
+        return None;
+    }
+    let name = first
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+        .collect::<String>();
+    (!name.is_empty()).then(|| canonical_project_name(&name))
+}
+
+fn canonical_project_name(name: &str) -> String {
+    name.to_ascii_lowercase().replace(['_', '.'], "-")
+}
+
+fn exact_requirement_version(line: &str) -> Option<String> {
+    let segment = line.split('#').next()?.split(';').next()?.trim();
+    let (_, version) = segment.split_once("==")?;
+    if segment.contains("===") {
+        return None;
+    }
+    let version = version
+        .split(',')
+        .next()
+        .unwrap_or(version)
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'');
+    (!version.is_empty() && !version.contains('*')).then(|| public_version(version).to_string())
+}
+
+fn public_version(version: &str) -> &str {
+    version.split('+').next().unwrap_or(version).trim()
+}
+
+fn index_build(index_url: &str) -> String {
+    let candidate = index_url
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if candidate == "cpu"
+        || candidate.strip_prefix("cu").is_some_and(|digits| {
+            !digits.is_empty() && digits.chars().all(|ch| ch.is_ascii_digit())
+        })
+    {
+        candidate
+    } else {
+        String::new()
+    }
+}
+
+fn installed_build(version: &str) -> String {
+    let local = version
+        .split_once('+')
+        .map(|(_, local)| local)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    local
+        .split(['.', '-', '+'])
+        .find(|part| {
+            *part == "cpu"
+                || part.strip_prefix("cu").is_some_and(|digits| {
+                    !digits.is_empty() && digits.chars().all(|ch| ch.is_ascii_digit())
+                })
+        })
+        .unwrap_or("")
+        .to_string()
+}
+
+fn build_matches(version: &str, expected_build: &str) -> bool {
+    if expected_build.is_empty() {
+        return true;
+    }
+    let installed = installed_build(version);
+    if expected_build == "cpu" {
+        installed.is_empty() || installed == "cpu"
+    } else {
+        installed == expected_build
+    }
+}
+
+pub(super) fn wheel_index_url_for_this_machine(pip_index_urls: &[String]) -> (String, String) {
+    wheel_index_url_for_cuda_version(
+        nvidia_smi_cuda_driver_version(),
+        wheel_base_url(pip_index_urls),
+    )
+}
+
+pub(super) fn wheel_base_url(pip_index_urls: &[String]) -> String {
+    if let Ok(value) = env::var("SHINSEKAI_PYTORCH_WHEEL_BASE") {
+        let trimmed = value.trim().trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if let Some(prefer_china) = explicit_pytorch_region() {
+        return if prefer_china {
+            "https://mirrors.aliyun.com/pytorch-wheels".to_string()
+        } else {
+            "https://download.pytorch.org/whl".to_string()
+        };
+    }
+    let configured_indexes = if pip_index_urls.is_empty() {
+        pip_index_urls_from_env()
+    } else {
+        pip_index_urls.to_vec()
+    };
+    if pip_indexes_prefer_china(&configured_indexes) {
+        "https://mirrors.aliyun.com/pytorch-wheels".to_string()
+    } else {
+        "https://download.pytorch.org/whl".to_string()
+    }
+}
+
+fn explicit_pytorch_region() -> Option<bool> {
+    let runtime_source = env::var("SHINSEKAI_RUNTIME_SOURCE")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    if matches!(
+        runtime_source.as_str(),
+        "china" | "cn" | "mainland" | "mainland_china"
+    ) {
+        return Some(true);
+    }
+    if matches!(
+        runtime_source.as_str(),
+        "official" | "global" | "intl" | "international" | "overseas" | "us"
+    ) {
+        return Some(false);
+    }
+    let mirror_region = env::var("SHINSEKAI_MIRROR_REGION")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    if matches!(
+        mirror_region.as_str(),
+        "china" | "cn" | "mainland" | "mainland_china"
+    ) {
+        return Some(true);
+    }
+    if matches!(
+        mirror_region.as_str(),
+        "official" | "global" | "intl" | "international" | "overseas" | "us"
+    ) {
+        return Some(false);
+    }
+    None
+}
+
+fn pip_index_urls_from_env() -> Vec<String> {
+    let mut urls = Vec::new();
+    for name in [
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+        "SHINSEKAI_PIP_INDEX_URL",
+        "SHINSEKAI_PIP_INDEX_URLS",
+    ] {
+        let Ok(raw) = env::var(name) else {
+            continue;
+        };
+        for line in raw.lines() {
+            for part in line.split(',') {
+                let value = part.trim();
+                if !value.is_empty() {
+                    urls.push(value.to_string());
+                }
+            }
+        }
+    }
+    urls
+}
+
+fn pip_indexes_prefer_china(pip_index_urls: &[String]) -> bool {
+    let Some(primary) = pip_index_urls.first() else {
+        return false;
+    };
+    let primary = primary.to_ascii_lowercase();
+    [
+        "pypi.tuna.tsinghua.edu.cn",
+        "mirrors.ustc.edu.cn",
+        "mirrors.hit.edu.cn",
+        "mirrors.aliyun.com",
+        "mirror.sjtu.edu.cn",
+    ]
+    .iter()
+    .any(|domain| primary.contains(domain))
+}
+
+pub(super) fn wheel_index_url_for_cuda_version(
+    version: Option<(u32, u32)>,
+    base_url: String,
+) -> (String, String) {
+    let Some((major, minor)) = version else {
+        return (
+            format!("{base_url}/cpu"),
+            "no_usable_nvidia_smi_cpu".to_string(),
+        );
+    };
+    let tag = if (major, minor) >= (12, 8) {
+        "cu128"
+    } else if (major, minor) >= (12, 6) {
+        "cu126"
+    } else if (major, minor) >= (12, 4) {
+        "cu124"
+    } else if major >= 12 {
+        "cu121"
+    } else {
+        "cu118"
+    };
+    (
+        format!("{base_url}/{tag}"),
+        format!("nvidia_driver_cuda_{major}.{minor}_{tag}"),
+    )
+}
+
+fn nvidia_smi_cuda_driver_version() -> Option<(u32, u32)> {
+    let output = Command::new("nvidia-smi").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_nvidia_smi_cuda_version(&stdout)
+}
+
+pub(super) fn parse_nvidia_smi_cuda_version(output: &str) -> Option<(u32, u32)> {
+    let (_, tail) = output.split_once("CUDA Version:")?;
+    let version_text = tail
+        .trim_start()
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit() || *ch == '.')
+        .collect::<String>();
+    let (major, minor) = version_text.split_once('.')?;
+    Some((major.parse().ok()?, minor.parse().ok()?))
+}

--- a/frontend_bridge_core/handler.py
+++ b/frontend_bridge_core/handler.py
@@ -190,6 +190,15 @@ _ALLOWED_CUSTOM_ORIGIN_SCHEMES = {"shinsekai", "tauri"}
 _ALLOWED_LOCAL_ORIGIN_HOSTS = {"127.0.0.1", "::1", "localhost", "tauri.localhost"}
 
 CHAT_RUNTIME_READY_TIMEOUT_SECONDS = 20.0
+_POLLING_PATHS = {
+    "/api/characters/memories/status",
+    "/api/health",
+    "/api/chat/runtime-status",
+    "/api/chat/snapshot",
+    "/api/memory/status",
+    "/api/model-assets/status",
+    "/api/plugins/status",
+}
 
 
 class _RangeNotSatisfiable(Exception):
@@ -208,13 +217,30 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             super().handle_one_request()
 
     def log_message(self, fmt: str, *args: Any) -> None:
-        logger.info(
+        method = getattr(self, "command", "")
+        path = urlparse(getattr(self, "path", "")).path
+        try:
+            status = int(args[1])
+        except (IndexError, TypeError, ValueError):
+            status = 0
+
+        is_polling_request = path in _POLLING_PATHS or (
+            method in {"GET", "HEAD", "OPTIONS"}
+            and path.startswith("/api/tasks/")
+            and not path.endswith("/cancel")
+        )
+        if is_polling_request and 0 < status < 400:
+            return
+
+        log = logger.error if status >= 500 else logger.warning if status >= 400 else logger.info
+        log(
             fmt,
             *args,
             extra={
                 "event": "http.request.completed",
-                "method": getattr(self, "command", ""),
-                "path": urlparse(getattr(self, "path", "")).path,
+                "method": method,
+                "path": path,
+                "status": status,
             },
         )
 

--- a/test/unit/config/test_mirror_env.py
+++ b/test/unit/config/test_mirror_env.py
@@ -25,7 +25,6 @@ def _clear_mirror_env(monkeypatch):
         "HF_ENDPOINT",
         "HF_HOME",
         "HF_HUB_CACHE",
-        "HF_HUB_DISABLE_XET",
         "HUGGINGFACE_HUB_ENDPOINT",
         "HUGGINGFACE_HUB_CACHE",
         "TRANSFORMERS_CACHE",
@@ -40,14 +39,6 @@ def _clear_mirror_env(monkeypatch):
         "SHINSEKAI_SKIP_NETWORK_REGION_PROBE",
         "SHINSEKAI_IP_REGION_URLS",
         "SHINSEKAI_MIRROR_REGION",
-        "HTTPS_PROXY",
-        "https_proxy",
-        "HTTP_PROXY",
-        "http_proxy",
-        "ALL_PROXY",
-        "all_proxy",
-        "SOCKS_PROXY",
-        "socks_proxy",
     ):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr("config.mirror_env._DETECT_CACHE", None)
@@ -85,44 +76,6 @@ def test_apply_mirror_environment_marks_global_pip_strategy(monkeypatch):
     assert values.region == "global"
     assert "SHINSEKAI_PIP_INDEX_URL" not in os.environ
     assert os.environ["SHINSEKAI_MIRROR_REGION"] == "global"
-
-
-def test_apply_mirror_environment_disables_xet_for_official_hub_over_proxy(monkeypatch):
-    _clear_mirror_env(monkeypatch)
-    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
-
-    values = apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
-
-    assert values.huggingface == ""
-    assert os.environ["HF_HUB_DISABLE_XET"] == "1"
-
-
-def test_apply_mirror_environment_keeps_xet_default_for_mirror_over_proxy(monkeypatch):
-    _clear_mirror_env(monkeypatch)
-    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
-
-    apply_mirror_environment(
-        SystemConfig(
-            mirror_auto_detect_china=False,
-            huggingface_mirror_url="https://hf.example",
-        )
-    )
-
-    assert "HF_HUB_DISABLE_XET" not in os.environ
-
-
-def test_apply_mirror_environment_treats_explicit_official_url_as_official(monkeypatch):
-    _clear_mirror_env(monkeypatch)
-    monkeypatch.setenv("ALL_PROXY", "socks5://127.0.0.1:7891")
-
-    apply_mirror_environment(
-        SystemConfig(
-            mirror_auto_detect_china=False,
-            huggingface_mirror_url=f"{OFFICIAL_HUGGINGFACE_URL}/",
-        )
-    )
-
-    assert os.environ["HF_HUB_DISABLE_XET"] == "1"
 
 
 def test_apply_mirror_environment_manual_values_override_region(monkeypatch, tmp_path):
@@ -240,8 +193,6 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
     assert applied[-1].pypi_index == "https://pypi.example/simple"
     assert applied[-1].pypi_source == "https://pypi.example/simple"
     assert applied[-1].detection_mode == "manual"
-    assert applied[-1].huggingface_transport == "auto"
-    assert applied[-1].huggingface_xet_disabled_for_proxy is False
     assert applied[-1].sets_standard_pip_env is False
     assert "region=global" in applied[-1].getMessage()
     assert "huggingface=https://***@hf.example" in applied[-1].getMessage()
@@ -249,7 +200,6 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
 
 def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     _clear_mirror_env(monkeypatch)
-    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
     caplog.set_level(logging.INFO, logger="config.mirror_env")
 
     apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
@@ -259,7 +209,4 @@ def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     assert applied[-1].huggingface_source == OFFICIAL_HUGGINGFACE_URL
     assert applied[-1].github_source == OFFICIAL_GITHUB_URL
     assert applied[-1].pypi_source == OFFICIAL_PYPI_INDEX_URL
-    assert applied[-1].huggingface_transport == "http"
-    assert applied[-1].huggingface_xet_disabled_for_proxy is True
     assert "mode=manual" in applied[-1].getMessage()
-    assert "huggingface_transport=http" in applied[-1].getMessage()

--- a/test/unit/config/test_mirror_env.py
+++ b/test/unit/config/test_mirror_env.py
@@ -87,9 +87,8 @@ def test_apply_mirror_environment_marks_global_pip_strategy(monkeypatch):
     assert os.environ["SHINSEKAI_MIRROR_REGION"] == "global"
 
 
-def test_apply_mirror_environment_disables_xet_for_official_hub_over_proxy(monkeypatch):
+def test_apply_mirror_environment_disables_xet_for_official_hub(monkeypatch):
     _clear_mirror_env(monkeypatch)
-    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
 
     values = apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
 
@@ -241,7 +240,7 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
     assert applied[-1].pypi_source == "https://pypi.example/simple"
     assert applied[-1].detection_mode == "manual"
     assert applied[-1].huggingface_transport == "auto"
-    assert applied[-1].huggingface_xet_disabled_for_proxy is False
+    assert applied[-1].huggingface_xet_disabled is False
     assert applied[-1].sets_standard_pip_env is False
     assert "region=global" in applied[-1].getMessage()
     assert "huggingface=https://***@hf.example" in applied[-1].getMessage()
@@ -249,7 +248,6 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
 
 def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     _clear_mirror_env(monkeypatch)
-    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
     caplog.set_level(logging.INFO, logger="config.mirror_env")
 
     apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
@@ -260,6 +258,6 @@ def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     assert applied[-1].github_source == OFFICIAL_GITHUB_URL
     assert applied[-1].pypi_source == OFFICIAL_PYPI_INDEX_URL
     assert applied[-1].huggingface_transport == "http"
-    assert applied[-1].huggingface_xet_disabled_for_proxy is True
+    assert applied[-1].huggingface_xet_disabled is True
     assert "mode=manual" in applied[-1].getMessage()
     assert "huggingface_transport=http" in applied[-1].getMessage()

--- a/test/unit/config/test_mirror_env.py
+++ b/test/unit/config/test_mirror_env.py
@@ -25,6 +25,7 @@ def _clear_mirror_env(monkeypatch):
         "HF_ENDPOINT",
         "HF_HOME",
         "HF_HUB_CACHE",
+        "HF_HUB_DISABLE_XET",
         "HUGGINGFACE_HUB_ENDPOINT",
         "HUGGINGFACE_HUB_CACHE",
         "TRANSFORMERS_CACHE",
@@ -39,6 +40,14 @@ def _clear_mirror_env(monkeypatch):
         "SHINSEKAI_SKIP_NETWORK_REGION_PROBE",
         "SHINSEKAI_IP_REGION_URLS",
         "SHINSEKAI_MIRROR_REGION",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "SOCKS_PROXY",
+        "socks_proxy",
     ):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr("config.mirror_env._DETECT_CACHE", None)
@@ -76,6 +85,44 @@ def test_apply_mirror_environment_marks_global_pip_strategy(monkeypatch):
     assert values.region == "global"
     assert "SHINSEKAI_PIP_INDEX_URL" not in os.environ
     assert os.environ["SHINSEKAI_MIRROR_REGION"] == "global"
+
+
+def test_apply_mirror_environment_disables_xet_for_official_hub_over_proxy(monkeypatch):
+    _clear_mirror_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+
+    values = apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
+
+    assert values.huggingface == ""
+    assert os.environ["HF_HUB_DISABLE_XET"] == "1"
+
+
+def test_apply_mirror_environment_keeps_xet_default_for_mirror_over_proxy(monkeypatch):
+    _clear_mirror_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+
+    apply_mirror_environment(
+        SystemConfig(
+            mirror_auto_detect_china=False,
+            huggingface_mirror_url="https://hf.example",
+        )
+    )
+
+    assert "HF_HUB_DISABLE_XET" not in os.environ
+
+
+def test_apply_mirror_environment_treats_explicit_official_url_as_official(monkeypatch):
+    _clear_mirror_env(monkeypatch)
+    monkeypatch.setenv("ALL_PROXY", "socks5://127.0.0.1:7891")
+
+    apply_mirror_environment(
+        SystemConfig(
+            mirror_auto_detect_china=False,
+            huggingface_mirror_url=f"{OFFICIAL_HUGGINGFACE_URL}/",
+        )
+    )
+
+    assert os.environ["HF_HUB_DISABLE_XET"] == "1"
 
 
 def test_apply_mirror_environment_manual_values_override_region(monkeypatch, tmp_path):
@@ -193,6 +240,8 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
     assert applied[-1].pypi_index == "https://pypi.example/simple"
     assert applied[-1].pypi_source == "https://pypi.example/simple"
     assert applied[-1].detection_mode == "manual"
+    assert applied[-1].huggingface_transport == "auto"
+    assert applied[-1].huggingface_xet_disabled_for_proxy is False
     assert applied[-1].sets_standard_pip_env is False
     assert "region=global" in applied[-1].getMessage()
     assert "huggingface=https://***@hf.example" in applied[-1].getMessage()
@@ -200,6 +249,7 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
 
 def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     _clear_mirror_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
     caplog.set_level(logging.INFO, logger="config.mirror_env")
 
     apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
@@ -209,4 +259,7 @@ def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     assert applied[-1].huggingface_source == OFFICIAL_HUGGINGFACE_URL
     assert applied[-1].github_source == OFFICIAL_GITHUB_URL
     assert applied[-1].pypi_source == OFFICIAL_PYPI_INDEX_URL
+    assert applied[-1].huggingface_transport == "http"
+    assert applied[-1].huggingface_xet_disabled_for_proxy is True
     assert "mode=manual" in applied[-1].getMessage()
+    assert "huggingface_transport=http" in applied[-1].getMessage()

--- a/test/unit/config/test_mirror_env.py
+++ b/test/unit/config/test_mirror_env.py
@@ -8,6 +8,9 @@ from config.mirror_env import (
     DEFAULT_HUGGINGFACE_CACHE_DIR,
     DEFAULT_HUGGINGFACE_MIRROR_URL,
     DEFAULT_PYPI_MIRROR_URL,
+    OFFICIAL_GITHUB_URL,
+    OFFICIAL_HUGGINGFACE_URL,
+    OFFICIAL_PYPI_INDEX_URL,
     apply_mirror_environment,
     apply_mirror_environment_from_system_config,
     detect_china_network,
@@ -186,5 +189,24 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
     applied = [record for record in caplog.records if getattr(record, "event", "") == "mirror.env.applied"]
     assert applied
     assert applied[-1].huggingface_mirror == "https://***@hf.example"
+    assert applied[-1].huggingface_source == "https://***@hf.example"
     assert applied[-1].pypi_index == "https://pypi.example/simple"
+    assert applied[-1].pypi_source == "https://pypi.example/simple"
+    assert applied[-1].detection_mode == "manual"
     assert applied[-1].sets_standard_pip_env is False
+    assert "region=global" in applied[-1].getMessage()
+    assert "huggingface=https://***@hf.example" in applied[-1].getMessage()
+
+
+def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
+    _clear_mirror_env(monkeypatch)
+    caplog.set_level(logging.INFO, logger="config.mirror_env")
+
+    apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
+
+    applied = [record for record in caplog.records if getattr(record, "event", "") == "mirror.env.applied"]
+    assert applied
+    assert applied[-1].huggingface_source == OFFICIAL_HUGGINGFACE_URL
+    assert applied[-1].github_source == OFFICIAL_GITHUB_URL
+    assert applied[-1].pypi_source == OFFICIAL_PYPI_INDEX_URL
+    assert "mode=manual" in applied[-1].getMessage()

--- a/test/unit/config/test_mirror_env.py
+++ b/test/unit/config/test_mirror_env.py
@@ -87,8 +87,9 @@ def test_apply_mirror_environment_marks_global_pip_strategy(monkeypatch):
     assert os.environ["SHINSEKAI_MIRROR_REGION"] == "global"
 
 
-def test_apply_mirror_environment_disables_xet_for_official_hub(monkeypatch):
+def test_apply_mirror_environment_disables_xet_for_official_hub_over_proxy(monkeypatch):
     _clear_mirror_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
 
     values = apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
 
@@ -240,7 +241,7 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
     assert applied[-1].pypi_source == "https://pypi.example/simple"
     assert applied[-1].detection_mode == "manual"
     assert applied[-1].huggingface_transport == "auto"
-    assert applied[-1].huggingface_xet_disabled is False
+    assert applied[-1].huggingface_xet_disabled_for_proxy is False
     assert applied[-1].sets_standard_pip_env is False
     assert "region=global" in applied[-1].getMessage()
     assert "huggingface=https://***@hf.example" in applied[-1].getMessage()
@@ -248,6 +249,7 @@ def test_apply_mirror_environment_logs_applied_values(monkeypatch, caplog):
 
 def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     _clear_mirror_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
     caplog.set_level(logging.INFO, logger="config.mirror_env")
 
     apply_mirror_environment(SystemConfig(mirror_auto_detect_china=False))
@@ -258,6 +260,6 @@ def test_apply_mirror_environment_logs_official_sources(monkeypatch, caplog):
     assert applied[-1].github_source == OFFICIAL_GITHUB_URL
     assert applied[-1].pypi_source == OFFICIAL_PYPI_INDEX_URL
     assert applied[-1].huggingface_transport == "http"
-    assert applied[-1].huggingface_xet_disabled is True
+    assert applied[-1].huggingface_xet_disabled_for_proxy is True
     assert "mode=manual" in applied[-1].getMessage()
     assert "huggingface_transport=http" in applied[-1].getMessage()

--- a/test/unit/frontend_bridge_core/test_handler_logging.py
+++ b/test/unit/frontend_bridge_core/test_handler_logging.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from frontend_bridge_core.handler import FrontendBridgeHandler
+
+
+def _handler(path: str, method: str = "GET") -> FrontendBridgeHandler:
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+    handler.path = path
+    handler.command = method
+    return handler
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/api/tasks/task-1", "GET"),
+        ("/api/tasks/task-1", "OPTIONS"),
+        ("/api/chat/runtime-status", "GET"),
+        ("/api/chat/snapshot", "GET"),
+        ("/api/health", "GET"),
+        ("/api/characters/memories/status", "POST"),
+        ("/api/model-assets/status", "POST"),
+        ("/api/plugins/status", "GET"),
+    ],
+)
+def test_successful_polling_requests_are_not_logged(path, method, caplog):
+    caplog.set_level(logging.INFO, logger="frontend_bridge_core.handler")
+
+    _handler(path, method).log_message('"%s" %s %s', f"{method} {path} HTTP/1.1", "200", "-")
+
+    completed = [record for record in caplog.records if getattr(record, "event", "") == "http.request.completed"]
+    assert completed == []
+
+
+def test_failed_polling_request_is_logged(caplog):
+    caplog.set_level(logging.WARNING, logger="frontend_bridge_core.handler")
+
+    _handler("/api/tasks/task-1").log_message(
+        '"%s" %s %s',
+        "GET /api/tasks/task-1 HTTP/1.1",
+        "500",
+        "-",
+    )
+
+    completed = [record for record in caplog.records if getattr(record, "event", "") == "http.request.completed"]
+    assert len(completed) == 1
+    assert completed[0].levelno == logging.ERROR
+    assert completed[0].status == 500
+
+
+def test_non_polling_request_is_still_logged(caplog):
+    caplog.set_level(logging.INFO, logger="frontend_bridge_core.handler")
+
+    _handler("/api/config").log_message('"%s" %s %s', "GET /api/config HTTP/1.1", "200", "-")
+
+    completed = [record for record in caplog.records if getattr(record, "event", "") == "http.request.completed"]
+    assert len(completed) == 1
+    assert completed[0].levelno == logging.INFO

--- a/test/unit/plugins/test_plugin_requirements_install.py
+++ b/test/unit/plugins/test_plugin_requirements_install.py
@@ -370,6 +370,87 @@ def test_install_lines_after_precheck_scans_installed_distributions_once(monkeyp
     assert len(calls) == 1
 
 
+def test_pytorch_cpu_build_is_force_reinstalled_from_cuda_index_without_plugin_target(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(
+        plugin_root,
+        "torch==2.7.1\ntorchvision==0.22.1\ntorchaudio==2.7.1\n",
+    )
+    monkeypatch.setattr(installer, "plugin_pip_target_directory", lambda: tmp_path / "target")
+    monkeypatch.setattr(
+        installer,
+        "_installed_distribution_versions",
+        lambda: {
+            "torch": "2.7.1+cpu",
+            "torchvision": "0.22.1+cpu",
+            "torchaudio": "2.7.1+cpu",
+        },
+    )
+
+    original_plan = installer._build_pytorch_install_plan
+
+    def cuda_plan(lines, installed_versions, *, requirement_is_satisfied):
+        return original_plan(
+            lines,
+            installed_versions,
+            requirement_is_satisfied=requirement_is_satisfied,
+            index_url="https://download.pytorch.org/whl/cu128",
+            index_reason="test_cuda",
+        )
+
+    monkeypatch.setattr(installer, "_build_pytorch_install_plan", cuda_plan)
+    calls = _capture_pip_invocation(monkeypatch, installer)
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    assert len(calls) == 1
+    cmd = calls[0]["cmd"]
+    assert "--force-reinstall" in cmd
+    assert "--upgrade" in cmd
+    assert "--target" not in cmd
+    assert cmd[cmd.index("--index-url") + 1] == "https://download.pytorch.org/whl/cu128"
+
+
+def test_matching_pytorch_stack_skips_pip(monkeypatch, tmp_path):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(
+        plugin_root,
+        "torch==2.7.1\ntorchvision==0.22.1\ntorchaudio==2.7.1\n",
+    )
+    monkeypatch.setattr(
+        installer,
+        "_installed_distribution_versions",
+        lambda: {
+            "torch": "2.7.1+cu128",
+            "torchvision": "0.22.1+cu128",
+            "torchaudio": "2.7.1+cu128",
+        },
+    )
+
+    original_plan = installer._build_pytorch_install_plan
+
+    def cuda_plan(lines, installed_versions, *, requirement_is_satisfied):
+        return original_plan(
+            lines,
+            installed_versions,
+            requirement_is_satisfied=requirement_is_satisfied,
+            index_url="https://download.pytorch.org/whl/cu128",
+            index_reason="test_cuda",
+        )
+
+    monkeypatch.setattr(installer, "_build_pytorch_install_plan", cuda_plan)
+    calls = _capture_pip_invocation(monkeypatch, installer)
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    assert calls == []
+
+
 def test_write_temp_requirements_removes_file_when_write_fails(monkeypatch, tmp_path):
     from core.plugins import plugin_requirements_install as installer
 

--- a/test/unit/plugins/test_plugin_requirements_install.py
+++ b/test/unit/plugins/test_plugin_requirements_install.py
@@ -407,12 +407,23 @@ def test_pytorch_cpu_build_is_force_reinstalled_from_cuda_index_without_plugin_t
     result = installer.install_plugin_requirements_txt(plugin_root)
 
     assert result == ("pip_ok", "")
-    assert len(calls) == 1
-    cmd = calls[0]["cmd"]
-    assert "--force-reinstall" in cmd
-    assert "--upgrade" in cmd
-    assert "--target" not in cmd
-    assert cmd[cmd.index("--index-url") + 1] == "https://download.pytorch.org/whl/cu128"
+    assert len(calls) == 2
+    reinstall_cmd = calls[0]["cmd"]
+    assert "--force-reinstall" in reinstall_cmd
+    assert "--upgrade" in reinstall_cmd
+    assert "--no-deps" in reinstall_cmd
+    assert "--target" not in reinstall_cmd
+    assert (
+        reinstall_cmd[reinstall_cmd.index("--index-url") + 1]
+        == "https://download.pytorch.org/whl/cu128"
+    )
+
+    dependency_repair_cmd = calls[1]["cmd"]
+    assert "--force-reinstall" not in dependency_repair_cmd
+    assert "--upgrade" not in dependency_repair_cmd
+    assert "--no-deps" not in dependency_repair_cmd
+    assert "--target" not in dependency_repair_cmd
+    assert calls[0]["requirements_text"] == calls[1]["requirements_text"]
 
 
 def test_matching_pytorch_stack_skips_pip(monkeypatch, tmp_path):

--- a/test/unit/plugins/test_plugin_requirements_install.py
+++ b/test/unit/plugins/test_plugin_requirements_install.py
@@ -23,6 +23,7 @@ def _capture_pip_invocation(monkeypatch, installer, result=("pip_ok", "")):
 
     def fake_run_pip_install(cmd, *, cwd, timeout_sec, on_output_line):
         req_path = Path(cmd[cmd.index("-r") + 1])
+        constraints_path = Path(cmd[cmd.index("-c") + 1]) if "-c" in cmd else None
         calls.append(
             {
                 "cmd": list(cmd),
@@ -30,6 +31,11 @@ def _capture_pip_invocation(monkeypatch, installer, result=("pip_ok", "")):
                 "timeout_sec": timeout_sec,
                 "requirements_path": req_path,
                 "requirements_text": req_path.read_text(encoding="utf-8"),
+                "constraints_text": (
+                    constraints_path.read_text(encoding="utf-8")
+                    if constraints_path is not None
+                    else None
+                ),
             }
         )
         return result
@@ -377,7 +383,7 @@ def test_pytorch_cpu_build_is_force_reinstalled_from_cuda_index_without_plugin_t
     installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
     _write_requirements(
         plugin_root,
-        "torch==2.7.1\ntorchvision==0.22.1\ntorchaudio==2.7.1\n",
+        "torch==99.0.0\n",
     )
     monkeypatch.setattr(installer, "plugin_pip_target_directory", lambda: tmp_path / "target")
     monkeypatch.setattr(
@@ -424,6 +430,11 @@ def test_pytorch_cpu_build_is_force_reinstalled_from_cuda_index_without_plugin_t
     assert "--no-deps" not in dependency_repair_cmd
     assert "--target" not in dependency_repair_cmd
     assert calls[0]["requirements_text"] == calls[1]["requirements_text"]
+    assert calls[0]["requirements_text"] == (
+        "torch==2.7.1\n"
+        "torchvision==0.22.1\n"
+        "torchaudio==2.7.1\n"
+    )
 
 
 def test_matching_pytorch_stack_skips_pip(monkeypatch, tmp_path):
@@ -460,6 +471,55 @@ def test_matching_pytorch_stack_skips_pip(monkeypatch, tmp_path):
 
     assert result == ("pip_ok", "")
     assert calls == []
+
+
+def test_plugin_pytorch_versions_are_replaced_and_transitive_torch_is_constrained(
+    monkeypatch,
+    tmp_path,
+):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    _write_requirements(
+        plugin_root,
+        "accelerate>=1.10.0\ntorch==99.0.0\n",
+    )
+    target = tmp_path / "target"
+    monkeypatch.setattr(installer, "plugin_pip_target_directory", lambda: target)
+    monkeypatch.setattr(
+        installer,
+        "_installed_distribution_versions",
+        lambda: {
+            "torch": "2.7.1+cu128",
+            "torchvision": "0.22.1+cu128",
+            "torchaudio": "2.7.1+cu128",
+        },
+    )
+    original_plan = installer._build_pytorch_install_plan
+
+    def cuda_plan(lines, installed_versions, *, requirement_is_satisfied):
+        return original_plan(
+            lines,
+            installed_versions,
+            requirement_is_satisfied=requirement_is_satisfied,
+            index_url="https://download.pytorch.org/whl/cu128",
+            index_reason="test_cuda",
+        )
+
+    monkeypatch.setattr(installer, "_build_pytorch_install_plan", cuda_plan)
+    calls = _capture_pip_invocation(monkeypatch, installer)
+
+    result = installer.install_plugin_requirements_txt(plugin_root)
+
+    assert result == ("pip_ok", "")
+    assert len(calls) == 1
+    cmd = calls[0]["cmd"]
+    assert "--target" not in cmd
+    assert "-c" in cmd
+    assert calls[0]["constraints_text"] == (
+        "torch==2.7.1\n"
+        "torchvision==0.22.1\n"
+        "torchaudio==2.7.1\n"
+    )
+    assert calls[0]["requirements_text"] == "accelerate>=1.10.0\n"
 
 
 def test_write_temp_requirements_removes_file_when_write_fails(monkeypatch, tmp_path):

--- a/test/unit/plugins/test_pytorch_runtime.py
+++ b/test/unit/plugins/test_pytorch_runtime.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from core.plugins.pytorch_runtime import (
+    build_pytorch_install_plan,
+    partition_pytorch_requirement_lines,
+    pytorch_wheel_base_url,
+    pytorch_wheel_index_url_for_cuda_version,
+)
+
+
+def _satisfied(line: str, installed: dict[str, str]) -> bool:
+    from packaging.requirements import Requirement
+
+    requirement = Requirement(line)
+    version = installed.get(requirement.name.lower())
+    return version is not None and requirement.specifier.contains(
+        version,
+        prereleases=True,
+    )
+
+
+def test_partition_pytorch_requirement_lines_keeps_stack_together():
+    pytorch, other = partition_pytorch_requirement_lines(
+        [
+            "torch==2.7.1",
+            "torchvision==0.22.1",
+            "torchaudio==2.7.1",
+            "transformers<5",
+        ]
+    )
+
+    assert pytorch == [
+        "torch==2.7.1",
+        "torchvision==0.22.1",
+        "torchaudio==2.7.1",
+    ]
+    assert other == ["transformers<5"]
+
+
+def test_cuda_12_8_and_newer_selects_cu128():
+    assert (
+        pytorch_wheel_index_url_for_cuda_version(
+            (13, 2),
+            base_url="https://download.pytorch.org/whl",
+        )[0]
+        == "https://download.pytorch.org/whl/cu128"
+    )
+    assert (
+        pytorch_wheel_index_url_for_cuda_version(
+            (12, 8),
+            base_url="https://download.pytorch.org/whl",
+        )[0]
+        == "https://download.pytorch.org/whl/cu128"
+    )
+
+
+def test_pytorch_wheel_base_follows_region_and_selected_pip_index(monkeypatch):
+    monkeypatch.delenv("SHINSEKAI_PYTORCH_WHEEL_BASE", raising=False)
+    monkeypatch.delenv("SHINSEKAI_RUNTIME_SOURCE", raising=False)
+    monkeypatch.delenv("SHINSEKAI_MIRROR_REGION", raising=False)
+
+    assert (
+        pytorch_wheel_base_url(["https://pypi.tuna.tsinghua.edu.cn/simple/"])
+        == "https://mirrors.aliyun.com/pytorch-wheels"
+    )
+    assert (
+        pytorch_wheel_base_url(["https://pypi.org/simple/"])
+        == "https://download.pytorch.org/whl"
+    )
+
+    monkeypatch.setenv("SHINSEKAI_MIRROR_REGION", "china")
+    assert (
+        pytorch_wheel_base_url(["https://pypi.org/simple/"])
+        == "https://mirrors.aliyun.com/pytorch-wheels"
+    )
+    monkeypatch.setenv("SHINSEKAI_MIRROR_REGION", "global")
+    assert (
+        pytorch_wheel_base_url(["https://pypi.tuna.tsinghua.edu.cn/simple/"])
+        == "https://download.pytorch.org/whl"
+    )
+
+
+def test_pytorch_wheel_base_explicit_override_wins(monkeypatch):
+    monkeypatch.setenv(
+        "SHINSEKAI_PYTORCH_WHEEL_BASE",
+        "https://mirror.example/pytorch/",
+    )
+    monkeypatch.setenv("SHINSEKAI_MIRROR_REGION", "china")
+
+    assert (
+        pytorch_wheel_base_url(["https://pypi.org/simple/"])
+        == "https://mirror.example/pytorch"
+    )
+
+
+def test_matching_versions_and_cuda_build_skip_install():
+    lines = [
+        "torch==2.7.1",
+        "torchvision==0.22.1",
+        "torchaudio==2.7.1",
+    ]
+    installed = {
+        "torch": "2.7.1+cu128",
+        "torchvision": "0.22.1+cu128",
+        "torchaudio": "2.7.1+cu128",
+    }
+
+    plan = build_pytorch_install_plan(
+        lines,
+        installed,
+        requirement_is_satisfied=_satisfied,
+        index_url="https://download.pytorch.org/whl/cu128",
+    )
+
+    assert plan.install_required is False
+    assert plan.force_reinstall is False
+
+
+def test_cpu_build_on_cuda_machine_forces_complete_reinstall():
+    lines = [
+        "torch==2.7.1",
+        "torchvision==0.22.1",
+        "torchaudio==2.7.1",
+    ]
+    installed = {
+        "torch": "2.7.1+cpu",
+        "torchvision": "0.22.1+cpu",
+        "torchaudio": "2.7.1+cpu",
+    }
+
+    plan = build_pytorch_install_plan(
+        lines,
+        installed,
+        requirement_is_satisfied=_satisfied,
+        index_url="https://download.pytorch.org/whl/cu128",
+    )
+
+    assert plan.install_required is True
+    assert plan.force_reinstall is True
+    assert "expected cu128 wheels" in plan.detail
+
+
+def test_broad_requirement_still_rejects_wrong_wheel_channel():
+    plan = build_pytorch_install_plan(
+        ["torch>=2.1.0"],
+        {"torch": "2.12.1+cpu"},
+        requirement_is_satisfied=_satisfied,
+        index_url="https://download.pytorch.org/whl/cu128",
+    )
+
+    assert plan.install_required is True
+    assert plan.force_reinstall is True
+    assert "expected cu128 wheels" in plan.detail
+
+
+def test_changed_versions_force_reinstall_even_on_matching_channel():
+    lines = [
+        "torch==2.7.1",
+        "torchvision==0.22.1",
+        "torchaudio==2.7.1",
+    ]
+    installed = {
+        "torch": "2.11.0+cu128",
+        "torchvision": "0.26.0+cu128",
+        "torchaudio": "2.11.0+cu128",
+    }
+
+    plan = build_pytorch_install_plan(
+        lines,
+        installed,
+        requirement_is_satisfied=_satisfied,
+        index_url="https://download.pytorch.org/whl/cu128",
+    )
+
+    assert plan.install_required is True
+    assert plan.force_reinstall is True
+    assert "versions do not match" in plan.detail
+
+
+def test_empty_environment_uses_normal_install():
+    plan = build_pytorch_install_plan(
+        ["torch==2.7.1", "torchaudio==2.7.1"],
+        {},
+        requirement_is_satisfied=_satisfied,
+        index_url="https://download.pytorch.org/whl/cpu",
+    )
+
+    assert plan.install_required is True
+    assert plan.force_reinstall is False
+    assert "missing packages" in plan.detail

--- a/test/unit/plugins/test_pytorch_runtime.py
+++ b/test/unit/plugins/test_pytorch_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from core.plugins.pytorch_runtime import (
+    HOST_PYTORCH_REQUIREMENTS,
     build_pytorch_install_plan,
     partition_pytorch_requirement_lines,
     pytorch_wheel_base_url,
@@ -52,6 +53,26 @@ def test_cuda_12_8_and_newer_selects_cu128():
         )[0]
         == "https://download.pytorch.org/whl/cu128"
     )
+
+
+def test_host_stack_uses_only_published_cuda_channels_and_cpu_fallback():
+    base_url = "https://download.pytorch.org/whl"
+
+    assert pytorch_wheel_index_url_for_cuda_version((12, 7), base_url=base_url)[
+        0
+    ].endswith("/cu126")
+    assert pytorch_wheel_index_url_for_cuda_version((11, 8), base_url=base_url)[
+        0
+    ].endswith("/cu118")
+    assert pytorch_wheel_index_url_for_cuda_version((12, 4), base_url=base_url)[
+        0
+    ].endswith("/cpu")
+    assert pytorch_wheel_index_url_for_cuda_version((12, 1), base_url=base_url)[
+        0
+    ].endswith("/cpu")
+    assert pytorch_wheel_index_url_for_cuda_version((11, 7), base_url=base_url)[
+        0
+    ].endswith("/cpu")
 
 
 def test_pytorch_wheel_base_follows_region_and_selected_pip_index(monkeypatch):
@@ -114,6 +135,7 @@ def test_matching_versions_and_cuda_build_skip_install():
 
     assert plan.install_required is False
     assert plan.force_reinstall is False
+    assert plan.requirement_lines == HOST_PYTORCH_REQUIREMENTS
 
 
 def test_cpu_build_on_cuda_machine_forces_complete_reinstall():
@@ -140,17 +162,21 @@ def test_cpu_build_on_cuda_machine_forces_complete_reinstall():
     assert "expected cu128 wheels" in plan.detail
 
 
-def test_broad_requirement_still_rejects_wrong_wheel_channel():
+def test_plugin_requirement_version_is_ignored_in_favor_of_host_stack():
     plan = build_pytorch_install_plan(
-        ["torch>=2.1.0"],
-        {"torch": "2.12.1+cpu"},
+        ["torch==99.0.0"],
+        {
+            "torch": "2.7.1+cu128",
+            "torchvision": "0.22.1+cu128",
+            "torchaudio": "2.7.1+cu128",
+        },
         requirement_is_satisfied=_satisfied,
         index_url="https://download.pytorch.org/whl/cu128",
     )
 
-    assert plan.install_required is True
-    assert plan.force_reinstall is True
-    assert "expected cu128 wheels" in plan.detail
+    assert plan.install_required is False
+    assert plan.force_reinstall is False
+    assert plan.requirement_lines == HOST_PYTORCH_REQUIREMENTS
 
 
 def test_changed_versions_force_reinstall_even_on_matching_channel():
@@ -188,3 +214,4 @@ def test_empty_environment_uses_normal_install():
     assert plan.install_required is True
     assert plan.force_reinstall is False
     assert "missing packages" in plan.detail
+    assert plan.requirement_lines == HOST_PYTORCH_REQUIREMENTS


### PR DESCRIPTION
## What changed

- centralize PyTorch stack planning for plugin and AI runtime installs
- ignore plugin-authored PyTorch versions and enforce the host-owned stack:
  - `torch==2.7.1`
  - `torchvision==0.22.1`
  - `torchaudio==2.7.1`
- verify installed versions and CPU/CUDA build tags before reuse
- select `cu128`, `cu126`, or `cu118` only where the host stack has a matching channel; otherwise use CPU wheels
- force reinstall only the declared host PyTorch stack with `--no-deps`
- repair only missing or incompatible transitive dependencies in a normal follow-up pass
- constrain ordinary dependencies so packages such as `accelerate` cannot install a second Torch stack
- select the Aliyun PyTorch wheel mirror for China and the official index globally
- log the detected mirror region, selection mode, and effective Hugging Face, GitHub, and PyPI sources
- suppress successful polling request logs while retaining HTTP warning/error records

## Why

Plugin constraints such as `torch>=2` allowed pip to select the latest wheel from the chosen index, while `pip --target` could resolve another Torch copy through packages such as `accelerate`. This caused version skew, duplicate downloads, broad forced reinstalls, and could leave Moondream proactive screen inference unable to run.

Mirror auto-detection and high-frequency task polling also made model-download failures difficult to diagnose: the effective source was hidden in structured fields while normal poll requests flooded the bridge log.

## Impact

Plugins only opt into PyTorch; they no longer control its version. Matching host stacks are reused without a download. Mismatched stacks replace only `torch`, `torchvision`, and `torchaudio`. Existing unrelated libraries are preserved, and unsupported CUDA-channel gaps fall back to CPU wheels.

Download diagnostics now show the effective mirror environment directly, while routine task, health, runtime-status, snapshot, and model-status polling stays quiet unless an HTTP error occurs.

## Validation

- pre-push Python suite: 1657 passed, 11 skipped, 7 subtests passed
- pre-push frontend suite: 740 passed; Prettier and TypeScript checks passed
- focused mirror and request-logging suite: 52 passed
- Python plugin suite: 116 passed
- Rust suite: 109 passed
- verified the official PyTorch 2.7.1 matrix publishes `cu118`, `cu126`, `cu128`, and CPU wheels
- verified the Aliyun `cu128` index contains Windows wheels for the host stack