### PR TITLE
feat(plugins): restore overlay bridge and hidden runtime inputs

### DIFF
--- a/core/messaging/chat_turn_service.py
+++ b/core/messaging/chat_turn_service.py
@@ -96,7 +96,7 @@ class ChatTurnService:
         self._typing = False
         self._closed = False
 
-    def submit(self, text: str, *, attachments: list[dict[str, Any]] | None = None) -> BatchState:
+    def submit(self, text: str, *, attachments: list[dict[str, Any]] | None = None, hidden: bool = False) -> BatchState:
         """Accept one processed user message.
 
         When batching is disabled the message is delivered immediately.  In
@@ -111,8 +111,8 @@ class ChatTurnService:
         if self.options.interrupt_enabled and self.is_active():
             self.interrupt()
 
-        if not self.options.batch_enabled:
-            self._deliver(value, attachment_payloads)
+        if hidden or not self.options.batch_enabled:
+            self._deliver(value, attachment_payloads, hidden=hidden)
             return self.batch_state()
 
         with self._lock:
@@ -291,7 +291,10 @@ class ChatTurnService:
             self._closed = True
             self._cancel_batch_timer_locked()
 
-    def _deliver(self, text: str, attachments: list[dict[str, Any]]) -> None:
+    def _deliver(self, text: str, attachments: list[dict[str, Any]], *, hidden: bool = False) -> None:
+        if hidden:
+            self._sink(text, attachments=attachments, hidden=True)
+            return
         if attachments:
             self._sink(text, attachments=attachments)
         else:

--- a/core/messaging/chat_turn_wiring.py
+++ b/core/messaging/chat_turn_wiring.py
@@ -27,12 +27,23 @@ def create_chat_turn_service(
         batch_separator=str(getattr(api_config, "batch_input_separator", "\n---\n")),
     )
 
-    def deliver(text: str, *, attachments: list[dict[str, object]] | None = None) -> None:
+    def deliver(
+        text: str,
+        *,
+        attachments: list[dict[str, object]] | None = None,
+        hidden: bool = False,
+    ) -> None:
         if user_input_queue is None:
             return
         from sdk.messages import UserInputMessage
 
-        user_input_queue.put(UserInputMessage(text=text, attachments=list(attachments or [])))
+        user_input_queue.put(
+            UserInputMessage(
+                text=text,
+                attachments=list(attachments or []),
+                hidden=hidden,
+            )
+        )
 
     def clear_queue(queue: object | None) -> Callable[[], None]:
         def clear() -> None:

--- a/core/plugins/plugin_host.py
+++ b/core/plugins/plugin_host.py
@@ -269,7 +269,7 @@ def wire_user_input_plugins(
     mgr = _plugin_manager
     processors: list[Callable[[str], str | None]] = []
 
-    def emit_user_text(text: str, *, attachments: list[dict[str, Any]] | None = None) -> bool:
+    def emit_user_text(text: str, *, attachments: list[dict[str, Any]] | None = None, hidden: bool = False) -> bool:
         t = text
         for proc in processors:
             try:
@@ -282,9 +282,12 @@ def wire_user_input_plugins(
             t = out
         attachment_payloads = list(attachments or [])
         if sink is not None:
-            sink(t, attachments=attachment_payloads)
+            if hidden:
+                sink(t, attachments=attachment_payloads, hidden=True)
+            else:
+                sink(t, attachments=attachment_payloads)
         else:
-            user_input_queue.put(UserInputMessage(text=t, attachments=attachment_payloads))
+            user_input_queue.put(UserInputMessage(text=t, attachments=attachment_payloads, hidden=hidden))
         return True
 
     if mgr is not None:

--- a/core/runtime/workers.py
+++ b/core/runtime/workers.py
@@ -175,16 +175,18 @@ class LLMWorker(QThreadDagNode):
                     },
                 )
                 tracker.start_cross("e2e")
-                self.ui_update_manager.post_notification("发送成功，正在等待回复中...")
+                if not message.hidden:
+                    self.ui_update_manager.post_notification("发送成功，正在等待回复中...")
 
-                if hasattr(self.ui_update_manager, "record_user_message"):
-                    self.ui_update_manager.record_user_message(prepared_input.display_text)
-                else:
-                    formatted_user_message = (
-                        "<p style='line-height: 135%; letter-spacing: 2px; color:white;'>"
-                        f"<b style='color:white;'>你</b>: {prepared_input.display_text}</p>"
-                    )
-                    self.ui_update_manager.chat_history.append(formatted_user_message)
+                if not message.hidden:
+                    if hasattr(self.ui_update_manager, "record_user_message"):
+                        self.ui_update_manager.record_user_message(prepared_input.display_text)
+                    else:
+                        formatted_user_message = (
+                            "<p style='line-height: 135%; letter-spacing: 2px; color:white;'>"
+                            f"<b style='color:white;'>你</b>: {prepared_input.display_text}</p>"
+                        )
+                        self.ui_update_manager.chat_history.append(formatted_user_message)
 
                 is_streaming = get_app_runtime().config.config.api_config.is_streaming
                 with tracker.track("LLM chat total"):

--- a/core/runtime/workers.py
+++ b/core/runtime/workers.py
@@ -195,6 +195,7 @@ class LLMWorker(QThreadDagNode):
                         "dialog_output_required": True,
                         "user_input_text": message.text,
                         "user_attachments": [attachment.to_payload() for attachment in attachments],
+                        "hidden": message.hidden,
                     }
                     if attachments:
                         chat_kwargs["user_display_text"] = prepared_input.display_text

--- a/core/sprite/chat_history.py
+++ b/core/sprite/chat_history.py
@@ -325,7 +325,7 @@ def revert_chat_history(user_index: int, llm_manager: Any, hist: list, window: A
     current_user_idx = -1
     for message in messages:
         role = message.get("role")
-        if role == "user":
+        if role == "user" and not message.get("hidden"):
             current_user_idx += 1
             if current_user_idx >= user_index:
                 break

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -562,11 +562,12 @@ export function ChatStagePage() {
   };
 
   const openPluginPage = useCallback(
-    ({ mode, pageId, pluginId }: PluginPageTarget) => {
-      if (mode === "overlay") {
-        setOverlayTarget({ mode, pageId, pluginId });
+    (target: PluginPageTarget) => {
+      if (target.mode === "overlay") {
+        setOverlayTarget(target);
         return;
       }
+      const { pageId, pluginId } = target;
       navigate(
         { pathname: "/settings/plugins", search: location.search },
         {
@@ -629,7 +630,13 @@ export function ChatStagePage() {
 
   return (
     <>
-      {overlayTarget ? <PluginPageOverlay onClose={closePluginPageOverlay} target={overlayTarget} /> : null}
+      {overlayTarget ? (
+        <PluginPageOverlay
+          key={`${overlayTarget.pluginId}\0${overlayTarget.pageId}`}
+          onClose={closePluginPageOverlay}
+          target={overlayTarget}
+        />
+      ) : null}
       <main
         className="chat-stage"
         data-background={transparentBackground ? "transparent" : "media"}

--- a/frontend/src/features/chat-stage/components/PluginPageOverlay.tsx
+++ b/frontend/src/features/chat-stage/components/PluginPageOverlay.tsx
@@ -10,6 +10,7 @@ import "./PluginPageOverlay.css";
 const DEFAULT_WIDTH = 360;
 const DEFAULT_HEIGHT = 640;
 const VIEWPORT_MARGIN = 8;
+const MINI_SCALE = 0.72;
 
 type Pos = { x: number; y: number };
 type Size = { height: number; width: number };
@@ -24,10 +25,30 @@ type OverlayPage = { src: string; title: string };
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(min, value), Math.max(min, max));
 
-function viewportSize(): Size {
+function miniStorageKey(pluginId: string, pageId: string): string {
+  return `shinsekai:plugin-overlay-mini:${pluginId}:${pageId}`;
+}
+
+function readInitialMini(pluginId: string, pageId: string, fallback: boolean): boolean {
+  try {
+    const stored = window.localStorage.getItem(miniStorageKey(pluginId, pageId));
+    if (stored === "1") {
+      return true;
+    }
+    if (stored === "0") {
+      return false;
+    }
+  } catch {
+    // localStorage may be unavailable; fall back to the declared default.
+  }
+  return fallback;
+}
+
+function frameSize(baseWidth: number, baseHeight: number, mini: boolean): Size {
+  const scale = mini ? MINI_SCALE : 1;
   return {
-    height: Math.max(1, Math.min(DEFAULT_HEIGHT, window.innerHeight - VIEWPORT_MARGIN * 2)),
-    width: Math.max(1, Math.min(DEFAULT_WIDTH, window.innerWidth - VIEWPORT_MARGIN * 2)),
+    height: Math.max(1, Math.min(baseHeight * scale, window.innerHeight - VIEWPORT_MARGIN * 2)),
+    width: Math.max(1, Math.min(baseWidth * scale, window.innerWidth - VIEWPORT_MARGIN * 2)),
   };
 }
 
@@ -55,11 +76,23 @@ function initialPosition(size: Size): Pos {
  * cooperating page — from any blank area inside it (the page streams
  * `{ __pluginOverlay: "drag", type, dx, dy }` messages using absolute screen
  * coordinates). Tapping the bottom bar (a press with no drag) collapses it.
+ *
+ * A cooperating page may also stream `{ __pluginOverlay: "drag", type: "size", mini }`
+ * to toggle a scaled-down "mini" footprint, or `{ ..., type: "theme", bg }` to tint the
+ * window chrome. The declared overlay size / background / initial-mini defaults come from
+ * the contribution (see FrontendChatUIContribution.overlay_*), and the mini choice is
+ * persisted per page in localStorage.
  */
 export function PluginPageOverlay({ onClose, target }: { onClose: () => void; target: PluginPageTarget }) {
   const { t } = useI18n();
-  const [size, setSize] = useState<Size>(viewportSize);
-  const [pos, setPos] = useState<Pos>(() => initialPosition(viewportSize()));
+  const { overlayBackground, overlayHeight, overlayInitialMini, overlayWidth, pageId, pluginId } = target;
+  const baseWidth = overlayWidth ?? DEFAULT_WIDTH;
+  const baseHeight = overlayHeight ?? DEFAULT_HEIGHT;
+
+  const [mini, setMini] = useState<boolean>(() => readInitialMini(pluginId, pageId, Boolean(overlayInitialMini)));
+  const [size, setSize] = useState<Size>(() => frameSize(baseWidth, baseHeight, mini));
+  const [pos, setPos] = useState<Pos>(() => initialPosition(frameSize(baseWidth, baseHeight, mini)));
+  const [themeBg, setThemeBg] = useState<string | undefined>(overlayBackground);
   const [page, setPage] = useState<OverlayPage | null>(null);
   const [pageError, setPageError] = useState(false);
   const posRef = useRef(pos);
@@ -75,13 +108,13 @@ export function PluginPageOverlay({ onClose, target }: { onClose: () => void; ta
     frameLoadedRef.current = false;
     setPage(null);
     setPageError(false);
-    void getPluginUiDetail(target.pluginId)
+    void getPluginUiDetail(pluginId)
       .then((detail) => {
         if (!active) {
           return;
         }
         const matchedPage = detail.pages.find(
-          (item) => item.id === target.pageId && item.pluginId === target.pluginId && item.frontendUrl,
+          (item) => item.id === pageId && item.pluginId === pluginId && item.frontendUrl,
         );
         if (!matchedPage?.frontendUrl) {
           setPageError(true);
@@ -89,7 +122,7 @@ export function PluginPageOverlay({ onClose, target }: { onClose: () => void; ta
         }
         setPage({
           src: resolvePlatformHttpUrl(matchedPage.frontendUrl),
-          title: matchedPage.title || target.pageId,
+          title: matchedPage.title || pageId,
         });
       })
       .catch(() => {
@@ -100,7 +133,7 @@ export function PluginPageOverlay({ onClose, target }: { onClose: () => void; ta
     return () => {
       active = false;
     };
-  }, [target.pageId, target.pluginId]);
+  }, [pageId, pluginId]);
 
   const postPresentation = useCallback(() => {
     const frameWindow = frameRef.current?.contentWindow;
@@ -130,14 +163,27 @@ export function PluginPageOverlay({ onClose, target }: { onClose: () => void; ta
   }, [postPresentation]);
 
   useEffect(() => {
-    const handleResize = () => {
-      const nextSize = viewportSize();
+    setThemeBg(overlayBackground);
+  }, [overlayBackground]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(miniStorageKey(pluginId, pageId), mini ? "1" : "0");
+    } catch {
+      // Best-effort persistence of the mini preference.
+    }
+  }, [mini, pageId, pluginId]);
+
+  useEffect(() => {
+    const applySize = () => {
+      const nextSize = frameSize(baseWidth, baseHeight, mini);
       setSize(nextSize);
       setPos((current) => clampPosition(current, nextSize));
     };
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
+    applySize();
+    window.addEventListener("resize", applySize);
+    return () => window.removeEventListener("resize", applySize);
+  }, [baseHeight, baseWidth, mini]);
 
   const onBarPointerDown = (event: ReactPointerEvent) => {
     if (event.button !== 0) {
@@ -188,13 +234,21 @@ export function PluginPageOverlay({ onClose, target }: { onClose: () => void; ta
 
   // Optional drag from inside a cooperating iframe page (press any blank area), streamed
   // via postMessage as absolute screen-coordinate deltas so moving the window stays exact.
+  // The same envelope carries "size" (mini toggle) and "theme" (chrome tint) requests.
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       const frame = frameRef.current;
       if (!frame || event.source !== frame.contentWindow) {
         return;
       }
-      const d = event.data as { __pluginOverlay?: string; dx?: number; dy?: number; type?: string } | null;
+      const d = event.data as {
+        __pluginOverlay?: string;
+        bg?: string;
+        dx?: number;
+        dy?: number;
+        mini?: boolean;
+        type?: string;
+      } | null;
       if (!d || d.__pluginOverlay !== "drag") {
         return;
       }
@@ -216,6 +270,14 @@ export function PluginPageOverlay({ onClose, target }: { onClose: () => void; ta
         dragBase.current = null;
       } else if (d.type === "close") {
         onClose();
+      } else if (d.type === "size") {
+        if (typeof d.mini === "boolean") {
+          setMini(d.mini);
+        }
+      } else if (d.type === "theme") {
+        if (typeof d.bg === "string" && d.bg.trim()) {
+          setThemeBg(d.bg.trim().slice(0, 120));
+        }
       }
     };
     window.addEventListener("message", onMessage);
@@ -224,12 +286,12 @@ export function PluginPageOverlay({ onClose, target }: { onClose: () => void; ta
 
   return createPortal(
     <section
-      aria-label={page?.title || target.pageId}
+      aria-label={page?.title || pageId}
       className="plugin-overlay"
       data-chat-stage-hitbox="true"
       data-plugin-page-overlay="true"
       role="dialog"
-      style={{ height: size.height, left: pos.x, top: pos.y, width: size.width }}
+      style={{ background: themeBg, height: size.height, left: pos.x, top: pos.y, width: size.width }}
     >
       {page ? (
         <iframe

--- a/frontend/src/shared/platform/types.ts
+++ b/frontend/src/shared/platform/types.ts
@@ -199,6 +199,10 @@ export interface PluginSlotContribution {
   icon: PluginSlotContributionIcon;
   id: string;
   order: number;
+  overlayBackground?: string;
+  overlayHeight?: number;
+  overlayInitialMini?: boolean;
+  overlayWidth?: number;
   pageId: string;
   pageMode?: PluginSlotContributionPageMode;
   pluginId: string;

--- a/frontend/src/shared/plugin/PluginSlot.tsx
+++ b/frontend/src/shared/plugin/PluginSlot.tsx
@@ -26,6 +26,10 @@ export interface PluginRenderContext {
 
 export interface PluginPageTarget {
   mode?: PluginSlotContributionPageMode;
+  overlayBackground?: string;
+  overlayHeight?: number;
+  overlayInitialMini?: boolean;
+  overlayWidth?: number;
   pageId: string;
   payload?: Record<string, unknown>;
   pluginId: string;
@@ -130,7 +134,15 @@ function SerializableContribution({
     }
     if (contribution.actionType === "open-plugin-page") {
       if (contribution.pageId && onOpenPluginPage) {
-        onOpenPluginPage({ mode: contribution.pageMode, pageId: contribution.pageId, pluginId: contribution.pluginId });
+        onOpenPluginPage({
+          mode: contribution.pageMode,
+          overlayBackground: contribution.overlayBackground,
+          overlayHeight: contribution.overlayHeight,
+          overlayInitialMini: contribution.overlayInitialMini,
+          overlayWidth: contribution.overlayWidth,
+          pageId: contribution.pageId,
+          pluginId: contribution.pluginId,
+        });
       }
       return;
     }

--- a/frontend/src/test/shared/plugin/pluginSlots.test.tsx
+++ b/frontend/src/test/shared/plugin/pluginSlots.test.tsx
@@ -212,4 +212,52 @@ describe("plugin slot registry", () => {
     });
     expect(repository.run).not.toHaveBeenCalled();
   });
+
+  it("forwards declared overlay presentation hints when opening a page", async () => {
+    repository.list.mockResolvedValue([
+      {
+        actionLabel: "Dashboard",
+        actionType: "open-plugin-page",
+        actionable: true,
+        description: "Open a generic plugin dashboard",
+        icon: "puzzle",
+        id: "demo.dashboard",
+        order: 20,
+        overlayBackground: "#101014",
+        overlayHeight: 720,
+        overlayInitialMini: true,
+        overlayWidth: 400,
+        pageId: "dashboard",
+        pageMode: "overlay",
+        pluginId: "demo.plugin",
+        pluginVersion: "1.0.0",
+        presentation: "button",
+        slot: "chat-dialog-actions",
+        title: "Dashboard",
+        variant: "ghost",
+      },
+    ]);
+    const onOpenPluginPage = vi.fn();
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <PluginSlot onOpenPluginPage={onOpenPluginPage} slot="chat-dialog-actions" />
+        </ToastProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dashboard" }));
+
+    expect(onOpenPluginPage).toHaveBeenCalledWith({
+      mode: "overlay",
+      overlayBackground: "#101014",
+      overlayHeight: 720,
+      overlayInitialMini: true,
+      overlayWidth: 400,
+      pageId: "dashboard",
+      pluginId: "demo.plugin",
+    });
+    expect(repository.run).not.toHaveBeenCalled();
+  });
 });

--- a/frontend_bridge_core/chat.py
+++ b/frontend_bridge_core/chat.py
@@ -679,6 +679,8 @@ def _serialize_history_entries_from_messages(
             continue
         role = str(message.get("role") or "").strip()
         if role == "user":
+            if message.get("hidden"):
+                continue
             text = str(message.get("display_content") or message.get("content") or "").strip()
             if not text:
                 continue

--- a/frontend_bridge_core/plugin_ui.py
+++ b/frontend_bridge_core/plugin_ui.py
@@ -353,6 +353,26 @@ def _frontend_chat_ui_action(contribution: Any) -> tuple[str, str, str]:
     return "none", "", "navigate"
 
 
+def _overlay_presentation(contribution: Any) -> dict[str, Any]:
+    """Return bounded optional presentation fields for plugin page overlays."""
+    out: dict[str, Any] = {}
+    for source, target, minimum, maximum in (
+        ("overlay_width", "overlayWidth", 240, 640),
+        ("overlay_height", "overlayHeight", 320, 960),
+    ):
+        try:
+            value = int(getattr(contribution, source, None))
+        except (TypeError, ValueError):
+            continue
+        out[target] = max(minimum, min(value, maximum))
+    background = getattr(contribution, "overlay_background", None)
+    if isinstance(background, str) and background.strip():
+        out["overlayBackground"] = background.strip()[:120]
+    if bool(getattr(contribution, "overlay_initial_mini", False)):
+        out["overlayInitialMini"] = True
+    return out
+
+
 def _frontend_chat_ui_contribution_payloads() -> list[dict[str, Any]]:
     allowed_slots = {"chat-dialog-actions", "chat-output", "chat-toolbar", "chat-top-toolbar"}
     allowed_icons = {"info", "play", "puzzle", "settings", "smartphone", "sparkles"}
@@ -375,25 +395,26 @@ def _frontend_chat_ui_contribution_payloads() -> list[dict[str, Any]]:
         if slot == "chat-top-toolbar":
             presentation = "icon-only"
         variant = str(getattr(contribution, "variant", "") or "ghost").strip()
-        rows.append(
-            {
-                "actionLabel": str(getattr(contribution, "action_label", "") or "").strip() or title,
-                "actionType": action_type,
-                "actionable": action_type != "none",
-                "description": str(getattr(contribution, "description", "") or "").strip()[:500],
-                "icon": icon if icon in allowed_icons else "puzzle",
-                "id": contribution_id,
-                "order": float(getattr(contribution, "order", 100.0) or 100.0),
-                "pageId": page_id,
-                "pageMode": page_mode,
-                "pluginId": plugin_id,
-                "pluginVersion": str(getattr(contribution, "plugin_version", "") or "")[:64],
-                "presentation": presentation if presentation in allowed_presentations else "button",
-                "slot": slot,
-                "title": title[:160],
-                "variant": variant if variant in allowed_variants else "ghost",
-            }
-        )
+        row = {
+            "actionLabel": str(getattr(contribution, "action_label", "") or "").strip() or title,
+            "actionType": action_type,
+            "actionable": action_type != "none",
+            "description": str(getattr(contribution, "description", "") or "").strip()[:500],
+            "icon": icon if icon in allowed_icons else "puzzle",
+            "id": contribution_id,
+            "order": float(getattr(contribution, "order", 100.0) or 100.0),
+            "pageId": page_id,
+            "pageMode": page_mode,
+            "pluginId": plugin_id,
+            "pluginVersion": str(getattr(contribution, "plugin_version", "") or "")[:64],
+            "presentation": presentation if presentation in allowed_presentations else "button",
+            "slot": slot,
+            "title": title[:160],
+            "variant": variant if variant in allowed_variants else "ghost",
+        }
+        if page_mode == "overlay":
+            row.update(_overlay_presentation(contribution))
+        rows.append(row)
     return rows
 
 

--- a/llm/llm_manager.py
+++ b/llm/llm_manager.py
@@ -820,6 +820,7 @@ class LLMManager:
             user_display_text = str(kwargs.pop("user_display_text", "") or "").strip()
             user_input_text = kwargs.pop("user_input_text", None)
             user_attachments = kwargs.pop("user_attachments", None)
+            hidden = bool(kwargs.pop("hidden", False))
             requested_tool_groups = kwargs.pop("tool_groups", ())
             if isinstance(requested_tool_groups, str):
                 requested_tool_groups = (requested_tool_groups,)
@@ -835,6 +836,8 @@ class LLMManager:
                     user_metadata["input_text"] = str(user_input_text or "")
                 if isinstance(user_attachments, list):
                     user_metadata["attachments"] = copy.deepcopy(user_attachments)
+                if hidden:
+                    user_metadata["hidden"] = True
                 self.add_message(
                     "user",
                     user_input,

--- a/main.py
+++ b/main.py
@@ -908,7 +908,7 @@ def main():
             current_user_idx = -1
             for message in llm_manager.get_messages():
                 role = message.get("role")
-                if role == "user":
+                if role == "user" and not message.get("hidden"):
                     current_user_idx += 1
                     if current_user_idx >= user_index:
                         break
@@ -918,7 +918,7 @@ def main():
         def _user_message(user_index: int) -> dict[str, object] | None:
             current_user_idx = -1
             for message in llm_manager.get_messages():
-                if message.get("role") != "user":
+                if message.get("role") != "user" or message.get("hidden"):
                     continue
                 current_user_idx += 1
                 if current_user_idx == user_index:

--- a/sdk/messages.py
+++ b/sdk/messages.py
@@ -19,6 +19,7 @@ class UserInputMessage(BaseModel):
         default_factory=list,
         description="User-selected chat attachments validated by core.media before processing.",
     )
+    hidden: bool = Field(False, description="Keep runtime control input out of the visible chat transcript.")
 
 
 class LLMDialogMessage(BaseModel):

--- a/sdk/types.py
+++ b/sdk/types.py
@@ -185,6 +185,10 @@ class FrontendChatUIContribution:
     variant: Literal["danger", "ghost", "primary"] = "ghost"
     plugin_id: str | None = None
     plugin_version: str | None = None
+    overlay_width: int | None = None
+    overlay_height: int | None = None
+    overlay_background: str | None = None
+    overlay_initial_mini: bool = False
 
 
 @dataclass(frozen=True)

--- a/test/unit/core/messaging/test_chat_turn_service.py
+++ b/test/unit/core/messaging/test_chat_turn_service.py
@@ -48,6 +48,22 @@ def test_submit_preserves_attachments_for_immediate_and_batched_delivery() -> No
     assert delivered == [("inspect", [image, document])]
 
 
+def test_submit_hidden_bypasses_batching_and_flags_the_sink() -> None:
+    delivered: list[tuple[str, bool]] = []
+    service = ChatTurnService(
+        sink=lambda text, *, attachments, hidden=False: delivered.append((text, hidden)),
+        options=ChatTurnOptions(
+            interrupt_enabled=False,
+            batch_enabled=True,
+            batch_idle_seconds=30,
+        ),
+    )
+
+    service.submit("/phone connect", hidden=True)
+
+    assert delivered == [("/phone connect", True)]
+
+
 def test_submit_interrupts_active_turn_before_delivery() -> None:
     events: list[str] = []
     service = ChatTurnService(

--- a/test/unit/core/messaging/test_chat_turn_wiring.py
+++ b/test/unit/core/messaging/test_chat_turn_wiring.py
@@ -62,6 +62,28 @@ def test_wiring_preserves_attachment_payloads() -> None:
     assert message.attachments == attachments
 
 
+def test_wiring_marks_hidden_control_input() -> None:
+    input_queue = Queue()
+    service = create_chat_turn_service(
+        config=make_config(interrupt_enabled=False),
+        user_input_queue=input_queue,
+        tts_queue=ClearableQueue(),
+        audio_queue=ClearableQueue(),
+        llm_manager=MagicMock(),
+        ui_worker=MagicMock(),
+        ui_updates=MagicMock(),
+    )
+
+    service.submit("/phone connect", hidden=True)
+    service.submit("hello there")
+
+    hidden_message = input_queue.get_nowait()
+    visible_message = input_queue.get_nowait()
+    assert hidden_message.text == "/phone connect"
+    assert hidden_message.hidden is True
+    assert visible_message.hidden is False
+
+
 def test_wiring_clears_downstream_ports_on_interrupt() -> None:
     input_queue = Queue()
     tts_queue = ClearableQueue()

--- a/test/unit/core/test_chat_history.py
+++ b/test/unit/core/test_chat_history.py
@@ -18,7 +18,12 @@ from llm.history_manager import (
     parse_assistant_dialog_content,
     HistoryManager,
 )
-from core.sprite.chat_history import canonical_user_turn_payload, pop_last_assistant_turn, pop_last_assistant_turn_payload
+from core.sprite.chat_history import (
+    canonical_user_turn_payload,
+    pop_last_assistant_turn,
+    pop_last_assistant_turn_payload,
+    revert_chat_history,
+)
 
 
 def _uh(msg: str) -> str:
@@ -504,3 +509,52 @@ class TestClearChatHistory:
         assert hm.get_history() == []
         assert json.loads(history_path.read_text(encoding="utf-8")) == []
         assert not tmp_path.exists()
+
+
+def _uhid(msg: str) -> dict:
+    return {"role": "user", "content": msg, "hidden": True}
+
+
+class _FakeLLMManager:
+    def __init__(self, messages):
+        self._messages = list(messages)
+
+    def get_messages(self):
+        return self._messages
+
+    def set_messages(self, messages):
+        self._messages = list(messages)
+
+
+class TestRevertChatHistoryHidden:
+    """Revert must count only *visible* user turns so the UI history and the LLM
+    message log stay aligned even when hidden control inputs are interleaved."""
+
+    def test_hidden_user_messages_are_not_counted_when_reverting(self):
+        # The UI history never contains hidden control turns — three visible turns.
+        hist = [
+            _uh("A"), _ah("Bot", "a1"),
+            _uh("B"), _ah("Bot", "a2"),
+            _uh("C"), _ah("Bot", "a3"),
+        ]
+        # The LLM log additionally carries a hidden "/phone connect" turn. If it
+        # were counted as a user, reverting to visible user #2 would break early
+        # and drop a whole visible turn from the LLM side (desync).
+        llm = _FakeLLMManager([
+            _uhid("/phone connect"),
+            _u("A"), _a("a1"),
+            _u("B"), _a("a2"),
+            _u("C"), _a("a3"),
+        ])
+
+        revert_chat_history(2, llm, hist, MagicMock())
+
+        # UI keeps the first two visible turns.
+        assert hist == [_uh("A"), _ah("Bot", "a1"), _uh("B"), _ah("Bot", "a2")]
+        # LLM keeps the same two visible turns AND the hidden context preceding
+        # them — counting by visible users keeps both sides aligned.
+        assert llm.get_messages() == [
+            _uhid("/phone connect"),
+            _u("A"), _a("a1"),
+            _u("B"), _a("a2"),
+        ]

--- a/test/unit/core/test_workers_behavior.py
+++ b/test/unit/core/test_workers_behavior.py
@@ -247,6 +247,24 @@ def test_llm_worker_passes_locally_read_attachments_without_file_tool_group(tmp_
     )
 
 
+def test_llm_worker_hidden_control_input_bypasses_visible_history() -> None:
+    user_input_queue = CountingQueue()
+    tts_queue = CountingQueue()
+    user_input_queue.put(UserInputMessage(text="/phone connect", hidden=True))
+    user_input_queue.put(None)
+
+    runtime = _make_app_runtime()
+    runtime.config.config.api_config.is_streaming = False
+    runtime.llm_manager.chat.return_value = '{"character_name":"Alice","speech":"Done","sprite":"0"}'
+    LLMWorker(user_input_queue, tts_queue).run()
+
+    # A hidden control input still reaches the model...
+    runtime.llm_manager.chat.assert_called_once()
+    # ...but is never surfaced as visible player dialogue or a send notification.
+    runtime.ui_update_manager.record_user_message.assert_not_called()
+    runtime.ui_update_manager.post_notification.assert_not_called()
+
+
 def test_tts_worker_exception_path_uses_original_put_data_fallback(
     monkeypatch,
 ) -> None:

--- a/test/unit/core/test_workers_behavior.py
+++ b/test/unit/core/test_workers_behavior.py
@@ -159,6 +159,7 @@ def test_llm_worker_run_uses_original_queues_and_marks_input_done(
         dialog_output_required=True,
         user_attachments=[],
         user_input_text="hello",
+        hidden=False,
     )
 
 
@@ -260,7 +261,10 @@ def test_llm_worker_hidden_control_input_bypasses_visible_history() -> None:
 
     # A hidden control input still reaches the model...
     runtime.llm_manager.chat.assert_called_once()
-    # ...but is never surfaced as visible player dialogue or a send notification.
+    # ...tagged as hidden so it is never later replayed as visible player input
+    # across persistence / fork / revert...
+    assert runtime.llm_manager.chat.call_args.kwargs.get("hidden") is True
+    # ...and it is never surfaced as visible player dialogue or a send notification.
     runtime.ui_update_manager.record_user_message.assert_not_called()
     runtime.ui_update_manager.post_notification.assert_not_called()
 

--- a/test/unit/frontend_bridge_core/test_frontend_plugin_ui.py
+++ b/test/unit/frontend_bridge_core/test_frontend_plugin_ui.py
@@ -171,6 +171,74 @@ def test_frontend_chat_ui_contribution_serializes_phone_page_navigation(monkeypa
     ]
 
 
+def test_frontend_chat_ui_contribution_bounds_overlay_presentation(monkeypatch):
+    monkeypatch.setattr(
+        plugin_ui,
+        "_frontend_chat_ui_contributions",
+        lambda: [
+            SimpleNamespace(
+                action={"type": "open-plugin-page", "page_id": "phone", "mode": "overlay"},
+                contribution_id="demo.phone",
+                description="Open phone",
+                icon="smartphone",
+                order=30,
+                overlay_background="  #101014  ",
+                overlay_height=100,
+                overlay_initial_mini=True,
+                overlay_width=99999,
+                plugin_id="demo.plugin",
+                plugin_version="1.0",
+                presentation="button",
+                slot="chat-top-toolbar",
+                title="Phone",
+                variant="ghost",
+            )
+        ],
+    )
+
+    payload = _frontend_chat_ui_contribution_payloads()[0]
+
+    assert payload["pageMode"] == "overlay"
+    assert payload["overlayWidth"] == 640  # clamped to the upper bound
+    assert payload["overlayHeight"] == 320  # clamped to the lower bound
+    assert payload["overlayBackground"] == "#101014"  # trimmed
+    assert payload["overlayInitialMini"] is True
+
+
+def test_frontend_chat_ui_contribution_ignores_overlay_fields_for_navigate(monkeypatch):
+    monkeypatch.setattr(
+        plugin_ui,
+        "_frontend_chat_ui_contributions",
+        lambda: [
+            SimpleNamespace(
+                action={"type": "open-plugin-page", "page_id": "phone", "mode": "navigate"},
+                contribution_id="demo.phone",
+                description="Open phone",
+                icon="smartphone",
+                order=30,
+                overlay_background="#101014",
+                overlay_height=700,
+                overlay_initial_mini=True,
+                overlay_width=400,
+                plugin_id="demo.plugin",
+                plugin_version="1.0",
+                presentation="button",
+                slot="chat-top-toolbar",
+                title="Phone",
+                variant="ghost",
+            )
+        ],
+    )
+
+    payload = _frontend_chat_ui_contribution_payloads()[0]
+
+    assert payload["pageMode"] == "navigate"
+    assert "overlayWidth" not in payload
+    assert "overlayHeight" not in payload
+    assert "overlayBackground" not in payload
+    assert "overlayInitialMini" not in payload
+
+
 def test_frontend_chat_ui_payload_does_not_truncate_lookup_identifiers(monkeypatch):
     long_contribution_id = "c" * 129
     long_page_id = "p" * 129

--- a/test/unit/frontend_bridge_core/test_history_serialization.py
+++ b/test/unit/frontend_bridge_core/test_history_serialization.py
@@ -1,0 +1,34 @@
+"""Hidden control inputs must never resurface as visible chat history when the
+runtime rebuilds the React history from persisted LLM messages."""
+
+from frontend_bridge_core.chat import _serialize_history_entries_from_messages
+
+
+def _assistant(speech: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": f'{{"dialog":[{{"character_name":"Bot","sprite":"1","speech":"{speech}"}}]}}',
+    }
+
+
+def test_serialize_from_messages_skips_hidden_user_turns():
+    messages = [
+        {"role": "system", "content": "S"},
+        {"role": "user", "content": "hello"},
+        _assistant("hi"),
+        {"role": "user", "content": "/phone connect", "hidden": True},
+        {"role": "user", "content": "bye"},
+        _assistant("cya"),
+    ]
+
+    entries = _serialize_history_entries_from_messages(messages)
+
+    user_entries = [entry for entry in entries if entry.get("role") == "user"]
+    # The hidden "/phone connect" turn is never rendered as player dialogue...
+    assert len(user_entries) == 2
+    assert user_entries[0]["text"].endswith("hello")
+    assert user_entries[1]["text"].endswith("bye")
+    # ...and revertUserIndex stays contiguous over visible users only, so it
+    # matches the fork/revert user index computed on the runtime side.
+    assert [entry["revertUserIndex"] for entry in user_entries] == [0, 1]
+    assert all("/phone connect" not in entry["text"] for entry in entries)

--- a/test/unit/managers/test_llm_manager.py
+++ b/test/unit/managers/test_llm_manager.py
@@ -514,6 +514,24 @@ class TestLLMManagerCompact:
         assert user_message["input_text"] == "Inspect"
         assert user_message["attachments"] == attachments
 
+    def test_chat_marks_hidden_control_input_in_persisted_history(self, mock_llm_adapter):
+        mock_llm_adapter.responses = ["Response."]
+        mgr = LLMManager(adapter=mock_llm_adapter, user_template="S")
+
+        mgr.chat("/phone connect", stream=False, include_local_time=False, hidden=True)
+
+        user_message = mgr.messages[-2]
+        assert user_message["role"] == "user"
+        assert user_message["hidden"] is True
+
+    def test_chat_omits_hidden_flag_for_normal_input(self, mock_llm_adapter):
+        mock_llm_adapter.responses = ["Response."]
+        mgr = LLMManager(adapter=mock_llm_adapter, user_template="S")
+
+        mgr.chat("hello", stream=False, include_local_time=False)
+
+        assert "hidden" not in mgr.messages[-2]
+
     def test_chat_activates_requested_tool_groups_inside_turn(self, mock_llm_adapter, monkeypatch):
         mock_llm_adapter.responses = ["Response."]
         mgr = LLMManager(adapter=mock_llm_adapter, user_template="S")

--- a/test/unit/sdk/test_frontend_config_contributions.py
+++ b/test/unit/sdk/test_frontend_config_contributions.py
@@ -209,6 +209,28 @@ def test_frontend_chat_ui_contribution_rejects_identifiers_over_runtime_limit() 
         )
 
 
+def test_frontend_chat_ui_contribution_carries_overlay_presentation_defaults() -> None:
+    default = FrontendChatUIContribution(contribution_id="demo.phone", slot="chat-output", title="Phone")
+    assert default.overlay_width is None
+    assert default.overlay_height is None
+    assert default.overlay_background is None
+    assert default.overlay_initial_mini is False
+
+    customized = FrontendChatUIContribution(
+        contribution_id="demo.phone",
+        slot="chat-output",
+        title="Phone",
+        overlay_width=400,
+        overlay_height=720,
+        overlay_background="#101014",
+        overlay_initial_mini=True,
+    )
+    assert customized.overlay_width == 400
+    assert customized.overlay_height == 720
+    assert customized.overlay_background == "#101014"
+    assert customized.overlay_initial_mini is True
+
+
 def test_frontend_page_contribution_gets_plugin_context() -> None:
     registry = PluginCapabilityRegistry()
     registry.set_settings_ui_plugin_context("demo.plugin", "1.2.3")


### PR DESCRIPTION
Salvage two deltas onto the current chat-UI architecture so the phone plugin works against the refactored React chat surface:

- Hidden runtime control input: phone connect/disconnect commands still reach the LLM but are kept out of the visible transcript (no send notification, no chat-history record). hidden is threaded through the UserInputMessage schema, chat turn service/wiring, plugin host, and the LLM worker.
- Plugin page overlay presentation bundle: overlay_width/height/ background and initial-mini scaling flow from the SDK contribution through the frontend bridge payload and PluginSlot target into the React PluginPageOverlay (size/theme postMessage protocol plus localStorage mini persistence).

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次审查的重点收拢一下，方便顺着往下看。

该 PR 尝试为 React 聊天舞台恢复插件电话页覆盖层桥接，并为运行时控制输入增加隐藏传递；新增 SDK、桥接与测试覆盖了若干层，但隐藏身份的持久化及覆盖层参数的最后一跳仍有缺口。

### New Features

- 为 `FrontendChatUIContribution` 增加覆盖层尺寸、背景和初始迷你状态声明。
- 在聊天提交、插件输入管道和 `UserInputMessage` 中引入 `hidden` 标记。

### Tests

- 增加聊天服务、接线、LLM Worker、桥接序列化和 `PluginSlot` 参数转发测试。

<details>
<summary>Original summary in English</summary>

This PR attempts to restore the plugin phone-overlay bridge for the React chat stage and add hidden runtime-control input propagation. It adds SDK, bridge, and test coverage across several layers, but hidden-state persistence and the final overlay-prop handoff remain incomplete.

### New Features

- Adds overlay size, background, and initial-mini declarations to `FrontendChatUIContribution`.
- Introduces a `hidden` flag through chat submission, the plugin input pipeline, and `UserInputMessage`.

### Tests

- Adds tests for the chat service, wiring, LLM worker, bridge serialization, and `PluginSlot` prop forwarding.

</details>

<!-- astrbot-review:end:summary -->