### PR TITLE
fix(application): enforce migration-safe path contracts

### DIFF
--- a/application/chat/handlers/tts.py
+++ b/application/chat/handlers/tts.py
@@ -15,6 +15,8 @@ from urllib.parse import urlparse
 
 import yaml
 from config.config_manager import ConfigManager
+from core.file_transactions import read_text_without_links
+from core.paths import project_root, resolve_runtime_asset_read_path
 from sdk.handlers import MessageHandler
 from core.messaging.dialog_tokens import (
     match_bgm_name,
@@ -28,17 +30,26 @@ from application.runtime.context import get_app_runtime, tts_emit_to_ui_queue
 from i18n import tr as tr_i18n
 
 _config = ConfigManager()
+_PROJECT_ROOT = project_root()
 logger = logging.getLogger(__name__)
+
+
+def _runtime_path(value: str) -> Path:
+    return resolve_runtime_asset_read_path(value, root=_PROJECT_ROOT)
+
+
+def _runtime_path_text(value: object) -> str:
+    raw = str(value or "")
+    return _runtime_path(raw).as_posix() if raw else ""
 
 
 def _read_sprite_voice_cfg(name_s: str, sprite_id: int):
     """直接从 YAML 读取立绘的 voice_type、voice_path、voice_text，避免跨进程缓存。"""
     try:
-        _chars_path = Path("data/config/characters.yaml")
+        _chars_path = Path(_config._CHARACTERS_CONFIG_PATH)
         if not _chars_path.is_file():
             return None, None, None
-        with open(_chars_path, "r", encoding="utf-8") as _fh:
-            _data = yaml.safe_load(_fh) or []
+        _data = yaml.safe_load(read_text_without_links(_chars_path)) or []
         for _c in _data:
             if _c.get("name") == name_s:
                 _sprites = _c.get("sprites") or []
@@ -85,7 +96,7 @@ def _is_remote_gpt_sovits() -> bool:
 
 
 def _is_remote_reference_path(path: str) -> bool:
-    return str(path or "").strip().startswith("/kaggle/")
+    return str(path or "").startswith("/kaggle/")
 
 
 def _sprite_value(sprite_data, key: str, default=None):
@@ -102,15 +113,15 @@ def _sprite_voice_audio(character_config, sprite_id: int, *allowed_types: str):
             character_config.name, sprite_id
         )
         voice_type = yaml_voice_type
-        voice_path = str(yaml_voice_path or "").strip()
+        voice_path = str(yaml_voice_path or "")
         voice_text = yaml_voice_text or ""
         if not voice_path:
             sprite_data = character_config.sprites[sprite_id]
             voice_type = _sprite_value(sprite_data, "voice_type")
-            voice_path = str(_sprite_value(sprite_data, "voice_path", "") or "").strip()
+            voice_path = str(_sprite_value(sprite_data, "voice_path", "") or "")
             voice_text = _sprite_value(sprite_data, "voice_text", "") or ""
         if voice_type in allowed_types and voice_path:
-            return voice_type, Path(voice_path).resolve().as_posix(), voice_text
+            return voice_type, _runtime_path(voice_path).as_posix(), voice_text
     except Exception:
         logger.debug(
             "Failed to resolve sprite voice audio for character=%s sprite_id=%s",
@@ -217,8 +228,8 @@ class DefaultCharacterTtsHandler(MessageHandler):
             try:
                 model_info = {
                     "character_name": name_s,
-                    "sovits_model_path": Path(character_config.sovits_model_path).resolve().as_posix(),
-                    "gpt_model_path": Path(character_config.gpt_model_path).resolve().as_posix(),
+                    "sovits_model_path": _runtime_path_text(character_config.sovits_model_path),
+                    "gpt_model_path": _runtime_path_text(character_config.gpt_model_path),
                 }
                 rt.tts_manager.switch_model(model_info)
                 print("TTSWorker: 使用模型", name_s, model_info)
@@ -243,7 +254,7 @@ class DefaultCharacterTtsHandler(MessageHandler):
                         )
                         return
 
-                ref_audio_path = Path(character_config.refer_audio_path).resolve().as_posix()
+                ref_audio_path = _runtime_path_text(character_config.refer_audio_path)
                 prompt_text = character_config.prompt_text
                 try:
                     if sprite_id < 0:
@@ -251,11 +262,11 @@ class DefaultCharacterTtsHandler(MessageHandler):
                     sprite_data = character_config.sprites[sprite_id]
                     _voice_type = _sprite_value(sprite_data, "voice_type")
                     _vt = _sprite_value(sprite_data, "voice_text")
-                    _vp = str(_sprite_value(sprite_data, "voice_path", "") or "").strip()
+                    _vp = str(_sprite_value(sprite_data, "voice_path", "") or "")
                     if _vp and (_voice_type == "reference" or (_voice_type is None and _vt)) and _vt and (
                         not _is_remote_gpt_sovits() or _is_remote_reference_path(_vp)
                     ):
-                        ref_audio_path = Path(_vp).resolve().as_posix()
+                        ref_audio_path = _runtime_path(_vp).as_posix()
                         prompt_text = _vt
                 except Exception:
                     print("没有立绘")
@@ -306,7 +317,12 @@ class DefaultCharacterTtsHandler(MessageHandler):
                             character_name=name_s,
                             speed_factor=_speed,
                         )
-                        if not _path or not Path(_path).is_file() or Path(_path).stat().st_size <= 0:
+                        resolved_audio = _runtime_path(_path) if _path else None
+                        if (
+                            resolved_audio is None
+                            or not resolved_audio.is_file()
+                            or resolved_audio.stat().st_size <= 0
+                        ):
                             print(
                                 "TTSWorker: 分句语音生成失败，停止后续分句播放，"
                                 f"segment={_i + 1}/{len(_sentences)}, text={_sent!r}"
@@ -323,7 +339,7 @@ class DefaultCharacterTtsHandler(MessageHandler):
                         _is_first = _i == 0
                         _is_last = _i == len(_sentences) - 1
                         rt.audio_path_queue.put(TTSOutputMessage(
-                            audio_path=_path or "",
+                            audio_path=resolved_audio.as_posix(),
                             name=name_s,
                             text=speech if _is_first else "",
                             asset_id=_asset_str if _is_first else _asset_str,

--- a/application/chat/history_paths.py
+++ b/application/chat/history_paths.py
@@ -1,23 +1,559 @@
-"""Path policy for chat history stored inside or outside the project root."""
+"""Project-root-aware chat history path resolution and import.
+
+Relative references are project-managed and stay inside the configured history
+collection. Explicit absolute references are external capabilities and retain
+their storage identity across launch, save, resume, and clear operations.
+"""
 
 from __future__ import annotations
 
+import hashlib
+import json
 import ntpath
 import os
+import re
+import stat
+import threading
 from pathlib import Path
 from typing import Any
 
-from sdk.path_utils import reject_control_chars, safe_project_path
+from core.sprite.chat_branch_storage import (
+    ACTIVE_HISTORY_FILENAME,
+    BRANCH_TREE_FILENAME,
+    chat_history_session_dir,
+)
+from core.file_transactions import (
+    atomic_write_text,
+    copy_directory_without_links,
+    copy_file_exclusive,
+    create_private_temporary_directory,
+    inspect_portable_directory_tree,
+    read_text_without_links,
+    rename_path_without_overwrite,
+    remove_directory_without_links,
+)
+from core.paths import (
+    _metadata_is_link_or_reparse_point,
+    path_is_link_or_reparse_point,
+    require_directory_without_links,
+    require_regular_file_without_links,
+    require_symlink_free_absolute_path,
+    resolve_managed_project_path,
+    validate_exact_path_text,
+)
+
+from sdk.path_references import (
+    display_path,
+    is_absolute_path_text,
+    legacy_project_relative_path,
+    portable_path_text,
+    project_relative_path,
+    resolved_path_is_within,
+    state_project_root,
+)
+from sdk.path_utils import safe_project_path
+
+
+_HISTORY_LEGACY_PREFIXES = (("data", "chat_history"),)
+_IMPORT_NAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_IMPORT_MARKER_FILENAME = ".shinsekai-import.json"
+_IMPORT_MARKER_VERSION = 1
+_IMPORT_PUBLICATION_LOCK = threading.Lock()
+_MAX_IMPORT_NAME_ATTEMPTS = 10_000
+
+
+def history_root_for_state(state: Any) -> Path:
+    """Return the configured history directory inside the authoritative root."""
+
+    root = state_project_root(state)
+    raw = str(getattr(state, "history_dir", "") or "data/chat_history")
+    history_root = resolve_managed_project_path(raw, root=root)
+    if history_root == root or not resolved_path_is_within(history_root, root):
+        raise PermissionError("chat history directory is outside project root")
+    return history_root
+
+
+def _history_path_shape(path: Path) -> Path:
+    if path.name in {ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME}:
+        return path.parent
+    if path.suffix.lower() == ".json" and not path.is_file():
+        return path.with_suffix("")
+    return path
+
+
+def _managed_history_path(path: Path, history_root: Path) -> Path:
+    """Return one concrete session path, never the history collection root.
+
+    A path such as ``data/chat_history/active.json`` shapes to its parent.  If
+    that parent is the collection root, passing it to the recursive clear
+    helper would erase every session.  Keep this invariant at the path
+    boundary so every reader and destructive caller receives the same value.
+    """
+
+    try:
+        root = history_root.resolve(strict=False)
+        lexical = path
+        if lexical == root:
+            raise PermissionError(
+                "chat history path must identify a session, not the history root"
+            )
+        if not resolved_path_is_within(lexical, root):
+            raise PermissionError(
+                "chat history must be stored under the history directory"
+            )
+        # Validate the unresolved value before shaping legacy ``*.json`` paths.
+        # Otherwise a linked session directory can be flattened into the real
+        # target and later clear/branch operations may mutate a different
+        # session while still appearing to remain under the history root.
+        inspected = resolve_managed_project_path(path, root=root)
+        shaped = _history_path_shape(inspected)
+        if shaped == root:
+            raise PermissionError(
+                "chat history path must identify a session, not the history root"
+            )
+        resolved = resolve_managed_project_path(shaped, root=root)
+    except PermissionError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError("historyPath could not be resolved") from exc
+    if resolved == root:
+        raise PermissionError("chat history path must identify a session, not the history root")
+    if not resolved_path_is_within(resolved, root):
+        raise PermissionError("chat history must be stored under the history directory")
+
+    session_dir = resolved if not resolved.is_file() else None
+    if session_dir is not None:
+        for name in (
+            ACTIVE_HISTORY_FILENAME,
+            BRANCH_TREE_FILENAME,
+            f"{ACTIVE_HISTORY_FILENAME}.tmp",
+        ):
+            if path_is_link_or_reparse_point(session_dir / name):
+                raise PermissionError("chat history session files must not be symbolic links")
+    return resolved
+
+
+def history_storage_exists(path: Path) -> bool:
+    """Return whether a legacy file or directory-based history has data."""
+
+    try:
+        if path_is_link_or_reparse_point(path):
+            return False
+        if path.is_file() and path.suffix.lower() == ".json":
+            return True
+        session_dir = path if path.is_dir() else chat_history_session_dir(path)
+        if path_is_link_or_reparse_point(session_dir):
+            return False
+        return any(
+            not path_is_link_or_reparse_point(candidate) and candidate.is_file()
+            for candidate in (
+                session_dir / ACTIVE_HISTORY_FILENAME,
+                session_dir / BRANCH_TREE_FILENAME,
+                session_dir / f"{ACTIVE_HISTORY_FILENAME}.tmp",
+            )
+        )
+    except OSError:
+        return False
+
+
+def _import_slug(
+    source: Path,
+    *,
+    source_is_file: bool | None = None,
+) -> str:
+    if source_is_file is None:
+        metadata = source.lstat()
+        source_is_file = stat.S_ISREG(metadata.st_mode)
+    stem = source.stem if source_is_file else source.name
+    slug = _IMPORT_NAME_RE.sub("-", stem).strip(".-")[:48] or "history"
+    identity = os.path.normcase(str(source))
+    digest = hashlib.sha256(identity.encode("utf-8", errors="surrogatepass")).hexdigest()[:12]
+    return f"imported-{slug}-{digest}"
+
+
+def _import_source_identity(source: Path) -> str:
+    return os.path.normcase(str(source))
+
+
+def _import_marker_payload(
+    source: Path,
+    *,
+    source_is_file: bool | None = None,
+) -> dict[str, Any]:
+    if source_is_file is None:
+        metadata = source.lstat()
+        source_is_file = stat.S_ISREG(metadata.st_mode)
+    return {
+        "kind": "file" if source_is_file else "directory",
+        "source": _import_source_identity(source),
+        "version": _IMPORT_MARKER_VERSION,
+    }
+
+
+def _write_import_marker(destination: Path, payload: dict[str, Any]) -> None:
+    marker = destination / _IMPORT_MARKER_FILENAME
+    atomic_write_text(
+        marker,
+        json.dumps(payload, ensure_ascii=False, indent=2),
+    )
+
+
+def _owned_import_destination(candidate: Path, marker_payload: dict[str, Any]) -> bool:
+    if path_is_link_or_reparse_point(candidate) or not candidate.is_dir():
+        return False
+    marker = candidate / _IMPORT_MARKER_FILENAME
+    if path_is_link_or_reparse_point(marker) or not marker.is_file():
+        return False
+    try:
+        raw = json.loads(read_text_without_links(marker))
+    except (OSError, ValueError):
+        return False
+    return (
+        isinstance(raw, dict)
+        and raw.get("version") == marker_payload["version"]
+        and raw.get("kind") == marker_payload["kind"]
+        and raw.get("source") == marker_payload["source"]
+        and history_storage_exists(candidate)
+    )
+
+
+def _select_import_destination(
+    history_root: Path,
+    slug: str,
+    marker_payload: dict[str, Any],
+) -> tuple[Path, bool]:
+    """Pick an owned destination without overwriting an unrelated collision."""
+
+    for index in range(_MAX_IMPORT_NAME_ATTEMPTS):
+        name = slug if index == 0 else f"{slug}-{index}"
+        candidate = history_root / name
+        # lexists is deliberate: a broken symlink is still an occupied name.
+        if not os.path.lexists(candidate):
+            return safe_project_path(candidate, root=history_root), False
+        if _owned_import_destination(candidate, marker_payload):
+            return _managed_history_path(candidate, history_root), True
+    raise RuntimeError("too many chat history import name collisions")
+
+
+def _validate_history_directory(source: Path) -> None:
+    if not history_storage_exists(source):
+        raise ValueError(f"所选目录不是有效的聊天历史目录: {display_path(source)}")
+    try:
+        inspect_portable_directory_tree(source)
+    except (OSError, ValueError) as exc:
+        raise PermissionError(
+            f"聊天历史目录包含符号链接或非常规路径，无法安全导入: {display_path(source)}"
+        ) from exc
+
+
+def import_external_history(state: Any, source: str | os.PathLike[str]) -> Path:
+    """Copy an external history into project-managed storage and return it."""
+
+    raw_source = validate_exact_path_text(source, field="external chat history path")
+    unresolved_source = Path(raw_source)
+    if not unresolved_source.is_absolute():
+        raise ValueError("external chat history path must be absolute")
+    try:
+        require_symlink_free_absolute_path(
+            unresolved_source,
+            field="external chat history path",
+        )
+    except PermissionError as exc:
+        raise PermissionError(
+            "external chat history path must not use symbolic links or reparse points: "
+            f"{display_path(unresolved_source)}"
+        ) from exc
+    source = unresolved_source.resolve(strict=True)
+    if source.name in {ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME}:
+        source = source.parent.resolve(strict=True)
+    source_identity = source.lstat()
+    if _metadata_is_link_or_reparse_point(source_identity):
+        raise PermissionError(
+            "external chat history path must not use symbolic links or reparse points"
+        )
+    source_is_file = stat.S_ISREG(source_identity.st_mode)
+    source_is_directory = stat.S_ISDIR(source_identity.st_mode)
+    if source_is_file and source.suffix.lower() != ".json":
+        raise ValueError(f"聊天历史文件必须是 JSON: {display_path(source)}")
+    if not source_is_file and not source_is_directory:
+        raise FileNotFoundError(display_path(source))
+
+    history_root = history_root_for_state(state)
+    history_root.mkdir(parents=True, exist_ok=True)
+    history_root = require_directory_without_links(
+        history_root,
+        field="chat history import directory",
+    )
+    slug = _import_slug(source, source_is_file=source_is_file)
+    marker_payload = _import_marker_payload(
+        source,
+        source_is_file=source_is_file,
+    )
+    if source_is_directory:
+        _validate_history_directory(source)
+        if not os.path.samestat(source_identity, source.lstat()):
+            raise PermissionError(
+                "external chat history directory changed while it was validated"
+            )
+
+    # Every import is published as a directory session.  In particular, a
+    # legacy ``foo.json`` becomes ``<managed>/.../active.json`` instead of a
+    # root-level file whose paired ``foo/`` directory could belong to someone
+    # else and be recursively removed by legacy cleanup semantics.
+    with _IMPORT_PUBLICATION_LOCK:
+        destination, already_imported = _select_import_destination(
+            history_root,
+            slug,
+            marker_payload,
+        )
+        if already_imported:
+            return destination
+
+        staging, staging_identity = create_private_temporary_directory(
+            directory=history_root,
+            prefix=f".{slug}.tmp-",
+        )
+        try:
+            staged_history = staging / "history"
+            if source_is_file:
+                staged_history.mkdir()
+                copy_file_exclusive(
+                    source,
+                    staged_history,
+                    ACTIVE_HISTORY_FILENAME,
+                    field="history filename",
+                    expected_source_identity=source_identity,
+                )
+            else:
+                copy_directory_without_links(
+                    source,
+                    staged_history,
+                    expected_source_identity=source_identity,
+                )
+                _validate_history_directory(staged_history)
+            _write_import_marker(staged_history, marker_payload)
+
+            # The process-local lock serializes bridge threads.  A second
+            # bridge process can still publish between selection and rename;
+            # retry that race and either reuse its owned snapshot or choose a
+            # collision suffix.  A complete session directory is non-empty,
+            # so rename cannot replace a peer publication on supported hosts.
+            while True:
+                if os.path.lexists(destination):
+                    destination, already_imported = _select_import_destination(
+                        history_root,
+                        slug,
+                        marker_payload,
+                    )
+                    if already_imported:
+                        return destination
+                    continue
+                try:
+                    rename_path_without_overwrite(
+                        staged_history,
+                        destination,
+                        expected_identity=staged_history.lstat(),
+                    )
+                except OSError:
+                    if os.path.lexists(destination):
+                        destination, already_imported = _select_import_destination(
+                            history_root,
+                            slug,
+                            marker_payload,
+                        )
+                        if already_imported:
+                            return destination
+                        continue
+                    raise
+                break
+        finally:
+            try:
+                remove_directory_without_links(
+                    staging,
+                    expected_identity=staging_identity,
+                )
+            except OSError:
+                pass
+    return _managed_history_path(destination, history_root)
+
+
+def resolve_history_reference(
+    state: Any,
+    raw_path: str | os.PathLike[str],
+    *,
+    recover_legacy_absolute: bool = False,
+) -> Path:
+    """Resolve a user/session history reference to project-managed storage.
+
+    Missing absolute paths are external identities during normal operation.
+    The optional legacy recovery is reserved for one-time persistence
+    migrations; otherwise an unrelated missing path whose tail happens to be
+    ``data/chat_history`` could be silently rebound to the active project.
+    """
+
+    raw = portable_path_text(raw_path, field="historyPath")
+    project_root = state_project_root(state)
+    history_root = history_root_for_state(state)
+
+    def collapses_to_collection_root() -> bool:
+        collapsed: list[str] = []
+        for component in raw.replace("\\", "/").split("/"):
+            if component in {"", "."}:
+                continue
+            if component == "..":
+                if collapsed:
+                    collapsed.pop()
+                continue
+            collapsed.append(component)
+        try:
+            history_relative = history_root.relative_to(project_root).as_posix()
+        except ValueError:
+            return False
+        return "/".join(collapsed) == history_relative
+
+    try:
+        validate_exact_path_text(
+            raw,
+            field="historyPath",
+            allow_non_native_absolute=True,
+        )
+    except PermissionError:
+        if collapses_to_collection_root():
+            raise PermissionError(
+                "chat history path must identify a session, not the history root"
+            ) from None
+        raise
+
+    if not is_absolute_path_text(raw):
+        try:
+            candidate = resolve_managed_project_path(raw, root=project_root)
+        except PermissionError:
+            # Preserve the higher-level collection-root invariant for values
+            # such as ``session/..`` while still rejecting any linked
+            # component through the original managed-path error.
+            if collapses_to_collection_root():
+                raise PermissionError(
+                    "chat history path must identify a session, not the history root"
+                )
+            raise
+        if resolved_path_is_within(candidate, history_root):
+            return _managed_history_path(candidate, history_root)
+        # An existing relative path is an explicit source selection.  Import
+        # it before applying the basename shorthand; otherwise a real
+        # ``<project>/session.json`` would be silently ignored in favor of a
+        # new empty ``data/chat_history/session``.
+        if candidate.exists():
+            return _managed_history_path(import_external_history(state, candidate), history_root)
+        # Preserve the useful shorthand ``session.json`` while ensuring it is
+        # created under the dedicated mutable-history directory.
+        normalized_parts = Path(raw.replace("\\", "/")).parts
+        if len(normalized_parts) == 1:
+            return _managed_history_path(
+                safe_project_path(history_root / normalized_parts[0], root=history_root),
+                history_root,
+            )
+        raise PermissionError("chat history must be stored under data/chat_history")
+
+    native_candidate = Path(raw).expanduser()
+    if native_candidate.is_absolute():
+        try:
+            require_symlink_free_absolute_path(
+                native_candidate,
+                field="external chat history path",
+            )
+        except PermissionError as exc:
+            raise PermissionError(
+                "external chat history path must not use symbolic links or reparse points: "
+                f"{display_path(native_candidate)}"
+            ) from exc
+        try:
+            resolved = native_candidate.resolve(strict=False)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ValueError("historyPath could not be resolved") from exc
+        if resolved_path_is_within(native_candidate, history_root) or resolved_path_is_within(
+            resolved,
+            history_root,
+        ):
+            return _managed_history_path(native_candidate, history_root)
+        if resolved.exists():
+            return _managed_history_path(import_external_history(state, resolved), history_root)
+
+    if recover_legacy_absolute:
+        legacy_relative = legacy_project_relative_path(
+            raw,
+            _HISTORY_LEGACY_PREFIXES,
+        )
+        if legacy_relative is not None:
+            migrated = safe_project_path(legacy_relative, root=project_root)
+            if resolved_path_is_within(migrated, history_root):
+                return _managed_history_path(migrated, history_root)
+
+    raise FileNotFoundError(f"外部聊天历史不存在，无法导入: {display_path(raw)}")
+
+
+def prepare_history_reference_for_launch(
+    state: Any,
+    raw_path: str | os.PathLike[str],
+) -> Path:
+    """Create and revalidate the exact managed history identity passed to chat.
+
+    Launchers must not call ``resolve()`` after this boundary. Doing so would
+    let a link inserted between selection and process creation silently change
+    the path consumed by the child process.
+    """
+
+    path = resolve_history_reference(state, raw_path)
+    if path.suffix.lower() == ".json" and os.path.lexists(path):
+        path = require_regular_file_without_links(
+            path,
+            field="chat history file",
+        )
+        require_directory_without_links(
+            path.parent,
+            field="chat history directory",
+        )
+        return path
+
+    session_dir = chat_history_session_dir(path)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    require_directory_without_links(
+        session_dir,
+        field="chat history session directory",
+    )
+    return path
+
+
+def project_history_value(state: Any, path: Path) -> str:
+    """Serialize a managed history as a portable project-relative value."""
+
+    managed = _managed_history_path(path, history_root_for_state(state))
+    relative = project_relative_path(managed, state_project_root(state))
+    if relative is None:
+        raise PermissionError("chat history is outside project root")
+    return relative
+
+
+def history_reference_value(state: Any, path: Path) -> str:
+    """Serialize one live history path without changing its storage scope.
+
+    Project-managed sessions stay portable and project-relative. An explicitly
+    external session stays external so a save/resume cycle cannot silently
+    redirect the runtime to a copied or guessed location.
+    """
+
+    candidate = resolve_history_path_for_project(state, path)
+    if is_unc_history_path(candidate):
+        return candidate.as_posix()
+    history_root = history_root_for_state(state)
+    if resolved_path_is_within(candidate, history_root):
+        return project_history_value(state, candidate)
+    return candidate.as_posix()
 
 
 def _state_project_root(state: Any) -> Path:
-    raw = (
-        str(getattr(state, "project_root_dir", "") or "").strip()
-        or os.environ.get("SHINSEKAI_PROJECT_ROOT", "").strip()
-        or os.environ.get("EASYAI_PROJECT_ROOT", "").strip()
-        or str(Path.cwd())
-    )
-    return Path(raw).expanduser().resolve(strict=False)
+    """Compatibility wrapper around the bridge's authoritative root policy."""
+
+    return state_project_root(state)
 
 
 def _validate_unc_share(value: str) -> None:
@@ -116,15 +652,52 @@ def _validate_history_storage_target(path: Path) -> Path:
 
 
 def resolve_history_path_for_project(state: Any, raw_path: Any) -> Path:
-    raw = str(raw_path or "").strip()
-    if not raw:
-        raise ValueError("history path is required")
-    raw = reject_control_chars(raw, field="history path")
+    """Resolve a live history path without deriving relative paths from cwd.
 
+    Relative references are project-managed. Explicit absolute references are
+    permitted for the React chat runtime (including another Windows drive or
+    an offline UNC share) and remain lexical so resolving an unavailable share
+    cannot block startup.
+    """
+
+    raw = portable_path_text(
+        os.fspath(raw_path) if raw_path is not None else "",
+        field="history path",
+    )
+
+    history_root = history_root_for_state(state)
     if _history_path_kind(raw) == "absolute":
         candidate = _absolute_history_path(raw)
+        if not is_unc_history_path(candidate):
+            candidate = require_symlink_free_absolute_path(
+                candidate,
+                field="external chat history path",
+            )
     else:
-        # Relative history paths are managed by the selected project/data root
-        # and never gain external privileges after a containment failure.
+        # Relative references never gain external privileges. A one-component
+        # legacy shorthand is rooted in the history collection; every other
+        # relative value must already identify a descendant of that collection.
         candidate = safe_project_path(raw, root=_state_project_root(state))
+        if not resolved_path_is_within(candidate, history_root):
+            parts = Path(raw.replace("\\", "/")).parts
+            if len(parts) != 1:
+                raise PermissionError(
+                    "relative chat history must be stored under the history directory"
+                )
+            candidate = safe_project_path(
+                history_root / parts[0],
+                root=history_root,
+            )
+    if candidate == history_root or (
+        candidate.parent == history_root
+        and candidate.name
+        in {
+            ACTIVE_HISTORY_FILENAME,
+            BRANCH_TREE_FILENAME,
+            f"{ACTIVE_HISTORY_FILENAME}.tmp",
+        }
+    ):
+        raise PermissionError(
+            "chat history path must identify a session, not the history root"
+        )
     return _validate_history_storage_target(candidate)

--- a/application/chat/history_state.py
+++ b/application/chat/history_state.py
@@ -19,7 +19,6 @@ from core.messaging.dialog_tokens import (
     normalize_character_name,
 )
 
-CHAT_HISTORY_PATH = "./data/chat_history"
 _SYSTEM_HISTORY_NAMES = COT_ALIASES | NARR_ALIASES | STAT_ALIASES | SCENE_ALIASES | BGM_ALIASES | CG_ALIASES
 
 chat_history: list[Any] = []

--- a/application/chat/runtime_process.py
+++ b/application/chat/runtime_process.py
@@ -14,6 +14,13 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+from sdk.file_transactions import (
+    capture_directory_identity,
+    open_binary_read_without_links,
+    open_text_append_without_links,
+    read_text_without_links,
+    require_directory_identity,
+)
 from core.messaging.dialog_tokens import (
     BGM_ALIASES,
     CG_ALIASES,
@@ -24,10 +31,21 @@ from core.messaging.dialog_tokens import (
     is_option_history_name,
     normalize_character_name,
 )
-from core.paths import app_root as runtime_app_root
-from core.paths import project_root as runtime_project_root
-from core.paths import source_root as runtime_source_root
+from sdk.path_contract import app_root as runtime_app_root
+from sdk.path_contract import (
+    managed_child_path,
+    managed_project_storage,
+    require_directory_without_links,
+    require_regular_file_without_links,
+    resolve_executable_file,
+    resolve_runtime_asset_read_path,
+)
+from sdk.path_contract import project_root as runtime_project_root
+from sdk.path_contract import source_root as runtime_source_root
+from sdk.process_launch import isolated_python_environment
+from application.runtime.restart_debug import write_restart_debug_log
 from core.media.chat_attachments import (
+    CHAT_ATTACHMENT_STAGE_SUBDIR,
     CHAT_ATTACHMENTS_ROOT_ENV,
     chat_attachment_display_text,
     resolve_chat_attachments,
@@ -41,28 +59,37 @@ from core.sprite.chat_branch_storage import (
     remove_chat_history_storage,
 )
 from core.sprite.chat_history_text import history_payload_to_plain_text, parse_assistant_dialog_content
+from core.sprite.sprite_cli import CHAT_LAUNCH_CONFIG_ENV
 from ai.tools.chat_ui_tools import sanitize_user_display_name
 
-from application.chat.history_paths import (
+from .history_paths import (
+    history_root_for_state,
     is_unc_history_path,
+    prepare_history_reference_for_launch,
     resolve_history_path_for_project,
 )
 from application.chat.mobile_access import (
     get_mobile_access_info,
     stop_mobile_access,
 )
-from application.chat.templates import (
+from sdk.path_references import (
+    resolve_from_root,
+    resolved_path_is_within,
+    state_project_root,
+)
+from application.runtime.dependencies import runtime_dependency_error_from_text
+from sdk.path_references import portable_path_text
+from sdk.path_utils import reject_control_chars, safe_child_path
+from application.runtime.state import BridgeState
+from .templates import (
     TEMP_SPLIT_META,
     _compose_runtime_template,
     _effective_user_scenario,
     _history_id_from_scenario,
     _scenario_from_template_like,
     _template_dir,
+    _write_runtime_template_files,
 )
-from application.runtime.dependencies import runtime_dependency_error_from_text
-from application.runtime.state import BridgeState
-from core.sprite.sprite_cli import CHAT_LAUNCH_CONFIG_ENV
-from sdk.path_utils import reject_control_chars
 
 TRANSPARENT_BACKGROUND_NAME = "透明场景"
 _TRANSPARENT_BACKGROUND_ALIAS = "透明背景"
@@ -90,8 +117,13 @@ _RUNTIME_CHAT_COMMANDS = {
 _main_chat_process: subprocess.Popen[bytes] | None = None
 _main_chat_process_lock = threading.Lock()
 _main_chat_log_file: Any = None
+_chat_transition_lock_creation = threading.Lock()
 _SYSTEM_HISTORY_NAMES = COT_ALIASES | NARR_ALIASES | STAT_ALIASES | SCENE_ALIASES | BGM_ALIASES | CG_ALIASES
 _DEFAULT_USER_DISPLAY_NAME = "你"
+
+
+def _chat_debug_log(message: str) -> None:
+    write_restart_debug_log("chat_launch", message)
 
 
 def _is_transparent_background_name(name: str | None) -> bool:
@@ -125,16 +157,43 @@ def _chat_turn_options(state: BridgeState) -> dict[str, Any]:
 
 def _hidden_subprocess_kwargs() -> dict[str, Any]:
     if os.name != "nt":
+        _chat_debug_log("subprocess_kwargs platform=posix start_new_session=true")
         return {"start_new_session": True}
-    return {
-        "creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
-        | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
-    }
+    flags = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000) | getattr(
+        subprocess,
+        "CREATE_NEW_PROCESS_GROUP",
+        0x00000200,
+    )
+    _chat_debug_log(f"subprocess_kwargs platform=windows creationflags={flags}")
+    return {"creationflags": flags}
 
 
 def _chat_process_running() -> bool:
     with _main_chat_process_lock:
         return _main_chat_process is not None and _main_chat_process.poll() is None
+
+
+def _chat_transition_lock(state: BridgeState) -> threading.RLock:
+    """Serialize launch, resume, and close as one state/storage transition."""
+
+    lock = getattr(state, "chat_transition_lock", None)
+    if lock is not None:
+        return lock
+    # SimpleNamespace-based integrations predate the BridgeState field.  Make
+    # lazy initialization race-free so they receive the same invariant.
+    with _chat_transition_lock_creation:
+        lock = getattr(state, "chat_transition_lock", None)
+        if lock is None:
+            lock = threading.RLock()
+            state.chat_transition_lock = lock
+    return lock
+
+
+def _process_return_code(process: subprocess.Popen[bytes]) -> int | None:
+    return_code = getattr(process, "returncode", None)
+    if return_code is not None:
+        return return_code
+    return process.poll()
 
 
 def _chat_runtime_closing(state: BridgeState) -> bool:
@@ -168,15 +227,16 @@ def _set_chat_runtime_closing(state: BridgeState, closing: bool) -> None:
         state.chat_runtime_closing = closing
 
 
-def _chat_log_path() -> Path:
-    log_dir = _project_root() / "logs"
+def _chat_log_path(project_root: Path | None = None) -> Path:
+    root = _project_root() if project_root is None else project_root
+    log_dir = managed_project_storage("logs", root=root)
     log_dir.mkdir(parents=True, exist_ok=True)
-    return log_dir / "main.log"
+    return managed_child_path(log_dir, "main.log", field="chat log filename")
 
 
 def _tail_text(path: Path, max_chars: int = 2400) -> str:
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = read_text_without_links(path, errors="replace")
     except OSError:
         return ""
     if len(text) <= max_chars:
@@ -195,30 +255,145 @@ def _close_chat_log_if_needed() -> None:
     _main_chat_log_file = None
 
 
-def _popen_chat_process(cmd: list[str], *, cwd: Path, env: dict[str, str]) -> tuple[subprocess.Popen[bytes], Path]:
+def _safe_chat_command(cmd: list[str]) -> list[str]:
+    return [portable_path_text(item, field="command argument") for item in cmd]
+
+
+def _require_launch_file_snapshot(
+    path: Path,
+    identity: os.stat_result,
+) -> None:
+    with open_binary_read_without_links(
+        path,
+        expected_identity=identity,
+    ):
+        pass
+
+
+def _terminate_invalid_launch(process: subprocess.Popen[bytes]) -> None:
+    try:
+        process.terminate()
+        process.wait(timeout=2)
+    except Exception:
+        try:
+            process.kill()
+        except Exception:
+            pass
+
+
+def _popen_chat_process(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    required_files: tuple[tuple[Path, os.stat_result], ...] = (),
+    required_directories: tuple[tuple[Path, os.stat_result], ...] = (),
+) -> tuple[subprocess.Popen[bytes], Path]:
     global _main_chat_log_file
     _close_chat_log_if_needed()
-    log_path = _chat_log_path()
-    _main_chat_log_file = log_path.open("a", encoding="utf-8", buffering=1)
+    safe_cmd = _safe_chat_command(cmd)
+    cwd, cwd_identity = capture_directory_identity(
+        cwd,
+        field="chat launch working directory",
+    )
+    for path, identity in required_directories:
+        require_directory_identity(
+            path,
+            identity,
+            field="chat launch directory",
+        )
+    for path, identity in required_files:
+        _require_launch_file_snapshot(path, identity)
+    log_path = _chat_log_path(cwd)
+    log_directory, log_directory_identity = capture_directory_identity(
+        log_path.parent,
+        field="chat log directory",
+    )
+    require_directory_identity(
+        cwd,
+        cwd_identity,
+        field="chat launch working directory",
+    )
+    for path, identity in required_directories:
+        require_directory_identity(
+            path,
+            identity,
+            field="chat launch directory",
+        )
+    for path, identity in required_files:
+        _require_launch_file_snapshot(path, identity)
+    _main_chat_log_file = open_text_append_without_links(
+        log_path,
+        expected_parent_identity=log_directory_identity,
+    )
     _main_chat_log_file.write(
         "\n"
         + "=" * 60
         + f"\n{datetime.now().isoformat(sep=' ', timespec='seconds')}  main.py launch\n"
         + f"cwd: {cwd}\n"
-        + f"cmd: {' '.join(cmd)}\n"
+        + f"cmd: {' '.join(safe_cmd)}\n"
     )
-    env = {**env, "PYTHONUNBUFFERED": "1"}
-    # The command contains only the trusted interpreter/entrypoint. Runtime
-    # options are delivered through a validated JSON environment payload.
+    env = isolated_python_environment(env)
+    env["PYTHONUNBUFFERED"] = "1"
+    _chat_debug_log(
+        f"subprocess_launch cwd={cwd} executable={safe_cmd[0] if safe_cmd else ''} args_count={max(len(safe_cmd) - 1, 0)} log_path={log_path}"
+    )
+    require_directory_identity(
+        cwd,
+        cwd_identity,
+        field="chat launch working directory",
+    )
+    for path, identity in required_directories:
+        require_directory_identity(
+            path,
+            identity,
+            field="chat launch directory",
+        )
+    require_directory_identity(
+        log_directory,
+        log_directory_identity,
+        field="chat log directory",
+    )
+    for path, identity in required_files:
+        _require_launch_file_snapshot(path, identity)
+    # safe_cmd is an argv list whose entries have passed control-character validation; shell=False is the default.
     # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
-    process = subprocess.Popen(
-        cmd,
-        cwd=str(cwd),
-        env=env,
-        stdout=_main_chat_log_file,
-        stderr=subprocess.STDOUT,
-        **_hidden_subprocess_kwargs(),
-    )
+    try:
+        process = subprocess.Popen(
+            safe_cmd,
+            cwd=str(cwd),
+            env=env,
+            stdout=_main_chat_log_file,
+            stderr=subprocess.STDOUT,
+            **_hidden_subprocess_kwargs(),
+        )
+    except BaseException:
+        _close_chat_log_if_needed()
+        raise
+    try:
+        require_directory_identity(
+            cwd,
+            cwd_identity,
+            field="chat launch working directory",
+        )
+        for path, identity in required_directories:
+            require_directory_identity(
+                path,
+                identity,
+                field="chat launch directory",
+            )
+        require_directory_identity(
+            log_directory,
+            log_directory_identity,
+            field="chat log directory",
+        )
+        for path, identity in required_files:
+            _require_launch_file_snapshot(path, identity)
+    except BaseException:
+        _terminate_invalid_launch(process)
+        _close_chat_log_if_needed()
+        raise
+    _chat_debug_log(f"subprocess_started pid={process.pid} log_path={log_path}")
     return process, log_path
 
 
@@ -265,8 +440,12 @@ def _wait_process_exit(process: subprocess.Popen[bytes], timeout: float) -> bool
 
 def _stop_chat_process(process: subprocess.Popen[bytes], *, wait_timeout: float) -> None:
     if process.poll() is not None:
+        _chat_debug_log(
+            f"stop_process skipped pid={process.pid} reason=already_exited code={_process_return_code(process)}"
+        )
         return
 
+    _chat_debug_log(f"stop_process start pid={process.pid} wait_timeout={wait_timeout}")
     deadline = time.monotonic() + max(wait_timeout, 0.15)
     graceful_timeout = max(0.45, wait_timeout - 0.7)
     steps: list[tuple[int | str, float]] = [
@@ -295,7 +474,11 @@ def _stop_chat_process(process: subprocess.Popen[bytes], *, wait_timeout: float)
                 _signal_process_tree(process, int(action))
         remaining = max(0.05, min(step_timeout, deadline - time.monotonic()))
         if _wait_process_exit(process, remaining):
+            _chat_debug_log(
+                f"stop_process completed pid={process.pid} action={action} code={_process_return_code(process)}"
+            )
             return
+    _chat_debug_log(f"stop_process timeout pid={process.pid} code={process.poll()}")
 
 
 def shutdown_active_chat_process(*, wait_timeout: float = 1.2, wait_before_signal: float = 0.0) -> None:
@@ -348,15 +531,20 @@ def _source_root() -> Path:
 
 
 def _app_root(state: BridgeState) -> Path:
-    for raw in (
-        str(getattr(state, "app_root_dir", "") or "").strip(),
-        os.environ.get("SHINSEKAI_APP_ROOT", "").strip(),
-    ):
-        if not raw:
-            continue
-        path = Path(raw).expanduser().resolve(strict=False)
-        if path.exists() and path.is_dir():
-            return path
+    source = "state.app_root_dir"
+    raw = str(getattr(state, "app_root_dir", "") or "")
+    if raw:
+        validated = reject_control_chars(raw, field="app root")
+        if validated != raw:
+            raise ValueError(f"invalid app root from {source}: non-portable characters")
+        try:
+            path = require_directory_without_links(
+                raw,
+                field="chat application root",
+            )
+        except (NotADirectoryError, ValueError) as exc:
+            raise ValueError(f"invalid app root from {source}: must be absolute") from exc
+        return path
     return runtime_app_root()
 
 
@@ -364,12 +552,11 @@ def _unique_paths(paths: list[Path]) -> list[Path]:
     result: list[Path] = []
     seen: set[str] = set()
     for path in paths:
-        resolved = path.resolve(strict=False)
-        key = os.path.normcase(str(resolved))
+        key = os.path.normcase(os.path.normpath(str(path)))
         if key in seen:
             continue
         seen.add(key)
-        result.append(resolved)
+        result.append(path)
     return result
 
 
@@ -382,6 +569,77 @@ def _main_exe_candidates(state: BridgeState) -> list[Path]:
 
 def _main_py_path() -> Path:
     return _source_root() / "main.py"
+
+
+def _launch_file(path: Path) -> Path | None:
+    snapshot = _launch_file_snapshot(path)
+    return snapshot[0] if snapshot is not None else None
+
+
+def _launch_file_snapshot(
+    path: Path,
+) -> tuple[Path, os.stat_result] | None:
+    try:
+        launch_path = require_regular_file_without_links(
+            path,
+            field="chat launch file",
+        )
+        with open_binary_read_without_links(launch_path) as source:
+            identity = os.fstat(source.fileno())
+        return launch_path, identity
+    except (FileNotFoundError, OSError, PermissionError, ValueError):
+        return None
+
+
+def _resolve_chat_launch_asset(
+    state: BridgeState,
+    raw_path: str,
+    *,
+    field: str,
+) -> str:
+    """Resolve one optional launch-time asset to an existing stable path."""
+
+    if not raw_path:
+        return ""
+    exact = portable_path_text(raw_path, field=field)
+    resolved = resolve_runtime_asset_read_path(
+        exact,
+        root=state_project_root(state),
+    )
+    return str(
+        require_regular_file_without_links(
+            resolved,
+            field=field,
+        )
+    )
+
+
+def _history_launch_snapshots(
+    history_path: Path,
+) -> tuple[
+    tuple[tuple[Path, os.stat_result], ...],
+    tuple[tuple[Path, os.stat_result], ...],
+]:
+    """Capture the exact mutable history container handed to the child."""
+
+    if history_path.suffix.lower() == ".json" and os.path.lexists(history_path):
+        file_snapshot = _launch_file_snapshot(history_path)
+        if file_snapshot is None:
+            raise FileNotFoundError(
+                f"chat history file is unavailable: {history_path}"
+            )
+        parent, parent_identity = capture_directory_identity(
+            history_path.parent,
+            field="chat history directory",
+        )
+        return (file_snapshot,), ((parent, parent_identity),)
+
+    session_dir = chat_history_session_dir(history_path)
+    session_dir, session_identity = capture_directory_identity(
+        session_dir,
+        field="chat history session directory",
+    )
+    return (), ((session_dir, session_identity),)
 
 
 def _launch_chat(
@@ -403,37 +661,111 @@ def _launch_chat(
     global _main_chat_process
 
     with _main_chat_process_lock:
+        _chat_debug_log(
+            f"launch_chat start runtime_mode={_chat_runtime_mode(state)} has_stream_endpoint={bool(stream_endpoint)} history_file={history_file or ''} workflow_path={workflow_path or ''}"
+        )
         if _main_chat_process is not None and _main_chat_process.poll() is not None:
+            _chat_debug_log(
+                f"launch_chat previous_process_exited pid={_main_chat_process.pid} code={_process_return_code(_main_chat_process)}"
+            )
             _close_chat_log_if_needed()
         if _main_chat_process is not None and _main_chat_process.poll() is None:
+            _chat_debug_log(f"launch_chat skipped reason=already_running pid={_main_chat_process.pid}")
             return f"进程已经在运行中！PID: {_main_chat_process.pid}"
+
+        init_sprite_path = _resolve_chat_launch_asset(
+            state,
+            init_sprite_path,
+            field="initial sprite file",
+        )
+        workflow_path = _resolve_chat_launch_asset(
+            state,
+            workflow_path,
+            field="chat workflow file",
+        )
+        launch_asset_snapshots: list[tuple[Path, os.stat_result]] = []
+        for asset_path in (init_sprite_path, workflow_path):
+            if not asset_path:
+                continue
+            asset_file = Path(asset_path)
+            with open_binary_read_without_links(asset_file) as source:
+                launch_asset_snapshots.append(
+                    (asset_file, os.fstat(source.fileno()))
+                )
 
         # 把用户情景放在系统模板末尾（紧跟 closing 提示后）
         effective_user_scenario = _effective_user_scenario(user_scenario)
         template = _compose_runtime_template(system_template, effective_user_scenario)
         template_dir = _template_dir(state)
-        (template_dir / "_temp.txt").write_text(template, encoding="utf-8")
-        (template_dir / TEMP_SPLIT_META).write_text(
-            json.dumps({"scenario": effective_user_scenario, "system": system_template}, ensure_ascii=False, indent=2),
-            encoding="utf-8",
+        _write_runtime_template_files(
+            template_dir,
+            template,
+            effective_user_scenario,
+            system_template,
         )
 
-        sc = state.config_manager.config.system_config.model_copy(deep=True)
+        previous_system_config = state.config_manager.config.system_config
+        sc = previous_system_config.model_copy(deep=True)
         sc.live_room_id = room_id
         state.config_manager.config.system_config = sc
-        state.config_manager.save_system_config()
+        try:
+            state.config_manager.save_system_config()
+        except BaseException:
+            state.config_manager.config.system_config = previous_system_config
+            raise
 
         template_hash = _history_id_from_scenario(user_scenario, character_names)
-        history_path = Path(history_file) if history_file else Path(state.history_dir) / template_hash
+        history_path = resolve_history_path_for_project(
+            state,
+            history_file if history_file else history_root_for_state(state) / template_hash,
+        )
         history_argument = str(history_path)
-        if not is_unc_history_path(history_path):
-            if history_path.suffix.lower() == ".json" and history_path.exists() and history_path.is_file():
-                history_path.parent.mkdir(parents=True, exist_ok=True)
+        if is_unc_history_path(history_path):
+            # Never probe or canonicalize an offline UNC share during launch.
+            # The child receives the exact lexical network path selected by
+            # the user and owns the eventual connection attempt.
+            history_file_snapshots = ()
+            history_directory_snapshots = ()
+        else:
+            history_root = history_root_for_state(state)
+            if resolved_path_is_within(history_path, history_root):
+                history_path = prepare_history_reference_for_launch(
+                    state,
+                    history_path,
+                )
+            elif history_path.suffix.lower() == ".json" and history_path.is_file():
+                # Existing legacy files remain external and are never copied
+                # into or deleted with project-managed storage.
+                pass
             else:
-                chat_history_session_dir(history_path).mkdir(parents=True, exist_ok=True)
-            history_argument = str(history_path.resolve())
-        project_root = _project_root()
-        app_root = _app_root(state)
+                chat_history_session_dir(history_path).mkdir(
+                    parents=True,
+                    exist_ok=True,
+                )
+            history_argument = str(history_path)
+            history_file_snapshots, history_directory_snapshots = (
+                _history_launch_snapshots(history_path)
+            )
+        template_dir, template_dir_identity = capture_directory_identity(
+            template_dir,
+            field="runtime template directory",
+        )
+        runtime_template_snapshots: list[tuple[Path, os.stat_result]] = []
+        for filename in ("_temp.txt", "_temp_split.json"):
+            snapshot = _launch_file_snapshot(template_dir / filename)
+            if snapshot is None:
+                raise FileNotFoundError(
+                    f"runtime template file is unavailable: {template_dir / filename}"
+                )
+            runtime_template_snapshots.append(snapshot)
+        project_root, project_root_identity = capture_directory_identity(
+            state_project_root(state),
+            field="chat project root",
+        )
+        app_root, app_root_identity = capture_directory_identity(
+            _app_root(state),
+            field="chat application root",
+        )
         tts_slug = str(state.config_manager.config.api_config.tts_provider or "gpt-sovits").strip() or "gpt-sovits"
         launch_config = {
             "template": "_temp",
@@ -445,22 +777,54 @@ def _launch_chat(
             "room_id": room_id,
             "tts": tts_slug,
         }
+        args = [
+            "--template=_temp",
+            f"--init_sprite_path={init_sprite_path or ''}",
+            f"--history={history_argument}",
+            f"--bg={selected_bg}",
+            f"--effect_names={effect_names}",
+            f"--t2i={'ComfyUI' if use_cg else ''}",
+            f"--room_id={room_id}",
+            f"--tts={tts_slug}",
+        ]
         if character_names:
-            launch_config["characters"] = json.dumps(character_names, ensure_ascii=False)
+            characters_json = json.dumps(character_names, ensure_ascii=False)
+            launch_config["characters"] = characters_json
+            args.append(f"--characters={characters_json}")
         if stream_endpoint:
             launch_config["stream_endpoint"] = stream_endpoint
+            args.append(f"--stream-endpoint={stream_endpoint}")
         if init_stream_endpoint:
             launch_config["init_stream_endpoint"] = init_stream_endpoint
+            args.append(f"--init-stream-endpoint={init_stream_endpoint}")
         if workflow_path:
             launch_config["workflow"] = workflow_path
+            args.append(f"--workflow={workflow_path}")
         env = os.environ.copy()
-        env[CHAT_LAUNCH_CONFIG_ENV] = json.dumps(launch_config, ensure_ascii=False)
+        env[CHAT_LAUNCH_CONFIG_ENV] = json.dumps(
+            launch_config,
+            ensure_ascii=False,
+        )
         env["SHINSEKAI_PROJECT_ROOT"] = str(project_root)
         env["EASYAI_PROJECT_ROOT"] = str(project_root)
         env["SHINSEKAI_APP_ROOT"] = str(app_root)
-        attachment_root = os.environ.get(CHAT_ATTACHMENTS_ROOT_ENV, "").strip() or str(project_root)
-        os.environ.setdefault(CHAT_ATTACHMENTS_ROOT_ENV, attachment_root)
-        env[CHAT_ATTACHMENTS_ROOT_ENV] = attachment_root
+        # Only bridge-staged uploads are valid attachment inputs. Giving the
+        # subprocess the whole project root would let a forged payload read
+        # unrelated project configuration or history files.
+        attachment_root = managed_project_storage(
+            Path(*CHAT_ATTACHMENT_STAGE_SUBDIR),
+            root=project_root,
+        )
+        attachment_root.mkdir(parents=True, exist_ok=True)
+        attachment_root = require_directory_without_links(
+            attachment_root,
+            field="chat attachment root",
+        )
+        attachment_root, attachment_root_identity = capture_directory_identity(
+            attachment_root,
+            field="chat attachment root",
+        )
+        env[CHAT_ATTACHMENTS_ROOT_ENV] = str(attachment_root)
         env["SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG"] = "1"
         api_config = state.config_manager.config.api_config
         env["SHINSEKAI_MEMORY_AUTO_ENABLED"] = "1" if bool(getattr(api_config, "memory_auto_enabled", False)) else "0"
@@ -483,25 +847,80 @@ def _launch_chat(
 
         if getattr(sys, "frozen", False):
             candidates = _main_exe_candidates(state)
-            exe = next((item for item in candidates if item.is_file()), None)
-            if exe is None:
+            executable_snapshot = next(
+                (
+                    validated
+                    for item in candidates
+                    if (validated := _launch_file_snapshot(item)) is not None
+                ),
+                None,
+            )
+            if executable_snapshot is None:
                 checked = " 与 ".join(str(item) for item in candidates)
+                _chat_debug_log(f"launch_chat failed reason=main_exe_missing checked={checked}")
                 return f"启动失败: 未找到 main.exe（已检查 {checked}）。"
-            _main_chat_process, log_path = _popen_chat_process([str(exe)], cwd=project_root, env=env)
-        else:
-            main_py = _main_py_path()
-            if not main_py.is_file():
-                return f"启动失败: 未找到 main.py（已检查 {main_py}）。"
+            exe, exe_identity = executable_snapshot
             _main_chat_process, log_path = _popen_chat_process(
-                [sys.executable, str(main_py)],
+                [str(exe)] + args,
                 cwd=project_root,
                 env=env,
+                required_files=(
+                    (exe, exe_identity),
+                    *launch_asset_snapshots,
+                    *runtime_template_snapshots,
+                    *history_file_snapshots,
+                ),
+                required_directories=(
+                    (project_root, project_root_identity),
+                    (app_root, app_root_identity),
+                    (attachment_root, attachment_root_identity),
+                    (template_dir, template_dir_identity),
+                    *history_directory_snapshots,
+                ),
+            )
+        else:
+            main_py_candidate = _main_py_path()
+            main_py_snapshot = _launch_file_snapshot(main_py_candidate)
+            if main_py_snapshot is None:
+                _chat_debug_log(
+                    f"launch_chat failed reason=main_py_missing checked={main_py_candidate}"
+                )
+                return f"启动失败: 未找到 main.py（已检查 {main_py_candidate}）。"
+            main_py, main_py_identity = main_py_snapshot
+            python_path = resolve_executable_file(
+                sys.executable,
+                field="chat Python executable",
+            )
+            python_snapshot = _launch_file_snapshot(python_path)
+            if python_snapshot is None:
+                return f"启动失败: Python 解释器不可用：{python_path}。"
+            python_path, python_identity = python_snapshot
+            _main_chat_process, log_path = _popen_chat_process(
+                [str(python_path), str(main_py)] + args,
+                cwd=project_root,
+                env=env,
+                required_files=(
+                    (python_path, python_identity),
+                    (main_py, main_py_identity),
+                    *launch_asset_snapshots,
+                    *runtime_template_snapshots,
+                    *history_file_snapshots,
+                ),
+                required_directories=(
+                    (project_root, project_root_identity),
+                    (app_root, app_root_identity),
+                    (attachment_root, attachment_root_identity),
+                    (template_dir, template_dir_identity),
+                    *history_directory_snapshots,
+                ),
             )
         try:
             exit_code = _main_chat_process.wait(timeout=1.2)
         except subprocess.TimeoutExpired:
+            _chat_debug_log(f"launch_chat running pid={_main_chat_process.pid}")
             return _chat_process_started_message(_main_chat_process)
         _close_chat_log_if_needed()
+        _chat_debug_log(f"launch_chat exited_early pid={_main_chat_process.pid} code={exit_code} log_path={log_path}")
         return _failed_launch_message(exit_code, log_path)
 
 
@@ -511,12 +930,27 @@ def _close_chat(
     reason: str = "聊天会话已结束。",
     wait_timeout: float = 4.0,
 ) -> dict[str, Any]:
+    with _chat_transition_lock(state):
+        return _close_chat_locked(
+            state,
+            reason=reason,
+            wait_timeout=wait_timeout,
+        )
+
+
+def _close_chat_locked(
+    state: BridgeState,
+    *,
+    reason: str,
+    wait_timeout: float,
+) -> dict[str, Any]:
     global _main_chat_process
 
     session_id = str(state.chat_session.get("sessionId") or "").strip()
     chat_stream = getattr(state, "chat_stream", None)
     _set_chat_runtime_closing(state, True)
     try:
+        _chat_debug_log(f"close_chat start session={session_id} reason={reason} wait_timeout={wait_timeout}")
         graceful_shutdown_requested = False
         if session_id and chat_stream is not None:
             try:
@@ -536,6 +970,7 @@ def _close_chat(
             snapshot = chat_stream.get_snapshot(session_id)
             if not isinstance(snapshot, dict) or not str(snapshot.get("sessionClosedReason") or "").strip():
                 chat_stream.close_session(session_id, reason=reason)
+        _chat_debug_log(f"close_chat completed session={session_id}")
     finally:
         try:
             stop_mobile_access(state)
@@ -557,7 +992,7 @@ def _resolve_history_file(state: BridgeState, raw_path: str | Path) -> Path:
 
 
 def _chat_history_path(state: BridgeState, payload: dict[str, Any], template: dict[str, Any]) -> Path:
-    raw = str(payload.get("historyPath") or "").strip()
+    raw = str(payload.get("historyPath") or "")
     if raw:
         path = _resolve_history_file(state, raw)
         if path.name in {ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME}:
@@ -574,7 +1009,7 @@ def _chat_history_path(state: BridgeState, payload: dict[str, Any], template: di
         characters = template.get("selectedCharacters")
     scenario = _scenario_from_template_like(template)
     template_hash = _history_id_from_scenario(scenario, characters)
-    return _resolve_history_file(state, Path(state.history_dir) / template_hash)
+    return history_root_for_state(state) / template_hash
 
 
 def _sprite_path(sprite: Any) -> str:
@@ -739,10 +1174,19 @@ def _chat_history_entries(state: BridgeState) -> list[dict[str, Any]]:
         if isinstance(snapshot, dict) and "historyEntries" in snapshot:
             entries = _history_entries_from_snapshot(snapshot)
             return entries
-    history_raw = str(state.chat_session.get("historyPath") or "").strip()
+    history_raw = str(state.chat_session.get("historyPath") or "")
     if history_raw and is_unc_history_path(history_raw):
         return []
-    history_path = _resolve_history_file(state, history_raw) if history_raw else None
+    if history_raw:
+        try:
+            history_path = _resolve_history_file(state, history_raw)
+        except (FileNotFoundError, OSError, PermissionError, ValueError):
+            # A stale/corrupt persisted reference must not make the whole chat
+            # snapshot unavailable.  Destructive commands resolve separately
+            # and still fail closed instead of acting on a guessed path.
+            history_path = None
+    else:
+        history_path = None
     if history_path is not None and is_unc_history_path(history_path):
         return []
     history_file = chat_history_active_path(history_path) if history_path is not None else None
@@ -854,12 +1298,11 @@ def _plain_history_text_from_entries(entries: list[dict[str, Any]]) -> str:
 def _read_history_file(path: Path) -> Any:
     if not path.is_file():
         return []
-    with path.open(encoding="utf-8") as file:
-        return json.load(file)
+    return json.loads(read_text_without_links(path))
 
 
 def _current_chat_history_download_file(state: BridgeState) -> Path:
-    history_raw = str(state.chat_session.get("historyPath") or "").strip()
+    history_raw = str(state.chat_session.get("historyPath") or "")
     if not history_raw:
         raise FileNotFoundError("没有已关联的聊天历史文件。")
     history_path = _resolve_history_file(state, history_raw)
@@ -918,7 +1361,7 @@ def _chat_history_download_file(state: BridgeState, capability: str) -> Path:
 
 def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, Any]:
     command = str(body.get("type") or "").strip()
-    history_raw = str(state.chat_session.get("historyPath") or "").strip()
+    history_raw = str(state.chat_session.get("historyPath") or "")
     session_id = str(state.chat_session.get("sessionId") or "").strip()
     chat_stream = getattr(state, "chat_stream", None)
 
@@ -1008,7 +1451,20 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
         if not history_raw:
             raise FileNotFoundError("没有已关联的聊天历史文件。")
         history_path = _resolve_history_file(state, history_raw)
-        remove_chat_history_storage(history_path)
+        try:
+            history_root = history_root_for_state(state)
+        except (OSError, PermissionError, RuntimeError, ValueError):
+            history_root = None
+        if (
+            history_root is not None
+            and resolved_path_is_within(history_path, history_root)
+        ):
+            remove_chat_history_storage(history_path, root=history_root)
+        else:
+            # Explicit external sessions are cleared in place, but the
+            # storage helper removes only Shinsekai's reserved files and
+            # preserves unrelated content.
+            remove_chat_history_storage(history_path)
         return _chat_snapshot(state, "idle", "历史记录已经清空。", extra={"historyEntries": [], "options": []})
 
     if command == "dismiss-plugin-page":
@@ -1140,7 +1596,15 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
         if command == "send-message" and isinstance(payload, dict):
             submitted_text = str(payload.get("text") or "").strip()
             raw_attachments = payload.get("attachments")
-            attachments = resolve_chat_attachments(raw_attachments if isinstance(raw_attachments, list) else [])
+            if isinstance(raw_attachments, list) and raw_attachments:
+                attachment_root = managed_project_storage(
+                    Path(*CHAT_ATTACHMENT_STAGE_SUBDIR),
+                    root=state_project_root(state),
+                )
+                attachments = resolve_chat_attachments(
+                    raw_attachments,
+                    root=attachment_root,
+                )
             body["payload"] = {
                 "attachments": [attachment.to_payload() for attachment in attachments],
                 "text": submitted_text,
@@ -1231,14 +1695,14 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
 
 def _chat_theme_payload(state: BridgeState) -> dict[str, Any]:
     system_config = state.config_manager.config.system_config
-    raw_path = str(system_config.chat_ui_theme_path or "").strip()
-    path = Path(raw_path) if raw_path else Path("data") / "chat_ui_theme.json"
-    if not path.is_absolute():
-        path = Path.cwd() / path
+    raw_path = str(system_config.chat_ui_theme_path or "")
+    path = resolve_from_root(
+        raw_path or "data/chat_ui_theme.json",
+        state_project_root(state),
+    )
     data: Any = {}
     if path.is_file():
-        with path.open(encoding="utf-8") as file:
-            parsed = json.load(file)
+        parsed = json.loads(read_text_without_links(path))
         if isinstance(parsed, dict):
             data = parsed
     return {

--- a/application/chat/session_store.py
+++ b/application/chat/session_store.py
@@ -1,4 +1,4 @@
-"""上次启动聊天时的选项快照（人物、背景、模板正文等）。"""
+"""Project-root-bound persistence for the React template launch session."""
 
 from __future__ import annotations
 
@@ -6,32 +6,235 @@ import json
 from pathlib import Path
 from typing import Any
 
+from sdk.file_transactions import (
+    atomic_write_text,
+    capture_directory_identity,
+    read_text_snapshot_without_links,
+    require_directory_identity,
+)
+from sdk.path_contract import (
+    managed_child_path,
+    managed_project_storage,
+    project_root as runtime_project_root,
+    require_directory_without_links,
+    resolve_managed_project_path,
+    resolve_project_path,
+)
+
+from sdk.path_references import make_path_reference, path_reference_value
+
 _SESSION_VERSION = 1
+_PATH_CONTRACT_VERSION = 1
+_SESSION_FILENAME = "template_tab_last_launch.json"
+_PATH_FIELD_CONTRACTS = {
+    "history_file": {
+        "legacy_project_prefixes": (("data", "chat_history"),),
+        "resource_prefixes": (),
+    },
+    "init_sprite_path": {
+        "legacy_project_prefixes": (("data", "sprite"),),
+        "resource_prefixes": (("assets",),),
+    },
+    "workflow_path": {
+        "legacy_project_prefixes": (
+            ("data", "workflows"),
+            ("test", "e2e"),
+        ),
+        "resource_prefixes": (("assets", "system", "workflow"),),
+    },
+}
 
 
-def template_session_file(template_dir_path: str) -> Path:
-    """与模板目录同处于 data/ 下：data/config/template_tab_last_launch.json"""
-    root = Path(template_dir_path).resolve().parent
-    return root / "config" / "template_tab_last_launch.json"
+def _authoritative_root(project_root: str | Path | None) -> Path:
+    return (
+        runtime_project_root()
+        if project_root is None
+        else resolve_project_path(".", root=project_root)
+    )
 
 
-def load_template_session(template_dir_path: str) -> dict[str, Any] | None:
-    p = template_session_file(template_dir_path)
-    if not p.is_file():
-        return None
+def template_session_file(
+    template_dir_path: str | Path,
+    *,
+    project_root: str | Path | None = None,
+) -> Path:
+    """Return the fixed session file without inferring ownership from its input."""
+
+    root = _authoritative_root(project_root)
+    # Validate the context value even though storage has a fixed location.
+    # A stale absolute path from a previous installation must not become a
+    # second data root merely because its parent happens to contain ``data``.
+    resolve_managed_project_path(template_dir_path, root=root)
+    config_root = managed_project_storage("data/config", root=root)
+    return managed_child_path(
+        config_root,
+        _SESSION_FILENAME,
+        field="template session filename",
+    )
+
+
+def _normalize_session_path_fields(
+    data: dict[str, Any],
+    *,
+    project_root: Path,
+    prefer_stored_references: bool,
+    recover_legacy_absolute: bool,
+) -> dict[str, Any]:
+    normalized = dict(data)
+    stored_references = data.get("path_refs")
+    stored_references = (
+        stored_references if isinstance(stored_references, dict) else {}
+    )
+    references: dict[str, dict[str, str]] = {}
+    for field, contract in _PATH_FIELD_CONTRACTS.items():
+        has_stored_reference = (
+            prefer_stored_references and field in stored_references
+        )
+        reference = (
+            stored_references.get(field) if has_stored_reference else None
+        )
+        value = path_reference_value(
+            reference,
+            project_prefixes=contract["legacy_project_prefixes"],
+            resource_prefixes=contract["resource_prefixes"],
+        )
+        if not has_stored_reference:
+            raw = str(data.get(field) or "")
+            reference = (
+                make_path_reference(
+                    raw,
+                    project_root,
+                    legacy_project_prefixes=contract[
+                        "legacy_project_prefixes"
+                    ],
+                    resource_prefixes=contract["resource_prefixes"],
+                    recover_legacy_absolute=recover_legacy_absolute,
+                )
+                if raw
+                else None
+            )
+            value = path_reference_value(
+                reference,
+                project_prefixes=contract["legacy_project_prefixes"],
+                resource_prefixes=contract["resource_prefixes"],
+            )
+        normalized[field] = value or ""
+        if isinstance(reference, dict) and value is not None:
+            scope = str(reference["scope"])
+            references[field] = {
+                "scope": scope,
+                "path": (
+                    value
+                    if scope.strip().lower() in {"project", "resource"}
+                    else str(reference["path"])
+                ),
+            }
+    normalized["path_refs"] = references
+    normalized["path_contract_version"] = _PATH_CONTRACT_VERSION
+    return normalized
+
+
+def _has_current_path_contract(data: dict[str, Any]) -> bool:
+    value = data.get("path_contract_version")
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value >= _PATH_CONTRACT_VERSION
+    )
+
+
+def load_template_session(
+    template_dir_path: str | Path,
+    *,
+    project_root: str | Path | None = None,
+) -> dict[str, Any] | None:
+    path = template_session_file(
+        template_dir_path,
+        project_root=project_root,
+    )
     try:
-        raw = json.loads(p.read_text(encoding="utf-8"))
+        parent, parent_identity = capture_directory_identity(
+            path.parent,
+            field="template session directory",
+        )
+        raw, _file_identity = read_text_snapshot_without_links(
+            path,
+            expected_parent_identity=parent_identity,
+        )
+        require_directory_identity(
+            parent,
+            parent_identity,
+            field="template session directory",
+        )
+        data = json.loads(raw)
+    except FileNotFoundError:
+        return None
     except (OSError, json.JSONDecodeError):
         return None
-    if not isinstance(raw, dict):
+    if not isinstance(data, dict) or data.get("version") != _SESSION_VERSION:
         return None
-    if raw.get("version") != _SESSION_VERSION:
-        return None
-    return raw
+    recover_legacy_absolute = not _has_current_path_contract(data)
+    normalized = _normalize_session_path_fields(
+        data,
+        project_root=_authoritative_root(project_root),
+        prefer_stored_references=True,
+        recover_legacy_absolute=recover_legacy_absolute,
+    )
+    if recover_legacy_absolute:
+        atomic_write_text(
+            path,
+            json.dumps(normalized, ensure_ascii=False, indent=2),
+            expected_parent_identity=parent_identity,
+        )
+        require_directory_identity(
+            parent,
+            parent_identity,
+            field="template session directory",
+        )
+    return normalized
 
 
-def save_template_session(template_dir_path: str, data: dict[str, Any]) -> None:
-    p = template_session_file(template_dir_path)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"version": _SESSION_VERSION, **data}
-    p.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+def save_template_session(
+    template_dir_path: str | Path,
+    data: dict[str, Any],
+    *,
+    project_root: str | Path | None = None,
+) -> None:
+    path = template_session_file(
+        template_dir_path,
+        project_root=project_root,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    parent, parent_identity = capture_directory_identity(
+        require_directory_without_links(
+            path.parent,
+            field="template session directory",
+        ),
+        field="template session directory",
+    )
+    payload = {
+        "version": _SESSION_VERSION,
+        **_normalize_session_path_fields(
+            data,
+            project_root=_authoritative_root(project_root),
+            prefer_stored_references=False,
+            recover_legacy_absolute=False,
+        ),
+    }
+    atomic_write_text(
+        path,
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        expected_parent_identity=parent_identity,
+    )
+    require_directory_identity(
+        parent,
+        parent_identity,
+        field="template session directory",
+    )
+
+
+__all__ = [
+    "load_template_session",
+    "save_template_session",
+    "template_session_file",
+]

--- a/application/chat/templates.py
+++ b/application/chat/templates.py
@@ -1,11 +1,33 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
+import os
+import stat
 from pathlib import Path
+from threading import RLock
 from typing import Any
 
 from config.config_manager import character_name_key
+from sdk.file_transactions import (
+    atomic_write_text,
+    capture_directory_identity,
+    ensure_portable_name_available,
+    read_text_without_links,
+    read_text_snapshot_without_links,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from sdk.path_contract import (
+    _metadata_is_link_or_reparse_point,
+    managed_child_path,
+    path_is_link_or_reparse_point,
+    project_root as runtime_project_root,
+    require_directory_without_links,
+    resolve_managed_project_path,
+    resolve_project_path,
+)
 from core.sprite.chat_branch_storage import ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME
 from core.sprite.initial_sprite import initial_sprite_path_for_characters
 from ai.llm.template_generator import (
@@ -14,19 +36,30 @@ from ai.llm.template_generator import (
     resolve_chat_template_characters,
 )
 
+from .history_paths import history_reference_value, resolve_history_path_for_project
+from sdk.path_references import state_project_root
+from sdk.path_utils import safe_filename, safe_project_path
 from application.runtime.state import BridgeState
-from sdk.path_utils import safe_child_path, safe_filename
 
 MARK_SCENARIO = "<<<EASYAI_USER_SCENARIO>>>"
 MARK_SYSTEM = "<<<EASYAI_SYSTEM_TEMPLATE>>>"
 TEMP_SPLIT_META = "_temp_split.json"
+RUNTIME_TEMPLATE_HASH_FIELD = "runtimeTemplateSha256"
 DEFAULT_EMPTY_SCENARIO = "你扮演一个RPG系统。"
+
+_RUNTIME_TEMPLATE_WRITE_LOCK = RLock()
 
 
 def _template_dir(state: BridgeState) -> Path:
-    path = Path(state.template_dir_path)
+    path = resolve_managed_project_path(
+        state.template_dir_path,
+        root=state_project_root(state),
+    )
     path.mkdir(parents=True, exist_ok=True)
-    return path
+    return require_directory_without_links(
+        path,
+        field="template directory",
+    )
 
 
 def _template_id(path: Path) -> str:
@@ -100,53 +133,192 @@ def _history_id_from_scenario(
     ).hexdigest()
 
 
-def _latest_history_json(history_dir: str) -> Path | None:
-    path = Path(history_dir)
-    if not path.is_dir():
-        return None
-    candidates: list[tuple[Path, float]] = [
-        (item, item.stat().st_mtime) for item in path.glob("*.json") if item.is_file()
-    ]
-    candidates.extend(
-        (
-            item,
-            max(
-                child.stat().st_mtime
-                for child in (
-                    item / ACTIVE_HISTORY_FILENAME,
-                    item / BRANCH_TREE_FILENAME,
-                    item / f"{ACTIVE_HISTORY_FILENAME}.tmp",
-                )
-                if child.is_file()
-            ),
-        )
-        for item in path.iterdir()
-        if item.is_dir()
-        and any(
-            (item / name).is_file()
-            for name in (ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME, f"{ACTIVE_HISTORY_FILENAME}.tmp")
-        )
+def _latest_history_json(history_dir: str, *, project_root: Path | None = None) -> Path | None:
+    root = (
+        resolve_project_path(".", root=project_root)
+        if project_root is not None
+        else runtime_project_root()
     )
-    candidates.extend(
-        (item.parent / item.name[:-4], item.stat().st_mtime)
-        for item in path.glob("*.json.tmp")
-        if item.is_file()
+    path = resolve_managed_project_path(history_dir, root=root)
+    if path == root:
+        raise PermissionError("chat history directory must not be the project root")
+    try:
+        path, path_identity, items = snapshot_directory_entries_without_links(
+            path,
+            field="chat history directory",
+        )
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    candidates: list[tuple[Path, float, os.stat_result]] = []
+    reserved_root_files = {ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME}
+    for item, item_metadata in items:
+        # Session symlinks make the configured root cease to be the deletion
+        # boundary.  They are never eligible for automatic resume.
+        if _metadata_is_link_or_reparse_point(item_metadata):
+            continue
+        try:
+            if stat.S_ISREG(item_metadata.st_mode):
+                if item.name in reserved_root_files:
+                    continue
+                if item.suffix.lower() == ".json":
+                    candidates.append((item, item_metadata.st_mtime, item_metadata))
+                # A root-level ``foo.json.tmp`` cannot be mapped safely after
+                # directory sessions were introduced: treating ``foo.json``
+                # as the latest session would launch an empty ``foo/`` and
+                # silently ignore the recovery data.  Only session-local
+                # ``active.json.tmp`` files below are eligible for recovery.
+                continue
+            if not stat.S_ISDIR(item_metadata.st_mode):
+                continue
+            child_root, child_identity, child_entries = (
+                snapshot_directory_entries_without_links(
+                    item,
+                    field="chat history session directory",
+                )
+            )
+            if not os.path.samestat(item_metadata, child_identity):
+                raise PermissionError(
+                    f"chat history session identity changed: {item}"
+                )
+            child_times: list[float] = []
+            wanted_names = {
+                ACTIVE_HISTORY_FILENAME,
+                BRANCH_TREE_FILENAME,
+                f"{ACTIVE_HISTORY_FILENAME}.tmp",
+            }
+            for child, child_metadata in child_entries:
+                if child.name not in wanted_names:
+                    continue
+                if (
+                    _metadata_is_link_or_reparse_point(child_metadata)
+                    or not stat.S_ISREG(child_metadata.st_mode)
+                ):
+                    continue
+                child_times.append(child_metadata.st_mtime)
+            require_directory_identity(
+                child_root,
+                child_identity,
+                field="chat history session directory",
+            )
+            if child_times:
+                candidates.append((item, max(child_times), item_metadata))
+        except FileNotFoundError:
+            # A clear operation may remove a candidate while resume is
+            # scanning. Ignore only that vanished candidate.
+            continue
+    require_directory_identity(
+        path,
+        path_identity,
+        field="chat history directory",
     )
     if not candidates:
         return None
-    return max(candidates, key=lambda item: item[1])[0]
-
-
-def _read_split_meta(template_dir: Path) -> tuple[str, str] | None:
-    meta_path = template_dir / TEMP_SPLIT_META
-    if not meta_path.is_file():
-        return None
+    selected, _mtime, selected_identity = max(
+        candidates,
+        key=lambda item: item[1],
+    )
     try:
-        data = json.loads(meta_path.read_text(encoding="utf-8"))
+        current_identity = selected.lstat()
+    except FileNotFoundError:
+        return None
+    if (
+        _metadata_is_link_or_reparse_point(current_identity)
+        or not os.path.samestat(selected_identity, current_identity)
+    ):
+        raise PermissionError(
+            f"latest chat history identity changed: {selected}"
+        )
+    require_directory_identity(
+        path,
+        path_identity,
+        field="chat history directory",
+    )
+    return selected
+
+
+def _runtime_template_hash(runtime_template: str) -> str:
+    return hashlib.sha256(runtime_template.encode("utf-8")).hexdigest()
+
+
+def _write_runtime_template_files(
+    template_dir: Path,
+    runtime_template: str,
+    scenario: str,
+    system: str,
+) -> None:
+    """Publish the runtime template and integrity-bound split metadata."""
+
+    template_dir, template_dir_identity = capture_directory_identity(
+        template_dir,
+        field="template directory",
+    )
+    temp_path = template_dir / "_temp.txt"
+    meta_path = template_dir / TEMP_SPLIT_META
+    if (
+        path_is_link_or_reparse_point(temp_path)
+        or path_is_link_or_reparse_point(meta_path)
+    ):
+        raise PermissionError("runtime template files must not be symbolic links")
+    metadata = json.dumps(
+        {
+            "scenario": scenario,
+            "system": system,
+            RUNTIME_TEMPLATE_HASH_FIELD: _runtime_template_hash(runtime_template),
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    with _RUNTIME_TEMPLATE_WRITE_LOCK:
+        atomic_write_text(
+            managed_child_path(template_dir, "_temp.txt", field="runtime template filename"),
+            runtime_template,
+            expected_parent_identity=template_dir_identity,
+        )
+        atomic_write_text(
+            managed_child_path(template_dir, TEMP_SPLIT_META, field="runtime template metadata filename"),
+            metadata,
+            expected_parent_identity=template_dir_identity,
+        )
+        require_directory_identity(
+            template_dir,
+            template_dir_identity,
+            field="template directory",
+        )
+
+
+def _read_split_meta(
+    template_dir: Path,
+    runtime_template: str,
+    *,
+    expected_parent_identity: os.stat_result | None = None,
+) -> tuple[tuple[str, str] | None, bool]:
+    """Return split fields and whether integrity metadata rejected the pair."""
+
+    meta_path = template_dir / TEMP_SPLIT_META
+    try:
+        data = json.loads(
+            read_text_without_links(
+                meta_path,
+                expected_parent_identity=expected_parent_identity,
+            )
+        )
+    except FileNotFoundError:
+        return None, False
+    except PermissionError:
+        if expected_parent_identity is not None:
+            raise
+        return None, False
     except (OSError, json.JSONDecodeError):
-        return None
+        return None, False
     if not isinstance(data, dict):
-        return None
+        return None, False
+    expected_hash = data.get(RUNTIME_TEMPLATE_HASH_FIELD)
+    if expected_hash is not None:
+        if not isinstance(expected_hash, str) or not hmac.compare_digest(
+            expected_hash,
+            _runtime_template_hash(runtime_template),
+        ):
+            return None, True
     scenario = data.get("scenario", "")
     system = data.get("system", "")
     if not isinstance(scenario, str):
@@ -154,8 +326,8 @@ def _read_split_meta(template_dir: Path) -> tuple[str, str] | None:
     if not isinstance(system, str):
         system = ""
     if scenario.strip() or system.strip():
-        return scenario, system
-    return None
+        return (scenario, system), False
+    return None, False
 
 
 def _repair_template_parts_from_session_if_needed(
@@ -165,48 +337,146 @@ def _repair_template_parts_from_session_if_needed(
 ) -> tuple[str, str]:
     if not _has_untranslated_template_keys(scenario, system):
         return scenario, system
-    from application.chat.session_store import load_template_session
-
-    repaired = _repair_template_session_if_needed(state, load_template_session(state.template_dir_path))
+    repaired = _repair_template_session_if_needed(
+        state,
+        load_template_session(
+            _template_dir(state).as_posix(),
+            project_root=state_project_root(state),
+        ),
+    )
     if not repaired:
         return scenario, system
     return str(repaired.get("scenario_text") or ""), str(repaired.get("system_template_text") or "")
 
 
-def _resume_template_parts(state: BridgeState) -> tuple[str, str, str] | None:
-    template_dir = _template_dir(state)
-    temp_path = template_dir / "_temp.txt"
-    if temp_path.is_file() and temp_path.stat().st_size > 0:
-        split_meta = _read_split_meta(template_dir)
-        if split_meta is not None:
-            scenario, system = _repair_template_parts_from_session_if_needed(state, split_meta[0], split_meta[1])
-            return scenario, system, "_temp.txt"
-        try:
-            scenario, system = _parse_stored_template(temp_path.read_text(encoding="utf-8"))
-        except OSError:
-            scenario, system = "", ""
-        if scenario.strip() or system.strip():
-            return scenario, system, "_temp.txt"
+def _resume_template_parts_from_directory(
+    template_dir: Path,
+) -> tuple[str, str, str] | None:
+    """Read one resume candidate from a stable template-directory snapshot."""
 
-    candidates = [item for item in template_dir.glob("*.txt") if item.is_file() and item.name != "_temp.txt"]
+    template_dir, template_dir_identity, entries = (
+        snapshot_directory_entries_without_links(
+            template_dir,
+            field="template directory",
+        )
+    )
+    regular_templates = [
+        (path, metadata)
+        for path, metadata in entries
+        if (
+            not _metadata_is_link_or_reparse_point(metadata)
+            and stat.S_ISREG(metadata.st_mode)
+            and path.suffix == ".txt"
+        )
+    ]
+    temp_candidate = next(
+        (
+            (path, metadata)
+            for path, metadata in regular_templates
+            if path.name == "_temp.txt"
+        ),
+        None,
+    )
+    if temp_candidate is not None and temp_candidate[1].st_size > 0:
+        temp_path, temp_identity = temp_candidate
+        try:
+            runtime_template, _runtime_identity = read_text_snapshot_without_links(
+                temp_path,
+                expected_identity=temp_identity,
+                expected_parent_identity=template_dir_identity,
+            )
+        except FileNotFoundError:
+            runtime_template = ""
+        split_meta, integrity_mismatch = _read_split_meta(
+            template_dir,
+            runtime_template,
+            expected_parent_identity=template_dir_identity,
+        )
+        if split_meta is not None:
+            require_directory_identity(
+                template_dir,
+                template_dir_identity,
+                field="template directory",
+            )
+            return split_meta[0], split_meta[1], "_temp.txt"
+        if not integrity_mismatch:
+            scenario, system = _parse_stored_template(runtime_template)
+            if scenario.strip() or system.strip():
+                require_directory_identity(
+                    template_dir,
+                    template_dir_identity,
+                    field="template directory",
+                )
+                return scenario, system, "_temp.txt"
+
+    candidates = [
+        (path, metadata)
+        for path, metadata in regular_templates
+        if path.name != "_temp.txt"
+    ]
     if not candidates:
         return None
-    path = max(candidates, key=lambda item: item.stat().st_mtime)
+    path, path_identity = max(
+        candidates,
+        key=lambda item: item[1].st_mtime_ns,
+    )
     try:
-        scenario, system = _parse_stored_template(path.read_text(encoding="utf-8"))
-    except OSError:
+        raw, _read_identity = read_text_snapshot_without_links(
+            path,
+            expected_identity=path_identity,
+            expected_parent_identity=template_dir_identity,
+        )
+        scenario, system = _parse_stored_template(raw)
+    except FileNotFoundError:
         return None
+    require_directory_identity(
+        template_dir,
+        template_dir_identity,
+        field="template directory",
+    )
     if scenario.strip() or system.strip():
         return scenario, system, path.name
     return None
 
 
+def _resume_template_parts(state: BridgeState) -> tuple[str, str, str] | None:
+    resumed = _resume_template_parts_from_directory(_template_dir(state))
+    if resumed is None:
+        return None
+    scenario, system, template_name = resumed
+    scenario, system = _repair_template_parts_from_session_if_needed(
+        state,
+        scenario,
+        system,
+    )
+    return scenario, system, template_name
+
+
 def _list_templates(state: BridgeState) -> list[dict[str, Any]]:
+    template_dir, template_dir_identity, entries = (
+        snapshot_directory_entries_without_links(
+            _template_dir(state),
+            field="template directory",
+        )
+    )
     rows: list[dict[str, Any]] = []
-    for path in sorted(_template_dir(state).glob("*.txt"), key=lambda item: item.name.lower()):
+    for path, path_identity in sorted(
+        entries,
+        key=lambda item: item[0].name.lower(),
+    ):
+        if (
+            path.suffix != ".txt"
+            or _metadata_is_link_or_reparse_point(path_identity)
+            or not stat.S_ISREG(path_identity.st_mode)
+        ):
+            continue
         try:
-            raw = path.read_text(encoding="utf-8")
-        except OSError:
+            raw, read_identity = read_text_snapshot_without_links(
+                path,
+                expected_identity=path_identity,
+                expected_parent_identity=template_dir_identity,
+            )
+        except FileNotFoundError:
             continue
         scenario, system = _parse_stored_template(raw)
         rows.append(
@@ -217,9 +487,14 @@ def _list_templates(state: BridgeState) -> list[dict[str, Any]]:
                 "path": path.as_posix(),
                 "scenario": scenario,
                 "system": system,
-                "updatedAt": str(int(path.stat().st_mtime)),
+                "updatedAt": str(int(read_identity.st_mtime)),
             }
         )
+    require_directory_identity(
+        template_dir,
+        template_dir_identity,
+        field="template directory",
+    )
     return rows
 
 
@@ -227,15 +502,33 @@ def _save_template_summary(state: BridgeState, payload: dict[str, Any]) -> dict[
     template = payload.get("template", payload)
     if not isinstance(template, dict):
         raise ValueError("template payload must be an object")
-    name = str(template.get("name") or template.get("id") or "").strip()
+    name = str(template.get("name") or template.get("id") or "")
     if not name:
         raise ValueError("template name is required")
     scenario = _scenario_from_template_like(template)
     system = str(template.get("system") or "")
     file_name = safe_filename(name, default_suffix=".txt")
-    safe_child_path(_template_dir(state), file_name).write_text(
+    template_dir = _template_dir(state)
+    template_dir, template_dir_identity = capture_directory_identity(
+        template_dir,
+        field="template directory",
+    )
+    ensure_portable_name_available(
+        template_dir,
+        file_name,
+        expected_directory_identity=template_dir_identity,
+    )
+    if path_is_link_or_reparse_point(template_dir / file_name):
+        raise PermissionError("template files must not be symbolic links")
+    atomic_write_text(
+        managed_child_path(template_dir, file_name, field="template filename"),
         _compose_stored_template(scenario, system),
-        encoding="utf-8",
+        expected_parent_identity=template_dir_identity,
+    )
+    require_directory_identity(
+        template_dir,
+        template_dir_identity,
+        field="template directory",
     )
     for row in _list_templates(state):
         if row["id"] == file_name:
@@ -251,10 +544,15 @@ def _generate_template_summary(state: BridgeState, payload: dict[str, Any]) -> d
     background = str(payload.get("backgroundName") or "")
     voice_language = str(payload.get("voiceLanguage") or "").strip()
     if voice_language:
-        sc = state.config_manager.config.system_config.model_copy(deep=True)
+        previous_system_config = state.config_manager.config.system_config
+        sc = previous_system_config.model_copy(deep=True)
         sc.voice_language = voice_language
         state.config_manager.config.system_config = sc
-        state.config_manager.save_system_config()
+        try:
+            state.config_manager.save_system_config()
+        except BaseException:
+            state.config_manager.config.system_config = previous_system_config
+            raise
     max_speech_chars = max(0, int(payload.get("maxSpeechChars") or 0))
     max_dialog_items = max(0, int(payload.get("maxDialogItems") or 0))
     content, result = state.template_generator.generate_chat_template(
@@ -343,7 +641,11 @@ def _template_session_to_frontend(raw: dict[str, Any] | None) -> dict[str, Any] 
 def _persist_template_session_repair(state: BridgeState, raw: dict[str, Any]) -> None:
     from application.chat.session_store import save_template_session
 
-    save_template_session(state.template_dir_path, raw)
+    save_template_session(
+        _template_dir(state).as_posix(),
+        raw,
+        project_root=state_project_root(state),
+    )
 
 
 def _reconcile_template_session_characters(
@@ -383,7 +685,10 @@ def _rename_template_session_character(
         return
     from application.chat.session_store import load_template_session
 
-    raw = load_template_session(state.template_dir_path)
+    raw = load_template_session(
+        _template_dir(state).as_posix(),
+        project_root=state_project_root(state),
+    )
     if not raw:
         return
     selected = _session_string_list(raw.get("selected_characters"))
@@ -403,7 +708,10 @@ def _rename_template_session_character(
 def _load_template_session_payload(state: BridgeState) -> dict[str, Any] | None:
     from application.chat.session_store import load_template_session
 
-    raw = load_template_session(state.template_dir_path)
+    raw = load_template_session(
+        _template_dir(state).as_posix(),
+        project_root=state_project_root(state),
+    )
     raw = _reconcile_template_session_characters(state, raw)
     raw = _repair_template_session_if_needed(state, raw)
     return _template_session_to_frontend(raw)
@@ -411,6 +719,14 @@ def _load_template_session_payload(state: BridgeState) -> dict[str, Any] | None:
 
 def _save_template_session_payload(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
     from application.chat.session_store import save_template_session
+
+    history_value = ""
+    history_raw = str(payload.get("historyPath") or "")
+    if history_raw:
+        history_value = history_reference_value(
+            state,
+            resolve_history_path_for_project(state, history_raw),
+        )
 
     selected_characters = _resolve_template_character_names(
         state,
@@ -441,11 +757,15 @@ def _save_template_session_payload(state: BridgeState, payload: dict[str, Any]) 
         "filename_stub": str(payload.get("filenameStub") or ""),
         "template_file_dropdown": str(payload.get("templateFileDropdown") or ""),
         "init_sprite_path": init_sprite_path,
-        "history_file": str(payload.get("historyPath") or ""),
+        "history_file": history_value,
         "room_id": str(payload.get("roomId") or ""),
         "workflow_path": str(payload.get("workflowPath") or ""),
     }
-    save_template_session(state.template_dir_path, data)
+    save_template_session(
+        _template_dir(state).as_posix(),
+        data,
+        project_root=state_project_root(state),
+    )
     loaded = _load_template_session_payload(state)
     if loaded is None:
         raise RuntimeError("template session was saved but not found")
@@ -483,9 +803,11 @@ def _repair_template_session_if_needed(state: BridgeState, raw: dict[str, Any] |
         repaired["scenario_text"] = ""
     repaired["system_template_text"] = content
     try:
-        from application.chat.session_store import save_template_session
-
-        save_template_session(state.template_dir_path, repaired)
+        save_template_session(
+            _template_dir(state).as_posix(),
+            repaired,
+            project_root=state_project_root(state),
+        )
     except Exception:
         pass
     return repaired

--- a/application/mcp.py
+++ b/application/mcp.py
@@ -20,6 +20,27 @@ def _as_str_list(value: Any) -> list[str]:
     return [str(item) for item in value]
 
 
+def _exact_mcp_text(
+    value: Any,
+    *,
+    field: str,
+    required: bool = False,
+) -> str:
+    raw = str(value or "")
+    if raw != raw.strip() or any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in raw
+    ):
+        raise ValueError(
+            f"{field} must not contain surrounding whitespace or control characters"
+        )
+    if required and not raw:
+        raise ValueError(f"{field} is required")
+    return raw
+
+
 def _mcp_config_response(data: dict[str, Any] | None = None) -> dict[str, Any]:
     from config.mcp_config import DEFAULT_MCP_CONFIG_PATH, read_mcp_config
 
@@ -53,6 +74,9 @@ def _mcp_config_response(data: dict[str, Any] | None = None) -> dict[str, Any]:
             entry["command"] = str(raw.get("command") or "")
             entry["args"] = _as_str_list(raw.get("args"))
             entry["env"] = _as_str_map(raw.get("env"))
+            cwd = str(raw.get("cwd") or "")
+            if cwd:
+                entry["cwd"] = cwd
         servers.append(entry)
     try:
         default_timeout = float(cfg.get("default_call_timeout", 300))
@@ -69,15 +93,22 @@ def _mcp_config_response(data: dict[str, Any] | None = None) -> dict[str, Any]:
 def _validate_mcp_server(raw: Any) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise ValueError("MCP server must be an object")
-    transport = str(raw.get("transport") or "sse").strip().lower()
+    transport = _exact_mcp_text(
+        raw.get("transport") or "sse",
+        field="MCP transport",
+        required=True,
+    ).lower()
     if transport not in {"sse", "stdio", "streamable_http"}:
         raise ValueError(f"Unknown MCP transport: {transport!r}")
     entry: dict[str, Any] = {
         "enabled": raw.get("enabled") is not False,
-        "name_prefix": str(raw.get("name_prefix") or "").strip(),
+        "name_prefix": _exact_mcp_text(
+            raw.get("name_prefix"),
+            field="MCP name prefix",
+        ),
         "transport": transport,
     }
-    group = str(raw.get("group") or "").strip()
+    group = _exact_mcp_text(raw.get("group"), field="MCP group")
     if group:
         entry["group"] = group
     if raw.get("call_timeout") not in (None, ""):
@@ -89,18 +120,22 @@ def _validate_mcp_server(raw: Any) -> dict[str, Any]:
             entry["call_timeout"] = timeout
 
     if transport in {"sse", "streamable_http"}:
-        url = str(raw.get("url") or "").strip()
-        if not url:
-            raise ValueError("MCP HTTP server requires a URL")
+        url = _exact_mcp_text(
+            raw.get("url"),
+            field="MCP HTTP URL",
+            required=True,
+        )
         entry["url"] = url
         headers = raw.get("headers")
         if headers is not None and not isinstance(headers, dict):
             raise ValueError("MCP headers must be an object")
         entry["headers"] = _as_str_map(headers)
     else:
-        command = str(raw.get("command") or "").strip()
-        if not command:
-            raise ValueError("MCP stdio server requires a command")
+        command = _exact_mcp_text(
+            raw.get("command"),
+            field="MCP stdio command",
+            required=True,
+        )
         args = raw.get("args")
         env = raw.get("env")
         if args is not None and not isinstance(args, list):
@@ -110,6 +145,12 @@ def _validate_mcp_server(raw: Any) -> dict[str, Any]:
         entry["command"] = command
         entry["args"] = _as_str_list(args)
         entry["env"] = _as_str_map(env)
+        cwd = _exact_mcp_text(
+            raw.get("cwd"),
+            field="MCP stdio working directory",
+        )
+        if cwd:
+            entry["cwd"] = cwd
     return entry
 
 

--- a/application/media/auto_annotation.py
+++ b/application/media/auto_annotation.py
@@ -1,5 +1,3 @@
-"""Image auto-annotation application use cases."""
-
 from __future__ import annotations
 
 import os
@@ -8,7 +6,17 @@ from pathlib import Path
 from typing import Any
 
 from ai.vision import VisionManager
+from sdk.file_transactions import (
+    open_binary_read_without_links,
+    read_bytes_without_links,
+)
 from core.media.asset_tags import normalize_generated_tags, numbered_tags, tag_contents
+from sdk.path_contract import (
+    relative_path_has_prefix,
+    resolve_managed_project_path,
+    resolve_project_path,
+    resolve_runtime_asset_read_path,
+)
 
 
 ProgressCallback = Callable[[int, int, str, str], None]
@@ -38,19 +46,44 @@ def _sprite_path(sprite: object) -> str:
     return str(getattr(sprite, "path", "") or "")
 
 
-def _safe_asset_file(raw_path: str, project_root: Path) -> Path:
-    if not raw_path.strip() or any(ord(char) < 32 for char in raw_path):
+def _safe_asset_file(
+    raw_path: str,
+    project_root: Path,
+) -> tuple[Path, os.stat_result]:
+    if (
+        not raw_path
+        or raw_path != raw_path.strip()
+        or any(
+            ord(char) < 32
+            or ord(char) == 127
+            or 0xD800 <= ord(char) <= 0xDFFF
+            for char in raw_path
+        )
+    ):
         raise ValueError("图片路径无效")
-    root = project_root.resolve()
-    candidate = Path(raw_path).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=True)
-    if os.path.commonpath([str(root), str(resolved)]) != str(root):
-        raise PermissionError("图片路径超出项目目录")
+    root = resolve_project_path(".", root=project_root)
+    try:
+        if (
+            not Path(raw_path).expanduser().is_absolute()
+            and relative_path_has_prefix(
+                raw_path,
+                (("assets",),),
+                field="image path",
+            )
+        ):
+            resolved = resolve_runtime_asset_read_path(
+                raw_path,
+                root=root,
+            )
+        else:
+            resolved = resolve_managed_project_path(raw_path, root=root)
+    except PermissionError as exc:
+        raise PermissionError("图片路径超出项目目录") from exc
     if not resolved.is_file() or resolved.suffix.lower() not in _IMAGE_SUFFIXES:
         raise ValueError("不是受支持的图片文件")
-    return resolved
+    with open_binary_read_without_links(resolved) as source:
+        identity = os.fstat(source.fileno())
+    return resolved, identity
 
 
 def annotate_unlabelled_images(
@@ -74,10 +107,16 @@ def annotate_unlabelled_images(
         if is_cancelled and is_cancelled():
             raise AnnotationCancelled("图片自动标注已取消")
         try:
-            image_path = _safe_asset_file(_sprite_path(sprites[index]), project_root)
+            image_path, image_identity = _safe_asset_file(
+                _sprite_path(sprites[index]),
+                project_root,
+            )
             first_inference = runner is None or completed == 0
             if runner is None:
-                runner = VisionManager("moondream").describe
+                runner = VisionManager(
+                    "moondream",
+                    root=project_root,
+                ).describe
             if on_progress:
                 if first_inference:
                     on_progress(
@@ -93,7 +132,15 @@ def annotate_unlabelled_images(
                         f"正在标注第 {completed + 1}/{len(missing_indexes)} 张图片…",
                         "annotating",
                     )
-            generated = normalize_generated_tags(runner(image_path.read_bytes(), prompt))
+            generated = normalize_generated_tags(
+                runner(
+                    read_bytes_without_links(
+                        image_path,
+                        expected_identity=image_identity,
+                    ),
+                    prompt,
+                )
+            )
             if not generated:
                 raise ValueError("Moondream 未返回标签")
             tags[index] = generated

--- a/application/memory/service.py
+++ b/application/memory/service.py
@@ -10,16 +10,41 @@ from pathlib import Path
 from typing import Any, Callable, Sequence
 
 
-def check_mem0_status(*, start_loading: bool = True) -> dict[str, Any]:
+def _runtime_kwargs(
+    root: str | Path | None,
+    config_manager: Any | None,
+) -> dict[str, Any]:
+    if root is None and config_manager is None:
+        return {}
+    return {"root": root, "config_manager": config_manager}
+
+
+def check_mem0_status(
+    *,
+    start_loading: bool = True,
+    root: str | Path | None = None,
+    config_manager: Any | None = None,
+) -> dict[str, Any]:
     from ai.memory.runtime import check_mem0_status as _check_mem0_status
 
-    return _check_mem0_status(start_loading=start_loading)
+    return _check_mem0_status(
+        start_loading=start_loading,
+        **_runtime_kwargs(root, config_manager),
+    )
 
 
-def list_memories(character_name: str) -> dict[str, Any]:
+def list_memories(
+    character_name: str,
+    *,
+    root: str | Path | None = None,
+    config_manager: Any | None = None,
+) -> dict[str, Any]:
     from ai.memory.operations import memory_list
 
-    return memory_list(character_name)
+    return memory_list(
+        character_name,
+        **_runtime_kwargs(root, config_manager),
+    )
 
 
 def search_memories(
@@ -27,34 +52,79 @@ def search_memories(
     *,
     character_name: str,
     limit: int = 10,
+    root: str | Path | None = None,
+    config_manager: Any | None = None,
 ) -> dict[str, Any]:
     from ai.memory.operations import memory_search
 
-    return memory_search(query, character_name=character_name, limit=limit)
+    return memory_search(
+        query,
+        character_name=character_name,
+        limit=limit,
+        **_runtime_kwargs(root, config_manager),
+    )
 
 
-def remember_memory(content: str, *, character_name: str) -> dict[str, Any]:
+def remember_memory(
+    content: str,
+    *,
+    character_name: str,
+    root: str | Path | None = None,
+    config_manager: Any | None = None,
+) -> dict[str, Any]:
     from ai.memory.operations import memory_remember
 
-    return memory_remember(content, character_name=character_name)
+    return memory_remember(
+        content,
+        character_name=character_name,
+        **_runtime_kwargs(root, config_manager),
+    )
 
 
-def forget_memory(memory_id: str) -> dict[str, Any]:
+def forget_memory(
+    memory_id: str,
+    *,
+    root: str | Path | None = None,
+    config_manager: Any | None = None,
+) -> dict[str, Any]:
     from ai.memory.operations import memory_forget
 
-    return memory_forget(memory_id)
+    return memory_forget(
+        memory_id,
+        **_runtime_kwargs(root, config_manager),
+    )
 
 
-def remember_and_list(content: str, *, character_name: str) -> dict[str, Any]:
+def remember_and_list(
+    content: str,
+    *,
+    character_name: str,
+    root: str | Path | None = None,
+    config_manager: Any | None = None,
+) -> dict[str, Any]:
     from ai.memory.operations import memory_remember_and_list
 
-    return memory_remember_and_list(content, character_name=character_name)
+    return memory_remember_and_list(
+        content,
+        character_name=character_name,
+        **_runtime_kwargs(root, config_manager),
+    )
 
 
-def forget_and_list(memory_id: str, *, character_name: str) -> dict[str, Any]:
+def forget_and_list(
+    memory_id: str,
+    *,
+    character_name: str,
+    root: str | Path | None = None,
+    config_manager: Any | None = None,
+) -> dict[str, Any]:
     from ai.memory.operations import memory_forget_and_list
 
-    return memory_forget_and_list(memory_id, character_name=character_name)
+    return memory_forget_and_list(
+        memory_id,
+        character_name=character_name,
+        **_runtime_kwargs(root, config_manager),
+    )
 
 
 def preview_import(
@@ -81,6 +151,7 @@ def execute_import(
     character_name: str,
     source_root: str | Path,
     config_manager: Any,
+    root: str | Path | None = None,
     progress_callback: Callable[[str, float, str, str | None], None],
     cancel_callback: Callable[[], None],
 ) -> dict[str, Any]:
@@ -90,12 +161,23 @@ def execute_import(
     )
     from ai.memory.imports import execute_memory_import
 
+    def remember(memory: str, active_character_name: str | None) -> dict[str, Any]:
+        from ai.memory.operations import memory_remember
+
+        return memory_remember(
+            memory,
+            character_name=active_character_name,
+            root=root,
+            config_manager=config_manager,
+        )
+
     return execute_memory_import(
         paths,
         character_name=character_name,
         source_root=source_root,
         llm_adapter=create_configured_memory_adapter(config_manager),
         max_chunk_tokens=configured_memory_chunk_tokens(config_manager),
+        remember_func=remember,
         progress_callback=progress_callback,
         cancel_callback=cancel_callback,
     )

--- a/application/model_assets/service.py
+++ b/application/model_assets/service.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from core.model_assets.service import ModelAssetSpec, download_model_asset, inspect_model_asset
+from sdk.path_contract import resolve_managed_project_path, resolve_project_path
 
+from sdk.path_references import is_absolute_path_text, state_project_root
+from sdk.path_utils import reject_control_chars
 from application.runtime.state import BridgeState
 from application.runtime.tasks import _update_task
-from sdk.path_utils import reject_control_chars
 
 _ASR_FASTER_WHISPER_ASSET_ID = "asr.faster-whisper"
 _MEMORY_EMBEDDING_ASSET_ID = "memory.embedding"
@@ -61,7 +63,10 @@ _MODEL_ASSET_ENQUEUE_LOCK = threading.Lock()
 
 
 def _validated_model_reference(value: str) -> str:
-    raw = reject_control_chars(str(value or ""), field="model reference")
+    supplied = str(value or "")
+    raw = reject_control_chars(supplied, field="model reference")
+    if raw != supplied:
+        raise ValueError("model reference must not contain surrounding whitespace")
     if len(raw) > _MAX_MODEL_REFERENCE_LENGTH:
         raise ValueError("model reference is too long")
     return raw
@@ -92,13 +97,15 @@ def _looks_like_local_model_reference(value: str) -> bool:
     )
 
 
-def _configured_local_model_path(value: str) -> Path:
+def _configured_local_model_path(value: str, *, project_root: Path) -> Path:
     raw = _validated_model_reference(value)
-    normalized = raw.replace("\\", "/")
     if _URI_SCHEME_RE.match(raw):
         raise ValueError("model paths must not use URI schemes")
+    portable = raw.replace("\\", "/")
+    if any(component in {".", ".."} for component in portable.split("/")):
+        raise ValueError("model path contains lexical path aliases")
     if os.name == "nt":
-        if normalized.startswith("//") or normalized.startswith("/??/"):
+        if portable.startswith("//") or portable.startswith("/??/"):
             raise ValueError("network and device model paths are not allowed")
         if raw.startswith(("/", "\\")):
             raise ValueError("drive-rooted model paths must include a drive letter")
@@ -107,14 +114,9 @@ def _configured_local_model_path(value: str) -> Path:
         drive_absolute = bool(_WINDOWS_DRIVE_ABSOLUTE_RE.match(raw))
         if ":" in raw and (not drive_absolute or ":" in raw[2:]):
             raise ValueError("model path contains an unsupported colon")
-
-    component_separator = r"[\\/]+" if os.name == "nt" else r"/+"
-    for component in re.split(component_separator, raw):
-        if component in {"", "."}:
-            continue
-        if component == "..":
-            raise ValueError("model path traversal is not allowed")
-        if os.name == "nt":
+        for component in re.split(r"[\\/]+", raw):
+            if not component or (drive_absolute and component == raw[:2]):
+                continue
             if component.endswith((" ", ".")):
                 raise ValueError(
                     "model path components must not end with spaces or dots"
@@ -122,24 +124,13 @@ def _configured_local_model_path(value: str) -> Path:
             device_name = component.split(".", 1)[0].rstrip(" .")
             if _WINDOWS_RESERVED_DEVICE_RE.fullmatch(device_name):
                 raise ValueError("Windows device names are not allowed in model paths")
-
-    candidate = Path(raw).expanduser()
-    if candidate.is_absolute():
-        return candidate.resolve(strict=False)
-
-    root = Path.cwd().resolve(strict=False)
-    resolved = (root / candidate).resolve(strict=False)
-    try:
-        within_root = os.path.commonpath([str(root), str(resolved)]) == str(root)
-    except ValueError:
-        within_root = False
-    if not within_root:
-        raise PermissionError("relative model path is outside the project root")
-    return resolved
+    if is_absolute_path_text(raw) or portable.split("/", 1)[0].startswith("~"):
+        return resolve_project_path(raw, root=project_root)
+    return resolve_managed_project_path(raw, root=project_root)
 
 
 def _faster_whisper_repo_id(model_name: str) -> str:
-    model = _validated_model_reference(str(model_name or "small").strip() or "small")
+    model = _validated_model_reference(str(model_name or "small"))
     if model in _ASR_MODEL_REPOS:
         return _ASR_MODEL_REPOS[model]
     if _is_huggingface_repo_id(model):
@@ -154,7 +145,7 @@ def _configured_asr_model(state: BridgeState) -> str:
     config_manager = getattr(state, "config_manager", None)
     config = getattr(config_manager, "config", None)
     system_config = getattr(config, "system_config", None)
-    return str(getattr(system_config, "asr_whisper_model_size", "") or "small").strip() or "small"
+    return str(getattr(system_config, "asr_whisper_model_size", "") or "small")
 
 
 def _resolve_model_asset(state: BridgeState, payload: dict[str, Any]) -> ModelAssetSpec:
@@ -202,14 +193,15 @@ def _resolve_model_asset(state: BridgeState, payload: dict[str, Any]) -> ModelAs
 
     title = f"faster-whisper {variant}"
     local_path: Path | None = None
+    project_root = state_project_root(state)
     if _looks_like_local_model_reference(variant):
-        local_path = _configured_local_model_path(variant)
+        local_path = _configured_local_model_path(variant, project_root=project_root)
     elif variant not in _ASR_MODEL_REPOS:
         # Preserve legacy relative local model configs without letting an HTTP
         # request value reach the filesystem. Explicit aliases always remain
         # Hugging Face models; ambiguous custom values are local only when the
         # validated configured path already exists.
-        configured_path = _configured_local_model_path(variant)
+        configured_path = _configured_local_model_path(variant, project_root=project_root)
         if configured_path.exists():
             local_path = configured_path
     if local_path is not None:
@@ -232,7 +224,11 @@ def _resolve_model_asset(state: BridgeState, payload: dict[str, Any]) -> ModelAs
 
 
 def _model_asset_status(state: BridgeState, payload: dict[str, Any]) -> dict[str, object]:
-    return inspect_model_asset(_resolve_model_asset(state, payload))
+    root = state_project_root(state)
+    return inspect_model_asset(
+        _resolve_model_asset(state, payload),
+        root=root,
+    )
 
 
 def _huggingface_token(state: BridgeState) -> str:
@@ -250,6 +246,7 @@ def _download_model_asset(state: BridgeState, task_id: str, spec: ModelAssetSpec
         spec,
         update_task=update_task,
         token=_huggingface_token(state),
+        root=state_project_root(state),
     )
 
 

--- a/application/plugins/updates.py
+++ b/application/plugins/updates.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
 import ast
-import shutil
+import os
+import stat
 import uuid
 from pathlib import Path
 from typing import Any
 
+from sdk.file_transactions import (
+    copy_directory_without_links,
+    private_sibling_path,
+    read_text_without_links,
+    remove_directory_without_links,
+    replace_directory_transactionally,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from sdk.path_contract import (
+    _metadata_is_link_or_reparse_point,
+    managed_project_storage,
+    path_is_link_or_reparse_point,
+    require_symlink_free_absolute_path,
+)
+from sdk.path_references import portable_path_text, state_project_root
 from application.plugins.catalog import _set_plugin_enabled
 from application.runtime.state import BridgeState
 from application.runtime.tasks import _append_task_log, _update_task
@@ -21,12 +38,28 @@ class PluginPackageDependencyInstallError(RuntimeError):
         self.detail = detail.strip() or self.user_message
 
 
+def _registry_manifest_entry(record: Any | None) -> str:
+    raw = str(getattr(record, "entry", "") or "")
+    if not raw:
+        return ""
+    return portable_path_text(raw, field="plugin registry manifest entry")
+
+
+def _plugins_root(state: BridgeState) -> Path:
+    project_root = state_project_root(state)
+    return managed_project_storage("plugins", root=project_root)
+
+
 def _app_update_info() -> dict[str, Any]:
-    from core.app_update.github_bundle import default_app_github_repo_slug, read_local_version, resolve_project_root
+    from core.app_update.github_bundle import (
+        default_app_github_repo_slug,
+        read_local_version,
+        resolve_project_root as resolve_app_root,
+    )
 
     return {
         "repo": default_app_github_repo_slug(),
-        "version": read_local_version(resolve_project_root()).strip(),
+        "version": read_local_version(resolve_app_root()).strip(),
     }
 
 
@@ -54,7 +87,7 @@ def _run_app_update(state: BridgeState, task_id: str, payload: dict[str, Any]) -
         default_app_github_repo_slug,
         overwrite_merge_app_tree,
         read_local_version,
-        resolve_project_root,
+        resolve_project_root as resolve_app_root,
     )
     from plugin_system.requirements.install import install_plugin_requirements_txt
     from plugin_system.registry.download import format_download_error
@@ -62,10 +95,15 @@ def _run_app_update(state: BridgeState, task_id: str, payload: dict[str, Any]) -
     slug = default_app_github_repo_slug().strip()
     if not slug or slug.count("/") < 1:
         raise ValueError("无法解析主程序 GitHub 仓库。")
-    ref_kind = str(payload.get("refKind") or "latest").strip()
+    ref_kind = portable_path_text(
+        str(payload.get("refKind") or "latest"),
+        field="app update ref kind",
+    )
     if ref_kind not in {"latest", "head", "tag"}:
-        ref_kind = "latest"
-    tag_name = str(payload.get("tagName") or "").strip()
+        raise ValueError(f"unsupported app update ref kind: {ref_kind!r}")
+    tag_name = str(payload.get("tagName") or "")
+    if tag_name:
+        tag_name = portable_path_text(tag_name, field="app update tag")
     if ref_kind == "tag" and not tag_name:
         raise ValueError("请选择一个有效的 tag。")
 
@@ -101,7 +139,13 @@ def _run_app_update(state: BridgeState, task_id: str, payload: dict[str, Any]) -
     def _pip_line(line: str) -> None:
         _append_task_log(state, task_id, line)
 
-    pip_code, detail = install_plugin_requirements_txt(resolve_project_root(), on_output_line=_pip_line)
+    app_root = resolve_app_root()
+    project_root = state_project_root(state)
+    pip_code, detail = install_plugin_requirements_txt(
+        app_root,
+        on_output_line=_pip_line,
+        root=project_root,
+    )
     if detail:
         _append_task_log(state, task_id, detail)
     _update_task(
@@ -112,9 +156,10 @@ def _run_app_update(state: BridgeState, task_id: str, payload: dict[str, Any]) -
         progress=0.92,
     )
     runtime_pip_code, runtime_detail = install_plugin_requirements_txt(
-        resolve_project_root(),
+        app_root,
         requirements_file="requirements-runtime-core.txt",
         on_output_line=_pip_line,
+        root=project_root,
     )
     if runtime_detail:
         _append_task_log(state, task_id, f"requirements-runtime-core.txt: {runtime_detail}")
@@ -127,7 +172,7 @@ def _run_app_update(state: BridgeState, task_id: str, payload: dict[str, Any]) -
         if item
     )
     pip_code = f"requirements.txt:{pip_code};requirements-runtime-core.txt:{runtime_pip_code}"
-    version = read_local_version(resolve_project_root()).strip()
+    version = read_local_version(app_root).strip()
     result = {
         "detail": detail,
         "frontendDistUpdated": bool(merge_result.get("frontendDistUpdated")),
@@ -146,7 +191,9 @@ def _repo_slug_from_source(source: str) -> str:
 
 
 def _is_repo_source(source: str) -> bool:
-    raw = source.strip().lower()
+    if not source or source != source.strip():
+        return False
+    raw = source.lower()
     if ":" in source and not (
         raw.startswith("http://") or raw.startswith("https://") or raw.startswith("git@github.com:")
     ):
@@ -156,7 +203,7 @@ def _is_repo_source(source: str) -> bool:
 
 def _lookup_registry_plugin(source: str) -> Any | None:
     repo_slug = _repo_slug_from_source(source).lower()
-    source_key = source.strip().lower()
+    source_key = source.lower()
     try:
         from plugin_system.registry.catalog import fetch_registry_plugins
         from plugin_system.registry.download import normalize_repo_slug
@@ -176,14 +223,36 @@ def _lookup_registry_plugin(source: str) -> Any | None:
             return rec
         if str(getattr(rec, "display_name", "") or "").strip().lower() == source_key:
             return rec
-        if rec.entry.strip().lower() == source_key:
+        try:
+            entry = _registry_manifest_entry(rec)
+        except ValueError:
+            continue
+        if entry.lower() == source_key:
             return rec
     return None
 
 
-def _plugin_class_from_file(path: Path) -> str:
+def _plugin_class_from_file(
+    path: Path,
+    *,
+    expected_identity: os.stat_result | None = None,
+    expected_parent_identity: os.stat_result | None = None,
+) -> str:
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        tree = ast.parse(
+            read_text_without_links(
+                path,
+                expected_identity=expected_identity,
+                expected_parent_identity=expected_parent_identity,
+            )
+        )
+    except PermissionError:
+        if (
+            expected_identity is not None
+            or expected_parent_identity is not None
+        ):
+            raise
+        return ""
     except (OSError, SyntaxError, UnicodeDecodeError):
         return ""
     for node in tree.body:
@@ -198,27 +267,101 @@ def _plugin_class_from_file(path: Path) -> str:
 
 
 def _infer_plugin_entry(plugin_root: Path) -> str:
+    plugin_root, plugin_root_identity, root_entries = (
+        snapshot_directory_entries_without_links(
+            plugin_root,
+            field="plugin directory",
+        )
+    )
     package = plugin_root.name
-    candidates = [plugin_root / "plugin.py", *sorted(plugin_root.glob("*/plugin.py"))]
-    for path in candidates:
-        if not path.is_file():
+    candidates: list[
+        tuple[Path, os.stat_result, os.stat_result]
+    ] = []
+    for path, metadata in root_entries:
+        if _metadata_is_link_or_reparse_point(metadata):
             continue
-        class_name = _plugin_class_from_file(path)
+        if path.name == "plugin.py" and stat.S_ISREG(metadata.st_mode):
+            candidates.insert(
+                0,
+                (path, metadata, plugin_root_identity),
+            )
+            continue
+        if not stat.S_ISDIR(metadata.st_mode):
+            continue
+        child_root, child_identity, child_entries = (
+            snapshot_directory_entries_without_links(
+                path,
+                field="plugin package directory",
+            )
+        )
+        if not os.path.samestat(metadata, child_identity):
+            raise PermissionError(
+                f"plugin package directory identity changed: {path}"
+            )
+        for child, child_metadata in child_entries:
+            if (
+                child.name == "plugin.py"
+                and not _metadata_is_link_or_reparse_point(child_metadata)
+                and stat.S_ISREG(child_metadata.st_mode)
+            ):
+                candidates.append(
+                    (child, child_metadata, child_identity)
+                )
+        require_directory_identity(
+            child_root,
+            child_identity,
+            field="plugin package directory",
+        )
+
+    candidates.sort(
+        key=lambda item: (
+            len(item[0].relative_to(plugin_root).parts),
+            item[0].relative_to(plugin_root).as_posix(),
+        )
+    )
+    for path, path_identity, parent_identity in candidates:
+        class_name = _plugin_class_from_file(
+            path,
+            expected_identity=path_identity,
+            expected_parent_identity=parent_identity,
+        )
         if not class_name:
             continue
         rel = path.relative_to(plugin_root).with_suffix("")
         module_parts = [package, *rel.parts]
         if all(part.isidentifier() for part in module_parts):
+            require_directory_identity(
+                plugin_root,
+                plugin_root_identity,
+                field="plugin directory",
+            )
             return f"plugins.{'.'.join(module_parts)}:{class_name}"
+    require_directory_identity(
+        plugin_root,
+        plugin_root_identity,
+        field="plugin directory",
+    )
     return ""
 
 
-def _plugin_result_from_manifest(entry: str) -> dict[str, Any]:
+def _plugin_result_from_manifest(
+    entry: str,
+    *,
+    project_root: Path,
+) -> dict[str, Any]:
     from plugin_system.host import append_plugin_manifest_entry_if_missing, normalize_manifest_entry
 
-    append_plugin_manifest_entry_if_missing(entry, enabled=True)
+    append_plugin_manifest_entry_if_missing(
+        entry,
+        enabled=True,
+        root=project_root,
+    )
     norm = normalize_manifest_entry(entry)
-    return _set_plugin_enabled(norm, True)
+    return _set_plugin_enabled(
+        norm,
+        True,
+        project_root=project_root,
+    )
 
 
 def _synthetic_plugin_result(
@@ -280,7 +423,7 @@ def _registry_package_metadata(
     metadata: dict[str, Any] = {
         "dependencyDetail": dependency_detail,
         "dependencyStatus": dependency_status,
-        "entry": str(getattr(record, "entry", "") or "").strip(),
+        "entry": _registry_manifest_entry(record),
         "packageSource": package_source if is_verified_package else "local",
         "packageStatus": package_status,
         "repo": str(getattr(record, "repo", "") or "").strip(),
@@ -359,14 +502,131 @@ def _update_task_package_error(state: BridgeState, task_id: str, details: dict[s
     _update_task(state, task_id, **updates)
 
 
-def _restore_package_target(target: Path, backup: Path | None, *, remove_new_target: bool) -> None:
-    if remove_new_target and target.exists():
-        shutil.rmtree(target, ignore_errors=True)
-    if backup is not None and backup.exists() and not target.exists():
-        backup.rename(target)
+def _restore_package_target(
+    target: Path,
+    backup: Path | None,
+    *,
+    remove_new_target: bool,
+    backup_identity: os.stat_result | None = None,
+    installed_target_identity: os.stat_result | None = None,
+    original_target_identity: os.stat_result | None = None,
+) -> None:
+    if backup is not None and os.path.lexists(backup):
+        backup = _verified_plugin_tree(backup, field="plugin rollback backup")
+        current_backup_identity = backup.lstat()
+        if (
+            backup_identity is not None
+            and not os.path.samestat(backup_identity, current_backup_identity)
+        ):
+            raise PermissionError("plugin rollback backup identity changed")
+
+        if os.path.lexists(target):
+            current_target = _verified_plugin_tree(
+                target,
+                field="failed plugin installation",
+            )
+            current_target_identity = current_target.lstat()
+        else:
+            current_target_identity = None
+        if installed_target_identity is not None:
+            if (
+                current_target_identity is not None
+                and not os.path.samestat(
+                    installed_target_identity,
+                    current_target_identity,
+                )
+            ):
+                raise PermissionError("failed plugin installation identity changed")
+        elif original_target_identity is not None:
+            if current_target_identity is not None and os.path.samestat(
+                original_target_identity,
+                current_target_identity,
+            ):
+                remove_directory_without_links(
+                    backup,
+                    expected_identity=current_backup_identity,
+                )
+                return
+            if current_target_identity is not None:
+                raise PermissionError(
+                    "plugin target changed before rollback ownership was established"
+                )
+
+        replace_directory_transactionally(
+            backup,
+            target,
+            overwrite=True,
+            expected_staging_identity=current_backup_identity,
+            expected_destination_identity=current_target_identity,
+        )
+        return
+    if backup is not None and backup_identity is not None:
+        raise FileNotFoundError(f"plugin rollback backup disappeared: {backup}")
+    if remove_new_target and os.path.lexists(target):
+        target = _verified_plugin_tree(target, field="failed plugin installation")
+        current_target_identity = target.lstat()
+        if installed_target_identity is not None:
+            if not os.path.samestat(
+                installed_target_identity,
+                current_target_identity,
+            ):
+                raise PermissionError("failed plugin installation identity changed")
+        elif original_target_identity is not None:
+            raise PermissionError(
+                "refusing to remove an unowned plugin target after failed installation"
+            )
+        remove_directory_without_links(
+            target,
+            expected_identity=current_target_identity,
+        )
+
+
+def _verified_plugin_tree(path: Path, *, field: str) -> Path:
+    exact = require_symlink_free_absolute_path(path, field=field)
+    if path_is_link_or_reparse_point(exact) or not exact.is_dir():
+        raise NotADirectoryError(exact)
+    return exact
+
+
+def _remove_plugin_backup(
+    backup: Path | None,
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    if backup is None or not os.path.lexists(backup):
+        return
+    backup = _verified_plugin_tree(backup, field="plugin rollback backup")
+    backup_identity = backup.lstat()
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, backup_identity)
+    ):
+        raise PermissionError("plugin rollback backup identity changed")
+    remove_directory_without_links(
+        backup,
+        expected_identity=backup_identity,
+    )
 
 
 def _install_registry_package_source(
+    state: BridgeState,
+    task_id: str,
+    record: Any,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    from plugin_system.install.package import registry_package_install_transaction
+
+    with registry_package_install_transaction():
+        return _install_registry_package_source_transaction(
+            state,
+            task_id,
+            record,
+            overwrite=overwrite,
+        )
+
+
+def _install_registry_package_source_transaction(
     state: BridgeState,
     task_id: str,
     record: Any,
@@ -378,15 +638,35 @@ def _install_registry_package_source(
     from plugin_system.registry.download import mark_repo_downloaded, normalize_repo_slug
 
     repo_slug = normalize_repo_slug(str(getattr(record, "repo", "") or ""))
-    entry = str(getattr(record, "entry", "") or "").strip()
+    entry = _registry_manifest_entry(record)
     display_name = str(getattr(record, "display_name", "") or getattr(record, "name", "") or "").strip()
     description = str(getattr(record, "description", "") or "").strip()
-    target = registry_package_target(record, plugins_parent=Path("plugins"))
+    plugins_parent = _plugins_root(state)
+    project_root = state_project_root(state)
+    target = registry_package_target(
+        record,
+        plugins_parent=plugins_parent,
+        root=project_root,
+    )
     existed_before = target.is_dir()
+    original_target_identity = target.lstat() if existed_before else None
     backup: Path | None = None
+    backup_identity: os.stat_result | None = None
     if overwrite and existed_before:
-        backup = target.with_name(f".{target.name}.backup-{uuid.uuid4().hex}")
-        target.rename(backup)
+        backup = require_symlink_free_absolute_path(
+            private_sibling_path(
+                target,
+                f".backup-{uuid.uuid4().hex}",
+                field="plugin rollback backup",
+            ),
+            field="plugin rollback backup",
+        )
+        copy_directory_without_links(
+            target,
+            backup,
+            expected_source_identity=original_target_identity,
+        )
+        backup_identity = backup.lstat()
 
     _update_task(
         state,
@@ -404,13 +684,17 @@ def _install_registry_package_source(
 
     dependency_status = ""
     dependency_detail = ""
+    installed_target_identity: os.stat_result | None = None
     try:
         package_status = "existing" if existed_before and not overwrite else "verified"
         plugin_root = install_registry_package_under_plugins(
             record,
             overwrite=overwrite,
-            plugins_parent=Path("plugins"),
+            plugins_parent=plugins_parent,
+            expected_target_identity=original_target_identity,
+            root=project_root,
         )
+        installed_target_identity = plugin_root.lstat()
         package_message = (
             "检测到已有插件目录，跳过官方包体校验。"
             if package_status == "existing"
@@ -424,7 +708,11 @@ def _install_registry_package_source(
             progress=0.72,
             packageStatus=package_status,
         )
-        dependency_status, dependency_detail = install_plugin_requirements_txt(plugin_root, on_output_line=_pip_line)
+        dependency_status, dependency_detail = install_plugin_requirements_txt(
+            plugin_root,
+            on_output_line=_pip_line,
+            root=project_root,
+        )
         if dependency_detail:
             _append_task_log(state, task_id, dependency_detail)
         if dependency_status in {"pip_failed", "pip_timeout", "pip_exception", "pip_conflict"}:
@@ -458,15 +746,29 @@ def _install_registry_package_source(
             dependencyInstallStatus=dependency_status,
         )
         if entry:
-            result = _plugin_result_from_manifest(entry)
+            result = _plugin_result_from_manifest(
+                entry,
+                project_root=project_root,
+            )
             if repo_slug:
-                mark_repo_downloaded(repo_slug, manifest_entry=entry, install_metadata=metadata)
+                mark_repo_downloaded(
+                    repo_slug,
+                    manifest_entry=entry,
+                    install_metadata=metadata,
+                    root=project_root,
+                )
             _update_task(state, task_id, message="官方包体安装完成。", phase="completed", progress=1)
-            if backup is not None:
-                shutil.rmtree(backup, ignore_errors=True)
+            _remove_plugin_backup(
+                backup,
+                expected_identity=backup_identity,
+            )
             return _with_install_metadata(result, metadata)
         if repo_slug:
-            mark_repo_downloaded(repo_slug, manifest_entry=None)
+            mark_repo_downloaded(
+                repo_slug,
+                manifest_entry=None,
+                root=project_root,
+            )
         result = _synthetic_plugin_result(
             description=description or f"包体已下载到 {plugin_root.as_posix()}，但没有找到可登记的插件入口。",
             enabled=False,
@@ -474,11 +776,20 @@ def _install_registry_package_source(
             title=display_name or target.name,
         )
         _update_task(state, task_id, message="官方包体已下载，但没有找到可登记的插件入口。", progress=1)
-        if backup is not None:
-            shutil.rmtree(backup, ignore_errors=True)
+        _remove_plugin_backup(
+            backup,
+            expected_identity=backup_identity,
+        )
         return _with_install_metadata(result, metadata)
     except Exception:
-        _restore_package_target(target, backup, remove_new_target=(not existed_before or backup is not None))
+        _restore_package_target(
+            target,
+            backup,
+            remove_new_target=(not existed_before or backup is not None),
+            backup_identity=backup_identity,
+            installed_target_identity=installed_target_identity,
+            original_target_identity=original_target_identity,
+        )
         _update_task(state, task_id, packageStatus="failed")
         raise
 
@@ -492,11 +803,11 @@ def _install_plugin_source(
     tag_name: str = "",
     overwrite: bool = False,
 ) -> dict[str, Any]:
-    source = source.strip()
-    if not source:
-        raise ValueError("plugin id is required")
-    ref_kind = ref_kind if ref_kind in {"latest", "head", "tag"} else "latest"
-    tag_name = tag_name.strip()
+    source = portable_path_text(source, field="plugin source")
+    if ref_kind not in {"latest", "head", "tag"}:
+        raise ValueError(f"unsupported plugin ref kind: {ref_kind!r}")
+    if tag_name:
+        tag_name = portable_path_text(tag_name, field="plugin tag")
     if ref_kind == "tag" and not tag_name:
         raise ValueError("tagName is required when refKind is tag")
 
@@ -571,11 +882,11 @@ def _install_github_plugin_source(
     tag_name: str = "",
     overwrite: bool = False,
 ) -> dict[str, Any]:
-    source = source.strip()
-    if not source:
-        raise ValueError("plugin id is required")
-    ref_kind = ref_kind if ref_kind in {"latest", "head", "tag"} else "latest"
-    tag_name = tag_name.strip()
+    source = portable_path_text(source, field="plugin source")
+    if ref_kind not in {"latest", "head", "tag"}:
+        raise ValueError(f"unsupported plugin ref kind: {ref_kind!r}")
+    if tag_name:
+        tag_name = portable_path_text(tag_name, field="plugin tag")
     if ref_kind == "tag" and not tag_name:
         raise ValueError("tagName is required when refKind is tag")
 
@@ -587,7 +898,10 @@ def _install_github_plugin_source(
             phase="manifest",
             progress=0.45,
         )
-        result = _plugin_result_from_manifest(source)
+        result = _plugin_result_from_manifest(
+            source,
+            project_root=state_project_root(state),
+        )
         _update_task(state, task_id, message="插件清单已更新。", progress=0.9)
         return result
 
@@ -604,7 +918,7 @@ def _install_github_plugin_source(
         progress=0.04,
     )
     registry_rec = _lookup_registry_plugin(repo_slug)
-    entry = str(getattr(registry_rec, "entry", "") or "").strip()
+    entry = _registry_manifest_entry(registry_rec)
     display_name = str(getattr(registry_rec, "name", "") or "").strip()
     description = str(getattr(registry_rec, "description", "") or "").strip()
 
@@ -637,7 +951,8 @@ def _install_github_plugin_source(
             ref_kind=ref_kind,  # type: ignore[arg-type]
             tag_name=tag_name,
             overwrite=overwrite,
-            plugins_parent=Path("plugins"),
+            plugins_parent=_plugins_root(state),
+            root=state_project_root(state),
             progress=_progress,
             on_phase=_phase,
         )
@@ -655,7 +970,12 @@ def _install_github_plugin_source(
     def _pip_line(line: str) -> None:
         _append_task_log(state, task_id, line)
 
-    pip_code, pip_detail = install_plugin_requirements_txt(plugin_root, on_output_line=_pip_line)
+    project_root = state_project_root(state)
+    pip_code, pip_detail = install_plugin_requirements_txt(
+        plugin_root,
+        on_output_line=_pip_line,
+        root=project_root,
+    )
     if pip_code in {"pip_failed", "pip_timeout", "pip_exception", "pip_conflict"}:
         detail = pip_detail or pip_code
         raise RuntimeError(f"插件依赖安装失败：{detail}")
@@ -664,9 +984,16 @@ def _install_github_plugin_source(
         entry = _infer_plugin_entry(plugin_root)
 
     _update_task(state, task_id, message="正在登记插件安装状态。", phase="manifest", progress=0.9)
-    mark_repo_downloaded(repo_slug, manifest_entry=entry or None)
+    mark_repo_downloaded(
+        repo_slug,
+        manifest_entry=entry or None,
+        root=project_root,
+    )
     if entry:
-        return _plugin_result_from_manifest(entry)
+        return _plugin_result_from_manifest(
+            entry,
+            project_root=project_root,
+        )
 
     return _synthetic_plugin_result(
         description=description or f"源码已下载到 {plugin_root.as_posix()}，但未找到 manifest entry。",

--- a/application/runtime/restart_debug.py
+++ b/application/runtime/restart_debug.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from core.file_transactions import open_text_append_without_links
+from core.paths import require_symlink_free_absolute_path, validate_exact_path_text
+
+
+def _portable_absolute_path(value: str | os.PathLike[str]) -> Path | None:
+    raw = os.fspath(value)
+    try:
+        validate_exact_path_text(raw, field="restart log path")
+    except (PermissionError, ValueError):
+        return None
+    try:
+        candidate = Path(raw)
+    except (KeyError, RuntimeError):
+        return None
+    if not candidate.is_absolute():
+        return None
+    try:
+        return require_symlink_free_absolute_path(
+            candidate,
+            field="restart log path",
+        )
+    except (OSError, PermissionError, ValueError):
+        return None
+
+
+def _restart_debug_log_path(
+    raw_path: str | None = None,
+    *,
+    temp_dir: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    """Return an absolute diagnostic path without consulting process cwd."""
+
+    configured = str(
+        os.environ.get("SHINSEKAI_RESTART_LOG", "")
+        if raw_path is None
+        else raw_path
+    )
+    if configured:
+        candidate = _portable_absolute_path(configured)
+        if candidate is not None:
+            return candidate
+    if temp_dir is None:
+        try:
+            # The platform-selected temp directory is trusted but may be
+            # spelled through an OS alias (for example /var on macOS).
+            temporary_source: str | os.PathLike[str] = Path(
+                tempfile.gettempdir()
+            ).resolve(strict=True)
+        except OSError:
+            temporary_source = tempfile.gettempdir()
+    else:
+        temporary_source = temp_dir
+    temporary = _portable_absolute_path(temporary_source)
+    if temporary is not None:
+        return temporary / "shinsekai-restart-debug.log"
+    return None
+
+
+def _sanitize_log_field(value: str) -> str:
+    return str(value).replace("\0", "\\0").replace("\r", "\\r").replace("\n", "\\n")
+
+
+def _append_restart_log(path: Path, line: str) -> None:
+    with open_text_append_without_links(path, buffering=1) as handle:
+        handle.write(line)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def write_restart_debug_log(component: str, message: str) -> None:
+    name = _sanitize_log_field(str(component or "runtime").strip() or "runtime")
+    safe_message = _sanitize_log_field(message)
+    line = f"ts={time.time():.3f} pid={os.getpid()} component={name} {safe_message}\n"
+    print(f"[restart-debug] {line}", end="")
+    path = _restart_debug_log_path()
+    if path is None:
+        return
+    try:
+        _append_restart_log(path, line)
+    except OSError:
+        pass

--- a/application/runtime/state.py
+++ b/application/runtime/state.py
@@ -14,15 +14,36 @@ if TYPE_CHECKING:
 
 
 def _default_project_root_dir() -> str:
-    raw = (
-        os.environ.get("SHINSEKAI_PROJECT_ROOT", "").strip()
-        or os.environ.get("EASYAI_PROJECT_ROOT", "").strip()
-    )
+    # Presence, not a trimmed interpretation, determines precedence.  An
+    # explicitly configured but invalid current root must fail closed instead
+    # of silently reviving a different legacy project.
+    if "SHINSEKAI_PROJECT_ROOT" in os.environ:
+        raw: str | None = os.environ["SHINSEKAI_PROJECT_ROOT"]
+    elif "EASYAI_PROJECT_ROOT" in os.environ:
+        raw = os.environ["EASYAI_PROJECT_ROOT"]
+    else:
+        raw = None
     try:
-        candidate = Path(raw).expanduser() if raw else Path.cwd()
-        return str(candidate.resolve(strict=False))
-    except (OSError, RuntimeError, ValueError):
-        return raw or "."
+        if raw is not None:
+            if raw != raw.strip() or any(
+                ord(character) < 32
+                or ord(character) == 127
+                or 0xD800 <= ord(character) <= 0xDFFF
+                for character in raw
+            ):
+                raise ValueError("configured project root contains non-portable characters")
+            from core.paths import resolve_project_path
+
+            candidate = resolve_project_path(".", root=raw)
+        else:
+            from core.paths import project_root
+
+            candidate = project_root()
+        return str(candidate)
+    except (OSError, RuntimeError, ValueError) as exc:
+        if raw is not None:
+            raise ValueError("configured project root is invalid") from exc
+        raise RuntimeError("stable project root is unavailable") from exc
 
 
 @dataclass
@@ -33,8 +54,8 @@ class BridgeState:
     template_generator: Any
     task_lock: threading.Lock = field(default_factory=threading.Lock)
     tasks: dict[str, dict[str, Any]] = field(default_factory=dict)
-    template_dir_path: str = "./data/character_templates"
-    history_dir: str = "./data/chat_history"
+    template_dir_path: str = "data/character_templates"
+    history_dir: str = "data/chat_history"
     frontend_dist_dir: str = ""
     app_root_dir: str = ""
     auth_token: str = ""
@@ -47,6 +68,7 @@ class BridgeState:
     history_download_capabilities: dict[str, tuple[str, float]] = field(default_factory=dict)
     chat_init_lock: threading.Lock = field(default_factory=threading.Lock)
     chat_init_task_id: str = ""
+    chat_transition_lock: threading.RLock = field(default_factory=threading.RLock)
     plugin_load_lock: threading.Lock = field(default_factory=threading.Lock)
     plugin_load_status: str = "idle"
     plugin_load_error: str = ""

--- a/application/runtime/workflow.py
+++ b/application/runtime/workflow.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from queue import Queue
-from pathlib import Path
 from typing import Any
 
-from core.paths import resource_path
+from core.paths import (
+    project_root,
+    require_regular_file_without_links,
+    resolve_runtime_asset_read_path,
+)
 from sdk.graph import Dag
 
 DEFAULT_WORKFLOW_PATH = "assets/system/workflow/default.yaml"
@@ -63,9 +66,9 @@ def build_runtime_workflow(
     """Build the host runtime DAG and resolve its named exports."""
 
     dag = Dag(queue_factory=queue_factory)
-    selected_workflow = (workflow_path or "").strip()
-
-    selected_workflow = selected_workflow or DEFAULT_WORKFLOW_PATH
+    selected_workflow = (
+        DEFAULT_WORKFLOW_PATH if workflow_path in {None, ""} else workflow_path
+    )
     selected_workflow = _resolve_workflow_path(selected_workflow)
     dag.load_yaml(selected_workflow)
 
@@ -79,12 +82,16 @@ def build_runtime_workflow(
 
 
 def _resolve_workflow_path(workflow_path: str) -> str:
-    if "\n" in workflow_path or "\r" in workflow_path:
-        return workflow_path
-    path = Path(workflow_path).expanduser()
-    if path.is_absolute() or path.is_file():
-        return str(path)
-    return str(resource_path(path))
+    resolved = resolve_runtime_asset_read_path(
+        workflow_path,
+        root=project_root(),
+    )
+    return str(
+        require_regular_file_without_links(
+            resolved,
+            field="workflow file",
+        ),
+    )
 
 
 def get_chat_workflow_handles(workflow: RuntimeWorkflow) -> ChatWorkflowHandles:


### PR DESCRIPTION
## What changed

Applies strict path and storage handling to chat orchestration, media, memory,
model assets, plugins, and runtime state under `application/`.

## Why

Application services are the boundary between UI requests and lower-level
storage or process APIs, so they must pass a single validated path identity
through the full operation.

## Impact

Chat history, templates, media, runtime restarts, and plugin updates now use
consistent roots and safer file references.

## Root cause

Validation, rendered state, and the eventual filesystem operation could be
derived from different path spellings or roots.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `application/`.
