### PR TITLE
fix(config): enforce migration-safe path contracts

### DIFF
--- a/config/api_path_validation.py
+++ b/config/api_path_validation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from sdk.path_contract import resolve_runtime_asset_read_path
+
+
+DEFAULT_T2I_PROVIDER = "comfyui"
+DEFAULT_T2I_API_URL = "http://127.0.0.1:8188"
+T2I_WORKFLOW_RESOURCE_PREFIXES = (
+    ("assets", "system", "workflow"),
+    ("assets", "workflows"),
+)
+
+
+def validate_t2i_paths_for_save(config: Any, *, project_root: Path) -> None:
+    """Validate the persisted T2I paths against the runtime's exact read contract.
+
+    The default empty ComfyUI configuration means that image generation is
+    intentionally skipped.  Once any ComfyUI setting opts into the feature, the
+    workflow must be a readable regular file.  The work directory remains
+    optional because an already-running local or remote ComfyUI server does not
+    need to be launched by Shinsekai.
+    """
+
+    provider = str(getattr(config, "t2i_provider", DEFAULT_T2I_PROVIDER) or "").strip()
+    provider_key = provider.lower() or DEFAULT_T2I_PROVIDER
+    if provider_key != DEFAULT_T2I_PROVIDER:
+        return
+
+    api_url = str(getattr(config, "t2i_api_url", DEFAULT_T2I_API_URL) or "").strip()
+    workflow_path = str(getattr(config, "t2i_default_workflow_path", "") or "")
+    work_path = str(getattr(config, "t2i_work_path", "") or "")
+    is_skipped_default = (
+        not workflow_path
+        and not work_path
+        and api_url.lower() in {"", DEFAULT_T2I_API_URL}
+    )
+    if is_skipped_default:
+        return
+
+    if not workflow_path:
+        raise ValueError("启用 ComfyUI 时需要填写默认工作流文件。")
+    workflow = resolve_runtime_asset_read_path(
+        workflow_path,
+        root=project_root,
+        resource_prefixes=T2I_WORKFLOW_RESOURCE_PREFIXES,
+    )
+    if not workflow.is_file():
+        raise ValueError("ComfyUI 默认工作流必须是已存在的文件。")
+
+    if work_path:
+        work_directory = resolve_runtime_asset_read_path(
+            work_path,
+            root=project_root,
+            resource_prefixes=(),
+        )
+        if not work_directory.is_dir():
+            raise ValueError("ComfyUI 工作目录必须是已存在的目录。")

--- a/config/background_manager.py
+++ b/config/background_manager.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
 import os
-import shutil
+from copy import deepcopy
+from functools import wraps
 from pathlib import Path
+from threading import RLock
 from typing import TYPE_CHECKING, List, Dict, Any, Tuple, Optional, Union
 from config.schema import Background, Sprite # 确保导入了 Background 和 Sprite
 from config.config_manager import ConfigManager
 import tools.file_util as fu
 import yaml
+from sdk.file_transactions import (
+    copy_file_exclusive_with_identity,
+    portable_name_key,
+    remove_directory_without_links,
+    remove_empty_directory_without_links,
+    remove_file_without_links,
+)
+from sdk.path_contract import (
+    managed_project_directory,
+    managed_project_file,
+    portable_project_path,
+    project_root,
+    resolve_runtime_asset_path,
+    resolve_runtime_asset_read_path,
+    safe_path_component,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -15,15 +33,179 @@ if TYPE_CHECKING:
 # 不在此模块顶层 import UI 框架；配置模型必须可由 bridge 与 CLI 轻量加载。
 # PyInstaller 需为各子包补数据文件。旧 Gradio WebUI 仍通过本类；仅 handle_bgm_selection 在 Gradio 下使用。
 
-BACKGROUND_CONFIG_PATH = ConfigManager._BACKGOUND_CONFIG_PATH # 更正为背景配置路径
 BACKGROUND_UPLOAD_DIR = "data/backgrounds"
 BGM_UPLOAD_DIR = "data/bgm"
+
+_BACKGROUND_IO_LOCK = RLock()
+
+
+def _serialized_mutation(function):
+    @wraps(function)
+    def wrapped(*args, **kwargs):
+        with _BACKGROUND_IO_LOCK:
+            return function(*args, **kwargs)
+
+    return wrapped
+
+
+def _restore_model(target: Any, snapshot: Any) -> None:
+    for field_name in type(target).model_fields:
+        setattr(target, field_name, deepcopy(getattr(snapshot, field_name)))
+
+
+def _unlink_created_files(
+    paths: List[tuple[Path, os.stat_result]],
+) -> None:
+    for path, identity in reversed(paths):
+        try:
+            remove_file_without_links(
+                path,
+                missing_ok=True,
+                expected_identity=identity,
+            )
+        except (OSError, ValueError):
+            pass
 
 
 def _pd():
     import pandas as pd
 
     return pd
+
+
+def _managed_directory_snapshot(
+    root: Path,
+    base_dir: str,
+    component: str,
+) -> tuple[Path, os.stat_result] | None:
+    try:
+        target = managed_project_directory(base_dir, component, root=root)
+    except (OSError, PermissionError, ValueError):
+        return None
+    try:
+        identity = target.lstat()
+    except FileNotFoundError:
+        return None
+    return (target, identity) if target.is_dir() else None
+
+
+def _remove_managed_directory(
+    root: Path,
+    base_dir: str,
+    component: str,
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    snapshot = _managed_directory_snapshot(root, base_dir, component)
+    if snapshot is None:
+        return
+    target, current_identity = snapshot
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, current_identity)
+    ):
+        return
+    try:
+        remove_directory_without_links(
+            target,
+            expected_identity=current_identity,
+        )
+    except OSError:
+        pass
+
+
+def _managed_file_snapshot(
+    root: Path,
+    base_dir: str,
+    raw_path: str,
+) -> tuple[Path, os.stat_result] | None:
+    try:
+        target = managed_project_file(raw_path, base_dir, root=root)
+    except (OSError, PermissionError, ValueError):
+        return None
+    if target is None:
+        return None
+    try:
+        identity = target.lstat()
+    except FileNotFoundError:
+        return None
+    return (target, identity) if target.is_file() else None
+
+
+def _unlink_managed_file(
+    root: Path,
+    base_dir: str,
+    raw_path: str,
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    snapshot = _managed_file_snapshot(root, base_dir, raw_path)
+    if snapshot is None:
+        return
+    target, current_identity = snapshot
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, current_identity)
+    ):
+        return
+    try:
+        remove_file_without_links(
+            target,
+            expected_identity=current_identity,
+        )
+    except (OSError, ValueError):
+        pass
+
+
+def _prefix_in_use(backgrounds: List[Background], prefix: str) -> bool:
+    key = _prefix_key(prefix)
+    return bool(key) and any(
+        _prefix_key(background.sprite_prefix) == key
+        for background in backgrounds
+    )
+
+
+def _prefix_key(value: Any) -> str:
+    raw = str(value or "")
+    try:
+        return portable_name_key(safe_path_component(raw, field="sprite_prefix"))
+    except ValueError:
+        return ""
+
+
+def _managed_background_path_in_use(
+    manager: "BackgroundManager",
+    raw_path: str,
+    *,
+    kind: str,
+    base_dir: str,
+) -> bool:
+    try:
+        target = managed_project_file(raw_path, base_dir, root=manager._project_root)
+    except (OSError, PermissionError, ValueError):
+        return False
+    if target is None:
+        return False
+    for background in manager._config_manager.config.background_list:
+        if kind == "sprite":
+            values = [
+                sprite.path if isinstance(sprite, Sprite) else sprite.get("path", "")
+                for sprite in (background.sprites or [])
+            ]
+        else:
+            values = list(background.bgm_list or [])
+        for candidate_raw in values:
+            try:
+                candidate = managed_project_file(
+                    str(candidate_raw or ""),
+                    base_dir,
+                    root=manager._project_root,
+                )
+            except (OSError, PermissionError, ValueError):
+                continue
+            if candidate == target:
+                return True
+    return False
 
 
 class BackgroundManager:
@@ -39,6 +221,7 @@ class BackgroundManager:
     def __init__(self):
         """初始化 BackgroundManager，获取 ConfigManager 单例。"""
         self._config_manager = ConfigManager()
+        self._project_root = project_root()
 
     def _get_background_list(self) -> List[Background]:
         """获取当前的 Background 列表"""
@@ -56,6 +239,7 @@ class BackgroundManager:
         """保存背景配置的便捷方法"""
         self._config_manager.save_background_config()
 
+    @_serialized_mutation
     def add_background(
         self,
         name: str,
@@ -78,19 +262,49 @@ class BackgroundManager:
             return "名称不能为空！", current_names
 
         background_list = self._config_manager.config.background_list
-        if edit_as_name and str(edit_as_name).strip():
-            target = self._config_manager.get_background_by_name(str(edit_as_name).strip())
+        try:
+            sprite_prefix = safe_path_component(
+                str(sprite_prefix or ""),
+                field="sprite_prefix",
+            )
+        except ValueError:
+            return "背景目录名无效！", current_names
+
+        prefix_key = portable_name_key(sprite_prefix)
+        edit_target_name = str(edit_as_name or "").strip()
+        for background in background_list:
+            if _prefix_key(background.sprite_prefix) != prefix_key:
+                continue
+            if edit_target_name and background.name.casefold() == edit_target_name.casefold():
+                continue
+            return (
+                f"背景目录名「{sprite_prefix}」已被背景组「{background.name}」占用！",
+                current_names,
+            )
+
+        if edit_target_name:
+            target = self._config_manager.get_background_by_name(edit_target_name)
             if target is not None:
+                if str(target.sprite_prefix or "") != sprite_prefix:
+                    return (
+                        "背景资源目录创建后不可直接修改；请新建背景组后迁移资源。",
+                        [b.name for b in background_list],
+                    )
                 taken = self._config_manager.get_background_by_name(name)
                 if taken is not None and taken is not target:
                     return f"名称「{name}」已与其他背景组重复！", [b.name for b in background_list]
-                target.name = name
-                target.sprite_prefix = sprite_prefix
-                if bg_tags is not None:
-                    target.bg_tags = bg_tags
-                if bgm_tags is not None:
-                    target.bgm_tags = bgm_tags
-                self._save_background_config()
+                snapshot = target.model_copy(deep=True)
+                try:
+                    target.name = name
+                    target.sprite_prefix = sprite_prefix
+                    if bg_tags is not None:
+                        target.bg_tags = bg_tags
+                    if bgm_tags is not None:
+                        target.bgm_tags = bgm_tags
+                    self._save_background_config()
+                except BaseException:
+                    _restore_model(target, snapshot)
+                    raise
                 return "背景组已更新！", [b.name for b in background_list]
 
         existing_background: Optional[Background] = self._config_manager.get_background_by_name(name)
@@ -106,21 +320,41 @@ class BackgroundManager:
                 bgm_tags=bgm_tags or "",
             )    
             background_list.append(new_background)
-            self._save_background_config()
+            try:
+                self._save_background_config()
+            except BaseException:
+                if background_list and background_list[-1] is new_background:
+                    background_list.pop()
+                else:
+                    try:
+                        background_list.remove(new_background)
+                    except ValueError:
+                        pass
+                raise
             return "背景组已添加！", [b.name for b in background_list] # 修正返回消息
         else:
             # 更新现有 Background 实例的属性
-            existing_background.name = name
-            existing_background.sprite_prefix = sprite_prefix
-            if bg_tags is not None:
-                existing_background.bg_tags = bg_tags
-            if bgm_tags is not None:
-                existing_background.bgm_tags = bgm_tags
-
-            self._save_background_config()
+            if str(existing_background.sprite_prefix or "") != sprite_prefix:
+                return (
+                    "背景资源目录创建后不可直接修改；请新建背景组后迁移资源。",
+                    [b.name for b in background_list],
+                )
+            snapshot = existing_background.model_copy(deep=True)
+            try:
+                existing_background.name = name
+                existing_background.sprite_prefix = sprite_prefix
+                if bg_tags is not None:
+                    existing_background.bg_tags = bg_tags
+                if bgm_tags is not None:
+                    existing_background.bgm_tags = bgm_tags
+                self._save_background_config()
+            except BaseException:
+                _restore_model(existing_background, snapshot)
+                raise
             return "背景组已更新！", [b.name for b in background_list] # 修正返回消息
 
 
+    @_serialized_mutation
     def delete_background(self, name: str) -> Tuple[str, List[str]]:
         """
         删除背景组及其相关文件。
@@ -138,31 +372,46 @@ class BackgroundManager:
         
         if background_to_delete is None:
             return f"找不到背景组: {name}", current_names
-        
-        # 移除背景组
+
+        sprite_prefix = background_to_delete.sprite_prefix
+        directory_snapshots = {
+            base_dir: _managed_directory_snapshot(
+                self._project_root,
+                base_dir,
+                sprite_prefix,
+            )
+            for base_dir in (BACKGROUND_UPLOAD_DIR, BGM_UPLOAD_DIR)
+        } if sprite_prefix else {}
+
+        original_index = background_list.index(background_to_delete)
         try:
             background_list.remove(background_to_delete)
         except ValueError:
             return f"找不到背景组: {name}", current_names
-            
-        self._save_background_config() # 修正保存方法
+        try:
+            self._save_background_config()
+        except BaseException:
+            background_list.insert(original_index, background_to_delete)
+            raise
         new_names = [b.name for b in background_list]
 
-        sprite_prefix = background_to_delete.sprite_prefix
         if not sprite_prefix:
             return "已删除背景组", new_names
         
-        # 删除相关目录 (只删除背景图片目录)
-        char_dir = os.path.join(BACKGROUND_UPLOAD_DIR, sprite_prefix) # 修正为背景目录
-        if sprite_prefix and os.path.exists(char_dir):
-            shutil.rmtree(char_dir)
-
-        bgm_dir = os.path.join(BGM_UPLOAD_DIR, sprite_prefix) # 删除相关 BGM 目录
-        if sprite_prefix and os.path.exists(bgm_dir):
-            shutil.rmtree(bgm_dir)
+        if not _prefix_in_use(background_list, sprite_prefix):
+            for base_dir in (BACKGROUND_UPLOAD_DIR, BGM_UPLOAD_DIR):
+                directory_snapshot = directory_snapshots.get(base_dir)
+                if directory_snapshot is not None:
+                    _remove_managed_directory(
+                        self._project_root,
+                        base_dir,
+                        sprite_prefix,
+                        expected_identity=directory_snapshot[1],
+                    )
         
         return f"背景组 {name} 已删除！", new_names
 
+    @_serialized_mutation
     def upload_sprites(self, background_name: str, sprite_files: List[Any], bg_tags: str) -> Tuple[str, List[str], str]: # 修正参数名
         """
         上传背景图片文件并更新背景的图片列表和标签。
@@ -181,36 +430,71 @@ class BackgroundManager:
             return f"找不到背景组: {background_name}", [], '' # 修正提示
         
         # 修正目录，使用 Background 的 prefix 和 BACKGROUND_UPLOAD_DIR
-        bg_dir = os.path.join(BACKGROUND_UPLOAD_DIR, background.sprite_prefix) 
-        Path(bg_dir).mkdir(parents=True, exist_ok=True)
-        
-        if background.sprites is None:
-            background.sprites = []
+        try:
+            bg_dir = managed_project_directory(
+                BACKGROUND_UPLOAD_DIR,
+                background.sprite_prefix,
+                root=self._project_root,
+            )
+        except (PermissionError, ValueError):
+            return "背景目录名无效！", [], bg_tags
+        directory_was_missing = not bg_dir.exists()
+        created_directory_identity: os.stat_result | None = None
+        snapshot = background.model_copy(deep=True)
+        created_files: List[tuple[Path, os.stat_result]] = []
+        try:
+            if background.sprites is None:
+                background.sprites = []
 
-        num_existing_sprites = len(background.sprites)
-        bg_tags_to_add = '' # 修正变量名
-        
-        for i, file in enumerate(sprite_files):
-            filename = os.path.basename(file.name)
-            dest_path = os.path.join(bg_dir, filename)
-            shutil.copyfile(file.name, dest_path)
-            
-            new_sprite_data = {"path": dest_path}
-            # Background 模型中的 Sprite 没有 voice_path/voice_text, 保持简单
-            background.sprites.append(new_sprite_data)
-            
-            # 为新上传的图片添加标签占位符
-            bg_tags_to_add += f'场景 {num_existing_sprites + i + 1}：\n'
-            
-        current_bg_tags = background.bg_tags if background.bg_tags else "" # 修正变量名
-        background.bg_tags = current_bg_tags + bg_tags_to_add # 修正变量名
+            num_existing_sprites = len(background.sprites)
+            bg_tags_to_add = ''
 
-        self._config_manager.save_background_config() # 修正保存方法
+            for i, file in enumerate(sprite_files):
+                source = resolve_runtime_asset_read_path(
+                    file.name,
+                    root=self._project_root,
+                )
+                filename = safe_path_component(
+                    source.name,
+                    field="background filename",
+                )
+                dest_path, dest_identity = copy_file_exclusive_with_identity(
+                    source,
+                    bg_dir,
+                    filename,
+                    field="background filename",
+                )
+                created_files.append((dest_path, dest_identity))
+                if (
+                    directory_was_missing
+                    and created_directory_identity is None
+                ):
+                    created_directory_identity = bg_dir.lstat()
+                stored_path = portable_project_path(dest_path, root=self._project_root)
+                background.sprites.append({"path": stored_path})
+                bg_tags_to_add += f'场景 {num_existing_sprites + i + 1}：\n'
+
+            current_bg_tags = background.bg_tags if background.bg_tags else ""
+            background.bg_tags = current_bg_tags + bg_tags_to_add
+            self._config_manager.save_background_config()
+        except BaseException:
+            _restore_model(background, snapshot)
+            _unlink_created_files(created_files)
+            if directory_was_missing and created_directory_identity is not None:
+                try:
+                    remove_empty_directory_without_links(
+                        bg_dir,
+                        expected_identity=created_directory_identity,
+                    )
+                except (OSError, ValueError):
+                    pass
+            raise
 
         all_sprite_paths = [s.path if isinstance(s, Sprite) else s.get('path', '') for s in background.sprites]
         return f"成功为 {background_name} 上传 {len(sprite_files)} 张背景图片！", all_sprite_paths, background.bg_tags # 修正消息
 
 
+    @_serialized_mutation
     def delete_all_sprites(self, background_name: str) -> Tuple[str, List[str], str]: # 修正参数名
         """
         删除背景组的所有背景图片。
@@ -224,21 +508,41 @@ class BackgroundManager:
         background: Optional[Background] = self._config_manager.get_background_by_name(background_name) # 修正方法
         if not background:
             return f"找不到背景组: {background_name}", [], "" # 修正提示
-        
-        # 删除背景图片目录
-        bg_dir = os.path.join(BACKGROUND_UPLOAD_DIR, background.sprite_prefix) # 修正目录
-        if os.path.exists(bg_dir):
-            shutil.rmtree(bg_dir)
-        
-        # 清空背景属性
-        background.sprites = []
-        background.bg_tags = "" # 修正属性
-        
-        self._config_manager.save_background_config() # 修正保存方法
+
+        directory_snapshot = _managed_directory_snapshot(
+            self._project_root,
+            BACKGROUND_UPLOAD_DIR,
+            background.sprite_prefix,
+        )
+        snapshot = background.model_copy(deep=True)
+        try:
+            background.sprites = []
+            background.bg_tags = ""
+            self._config_manager.save_background_config()
+        except BaseException:
+            _restore_model(background, snapshot)
+            raise
+
+        others = [
+            item
+            for item in self._config_manager.config.background_list
+            if item is not background
+        ]
+        if (
+            directory_snapshot is not None
+            and not _prefix_in_use(others, background.sprite_prefix)
+        ):
+            _remove_managed_directory(
+                self._project_root,
+                BACKGROUND_UPLOAD_DIR,
+                background.sprite_prefix,
+                expected_identity=directory_snapshot[1],
+            )
         
         return f"已删除 {background_name} 的所有背景图片！", [], "" # 修正消息
 
 
+    @_serialized_mutation
     def delete_single_sprite(self, background_name: str, sprite_index: int) -> Tuple[str, List[str], str]: # 修正参数名
         """
         删除背景组的指定背景图片。
@@ -262,13 +566,14 @@ class BackgroundManager:
         
         # 获取路径
         sprite_path = sprite_data.path if isinstance(sprite_data, Sprite) else sprite_data.get("path", "")
+        sprite_snapshot = _managed_file_snapshot(
+            self._project_root,
+            BACKGROUND_UPLOAD_DIR,
+            str(sprite_path),
+        ) if sprite_path else None
         # 背景图片没有语音文件，移除 voice_path 相关代码
         
-        # 删除文件
-        if sprite_path and os.path.exists(sprite_path) and os.path.isfile(sprite_path):
-            os.remove(sprite_path)
-        
-        # 从列表中移除
+        snapshot = background.model_copy(deep=True)
         background.sprites.pop(sprite_index)
         
         # 更新标签
@@ -284,14 +589,31 @@ class BackgroundManager:
             current_tag = parts[-1].strip() if len(parts) > 1 else ""
             bg_tags += f'场景 {i+1}：{current_tag}\n' # 修正标签前缀
             
-        background.bg_tags = bg_tags # 修正属性
-        
-        self._config_manager.save_background_config() # 修正保存方法
+        background.bg_tags = bg_tags
+        try:
+            self._config_manager.save_background_config()
+        except BaseException:
+            _restore_model(background, snapshot)
+            raise
+
+        if sprite_snapshot is not None and not _managed_background_path_in_use(
+            self,
+            str(sprite_path),
+            kind="sprite",
+            base_dir=BACKGROUND_UPLOAD_DIR,
+        ):
+            _unlink_managed_file(
+                self._project_root,
+                BACKGROUND_UPLOAD_DIR,
+                str(sprite_path),
+                expected_identity=sprite_snapshot[1],
+            )
         
         remaining_sprite_paths = [s.path if isinstance(s, Sprite) else s.get('path', '') for s in background.sprites]
         return f"已删除 {background_name} 的第 {sprite_index+1} 张背景图片！", remaining_sprite_paths, bg_tags # 修正消息
 
 
+    @_serialized_mutation
     def upload_bg_tags(self, background_name: str, bg_tags: str) -> str: # 修正函数名和参数名
         """
         上传/更新背景的标签文本。
@@ -309,11 +631,13 @@ class BackgroundManager:
         if not background:
             return f"找不到背景组: {background_name}" # 修正提示
         
+        snapshot = background.model_copy(deep=True)
         try:
             background.bg_tags = bg_tags # 修正属性
             self._config_manager.save_background_config() # 修正保存方法
             return "标注成功！"
         except Exception as e:
+            _restore_model(background, snapshot)
             return f"标注出错了：{e}"
 
     def get_background_sprites(self, background_name: str) -> Tuple[List[str], str, List[Any]]: # 修正函数名和参数名
@@ -361,7 +685,13 @@ class BackgroundManager:
             return f"加载失败: {str(e)}", bg_info_list
         
     # ------------------------- BGM 管理 --------------------------
-    def upload_bgms(self, background_name: str, bgm_files: List[Any]):
+    @_serialized_mutation
+    def upload_bgms(
+        self,
+        background_name: str,
+        bgm_files: List[Any],
+        bgm_tags: Optional[str] = None,
+    ):
         """
         上传背景音乐文件并更新背景的音乐列表和标签。
 
@@ -379,37 +709,77 @@ class BackgroundManager:
             return f"找不到背景组: {background_name}", _pd().DataFrame(), ''
         
         # 修正目录，使用 Background 的 prefix 和 BGM_UPLOAD_DIR
-        bgm_dir = os.path.join(BGM_UPLOAD_DIR, background.sprite_prefix) # 使用 sprite_prefix 作为子目录名
-        Path(bgm_dir).mkdir(parents=True, exist_ok=True)
-        
-        # 确保 bgm_list 存在
-        if not hasattr(background, 'bgm_list') or background.bgm_list is None:
-            background.bgm_list = []
+        try:
+            bgm_dir = managed_project_directory(
+                BGM_UPLOAD_DIR,
+                background.sprite_prefix,
+                root=self._project_root,
+            )
+        except (PermissionError, ValueError):
+            return "背景音乐目录名无效！", _pd().DataFrame(), ""
+        directory_was_missing = not bgm_dir.exists()
+        created_directory_identity: os.stat_result | None = None
+        snapshot = background.model_copy(deep=True)
+        created_files: List[tuple[Path, os.stat_result]] = []
+        try:
+            if not hasattr(background, 'bgm_list') or background.bgm_list is None:
+                background.bgm_list = []
 
-        num_existing_bgms = len(background.bgm_list)
-        bgm_tags_to_add = ''
-        
-        for i, file in enumerate(bgm_files):
-            filename = os.path.basename(file.name)
-            dest_path = os.path.join(bgm_dir, filename)
-            shutil.copyfile(file.name, dest_path)
-            
-            # 假设 bgm_list 存储的是路径字符串
-            background.bgm_list.append(dest_path) 
-            
-            # 为新上传的音乐添加标签占位符
-            bgm_tags_to_add += f'音乐 {num_existing_bgms + i + 1}：\n'
-            
-        current_bgm_tags = background.bgm_tags if hasattr(background, 'bgm_tags') and background.bgm_tags else ""
-        background.bgm_tags = current_bgm_tags + bgm_tags_to_add
+            num_existing_bgms = len(background.bgm_list)
+            bgm_tags_to_add = ''
 
-        self._config_manager.save_background_config()
+            for i, file in enumerate(bgm_files):
+                source = resolve_runtime_asset_read_path(
+                    file.name,
+                    root=self._project_root,
+                )
+                filename = safe_path_component(
+                    source.name,
+                    field="BGM filename",
+                )
+                dest_path, dest_identity = copy_file_exclusive_with_identity(
+                    source,
+                    bgm_dir,
+                    filename,
+                    field="BGM filename",
+                )
+                created_files.append((dest_path, dest_identity))
+                if (
+                    directory_was_missing
+                    and created_directory_identity is None
+                ):
+                    created_directory_identity = bgm_dir.lstat()
+                background.bgm_list.append(
+                    portable_project_path(dest_path, root=self._project_root)
+                )
+                bgm_tags_to_add += f'音乐 {num_existing_bgms + i + 1}：\n'
+
+            current_bgm_tags = (
+                str(bgm_tags)
+                if bgm_tags is not None
+                else str(background.bgm_tags or "")
+            )
+            background.bgm_tags = current_bgm_tags + bgm_tags_to_add
+            self._config_manager.save_background_config()
+        except BaseException:
+            _restore_model(background, snapshot)
+            _unlink_created_files(created_files)
+            if directory_was_missing and created_directory_identity is not None:
+                try:
+                    remove_empty_directory_without_links(
+                        bgm_dir,
+                        expected_identity=created_directory_identity,
+                    )
+                except (OSError, ValueError):
+                    pass
+            raise
 
         df, tags = self.load_bgms_and_tags(background_name)
 
         return f"成功为 {background_name} 上传 {len(bgm_files)} 个背景音乐文件！", df, tags
 
 
+    @_serialized_mutation
     def delete_all_bgms(self, background_name: str) -> Tuple[str, List[str], str]:
         """
         删除背景组的所有背景音乐文件。
@@ -423,23 +793,43 @@ class BackgroundManager:
         background: Optional[Background] = self._config_manager.get_background_by_name(background_name)
         if not background:
             return f"找不到背景组: {background_name}", [], ""
-        
-        # 删除背景音乐目录
-        bgm_dir = os.path.join(BGM_UPLOAD_DIR, background.sprite_prefix)
-        if os.path.exists(bgm_dir):
-            shutil.rmtree(bgm_dir)
-        
-        # 清空背景属性
-        if hasattr(background, 'bgm_list'):
-            background.bgm_list = []
-        if hasattr(background, 'bgm_tags'):
-            background.bgm_tags = ""
-        
-        self._config_manager.save_background_config()
+
+        directory_snapshot = _managed_directory_snapshot(
+            self._project_root,
+            BGM_UPLOAD_DIR,
+            background.sprite_prefix,
+        )
+        snapshot = background.model_copy(deep=True)
+        try:
+            if hasattr(background, 'bgm_list'):
+                background.bgm_list = []
+            if hasattr(background, 'bgm_tags'):
+                background.bgm_tags = ""
+            self._config_manager.save_background_config()
+        except BaseException:
+            _restore_model(background, snapshot)
+            raise
+
+        others = [
+            item
+            for item in self._config_manager.config.background_list
+            if item is not background
+        ]
+        if (
+            directory_snapshot is not None
+            and not _prefix_in_use(others, background.sprite_prefix)
+        ):
+            _remove_managed_directory(
+                self._project_root,
+                BGM_UPLOAD_DIR,
+                background.sprite_prefix,
+                expected_identity=directory_snapshot[1],
+            )
         
         return f"已删除 {background_name} 的所有背景音乐！", [], ""
 
 
+    @_serialized_mutation
     def upload_bgm_tags(self, background_name: str, bgm_tags: str) -> str:
         """
         上传/更新背景的音乐标签文本。
@@ -457,11 +847,13 @@ class BackgroundManager:
         if not background:
             return f"找不到背景组: {background_name}"
         
+        snapshot = background.model_copy(deep=True)
         try:
             background.bgm_tags = bgm_tags
             self._config_manager.save_background_config()
             return "背景音乐标注成功！"
         except Exception as e:
+            _restore_model(background, snapshot)
             return f"背景音乐标注出错了：{e}"
 
 
@@ -524,6 +916,7 @@ class BackgroundManager:
         
         return bgm_dataframe, bgm_tags
     
+    @_serialized_mutation
     def delete_single_bgm(self, background_name: str, bgm_index: int) -> Tuple[str, List[str], str]:
         """
         删除背景组的指定背景音乐文件。
@@ -546,12 +939,13 @@ class BackgroundManager:
             return "背景音乐不存在！", bgm_list, bgm_tags
         
         bgm_path: str = bgm_list[bgm_index]
+        bgm_snapshot = _managed_file_snapshot(
+            self._project_root,
+            BGM_UPLOAD_DIR,
+            str(bgm_path),
+        ) if bgm_path else None
         
-        # 删除文件
-        if bgm_path and os.path.exists(bgm_path) and os.path.isfile(bgm_path):
-            os.remove(bgm_path)
-        
-        # 从列表中移除
+        snapshot = background.model_copy(deep=True)
         bgm_list.pop(bgm_index)
         
         # 更新标签
@@ -568,8 +962,24 @@ class BackgroundManager:
             new_bgm_tags += f'音乐 {i+1}：{current_tag}\n'
         
         background.bgm_tags = new_bgm_tags
-        
-        self._config_manager.save_background_config()
+        try:
+            self._config_manager.save_background_config()
+        except BaseException:
+            _restore_model(background, snapshot)
+            raise
+
+        if bgm_snapshot is not None and not _managed_background_path_in_use(
+            self,
+            str(bgm_path),
+            kind="bgm",
+            base_dir=BGM_UPLOAD_DIR,
+        ):
+            _unlink_managed_file(
+                self._project_root,
+                BGM_UPLOAD_DIR,
+                str(bgm_path),
+                expected_identity=bgm_snapshot[1],
+            )
         
         return f"已删除 {background_name} 的第 {bgm_index+1} 个背景音乐文件！", bgm_list, new_bgm_tags
 
@@ -653,11 +1063,17 @@ class BackgroundManager:
         # 假设 '路径' 是 Dataframe 中的一列
         try:
             selected_path = bgm_dataframe.iloc[row_index]['路径']
-            
-            if not selected_path or not os.path.exists(selected_path):
+            try:
+                resolved = resolve_runtime_asset_path(
+                    str(selected_path or ""),
+                    root=self._project_root,
+                )
+                if not resolved.is_file():
+                    raise FileNotFoundError(resolved)
+            except (OSError, PermissionError, RuntimeError, ValueError):
                 return f"文件路径不存在: {selected_path}", ""
-                
-            file_name = os.path.basename(selected_path)
+            selected_path = resolved.as_posix()
+            file_name = resolved.name
             
             # 返回更新后的 Audio 组件
             return (
@@ -678,30 +1094,47 @@ class BackgroundManager:
             if not background:
                 return f"找不到背景组: {background_name}"
 
-            fu.export_background([background], f"./output/{background_name}.bg")
-            return f"背景组已导出到: /output/{background_name}.bg"
+            filename = safe_path_component(
+                f"{background_name}.bg",
+                field="background export filename",
+            )
+            output = self._project_root / "output" / filename
+            fu.export_background(
+                [background],
+                output.as_posix(),
+                project_root=self._project_root,
+            )
+            return f"背景组已导出到: {output}"
         except Exception as e:
             return f"背景导出失败: {e}"
     def import_background_file(self, input_path: str):
         """从 .bg 文件导入背景配置"""
+        existing_configs = self._config_manager.config.background_list
+        previous_configs = list(existing_configs)
         try:
-            existing_configs = self._config_manager.config.background_list
-            new_configs = fu.import_background(input_path, existing_configs)
-            
-            # 将导入的配置合并到现有配置中
-            # 注意：import_background 已经处理了冲突，这里只需要追加
-            for config in new_configs:
-                # 检查是否因为冲突被重命名，如果 name 已在 existing_configs 中，则说明是 import 函数解决的冲突
-                if config not in existing_configs:
-                     existing_configs.append(config)
+            with fu.package_import_transaction() as transaction_paths:
+                new_configs = fu.import_background(
+                    input_path,
+                    existing_configs,
+                    project_root=self._project_root,
+                    transaction_paths=transaction_paths,
+                )
 
-            self._config_manager.save_background_config()
+                # 将导入的配置合并到现有配置中
+                # 注意：import_background 已经处理了冲突，这里只需要追加
+                for config in new_configs:
+                    # 检查是否因为冲突被重命名，如果 name 已在 existing_configs 中，则说明是 import 函数解决的冲突
+                    if config not in existing_configs:
+                        existing_configs.append(config)
+
+                self._config_manager.save_background_config()
             
             # 刷新显示列表 (与 load_backgrounds_from_file 类似)
             bg_name_list = [b.name for b in existing_configs]
             
             return f"成功导入 {len(new_configs)} 个背景组！", bg_name_list
         except Exception as e:
+            existing_configs[:] = previous_configs
             # 刷新显示列表
             bg_name_list = [b.name for b in self._config_manager.config.background_list]
             return f"背景导入失败: {e}", bg_name_list

--- a/config/character_config.py
+++ b/config/character_config.py
@@ -1,6 +1,8 @@
 import yaml
 
 from config.sprite_voice import normalize_sprite_voice_types
+from sdk.file_transactions import read_text_without_links
+from sdk.path_contract import project_root, resolve_project_read_path
 
 
 class CharacterConfig:
@@ -36,8 +38,8 @@ class CharacterConfig:
         Returns:
             list[CharacterConfig]: 包含所有角色配置的列表
         """
-        with open(path, 'r', encoding='utf-8') as file:
-            config_data = yaml.safe_load(file)
+        resolved_path = resolve_project_read_path(path, root=project_root())
+        config_data = yaml.safe_load(read_text_without_links(resolved_path))
         
         characters = []
         for char_data in config_data:

--- a/config/character_manager.py
+++ b/config/character_manager.py
@@ -1,17 +1,64 @@
-import os
-import shutil
 import hashlib
+import os
 import re
-from pathlib import Path
+from copy import deepcopy
+from functools import wraps
+from pathlib import Path, PurePosixPath
+from threading import RLock
 from typing import List, Dict, Any, Tuple, Optional, Union
 from config.schema import Character, Sprite
 from config.config_manager import ConfigManager
 import yaml
+from sdk.file_transactions import (
+    copy_file_exclusive_with_identity,
+    portable_name_key,
+    remove_directory_without_links,
+    remove_empty_directory_without_links,
+    remove_file_without_links,
+)
+from sdk.path_contract import (
+    managed_project_directory,
+    managed_project_file,
+    portable_project_path,
+    project_root,
+    resolve_runtime_asset_read_path,
+    safe_path_component,
+    safe_path_component_with_suffix,
+)
 
 UPLOAD_DIR = "data/sprite"
 VOICE_DIR = "data/speech"
 MODEL_DIR = "data/models"
-CHARACTER_CONFIG_PATH = ConfigManager._CHARACTERS_CONFIG_PATH 
+
+_CHARACTER_IO_LOCK = RLock()
+
+
+def _serialized_mutation(function):
+    @wraps(function)
+    def wrapped(*args, **kwargs):
+        with _CHARACTER_IO_LOCK:
+            return function(*args, **kwargs)
+
+    return wrapped
+
+
+def _restore_model(target: Any, snapshot: Any) -> None:
+    for field_name in type(target).model_fields:
+        setattr(target, field_name, deepcopy(getattr(snapshot, field_name)))
+
+
+def _unlink_created_files(
+    paths: List[tuple[Path, os.stat_result]],
+) -> None:
+    for path, identity in reversed(paths):
+        try:
+            remove_file_without_links(
+                path,
+                missing_ok=True,
+                expected_identity=identity,
+            )
+        except (OSError, ValueError):
+            pass
 
 
 def _sprite_field(sprite_data: Union[Sprite, dict], key: str, default: Any = "") -> Any:
@@ -22,21 +69,147 @@ def _sprite_field(sprite_data: Union[Sprite, dict], key: str, default: Any = "")
 
 def _voice_filename_for_sprite(sprite_data: Union[Sprite, dict], sprite_index: int, file_ext: str) -> str:
     sprite_path = str(_sprite_field(sprite_data, "path", "") or "")
-    sprite_stem = Path(sprite_path).stem
+    portable_sprite_path = sprite_path.replace("\\", "/")
+    sprite_stem = PurePosixPath(portable_sprite_path).stem
     safe_stem = re.sub(r"[^A-Za-z0-9._-]+", "_", sprite_stem).strip("._-")
     if not safe_stem:
         safe_stem = f"sprite_{sprite_index:02d}"
-    digest_source = sprite_path or safe_stem or str(sprite_index)
+    digest_source = portable_sprite_path or safe_stem or str(sprite_index)
     digest = hashlib.sha1(digest_source.encode("utf-8")).hexdigest()[:10]
-    return f"voice_{safe_stem}_{digest}{file_ext}"
+    return safe_path_component_with_suffix(
+        f"voice_{safe_stem}",
+        f"_{digest}{file_ext}",
+        field="voice filename",
+    )
 
 
-def _is_path_inside_directory(path: str, directory: str) -> bool:
+def _managed_directory_snapshot(
+    root: Path,
+    base_dir: str,
+    component: str,
+) -> tuple[Path, os.stat_result] | None:
     try:
-        Path(path).resolve(strict=False).relative_to(Path(directory).resolve(strict=False))
-        return True
+        target = managed_project_directory(base_dir, component, root=root)
+    except (OSError, PermissionError, ValueError):
+        return None
+    try:
+        identity = target.lstat()
+    except FileNotFoundError:
+        return None
+    return (target, identity) if target.is_dir() else None
+
+
+def _remove_managed_directory(
+    root: Path,
+    base_dir: str,
+    component: str,
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    snapshot = _managed_directory_snapshot(root, base_dir, component)
+    if snapshot is None:
+        return
+    target, current_identity = snapshot
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, current_identity)
+    ):
+        return
+    try:
+        remove_directory_without_links(
+            target,
+            expected_identity=current_identity,
+        )
+    except OSError:
+        pass
+
+
+def _managed_file_snapshot(
+    root: Path,
+    base_dir: str,
+    raw_path: str,
+) -> tuple[Path, os.stat_result] | None:
+    try:
+        target = managed_project_file(raw_path, base_dir, root=root)
+    except (OSError, PermissionError, ValueError):
+        return None
+    if target is None:
+        return None
+    try:
+        identity = target.lstat()
+    except FileNotFoundError:
+        return None
+    return (target, identity) if target.is_file() else None
+
+
+def _unlink_managed_file(
+    root: Path,
+    base_dir: str,
+    raw_path: str,
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    snapshot = _managed_file_snapshot(root, base_dir, raw_path)
+    if snapshot is None:
+        return
+    target, current_identity = snapshot
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, current_identity)
+    ):
+        return
+    try:
+        remove_file_without_links(
+            target,
+            expected_identity=current_identity,
+        )
     except (OSError, ValueError):
+        pass
+
+
+def _prefix_in_use(characters: List[Character], prefix: str) -> bool:
+    key = _prefix_key(prefix)
+    return bool(key) and any(
+        _prefix_key(character.sprite_prefix) == key
+        for character in characters
+    )
+
+
+def _prefix_key(value: Any) -> str:
+    raw = str(value or "")
+    try:
+        return portable_name_key(safe_path_component(raw, field="sprite_prefix"))
+    except ValueError:
+        return ""
+
+
+def _managed_sprite_path_in_use(
+    manager: "CharacterManager",
+    raw_path: str,
+    *,
+    field: str,
+    base_dir: str,
+) -> bool:
+    try:
+        target = managed_project_file(raw_path, base_dir, root=manager._project_root)
+    except (OSError, PermissionError, ValueError):
         return False
+    if target is None:
+        return False
+    for character in manager._config_manager.config.characters:
+        for sprite in character.sprites or []:
+            candidate_raw = str(_sprite_field(sprite, field, "") or "")
+            try:
+                candidate = managed_project_file(
+                    candidate_raw,
+                    base_dir,
+                    root=manager._project_root,
+                )
+            except (OSError, PermissionError, ValueError):
+                continue
+            if candidate == target:
+                return True
+    return False
 
 
 class CharacterManager:
@@ -50,6 +223,7 @@ class CharacterManager:
     def __init__(self):
         """初始化 CharacterManager，获取 ConfigManager 单例。"""
         self._config_manager = ConfigManager()
+        self._project_root = project_root()
 
     def _get_characters(self) -> List[Character]:
         """获取当前的 Character 列表"""
@@ -74,11 +248,12 @@ class CharacterManager:
         """
         try:
             self._save_characters_config()
-            return f"人物设定已保存到 {CHARACTER_CONFIG_PATH}！"
+            return f"人物设定已保存到 {self._config_manager._CHARACTERS_CONFIG_PATH}！"
         except Exception as e:
             return f"保存失败: {str(e)}"
 
 
+    @_serialized_mutation
     def add_character(self, name: str, color: str, sprite_prefix: str, gpt_model_path: str,
                      sovits_model_path: str, refer_audio_path: str, prompt_text: str,
                      prompt_lang: str, character_setting: str,
@@ -103,15 +278,22 @@ class CharacterManager:
         characters = self._config_manager.config.characters
 
         # check sprite_prefix collision (unique per-character upload directory)
-        _prefix = (sprite_prefix or "").strip()
+        edit_target_name = str(edit_as_name or "").strip()
+        _prefix = str(sprite_prefix or "")
         if _prefix:
+            try:
+                _prefix = safe_path_component(_prefix, field="sprite_prefix")
+            except ValueError:
+                return "立绘目录名无效！", current_names
+            sprite_prefix = _prefix
+            prefix_key = portable_name_key(_prefix)
             for c in characters:
-                _c_prefix = (c.sprite_prefix or "").strip()
-                if not _c_prefix or _prefix != _c_prefix:
+                _c_prefix_key = _prefix_key(c.sprite_prefix)
+                if not _c_prefix_key or prefix_key != _c_prefix_key:
                     continue
                 # editing: new prefix must not collide with *other* characters
-                if edit_as_name and str(edit_as_name).strip():
-                    if c.name != str(edit_as_name).strip():
+                if edit_target_name:
+                    if c.name.casefold() != edit_target_name.casefold():
                         return (
                             f"立绘目录名「{_prefix}」已被角色「{c.name}」占用！",
                             current_names,
@@ -122,28 +304,39 @@ class CharacterManager:
                         current_names,
                     )
 
-        if edit_as_name and str(edit_as_name).strip():
-            target = self._config_manager.get_character_by_name(str(edit_as_name).strip())
+        if edit_target_name:
+            target = self._config_manager.get_character_by_name(edit_target_name)
             if target is not None:
+                old_prefix = str(target.sprite_prefix or "")
+                if old_prefix and old_prefix != str(sprite_prefix or ""):
+                    return (
+                        "人物资源目录创建后不可直接修改；请新建人物后迁移资源。",
+                        [c.name for c in characters],
+                    )
                 taken = self._config_manager.get_character_by_name(name)
                 if taken is not None and taken is not target:
                     return f"名称「{name}」已与其他角色重复！", [c.name for c in characters]
-                target.name = name
-                target.color = color
-                target.sprite_prefix = sprite_prefix
-                target.gpt_model_path = gpt_model_path
-                target.sovits_model_path = sovits_model_path
-                target.prompt_text = prompt_text
-                target.prompt_lang = prompt_lang
-                target.refer_audio_path = refer_audio_path
-                target.character_setting = character_setting
-                target.speech_speed = speech_speed
-                target.speech_volume = speech_volume
-                if pronunciation_map is not None:
-                    target.pronunciation_map = pronunciation_map
-                if emotion_tags is not None:
-                    target.emotion_tags = emotion_tags
-                self._save_characters_config()
+                snapshot = target.model_copy(deep=True)
+                try:
+                    target.name = name
+                    target.color = color
+                    target.sprite_prefix = sprite_prefix
+                    target.gpt_model_path = gpt_model_path
+                    target.sovits_model_path = sovits_model_path
+                    target.prompt_text = prompt_text
+                    target.prompt_lang = prompt_lang
+                    target.refer_audio_path = refer_audio_path
+                    target.character_setting = character_setting
+                    target.speech_speed = speech_speed
+                    target.speech_volume = speech_volume
+                    if pronunciation_map is not None:
+                        target.pronunciation_map = pronunciation_map
+                    if emotion_tags is not None:
+                        target.emotion_tags = emotion_tags
+                    self._save_characters_config()
+                except BaseException:
+                    _restore_model(target, snapshot)
+                    raise
                 return "人物已更新！", [c.name for c in characters]
 
         existing_character: Optional[Character] = self._config_manager.get_character_by_name(name)
@@ -168,30 +361,51 @@ class CharacterManager:
                 pronunciation_map=pronunciation_map or {},
             )
             characters.append(new_character)
-            self._save_characters_config()
+            try:
+                self._save_characters_config()
+            except BaseException:
+                if characters and characters[-1] is new_character:
+                    characters.pop()
+                else:
+                    try:
+                        characters.remove(new_character)
+                    except ValueError:
+                        pass
+                raise
             return "人物已添加！", [c.name for c in characters]
         else:
             # 更新现有 Character 实例的属性
-            existing_character.name = name
-            existing_character.color = color
-            existing_character.sprite_prefix = sprite_prefix
-            existing_character.gpt_model_path = gpt_model_path
-            existing_character.sovits_model_path = sovits_model_path
-            existing_character.prompt_text = prompt_text
-            existing_character.prompt_lang = prompt_lang
-            existing_character.refer_audio_path = refer_audio_path
-            existing_character.character_setting = character_setting
-            existing_character.speech_speed = speech_speed
-            existing_character.speech_volume = speech_volume
-            if pronunciation_map is not None:
-                existing_character.pronunciation_map = pronunciation_map
-            if emotion_tags is not None:
-                existing_character.emotion_tags = emotion_tags
-
-            self._save_characters_config()
+            old_prefix = str(existing_character.sprite_prefix or "")
+            if old_prefix and old_prefix != str(sprite_prefix or ""):
+                return (
+                    "人物资源目录创建后不可直接修改；请新建人物后迁移资源。",
+                    [c.name for c in characters],
+                )
+            snapshot = existing_character.model_copy(deep=True)
+            try:
+                existing_character.name = name
+                existing_character.color = color
+                existing_character.sprite_prefix = sprite_prefix
+                existing_character.gpt_model_path = gpt_model_path
+                existing_character.sovits_model_path = sovits_model_path
+                existing_character.prompt_text = prompt_text
+                existing_character.prompt_lang = prompt_lang
+                existing_character.refer_audio_path = refer_audio_path
+                existing_character.character_setting = character_setting
+                existing_character.speech_speed = speech_speed
+                existing_character.speech_volume = speech_volume
+                if pronunciation_map is not None:
+                    existing_character.pronunciation_map = pronunciation_map
+                if emotion_tags is not None:
+                    existing_character.emotion_tags = emotion_tags
+                self._save_characters_config()
+            except BaseException:
+                _restore_model(existing_character, snapshot)
+                raise
             return "人物已更新！", [c.name for c in characters]
 
 
+    @_serialized_mutation
     def delete_character(self, name: str) -> Tuple[str, List[str]]:
         """
         删除角色及其相关文件。
@@ -209,25 +423,44 @@ class CharacterManager:
         
         if character_to_delete is None:
             return f"找不到角色: {name}", current_names
-        
-        # 移除角色
+
+        sprite_prefix = character_to_delete.sprite_prefix
+        directory_snapshots = {
+            base_dir: _managed_directory_snapshot(
+                self._project_root,
+                base_dir,
+                sprite_prefix,
+            )
+            for base_dir in (UPLOAD_DIR, VOICE_DIR, MODEL_DIR)
+        } if sprite_prefix else {}
+
+        # 先提交引用删除，再做最佳努力的磁盘清理；保存失败时恢复原顺序。
+        original_index = characters.index(character_to_delete)
         try:
             characters.remove(character_to_delete)
         except ValueError:
             return f"找不到角色: {name}", current_names
-            
-        self._save_characters_config()
+        try:
+            self._save_characters_config()
+        except BaseException:
+            characters.insert(original_index, character_to_delete)
+            raise
         new_names = [c.name for c in characters]
 
-        sprite_prefix = character_to_delete.sprite_prefix
         if not sprite_prefix:
             return "已删除角色", new_names
         
-        # 删除相关目录
-        for base_dir in [UPLOAD_DIR, VOICE_DIR, MODEL_DIR]:
-            char_dir = os.path.join(base_dir, sprite_prefix)
-            if os.path.exists(char_dir):
-                shutil.rmtree(char_dir)
+        # 旧配置可能存在重复 prefix；只要仍被引用，就不清理共享目录。
+        if not _prefix_in_use(characters, sprite_prefix):
+            for base_dir in [UPLOAD_DIR, VOICE_DIR, MODEL_DIR]:
+                snapshot = directory_snapshots.get(base_dir)
+                if snapshot is not None:
+                    _remove_managed_directory(
+                        self._project_root,
+                        base_dir,
+                        sprite_prefix,
+                        expected_identity=snapshot[1],
+                    )
         
         return f"角色 {name} 已删除！", new_names
 
@@ -247,6 +480,7 @@ class CharacterManager:
             return [c.name for c in self._get_characters()]
 
 
+    @_serialized_mutation
     def upload_sprites(self, character_name: str, sprite_files: List[Any], emotion_tags: str) -> Tuple[str, List[str], str]:
         """
         上传立绘文件并更新角色的立绘列表和情绪标签。
@@ -264,34 +498,72 @@ class CharacterManager:
         if not character:
             return f"找不到角色: {character_name}", [], ''
         
-        char_dir = os.path.join(UPLOAD_DIR, character.sprite_prefix)
-        Path(char_dir).mkdir(parents=True, exist_ok=True)
-        
-        if character.sprites is None:
-            character.sprites = []
+        try:
+            char_dir = managed_project_directory(
+                UPLOAD_DIR,
+                character.sprite_prefix,
+                root=self._project_root,
+            )
+        except (PermissionError, ValueError):
+            return "立绘目录名无效！", [], emotion_tags
+        directory_was_missing = not char_dir.exists()
+        created_directory_identity: os.stat_result | None = None
+        snapshot = character.model_copy(deep=True)
+        created_files: List[tuple[Path, os.stat_result]] = []
+        try:
+            if character.sprites is None:
+                character.sprites = []
 
-        num_existing_sprites = len(character.sprites)
-        emotion_tags_to_add = ''
-        
-        for i, file in enumerate(sprite_files):
-            filename = os.path.basename(file.name)
-            dest_path = os.path.join(char_dir, filename)
-            shutil.copyfile(file.name, dest_path)
-            
-            new_sprite_data = {"path": dest_path}
-            character.sprites.append(new_sprite_data)
-            
-            emotion_tags_to_add += f'立绘 {num_existing_sprites + i + 1}：\n'
-            
-        current_emotion_tags = character.emotion_tags if character.emotion_tags else ""
-        character.emotion_tags = current_emotion_tags + emotion_tags_to_add
+            num_existing_sprites = len(character.sprites)
+            emotion_tags_to_add = ''
 
-        self._config_manager.save_characters_config()
+            for i, file in enumerate(sprite_files):
+                source = resolve_runtime_asset_read_path(
+                    file.name,
+                    root=self._project_root,
+                )
+                filename = safe_path_component(
+                    source.name,
+                    field="sprite filename",
+                )
+                dest_path, dest_identity = copy_file_exclusive_with_identity(
+                    source,
+                    char_dir,
+                    filename,
+                    field="sprite filename",
+                )
+                created_files.append((dest_path, dest_identity))
+                if (
+                    directory_was_missing
+                    and created_directory_identity is None
+                ):
+                    created_directory_identity = char_dir.lstat()
+                stored_path = portable_project_path(dest_path, root=self._project_root)
+
+                character.sprites.append({"path": stored_path})
+                emotion_tags_to_add += f'立绘 {num_existing_sprites + i + 1}：\n'
+
+            current_emotion_tags = character.emotion_tags if character.emotion_tags else ""
+            character.emotion_tags = current_emotion_tags + emotion_tags_to_add
+            self._config_manager.save_characters_config()
+        except BaseException:
+            _restore_model(character, snapshot)
+            _unlink_created_files(created_files)
+            if directory_was_missing and created_directory_identity is not None:
+                try:
+                    remove_empty_directory_without_links(
+                        char_dir,
+                        expected_identity=created_directory_identity,
+                    )
+                except (OSError, ValueError):
+                    pass
+            raise
 
         all_sprite_paths = [s.path if isinstance(s, Sprite) else s.get('path', '') for s in character.sprites]
         return f"成功为 {character_name} 上传 {len(sprite_files)} 张立绘！", all_sprite_paths, character.emotion_tags
 
 
+    @_serialized_mutation
     def delete_all_sprites(self, character_name: str) -> Tuple[str, List[str], str]:
         """
         删除角色的所有立绘及其语音文件。
@@ -305,26 +577,44 @@ class CharacterManager:
         character: Optional[Character] = self._config_manager.get_character_by_name(character_name)
         if not character:
             return f"找不到角色: {character_name}", [], ""
-        
-        # 删除立绘目录
-        char_dir = os.path.join(UPLOAD_DIR, character.sprite_prefix)
-        if os.path.exists(char_dir):
-            shutil.rmtree(char_dir)
 
-        # 删除语音目录
-        char_voice_dir = os.path.join(VOICE_DIR, character.sprite_prefix)
-        if os.path.exists(char_voice_dir):
-            shutil.rmtree(char_voice_dir)
-        
-        # 清空角色属性
-        character.sprites = []
-        character.emotion_tags = ""
-        
-        self._config_manager.save_characters_config()
+        directory_snapshots = {
+            base_dir: _managed_directory_snapshot(
+                self._project_root,
+                base_dir,
+                character.sprite_prefix,
+            )
+            for base_dir in (UPLOAD_DIR, VOICE_DIR)
+        }
+        snapshot = character.model_copy(deep=True)
+        try:
+            character.sprites = []
+            character.emotion_tags = ""
+            self._config_manager.save_characters_config()
+        except BaseException:
+            _restore_model(character, snapshot)
+            raise
+
+        other_characters = [
+            item
+            for item in self._config_manager.config.characters
+            if item is not character
+        ]
+        if not _prefix_in_use(other_characters, character.sprite_prefix):
+            for base_dir in (UPLOAD_DIR, VOICE_DIR):
+                directory_snapshot = directory_snapshots.get(base_dir)
+                if directory_snapshot is not None:
+                    _remove_managed_directory(
+                        self._project_root,
+                        base_dir,
+                        character.sprite_prefix,
+                        expected_identity=directory_snapshot[1],
+                    )
         
         return f"已删除 {character_name} 的所有立绘！", [], ""
 
 
+    @_serialized_mutation
     def delete_single_sprite(self, character_name: str, sprite_index: int) -> Tuple[str, List[str], str]:
         """
         删除角色的指定立绘及其语音文件。
@@ -349,15 +639,18 @@ class CharacterManager:
         # 获取路径
         sprite_path = sprite_data.path if isinstance(sprite_data, Sprite) else sprite_data.get("path", "")
         voice_path = sprite_data.voice_path if isinstance(sprite_data, Sprite) else sprite_data.get("voice_path", "")
+        sprite_snapshot = _managed_file_snapshot(
+            self._project_root,
+            UPLOAD_DIR,
+            str(sprite_path),
+        ) if sprite_path else None
+        voice_snapshot = _managed_file_snapshot(
+            self._project_root,
+            VOICE_DIR,
+            str(voice_path),
+        ) if voice_path else None
 
-        # 删除文件
-        if sprite_path and os.path.exists(sprite_path) and os.path.isfile(sprite_path):
-            os.remove(sprite_path)
-            
-        if voice_path and os.path.exists(voice_path) and os.path.isfile(voice_path):
-            os.remove(voice_path)
-        
-        # 从列表中移除
+        snapshot = character.model_copy(deep=True)
         character.sprites.pop(sprite_index)
         
         # 更新情绪标签
@@ -373,13 +666,50 @@ class CharacterManager:
             emotion_tags += f'立绘 {i+1}：{current_tag}\n'
             
         character.emotion_tags = emotion_tags
-        
-        self._config_manager.save_characters_config()
+        try:
+            self._config_manager.save_characters_config()
+        except BaseException:
+            _restore_model(character, snapshot)
+            raise
+
+        if sprite_snapshot is not None and not _managed_sprite_path_in_use(
+            self,
+            str(sprite_path),
+            field="path",
+            base_dir=UPLOAD_DIR,
+        ):
+            _unlink_managed_file(
+                self._project_root,
+                UPLOAD_DIR,
+                str(sprite_path),
+                expected_identity=(
+                    sprite_snapshot[1]
+                    if sprite_snapshot is not None
+                    else None
+                ),
+            )
+        if voice_snapshot is not None and not _managed_sprite_path_in_use(
+            self,
+            str(voice_path),
+            field="voice_path",
+            base_dir=VOICE_DIR,
+        ):
+            _unlink_managed_file(
+                self._project_root,
+                VOICE_DIR,
+                str(voice_path),
+                expected_identity=(
+                    voice_snapshot[1]
+                    if voice_snapshot is not None
+                    else None
+                ),
+            )
         
         remaining_sprite_paths = [s.path if isinstance(s, Sprite) else s.get('path', '') for s in character.sprites]
         return f"已删除 {character_name} 的第 {sprite_index+1} 张立绘！", remaining_sprite_paths, emotion_tags
 
 
+    @_serialized_mutation
     def upload_emotion_tags(self, character_name: str, emotion_tags: str) -> str:
         """
         上传/更新角色的情绪标签文本。
@@ -397,14 +727,17 @@ class CharacterManager:
         if not character:
             return f"找不到角色: {character_name}"
         
+        snapshot = character.model_copy(deep=True)
         try:
             character.emotion_tags = emotion_tags
             self._config_manager.save_characters_config()
             return "标注成功！"
         except Exception as e:
+            _restore_model(character, snapshot)
             return f"标注出错了：{e}"
 
 
+    @_serialized_mutation
     def upload_voice(self, character_name: str, sprite_index: int, voice_file: str, voice_text: str, voice_type: str = "") -> Tuple[str, Optional[str]]:
         """
         为指定立绘上传语音文件。
@@ -424,44 +757,113 @@ class CharacterManager:
         
         sprite_data: Union[Sprite, dict] = character.sprites[sprite_index]
         original_voice_path = str(_sprite_field(sprite_data, "voice_path", "") or "")
+        original_voice_snapshot = _managed_file_snapshot(
+            self._project_root,
+            VOICE_DIR,
+            original_voice_path,
+        ) if original_voice_path else None
         
         if (not voice_file) and (not original_voice_path):
             return "请选择语音文件！", None
         
-        voice_char_dir = os.path.join(VOICE_DIR, character.sprite_prefix)
-        Path(voice_char_dir).mkdir(parents=True, exist_ok=True)
-        
-        file_ext = Path(voice_file).suffix
-        voice_filename = _voice_filename_for_sprite(sprite_data, sprite_index, file_ext)
-        voice_path = os.path.join(voice_char_dir, voice_filename)
-        shutil.copyfile(voice_file, voice_path)
-        
-        # 更新角色数据
-        if isinstance(sprite_data, Sprite):
-            sprite_data.voice_path = voice_path
-            sprite_data.voice_text = voice_text
-            if voice_type:
-                sprite_data.voice_type = voice_type
-        else:
-            character.sprites[sprite_index]["voice_path"] = voice_path
-            character.sprites[sprite_index]["voice_text"] = voice_text
-            if voice_type:
-                character.sprites[sprite_index]["voice_type"] = voice_type
-            
-        self._config_manager.save_characters_config()
+        snapshot = character.model_copy(deep=True)
+        created_voice_path: Path | None = None
+        created_voice_identity: os.stat_result | None = None
+        voice_char_dir: Path | None = None
+        directory_was_missing = False
+        created_directory_identity: os.stat_result | None = None
+        try:
+            if voice_file:
+                try:
+                    voice_char_dir = managed_project_directory(
+                        VOICE_DIR,
+                        character.sprite_prefix,
+                        root=self._project_root,
+                    )
+                except (PermissionError, ValueError):
+                    return "语音目录名无效！", None
+                directory_was_missing = not voice_char_dir.exists()
+                source_voice = resolve_runtime_asset_read_path(
+                    voice_file,
+                    root=self._project_root,
+                )
+                file_ext = source_voice.suffix
+                voice_filename = _voice_filename_for_sprite(sprite_data, sprite_index, file_ext)
+                (
+                    created_voice_path,
+                    created_voice_identity,
+                ) = copy_file_exclusive_with_identity(
+                    source_voice,
+                    voice_char_dir,
+                    voice_filename,
+                    field="voice filename",
+                )
+                if directory_was_missing:
+                    created_directory_identity = voice_char_dir.lstat()
+                stored_voice_path = portable_project_path(
+                    created_voice_path,
+                    root=self._project_root,
+                )
+            else:
+                stored_voice_path = original_voice_path
+
+            if isinstance(sprite_data, Sprite):
+                sprite_data.voice_path = stored_voice_path
+                sprite_data.voice_text = voice_text
+                if voice_type:
+                    sprite_data.voice_type = voice_type
+            else:
+                character.sprites[sprite_index]["voice_path"] = stored_voice_path
+                character.sprites[sprite_index]["voice_text"] = voice_text
+                if voice_type:
+                    character.sprites[sprite_index]["voice_type"] = voice_type
+
+            self._config_manager.save_characters_config()
+        except BaseException:
+            _restore_model(character, snapshot)
+            if (
+                created_voice_path is not None
+                and created_voice_identity is not None
+            ):
+                _unlink_created_files(
+                    [(created_voice_path, created_voice_identity)]
+                )
+            if (
+                directory_was_missing
+                and voice_char_dir is not None
+                and created_directory_identity is not None
+            ):
+                try:
+                    remove_empty_directory_without_links(
+                        voice_char_dir,
+                        expected_identity=created_directory_identity,
+                    )
+                except (OSError, ValueError):
+                    pass
+            raise
 
         if (
-            original_voice_path
-            and os.path.abspath(original_voice_path) != os.path.abspath(voice_path)
-            and _is_path_inside_directory(original_voice_path, voice_char_dir)
+            created_voice_path is not None
+            and original_voice_snapshot is not None
+            and not _managed_sprite_path_in_use(
+                self,
+                original_voice_path,
+                field="voice_path",
+                base_dir=VOICE_DIR,
+            )
         ):
-            try:
-                if os.path.isfile(original_voice_path):
-                    os.remove(original_voice_path)
-            except OSError:
-                pass
+            _unlink_managed_file(
+                self._project_root,
+                VOICE_DIR,
+                original_voice_path,
+                expected_identity=(
+                    original_voice_snapshot[1]
+                    if original_voice_snapshot is not None
+                    else None
+                ),
+            )
         
-        return f"语音已上传到立绘 {sprite_index+1}！", voice_path
+        return f"语音已上传到立绘 {sprite_index+1}！", stored_voice_path
 
 
     def get_sprite_voice(self, character_name: str, sprite_index: int) -> Tuple[Optional[str], str]:
@@ -490,6 +892,7 @@ class CharacterManager:
 
         return voice_path, voice_text
 
+    @_serialized_mutation
     def save_sprite_voice_text(self, character_name: str, sprite_index: int, voice_text: str) -> str:
         """单独保存立绘的语音文字，不需要重新上传音频。"""
         if not character_name:
@@ -500,15 +903,20 @@ class CharacterManager:
         if not character.sprites or sprite_index < 0 or sprite_index >= len(character.sprites):
             return "立绘不存在！"
 
-        sprite_data = character.sprites[sprite_index]
-        if isinstance(sprite_data, Sprite):
-            sprite_data.voice_text = voice_text if voice_text else None
-        else:
-            sprite_data["voice_text"] = voice_text if voice_text else None
-
-        self._config_manager.save_characters_config()
+        snapshot = character.model_copy(deep=True)
+        try:
+            sprite_data = character.sprites[sprite_index]
+            if isinstance(sprite_data, Sprite):
+                sprite_data.voice_text = voice_text if voice_text else None
+            else:
+                sprite_data["voice_text"] = voice_text if voice_text else None
+            self._config_manager.save_characters_config()
+        except BaseException:
+            _restore_model(character, snapshot)
+            raise
         return "语音文字已保存"
 
+    @_serialized_mutation
     def save_sprite_voice_type(self, character_name: str, sprite_index: int, voice_type: str) -> str:
         """单独保存立绘的语音类型（preset/reference），不需要重新上传音频。"""
         if not character_name:
@@ -519,15 +927,20 @@ class CharacterManager:
         if not character.sprites or sprite_index < 0 or sprite_index >= len(character.sprites):
             return "立绘不存在！"
 
-        sprite_data = character.sprites[sprite_index]
-        if isinstance(sprite_data, Sprite):
-            sprite_data.voice_type = voice_type if voice_type else None
-        else:
-            sprite_data["voice_type"] = voice_type if voice_type else None
-
-        self._config_manager.save_characters_config()
+        snapshot = character.model_copy(deep=True)
+        try:
+            sprite_data = character.sprites[sprite_index]
+            if isinstance(sprite_data, Sprite):
+                sprite_data.voice_type = voice_type if voice_type else None
+            else:
+                sprite_data["voice_type"] = voice_type if voice_type else None
+            self._config_manager.save_characters_config()
+        except BaseException:
+            _restore_model(character, snapshot)
+            raise
         return "语音类型已保存"
 
+    @_serialized_mutation
     def delete_sprite_voice(self, character_name: str, sprite_index: int) -> str:
         """删除指定立绘的语音文件和引用。"""
         if not character_name:
@@ -539,22 +952,41 @@ class CharacterManager:
             return "立绘不存在！"
 
         sprite_data = character.sprites[sprite_index]
-        if isinstance(sprite_data, Sprite):
-            voice_path = sprite_data.voice_path
-            sprite_data.voice_path = None
-            sprite_data.voice_text = None
-        else:
-            voice_path = sprite_data.get("voice_path", None)
-            sprite_data["voice_path"] = None
-            sprite_data["voice_text"] = None
+        existing_voice_path = str(
+            _sprite_field(sprite_data, "voice_path", "") or ""
+        )
+        voice_snapshot = _managed_file_snapshot(
+            self._project_root,
+            VOICE_DIR,
+            existing_voice_path,
+        ) if existing_voice_path else None
+        snapshot = character.model_copy(deep=True)
+        try:
+            if isinstance(sprite_data, Sprite):
+                voice_path = sprite_data.voice_path
+                sprite_data.voice_path = None
+                sprite_data.voice_text = None
+            else:
+                voice_path = sprite_data.get("voice_path", None)
+                sprite_data["voice_path"] = None
+                sprite_data["voice_text"] = None
+            self._config_manager.save_characters_config()
+        except BaseException:
+            _restore_model(character, snapshot)
+            raise
 
-        self._config_manager.save_characters_config()
-
-        if voice_path and os.path.isfile(voice_path):
-            try:
-                os.remove(voice_path)
-            except OSError:
-                pass
+        if voice_snapshot is not None and not _managed_sprite_path_in_use(
+            self,
+            str(voice_path),
+            field="voice_path",
+            base_dir=VOICE_DIR,
+        ):
+            _unlink_managed_file(
+                self._project_root,
+                VOICE_DIR,
+                str(voice_path),
+                expected_identity=voice_snapshot[1],
+            )
 
         return f"已删除立绘 {sprite_index + 1} 的语音"
 
@@ -579,6 +1011,7 @@ class CharacterManager:
         return sprite_paths, emotion_tags, []
 
 
+    @_serialized_mutation
     def save_sprite_scale(self, name: str, scale: float) -> str:
         """
         保存角色的立绘缩放比例。
@@ -592,8 +1025,13 @@ class CharacterManager:
         character: Optional[Character] = self._config_manager.get_character_by_name(name)
 
         if character:
-            character.sprite_scale = scale
-            self._config_manager.save_characters_config()
+            snapshot = character.model_copy(deep=True)
+            try:
+                character.sprite_scale = scale
+                self._config_manager.save_characters_config()
+            except BaseException:
+                _restore_model(character, snapshot)
+                raise
             return "保存立绘缩放倍率成功"
         
         return f"找不到角色: {name}"

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -1,5 +1,6 @@
+import os
+import threading
 import yaml
-import sys
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Union
 from pydantic import ValidationError
@@ -20,11 +21,332 @@ from config.tts_provider_config import (
     tts_server_url_or_default,
     uses_shared_tts_server_config,
 )
+from config.api_path_validation import validate_t2i_paths_for_save
 from config.llm_defaults import LLM_BASE_URLS
 from config.mirror_env import apply_mirror_environment
 from config.network_proxy import apply_network_proxy_environment
 from config.sprite_voice import normalize_sprite_voice_types
 import traceback
+from sdk.path_contract import (
+    project_root,
+    resolve_managed_project_path,
+    resolve_project_path,
+    resolve_runtime_asset_read_path,
+    validate_exact_path_text,
+)
+from sdk.file_transactions import atomic_write_text, read_text_without_links
+from sdk.path_references import (
+    make_path_reference,
+    normalize_project_relative_path,
+)
+
+
+_CONFIG_WRITE_LOCK = threading.RLock()
+_PATH_CONTRACT_VERSION = 1
+
+
+def _migrate_legacy_dot_relative_path(raw: str) -> str:
+    """Canonicalize the one relative alias emitted by pre-contract releases.
+
+    Older PyQt/early React defaults were persisted as ``./data/...`` (and the
+    Windows spelling ``.\\data\\...``).  Runtime resolvers deliberately reject
+    lexical aliases now, so accept exactly one historical leading ``./`` only
+    while loading a known configuration path and immediately save the
+    canonical portable value.  Nested aliases and traversal remain invalid.
+    """
+
+    portable = raw.replace("\\", "/")
+    if not portable.startswith("./"):
+        return raw
+    normalized = normalize_project_relative_path(portable[2:])
+    if normalized is None:
+        raise ValueError("legacy project path contains lexical path aliases")
+    return normalized
+
+
+def _migrate_legacy_duplicated_storage_path(raw: str) -> str:
+    """Collapse the exact duplicated storage prefix emitted by an old UI.
+
+    A migration-era join bug persisted values such as
+    ``data/sprite/mika/sprite/mika/idle.png``.  Runtime file serving used to
+    guess several alternative targets on every request, which let a displayed
+    path name one file while the bridge served another.  Recognize only that
+    documented repeated ``<family>/<owner>`` shape here so the corrected value
+    is saved once with the rest of the configuration migration.
+    """
+
+    parts = raw.split("/")
+    managed_families = {"backgrounds", "bgm", "effects", "speech", "sprite"}
+    if (
+        len(parts) >= 6
+        and parts[0] == "data"
+        and parts[1] in managed_families
+        and parts[2]
+        and parts[3] == parts[1]
+        and parts[4] == parts[2]
+    ):
+        return "/".join(parts[:3] + parts[5:])
+    return raw
+
+
+def _migrate_path_value(
+    mapping: dict[str, Any],
+    key: str,
+    root: Path,
+    *legacy_prefixes: tuple[str, ...],
+    resource_prefixes: tuple[tuple[str, ...], ...] = (),
+    recover_legacy_absolute: bool = True,
+) -> bool:
+    """Normalize one persisted path and report whether storage changed."""
+
+    raw_value = mapping.get(key)
+    if raw_value is None:
+        return False
+    raw = str(raw_value)
+    if not raw:
+        return False
+    migrated_raw = _migrate_legacy_dot_relative_path(raw)
+    reference = make_path_reference(
+        migrated_raw,
+        root,
+        legacy_project_prefixes=legacy_prefixes,
+        resource_prefixes=resource_prefixes,
+        recover_legacy_absolute=recover_legacy_absolute,
+    )
+    if reference is None:
+        return False
+    normalized = _migrate_legacy_duplicated_storage_path(reference["path"])
+    mapping[key] = normalized
+    return normalized != raw
+
+
+def _migrate_config_asset_paths(
+    *,
+    root: Path,
+    api_data: Any,
+    characters_data: Any,
+    system_data: Any,
+    background_data: Any,
+    effect_data: Any,
+    recover_legacy_absolute: bool = True,
+) -> set[str]:
+    """Rebase stale pre-migration managed paths before model validation."""
+
+    changed: set[str] = set()
+    if isinstance(characters_data, list):
+        for character in characters_data:
+            if not isinstance(character, dict):
+                continue
+            for field in ("gpt_model_path", "sovits_model_path", "refer_audio_path"):
+                if _migrate_path_value(
+                    character,
+                    field,
+                    root,
+                    ("data", "models"),
+                    ("data", "speech"),
+                    resource_prefixes=(
+                        (("assets", "system", "sound"),)
+                        if field == "refer_audio_path"
+                        else ()
+                    ),
+                    recover_legacy_absolute=recover_legacy_absolute,
+                ):
+                    changed.add("characters")
+            for sprite in character.get("sprites") or []:
+                if not isinstance(sprite, dict):
+                    continue
+                if _migrate_path_value(
+                    sprite,
+                    "path",
+                    root,
+                    ("data", "sprite"),
+                    resource_prefixes=(
+                        ("assets", "present_example.png"),
+                        ("assets", "system", "picture"),
+                    ),
+                    recover_legacy_absolute=recover_legacy_absolute,
+                ):
+                    changed.add("characters")
+                if _migrate_path_value(
+                    sprite,
+                    "voice_path",
+                    root,
+                    ("data", "speech"),
+                    resource_prefixes=(("assets", "system", "sound"),),
+                    recover_legacy_absolute=recover_legacy_absolute,
+                ):
+                    changed.add("characters")
+
+    if isinstance(background_data, list):
+        for background in background_data:
+            if not isinstance(background, dict):
+                continue
+            for sprite in background.get("sprites") or []:
+                if isinstance(sprite, dict) and _migrate_path_value(
+                    sprite,
+                    "path",
+                    root,
+                    ("data", "backgrounds"),
+                    resource_prefixes=(("assets", "system", "picture"),),
+                    recover_legacy_absolute=recover_legacy_absolute,
+                ):
+                    changed.add("background")
+            bgm_list = background.get("bgm_list")
+            if isinstance(bgm_list, list):
+                for index, value in enumerate(bgm_list):
+                    holder = {"path": value}
+                    if _migrate_path_value(
+                        holder,
+                        "path",
+                        root,
+                        ("data", "bgm"),
+                        resource_prefixes=(("assets", "system", "sound"),),
+                        recover_legacy_absolute=recover_legacy_absolute,
+                    ):
+                        changed.add("background")
+                    bgm_list[index] = holder["path"]
+
+    if isinstance(effect_data, list):
+        for effect in effect_data:
+            if not isinstance(effect, dict):
+                continue
+            audio_list = effect.get("audio_list")
+            if not isinstance(audio_list, list):
+                continue
+            for index, value in enumerate(audio_list):
+                holder = {"path": value}
+                if _migrate_path_value(
+                    holder,
+                    "path",
+                    root,
+                    ("data", "effects"),
+                    resource_prefixes=(("assets", "system", "sound"),),
+                    recover_legacy_absolute=recover_legacy_absolute,
+                ):
+                    changed.add("effect")
+                audio_list[index] = holder["path"]
+
+    if isinstance(system_data, dict):
+        system_path_prefixes = {
+            "background_path": (("data", "backgrounds"),),
+            "bgm_path": (("data", "bgm"),),
+            "chat_ui_theme_path": (
+                ("data", "chat_ui_themes"),
+                ("data", "chat_ui_theme.json"),
+            ),
+            "huggingface_cache_dir": (("data", "cache"),),
+            "music_cover_work_dir": (("data", "music_cover"),),
+            "music_cover_yt_dlp_exe": (),
+            "music_cover_ffmpeg_exe": (),
+            "music_cover_rvc_model_path": (("data", "models"), ("data", "music_cover")),
+            "music_cover_rvc_index_path": (("data", "models"), ("data", "music_cover")),
+            "asr_whisper_model_size": (("data", "models"), ("data", "cache")),
+        }
+        system_resource_prefixes = {
+            "background_path": (("assets", "system", "picture"),),
+            "bgm_path": (("assets", "system", "sound"),),
+        }
+        for field, prefixes in system_path_prefixes.items():
+            if _migrate_path_value(
+                system_data,
+                field,
+                root,
+                *prefixes,
+                resource_prefixes=system_resource_prefixes.get(field, ()),
+                recover_legacy_absolute=recover_legacy_absolute,
+            ):
+                changed.add("system")
+
+    if isinstance(api_data, dict):
+        api_path_prefixes = {
+            "gpt_sovits_api_path": (("data", "tts_bundles"),),
+            # A ComfyUI installation is normally external.  With no legacy
+            # prefix, an existing path under the current project is still
+            # serialized relatively, but an unrelated stale /.../data/...
+            # path is never guessed to belong to Shinsekai.
+            "t2i_work_path": (),
+            "t2i_default_workflow_path": (("data", "workflows"),),
+        }
+        for field, prefixes in api_path_prefixes.items():
+            resource_prefixes = (
+                (
+                    ("assets", "system", "workflow"),
+                    ("assets", "workflows"),
+                )
+                if field == "t2i_default_workflow_path"
+                else ()
+            )
+            if _migrate_path_value(
+                api_data,
+                field,
+                root,
+                *prefixes,
+                resource_prefixes=resource_prefixes,
+                recover_legacy_absolute=recover_legacy_absolute,
+            ):
+                changed.add("api")
+        asr_configs = api_data.get("asr_extra_configs")
+        vosk_config = asr_configs.get("vosk") if isinstance(asr_configs, dict) else None
+        if isinstance(vosk_config, dict) and _migrate_path_value(
+            vosk_config,
+            "model_path",
+            root,
+            ("data", "models"),
+            ("data", "cache"),
+            resource_prefixes=(("assets", "system", "models"),),
+            recover_legacy_absolute=recover_legacy_absolute,
+        ):
+            changed.add("api")
+        tts_configs = api_data.get("tts_extra_configs")
+        kaggle_config = (
+            tts_configs.get("kaggle-gpt-sovits")
+            if isinstance(tts_configs, dict)
+            else None
+        )
+        if isinstance(kaggle_config, dict):
+            for field in (
+                "remote_gpt_model_path",
+                "remote_sovits_model_path",
+                "remote_ref_audio_path",
+            ):
+                raw_value = str(kaggle_config.get(field) or "")
+                if raw_value:
+                    # Kaggle paths belong to the remote filesystem. Validate
+                    # their exact text without assigning local path ownership.
+                    validate_exact_path_text(
+                        raw_value,
+                        field=field,
+                        allow_non_native_absolute=True,
+                    )
+    return changed
+
+
+def _normalize_config_payload_paths(kind: str, payload: Any, root: Path) -> Any:
+    """Serialize project-owned paths portably on every config write."""
+
+    values: dict[str, Any] = {
+        "api_data": {},
+        "characters_data": [],
+        "system_data": {},
+        "background_data": [],
+        "effect_data": [],
+    }
+    field = {
+        "api": "api_data",
+        "characters": "characters_data",
+        "system": "system_data",
+        "background": "background_data",
+        "effect": "effect_data",
+    }.get(kind)
+    if field is None:
+        raise ValueError(f"unknown config payload kind: {kind}")
+    values[field] = payload
+    _migrate_config_asset_paths(
+        root=root,
+        recover_legacy_absolute=False,
+        **values,
+    )
+    return payload
 
 
 def character_name_key(name: str) -> str:
@@ -58,35 +380,60 @@ class ConfigManager:
     _SYSTEM_CONFIG_PATH = Path("data/config/system_config.yaml")
     _BACKGOUND_CONFIG_PATH = Path("data/config/background.yaml")
     _EFFECT_CONFIG_PATH = Path("data/config/effect.yaml")
-    _VERSION_PATH = Path("VERSION")
 
     def __new__(cls, *args, **kwargs):
         """实现单例模式"""
         if cls._instance is None:
             cls._instance = super(ConfigManager, cls).__new__(cls)
+            cls._instance._bind_project_paths()
             # 在首次创建时尝试加载配置
             cls._instance._load_all_configs()
         return cls._instance
 
+    def _bind_project_paths(self) -> None:
+        """Freeze all writable config paths to the authoritative project root."""
+
+        root = project_root()
+        self._project_root = root
+        for attribute in (
+            "_API_CONFIG_PATH",
+            "_CHARACTERS_CONFIG_PATH",
+            "_SYSTEM_CONFIG_PATH",
+            "_BACKGOUND_CONFIG_PATH",
+            "_EFFECT_CONFIG_PATH",
+        ):
+            configured = getattr(type(self), attribute)
+            resolved = resolve_managed_project_path(configured, root=root)
+            setattr(
+                self,
+                attribute,
+                resolved,
+            )
+
     @property
     def version(self) -> str:
-        """读取项目根目录 VERSION 文件，缺失时返回占位字符串。"""
-        candidates = [self._VERSION_PATH]
-        frozen_root = getattr(sys, "_MEIPASS", None)
-        if frozen_root:
-            candidates.append(Path(frozen_root) / "VERSION")
-        candidates.append(Path(sys.executable).resolve(strict=False).parent / "VERSION")
+        """Read immutable application version metadata, never project data."""
+
+        candidates: list[Path] = []
+        try:
+            from sdk.path_contract import resolve_runtime_asset_read_path
+
+            candidates.append(
+                resolve_runtime_asset_read_path(
+                    "VERSION",
+                    root=self._project_root,
+                    resource_prefixes=(("VERSION",),),
+                )
+            )
+        except Exception:
+            pass
         seen: set[Path] = set()
         for candidate in candidates:
-            try:
-                path = candidate.resolve(strict=False)
-            except OSError:
-                path = candidate
-            if path in seen:
+            if candidate in seen:
                 continue
-            seen.add(path)
+            seen.add(candidate)
             try:
-                text = path.read_text(encoding="utf-8").strip()
+                text = read_text_without_links(candidate).strip()
             except Exception:
                 continue
             if text:
@@ -106,12 +453,13 @@ class ConfigManager:
     # --- 内部加载/合并逻辑 ---
     def _load_yaml(self, file_path: Path) -> Dict[str, Any]:
         """加载单个 YAML 文件"""
+        root = getattr(self, "_project_root", None) or project_root()
+        file_path = resolve_managed_project_path(file_path, root=root)
         if not file_path.exists():
             print(f"警告：配置文件未找到：{file_path}")
             return {}
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                return yaml.safe_load(f)
+            return yaml.safe_load(read_text_without_links(file_path))
         except Exception as e:
             raise IOError(f"加载配置文件 {file_path} 失败: {e}")
 
@@ -125,6 +473,38 @@ class ConfigManager:
             background_data = self._load_yaml(self._BACKGOUND_CONFIG_PATH)
             effect_data = self._load_yaml(self._EFFECT_CONFIG_PATH)
 
+            path_contract_version = (
+                system_data.get("path_contract_version")
+                if isinstance(system_data, dict)
+                else None
+            )
+            recover_legacy_absolute = not (
+                isinstance(path_contract_version, int)
+                and not isinstance(path_contract_version, bool)
+                and path_contract_version >= _PATH_CONTRACT_VERSION
+            )
+            migrated = _migrate_config_asset_paths(
+                root=getattr(self, "_project_root", None) or project_root(),
+                api_data=api_data,
+                characters_data=characters_data,
+                system_data=system_data,
+                background_data=background_data,
+                effect_data=effect_data,
+                recover_legacy_absolute=recover_legacy_absolute,
+            )
+            if recover_legacy_absolute:
+                if not isinstance(system_data, dict):
+                    system_data = {}
+                system_data["path_contract_version"] = _PATH_CONTRACT_VERSION
+                migrated.add("system")
+            migrated_payloads = {
+                "api": (self._API_CONFIG_PATH, api_data),
+                "characters": (self._CHARACTERS_CONFIG_PATH, characters_data),
+                "system": (self._SYSTEM_CONFIG_PATH, system_data),
+                "background": (self._BACKGOUND_CONFIG_PATH, background_data),
+                "effect": (self._EFFECT_CONFIG_PATH, effect_data),
+            }
+
             # 通过 Pydantic 进行验证和结构化
             api_config = ApiConfig.model_validate(api_data)
             system_config = SystemConfig.model_validate(system_data)
@@ -134,6 +514,8 @@ class ConfigManager:
                 characters_data = [] # 处理文件为空或格式错误的情况
                 
             character_list = [Character.model_validate(normalize_sprite_voice_types(item)) for item in characters_data]
+            if not isinstance(background_data, list):
+                background_data = []
             background = [Background.model_validate(item) for item in background_data]
             if not isinstance(effect_data, list):
                 effect_data = []
@@ -147,8 +529,31 @@ class ConfigManager:
                 background_list=background,
                 effect_list=effect_list,
             )
+            # Persist the one-time migration marker only after every config
+            # payload has validated. Otherwise a malformed unrelated file
+            # could permanently suppress the legacy recovery on the next
+            # successful launch.
+            # The system file owns ``path_contract_version`` and therefore acts
+            # as the commit record for this multi-file migration. Publish every
+            # other repaired payload first and the marker last. If any earlier
+            # write fails, the next launch must retry legacy-path recovery.
+            migration_write_order = (
+                "api",
+                "characters",
+                "background",
+                "effect",
+                "system",
+            )
+            for name in migration_write_order:
+                if name not in migrated:
+                    continue
+                path, payload = migrated_payloads[name]
+                self._save_single_config(path, payload)
             apply_network_proxy_environment(system_config)
-            apply_mirror_environment(system_config)
+            apply_mirror_environment(
+                system_config,
+                root=getattr(self, "_project_root", None) or project_root(),
+            )
             print("配置加载成功！")
         except ValidationError as e:
             self._config = None
@@ -172,9 +577,15 @@ class ConfigManager:
         
         print("正在保存 api.yaml...")
         # 将 Pydantic 实体转换为字典进行保存
+        payload = self.config.api_config.model_dump(by_alias=True)
+        _normalize_config_payload_paths(
+            "api",
+            payload,
+            getattr(self, "_project_root", None) or project_root(),
+        )
         self._save_single_config(
             self._API_CONFIG_PATH, 
-            self.config.api_config.model_dump(by_alias=True)
+            payload,
         )
         print("api.yaml 保存完成。")
 
@@ -185,12 +596,21 @@ class ConfigManager:
             return
             
         print("正在保存 system_config.yaml...")
+        payload = self.config.system_config.model_dump(by_alias=True)
+        _normalize_config_payload_paths(
+            "system",
+            payload,
+            getattr(self, "_project_root", None) or project_root(),
+        )
         self._save_single_config(
             self._SYSTEM_CONFIG_PATH, 
-            self.config.system_config.model_dump(by_alias=True)
+            payload,
         )
         apply_network_proxy_environment(self.config.system_config)
-        apply_mirror_environment(self.config.system_config)
+        apply_mirror_environment(
+            self.config.system_config,
+            root=getattr(self, "_project_root", None) or project_root(),
+        )
         print("system_config.yaml 保存完成。")
 
     def set_ui_language(self, code: str) -> None:
@@ -201,8 +621,13 @@ class ConfigManager:
 
         sc = self.config.system_config.model_copy(deep=True)
         sc.ui_language = normalize_lang(code)
+        previous = self.config.system_config
         self.config.system_config = sc
-        self.save_system_config()
+        try:
+            self.save_system_config()
+        except BaseException:
+            self.config.system_config = previous
+            raise
     
     def save_api_config_new(
         self,
@@ -266,27 +691,40 @@ class ConfigManager:
         current_api_config.gpt_sovits_api_path = default_tts_work_path(
             current_api_config.tts_provider,
             gpt_sovits_api_path,
+            getattr(self, "_project_root", None) or project_root(),
         )
         if uses_shared_tts_server_config(current_api_config.tts_provider):
             tts_url = str(current_api_config.gpt_sovits_url or "").strip()
-            tts_path = str(current_api_config.gpt_sovits_api_path or "").strip()
+            tts_path = str(current_api_config.gpt_sovits_api_path or "")
             if not tts_url:
                 return "错误：当前 TTS 引擎需要填写 URL。"
             if not is_http_url(tts_url):
                 return "错误：TTS URL 必须是有效的 http(s) URL。"
             if requires_tts_work_path(current_api_config.tts_provider) and not tts_path:
                 return "错误：本地 TTS 引擎需要填写服务启动路径。"
-            if (
-                tts_path
-                and current_api_config.tts_provider != "kaggle-gpt-sovits"
-                and not Path(tts_path).expanduser().is_dir()
-            ):
-                return "错误：TTS 服务启动路径必须是已存在的目录。"
+            if tts_path and current_api_config.tts_provider != "kaggle-gpt-sovits":
+                try:
+                    tts_directory = resolve_runtime_asset_read_path(
+                        tts_path,
+                        root=getattr(self, "_project_root", None) or project_root(),
+                        resource_prefixes=(),
+                    )
+                except (OSError, RuntimeError, ValueError):
+                    return "错误：TTS 服务启动路径必须是已存在且不经过链接的目录。"
+                if not tts_directory.is_dir():
+                    return "错误：TTS 服务启动路径必须是已存在的目录。"
         current_api_config.t2i_api_url=t2i_url
         current_api_config.t2i_work_path=t2i_work_path
         current_api_config.t2i_default_workflow_path=t2i_default_workflow_path
         current_api_config.t2i_prompt_node_id=prompt_node_id
         current_api_config.t2i_output_node_id=output_node_id
+        try:
+            validate_t2i_paths_for_save(
+                current_api_config,
+                project_root=getattr(self, "_project_root", None) or project_root(),
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            return f"错误：{exc}"
         current_api_config.temperature = float(temperature)
         current_api_config.repetition_penalty = float(repetition_penalty)
         current_api_config.presence_penalty = float(presence_penalty)
@@ -302,14 +740,15 @@ class ConfigManager:
         current_api_config.history_recent_messages = int(history_recent_messages)
         current_api_config.max_tool_result_chars = int(max_tool_result_chars)
         current_api_config.max_active_tool_groups = int(max_active_tool_groups)
+        previous_api_config = self.config.api_config
         self.config.api_config = current_api_config
 
-        
         # 6. 持久化到文件
-        self._save_single_config(
-            self._API_CONFIG_PATH, 
-            self.config.api_config.model_dump(by_alias=True)
-        )
+        try:
+            self.save_api_config()
+        except BaseException:
+            self.config.api_config = previous_api_config
+            raise
         return "API配置已保存！"
 
     def update_llm_info(self, llm_provider: str) -> tuple[str, str, str]:
@@ -341,6 +780,11 @@ class ConfigManager:
         print("正在保存 characters.yaml...")
         # 角色列表需要将每个 Character 实体转换为字典
         characters_data = [char.model_dump(by_alias=True) for char in self.config.characters]
+        _normalize_config_payload_paths(
+            "characters",
+            characters_data,
+            getattr(self, "_project_root", None) or project_root(),
+        )
         self._save_single_config(self._CHARACTERS_CONFIG_PATH, characters_data)
         print("characters.yaml 保存完成。")
     
@@ -351,6 +795,11 @@ class ConfigManager:
 
         print("正在保存 background.yaml...")
         background_data = [char.model_dump(by_alias=True) for char in self.config.background_list]
+        _normalize_config_payload_paths(
+            "background",
+            background_data,
+            getattr(self, "_project_root", None) or project_root(),
+        )
         self._save_single_config(self._BACKGOUND_CONFIG_PATH, background_data)
         print("background.yaml 保存完成。")
 
@@ -361,18 +810,29 @@ class ConfigManager:
 
         print("正在保存 effect.yaml...")
         effect_data = [ef.model_dump(by_alias=True) for ef in self.config.effect_list]
+        _normalize_config_payload_paths(
+            "effect",
+            effect_data,
+            getattr(self, "_project_root", None) or project_root(),
+        )
         self._save_single_config(self._EFFECT_CONFIG_PATH, effect_data)
         print("effect.yaml 保存完成。")
 
     def _save_single_config(self, file_path: Path, data: Union[Dict, List]) -> None:
-        """保存单个配置到 YAML 文件"""
-        file_path.parent.mkdir(parents=True, exist_ok=True) # 确保目录存在
-        try:
-            with open(file_path, 'w', encoding='utf-8') as f:
-                # 使用 default_flow_style=False 提高 YAML 的可读性
-                yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
-        except Exception as e:
-            print(f"错误：保存配置到 {file_path} 失败: {e}")
+        """Atomically publish one YAML config or leave the prior file untouched."""
+
+        raw_file_path = validate_exact_path_text(file_path, field="config file path")
+        root = getattr(self, "_project_root", None) or project_root()
+        file_path = resolve_managed_project_path(raw_file_path, root=root)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        serialized = yaml.dump(
+            data,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+        with _CONFIG_WRITE_LOCK:
+            atomic_write_text(file_path, serialized)
 
     def get_background_by_name(self, name: str) -> Optional[Background]:
         for char in self.config.background_list:
@@ -407,7 +867,11 @@ class ConfigManager:
         provider = normalize_tts_provider(self.config.api_config.tts_provider)
         return (
             tts_server_url_or_default(provider, self.config.api_config.gpt_sovits_url),
-            default_tts_work_path(provider, self.config.api_config.gpt_sovits_api_path),
+            default_tts_work_path(
+                provider,
+                self.config.api_config.gpt_sovits_api_path,
+                getattr(self, "_project_root", None) or project_root(),
+            ),
             provider,
         )
 
@@ -502,7 +966,7 @@ class ConfigManager:
         if self._config is None:
             return "错误：配置未加载，无法保存。"
         sc = self.config.system_config.model_copy(deep=True)
-        sc.music_cover_work_dir = work_dir or "./data/music_cover"
+        sc.music_cover_work_dir = work_dir or "data/music_cover"
         sc.music_cover_yt_dlp_exe = yt_dlp_exe or ""
         sc.music_cover_ffmpeg_exe = ffmpeg_exe or ""
         sc.music_cover_uvr_cmd_template = uvr_cmd_template or ""
@@ -518,6 +982,11 @@ class ConfigManager:
         sc.music_cover_rvc_resample_sr = int(rvc_resample_sr)
         sc.music_cover_rvc_rms_mix_rate = float(rvc_rms_mix_rate)
         sc.music_cover_rvc_protect = float(rvc_protect)
+        previous_system_config = self.config.system_config
         self.config.system_config = sc
-        self.save_system_config()
+        try:
+            self.save_system_config()
+        except BaseException:
+            self.config.system_config = previous_system_config
+            raise
         return "音乐翻唱配置已保存。"

--- a/config/mcp_config.py
+++ b/config/mcp_config.py
@@ -1,66 +1,147 @@
-"""Schema defaults and persistence for ``data/config/mcp.yaml``."""
+"""MCP 配置文件读写（仅 PyYAML，不依赖 ``mcp`` 包）。"""
 
 from __future__ import annotations
 
+import os
+import threading
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from sdk.file_transactions import atomic_write_text, read_text_without_links
+from sdk.path_contract import project_root as configured_project_root
+from sdk.path_contract import (
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resolve_project_output_path,
+    resolve_project_path,
+    validate_exact_path_text,
+)
 
 DEFAULT_MCP_CONFIG_PATH = Path("data/config/mcp.yaml")
+_MCP_CONFIG_LOCK = threading.RLock()
+
+
+def resolve_mcp_config_path(
+    path: str | Path | None = None,
+    *,
+    project_root: str | Path | None = None,
+) -> Path:
+    raw = os.fspath(DEFAULT_MCP_CONFIG_PATH if path is None else path)
+    if not raw or raw != raw.strip() or any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in raw
+    ):
+        raise ValueError("MCP config path is empty or contains non-portable characters")
+    root = (
+        resolve_project_path(".", root=project_root)
+        if project_root is not None
+        else configured_project_root()
+    )
+    candidate = Path(raw).expanduser()
+    if candidate.is_absolute():
+        require_symlink_free_absolute_path(
+            candidate,
+            field="MCP config path",
+        )
+    return resolve_project_output_path(raw, root=root)
+
+
+def require_openable_mcp_config_path(path: str | Path) -> Path:
+    """Revalidate a bound config path immediately before handing it to the OS."""
+
+    return require_symlink_free_absolute_path(path, field="MCP config path")
+
+
+def resolve_mcp_stdio_working_directory(
+    value: str | Path | None = None,
+    *,
+    project_root: str | Path | None = None,
+) -> Path:
+    """Bind an MCP stdio working directory to one explicit project root.
+
+    Missing values intentionally mean the project root.  Relative values are
+    portable project references; absolute values retain their external
+    identity.  In both cases every existing path component must be link-free
+    so validation and process creation cannot address different directories.
+    """
+
+    root = (
+        resolve_project_path(".", root=project_root)
+        if project_root is not None
+        else configured_project_root()
+    )
+    raw = "." if value in (None, "") else os.fspath(value)
+    validate_exact_path_text(
+        raw,
+        field="MCP stdio working directory",
+        allow_dot_root=True,
+    )
+    resolved = resolve_project_path(raw, root=root)
+    if raw == ".":
+        lexical = root
+    else:
+        expanded = Path(raw).expanduser()
+        lexical = (
+            expanded
+            if expanded.is_absolute()
+            else root.joinpath(*raw.replace("\\", "/").split("/"))
+        )
+    exact = require_directory_without_links(
+        lexical,
+        field="MCP stdio working directory",
+        allow_filesystem_root=True,
+    )
+    if exact.resolve(strict=False) != resolved:
+        raise PermissionError("MCP stdio working directory changed identity")
+    return exact
 
 
 def default_mcp_config() -> dict[str, Any]:
-    return {
-        "enabled": True,
-        "default_call_timeout": 300.0,
-        "servers": [],
-    }
+    return {"enabled": True, "default_call_timeout": 300.0, "servers": []}
 
 
-def read_mcp_config(path: Path | None = None) -> dict[str, Any]:
-    config_path = path or DEFAULT_MCP_CONFIG_PATH
-    config = default_mcp_config()
-    if not config_path.is_file():
-        return config
+def read_mcp_config(path: str | Path | None = None) -> dict[str, Any]:
+    p = resolve_mcp_config_path(path)
+    base = default_mcp_config()
+    if not p.is_file():
+        return base
     try:
-        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        with _MCP_CONFIG_LOCK:
+            raw = yaml.safe_load(read_text_without_links(p))
     except Exception:
-        return config
+        return base
     if not isinstance(raw, dict):
-        return config
+        return base
     if "enabled" in raw:
-        config["enabled"] = bool(raw["enabled"])
+        base["enabled"] = bool(raw["enabled"])
     if raw.get("default_call_timeout") is not None:
         try:
-            config["default_call_timeout"] = float(raw["default_call_timeout"])
+            base["default_call_timeout"] = float(raw["default_call_timeout"])
         except (TypeError, ValueError):
             pass
     servers = raw.get("servers")
     if isinstance(servers, list):
-        config["servers"] = [server for server in servers if isinstance(server, dict)]
-    return config
+        base["servers"] = [x for x in servers if isinstance(x, dict)]
+    return base
 
 
-def write_mcp_config(
-    data: dict[str, Any],
-    path: Path | None = None,
-) -> None:
-    config_path = path or DEFAULT_MCP_CONFIG_PATH
-    config_path.parent.mkdir(parents=True, exist_ok=True)
+def write_mcp_config(data: dict[str, Any], path: str | Path | None = None) -> None:
+    p = resolve_mcp_config_path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "enabled": bool(data.get("enabled", True)),
         "default_call_timeout": float(data.get("default_call_timeout", 300)),
-        "servers": (
-            data.get("servers") if isinstance(data.get("servers"), list) else []
-        ),
+        "servers": data.get("servers") if isinstance(data.get("servers"), list) else [],
     }
-    with config_path.open("w", encoding="utf-8") as file:
-        yaml.safe_dump(
-            payload,
-            file,
-            allow_unicode=True,
-            default_flow_style=False,
-            sort_keys=False,
-        )
+    serialized = yaml.safe_dump(
+        payload,
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    with _MCP_CONFIG_LOCK:
+        atomic_write_text(p, serialized)

--- a/config/mirror_env.py
+++ b/config/mirror_env.py
@@ -13,12 +13,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from sdk.file_transactions import read_text_without_links
+from sdk.path_contract import (
+    project_root,
+    require_directory_without_links,
+    resolve_project_output_path,
+    resolve_project_path,
+    resolve_project_read_path,
+)
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_HUGGINGFACE_MIRROR_URL = "https://hf-mirror.com"
 DEFAULT_GITHUB_MIRROR_URL = "https://gh-proxy.com/"
 DEFAULT_PYPI_MIRROR_URL = "https://pypi.tuna.tsinghua.edu.cn/simple/"
-DEFAULT_HUGGINGFACE_CACHE_DIR = "./data/cache/huggingface"
+DEFAULT_HUGGINGFACE_CACHE_DIR = "data/cache/huggingface"
 OFFICIAL_HUGGINGFACE_URL = "https://huggingface.co"
 OFFICIAL_GITHUB_URL = "https://github.com"
 OFFICIAL_PYPI_INDEX_URL = "https://pypi.org/simple/"
@@ -140,7 +149,7 @@ def resolved_mirror_values(config: Any) -> MirrorValues:
         region = REGION_GLOBAL
 
     huggingface = str(getattr(config, "huggingface_mirror_url", "") or "").strip()
-    huggingface_cache_dir = str(getattr(config, "huggingface_cache_dir", "") or "").strip()
+    huggingface_cache_dir = str(getattr(config, "huggingface_cache_dir", "") or "")
     github = str(getattr(config, "github_mirror_url", "") or "").strip()
     pypi = str(getattr(config, "pypi_mirror_url", "") or "").strip()
     if use_china_defaults:
@@ -174,7 +183,11 @@ def system_config_payload_with_resolved_mirrors(config: Any) -> dict[str, Any]:
     return payload
 
 
-def apply_mirror_environment(config: Any) -> MirrorValues:
+def apply_mirror_environment(
+    config: Any,
+    *,
+    root: str | Path | None = None,
+) -> MirrorValues:
     values = resolved_mirror_values(config)
     detection_mode = "auto" if bool(getattr(config, "mirror_auto_detect_china", True)) else "manual"
     huggingface_source = _redact_url(values.huggingface or OFFICIAL_HUGGINGFACE_URL)
@@ -183,10 +196,31 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     _set_or_restore_env("HF_ENDPOINT", values.huggingface)
     _set_or_restore_env("HUGGINGFACE_HUB_ENDPOINT", values.huggingface)
     _set_or_restore_env("SHINSEKAI_HUGGINGFACE_MIRROR_URL", values.huggingface)
-    hf_home = _resolved_cache_path(values.huggingface_cache_dir)
-    hf_hub_cache = (Path(hf_home) / "hub").as_posix()
-    transformers_cache = (Path(hf_home) / "transformers").as_posix()
-    _ensure_cache_dirs(hf_home, hf_hub_cache, transformers_cache)
+    cache_project_root = (
+        project_root()
+        if root is None
+        else resolve_project_path(".", root=root)
+    )
+    hf_home_path = resolve_project_output_path(
+        values.huggingface_cache_dir or DEFAULT_HUGGINGFACE_CACHE_DIR,
+        root=cache_project_root,
+    )
+    hf_hub_cache_path = resolve_project_output_path(
+        hf_home_path / "hub",
+        root=cache_project_root,
+    )
+    transformers_cache_path = resolve_project_output_path(
+        hf_home_path / "transformers",
+        root=cache_project_root,
+    )
+    _ensure_cache_dirs(
+        hf_home_path,
+        hf_hub_cache_path,
+        transformers_cache_path,
+    )
+    hf_home = hf_home_path.as_posix()
+    hf_hub_cache = hf_hub_cache_path.as_posix()
+    transformers_cache = transformers_cache_path.as_posix()
     _set_or_restore_env("HF_HOME", hf_home)
     _set_or_restore_env("HF_HUB_CACHE", hf_hub_cache)
     _set_or_restore_env("HUGGINGFACE_HUB_CACHE", hf_hub_cache)
@@ -221,25 +255,43 @@ def apply_mirror_environment(config: Any) -> MirrorValues:
     return values
 
 
-def apply_mirror_environment_from_system_config(path: str | Path | None = None) -> MirrorValues:
+def apply_mirror_environment_from_system_config(
+    path: str | Path | None = None,
+    *,
+    root: str | Path | None = None,
+) -> MirrorValues:
     """Apply mirror env early without constructing the full ConfigManager."""
+    config_project_root = (
+        project_root()
+        if root is None
+        else resolve_project_path(".", root=root)
+    )
+    config_path = resolve_project_read_path(
+        "data/config/system_config.yaml" if path is None else path,
+        root=config_project_root,
+    )
     try:
         import yaml
         from config.schema import SystemConfig
 
-        config_path = Path(path or "data/config/system_config.yaml")
         raw = {}
         if config_path.is_file():
-            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            loaded = yaml.safe_load(read_text_without_links(config_path))
             raw = loaded if isinstance(loaded, dict) else {}
-        return apply_mirror_environment(SystemConfig.model_validate(raw))
+        return apply_mirror_environment(
+            SystemConfig.model_validate(raw),
+            root=config_project_root,
+        )
     except Exception as exc:
         logger.warning(
             "Falling back to default mirror configuration after config read failed: %s",
             exc,
             extra={"event": "mirror.env.fallback"},
         )
-        return apply_mirror_environment(_FallbackMirrorConfig())
+        return apply_mirror_environment(
+            _FallbackMirrorConfig(),
+            root=config_project_root,
+        )
 
 
 def mirror_github_url(url: str) -> str:
@@ -354,25 +406,25 @@ class _FallbackMirrorConfig:
     pypi_mirror_url = ""
 
 
-def _resolved_cache_path(raw: str) -> str:
-    path = Path(raw or DEFAULT_HUGGINGFACE_CACHE_DIR).expanduser()
-    if not path.is_absolute():
-        path = Path.cwd() / path
-    return path.resolve(strict=False).as_posix()
-
-
-def _ensure_cache_dirs(*paths: str) -> None:
-    for raw in paths:
+def _ensure_cache_dirs(*paths: Path) -> None:
+    for path in paths:
         try:
-            Path(raw).mkdir(parents=True, exist_ok=True)
+            path.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
             logger.warning(
                 "Could not create HuggingFace cache directory %s: %s",
-                raw,
+                path,
                 exc,
-                extra={"event": "mirror.cache.mkdir.failed", "path": raw},
+                extra={"event": "mirror.cache.mkdir.failed", "path": str(path)},
             )
-            pass
+            continue
+        # Do not downgrade an ownership/link violation to a warning. A path can
+        # be replaced between output resolution and mkdir; exporting that alias
+        # would let model downloads escape the selected project root.
+        require_directory_without_links(
+            path,
+            field="HuggingFace cache directory",
+        )
 
 
 def _redact_url(url: str) -> str:

--- a/config/network_proxy.py
+++ b/config/network_proxy.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import logging
 import os
 import platform as platform_module
-import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
+
+from sdk.file_transactions import read_text_without_links
+from sdk.process_launch import (
+    capture_command_executable,
+    capture_launch_directory,
+    run_with_stable_paths,
+)
+from sdk.path_contract import resolve_project_read_path, user_home_directory
 
 logger = logging.getLogger(__name__)
 
@@ -101,15 +108,15 @@ def apply_network_proxy_environment(config: Any) -> NetworkProxyValues:
 
 def apply_network_proxy_environment_from_system_config(path: str | Path | None = None) -> NetworkProxyValues:
     """Apply proxy env early without constructing the full ConfigManager."""
+    config_path = resolve_project_read_path(
+        "data/config/system_config.yaml" if path is None else path
+    )
     try:
         import yaml
         from config.schema import SystemConfig
 
-        config_path = Path(path or "data/config/system_config.yaml")
-        raw = {}
-        if config_path.is_file():
-            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-            raw = loaded if isinstance(loaded, dict) else {}
+        loaded = yaml.safe_load(read_text_without_links(config_path))
+        raw = loaded if isinstance(loaded, dict) else {}
         return apply_network_proxy_environment(SystemConfig.model_validate(raw))
     except Exception as exc:
         logger.warning(
@@ -294,8 +301,6 @@ def _parse_windows_proxy_server(value: str) -> NetworkProxyDetection:
 
 
 def _detect_macos_proxy() -> NetworkProxyDetection:
-    if not shutil.which("scutil"):
-        return NetworkProxyDetection("", "", "", "macos")
     output = _run_text_command(["scutil", "--proxy"])
     values = _parse_scutil_proxy_output(output)
     return NetworkProxyDetection(
@@ -331,8 +336,6 @@ def _parse_scutil_proxy_output(output: str) -> dict[str, str]:
 
 
 def _detect_gnome_proxy() -> NetworkProxyDetection:
-    if not shutil.which("gsettings"):
-        return NetworkProxyDetection("", "", "", "gnome")
     mode = _strip_command_value(_run_text_command(["gsettings", "get", "org.gnome.system.proxy", "mode"]))
     if mode != "manual":
         return NetworkProxyDetection("", "", "", "gnome")
@@ -357,15 +360,16 @@ def _detect_gnome_proxy() -> NetworkProxyDetection:
 
 
 def _detect_kde_proxy() -> NetworkProxyDetection:
-    config_path = Path.home() / ".config" / "kioslaverc"
-    if not config_path.is_file():
+    try:
+        config_path = user_home_directory() / ".config" / "kioslaverc"
+    except (KeyError, OSError, RuntimeError, ValueError):
         return NetworkProxyDetection("", "", "", "kde")
     try:
         import configparser
 
         parser = configparser.ConfigParser()
         parser.optionxform = str  # preserve KDE key casing
-        parser.read(config_path, encoding="utf-8")
+        parser.read_string(read_text_without_links(config_path))
         section = parser["Proxy Settings"]
         if str(section.get("ProxyType", "")).strip() != "1":
             return NetworkProxyDetection("", "", "", "kde")
@@ -380,8 +384,21 @@ def _detect_kde_proxy() -> NetworkProxyDetection:
 
 
 def _run_text_command(command: list[str]) -> str:
-    completed = subprocess.run(
-        command,
+    if not command:
+        raise ValueError("proxy probe command is empty")
+    executable = capture_command_executable(
+        command[0],
+        field="proxy probe executable",
+    )
+    cwd = capture_launch_directory(
+        user_home_directory(),
+        field="proxy probe working directory",
+    )
+    completed = run_with_stable_paths(
+        [executable.path, *command[1:]],
+        cwd=cwd,
+        executable=executable,
+        run_factory=subprocess.run,
         capture_output=True,
         check=False,
         text=True,

--- a/config/schema.py
+++ b/config/schema.py
@@ -35,9 +35,14 @@ def clamp_compact_target_ratio(compact_threshold: float, compact_target_ratio: f
 
 # Character Config Models
 class Sprite(BaseModel):
-    """角色的单个立绘/语音配置"""
-    path: FilePath = Field(..., description="立绘图片的文件路径")
-    voice_path: Optional[FilePath] = Field(None, description="对应的语音文件的路径 (可选)")
+    """角色的单个立绘/语音引用。
+
+    配置解析不能访问文件系统来决定整份配置是否有效。项目迁移、离线盘符
+    或单个素材缺失时仍需允许应用启动，由实际读取/上传边界报告并修复素材。
+    """
+
+    path: str = Field(..., description="立绘图片的文件路径")
+    voice_path: Optional[str] = Field(None, description="对应的语音文件的路径 (可选)")
     voice_text: Optional[str] = Field(None, description="语音对应的文本内容 (可选, 存在于某些条目中)")
     voice_type: Optional[str] = Field(None, description="语音类型: fallback、preset 或 reference")
 
@@ -153,6 +158,10 @@ class ApiConfig(BaseModel):
 # System Config Model
 class SystemConfig(BaseModel):
     """系统相关的通用配置"""
+    path_contract_version: DefaultIfNone[int] = Field(
+        default=1,
+        description="持久化路径契约版本（内部迁移标记）",
+    )
     # 应用 DefaultIfNone
     base_font_size_px: DefaultIfNone[int] = Field(default=56, description="基础字体大小 (像素)")
     ui_language: DefaultIfNone[str] = Field(
@@ -278,7 +287,7 @@ class SystemConfig(BaseModel):
         return self
 
     music_cover_work_dir: DefaultIfNone[str] = Field(
-        default="./data/music_cover",
+        default="data/music_cover",
         description="翻唱流水线工作目录（下载、分离、中间文件与成品）",
     )
     music_cover_yt_dlp_exe: DefaultIfNone[str] = Field(

--- a/config/sprite_voice.py
+++ b/config/sprite_voice.py
@@ -18,8 +18,8 @@ def normalize_sprite_voice_types(character_data: MutableMapping[str, Any]) -> Mu
         if voice_type in VALID_SPRITE_VOICE_TYPES:
             sprite["voice_type"] = voice_type
             continue
-        voice_path = str(sprite.get("voice_path") or "").strip()
-        if not voice_path:
+        voice_path = str(sprite.get("voice_path") or "")
+        if not voice_path or voice_path != voice_path.strip():
             continue
         voice_text = str(sprite.get("voice_text") or "").strip()
         sprite["voice_type"] = "reference" if voice_text else "fallback"

--- a/config/tts_provider_config.py
+++ b/config/tts_provider_config.py
@@ -1,7 +1,21 @@
 from __future__ import annotations
 
+import os
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
+
+from sdk.file_transactions import (
+    file_snapshot_is_stable,
+    inspect_portable_directory_tree_with_metadata,
+)
+from sdk.path_contract import (
+    managed_project_directory,
+    managed_project_storage,
+    path_is_within,
+    project_root as configured_project_root,
+    resolve_project_path,
+)
 
 LEGACY_DEFAULT_TTS_SERVER_URL = "http://127.0.0.1:9880"
 HTTPS_DEFAULT_TTS_SERVER_URL = "https://127.0.0.1:9880"
@@ -20,6 +34,12 @@ TTS_PROVIDER_BUNDLE_KEYS: dict[str, tuple[str, ...]] = {
     "genie-tts": ("genie_tts_server",),
     "gpt-sovits": ("gpt_sovits_v2pro", "gpt_sovits_nvidia50"),
 }
+
+
+@dataclass(frozen=True)
+class _InstalledBundleSnapshot:
+    path: Path
+    identity: os.stat_result
 
 
 def normalize_tts_provider(value: str | None) -> str:
@@ -68,35 +88,96 @@ def tts_server_url_or_default(provider: str | None, current_url: str | None = ""
     return clean_url
 
 
-def _resolve_extracted_bundle_root(path: Path) -> Path:
-    sub = [entry for entry in path.iterdir() if not entry.name.startswith(".")]
-    if len(sub) == 1 and sub[0].is_dir():
-        return sub[0]
-    return path
+def _inspect_installed_bundle(
+    provider: str,
+    path: Path,
+) -> _InstalledBundleSnapshot | None:
+    root_identity, directories, files = (
+        inspect_portable_directory_tree_with_metadata(path)
+    )
+    directory_identities = dict(directories)
+    file_identities = dict(files)
+    visible_top_level = [
+        entry
+        for entry in (*directory_identities, *file_identities)
+        if len(entry.parts) == 1 and not entry.name.startswith(".")
+    ]
+    relative_root = Path()
+    bundle_identity = root_identity
+    if (
+        len(visible_top_level) == 1
+        and visible_top_level[0] in directory_identities
+    ):
+        relative_root = visible_top_level[0]
+        bundle_identity = directory_identities[relative_root]
 
-
-def _is_valid_bundle_root(provider: str, path: Path) -> bool:
+    required_file: Path | None = None
+    required_directory: Path | None = None
     if provider == "gpt-sovits":
-        return (path / "api_v2.py").is_file()
-    if provider == "genie-tts":
-        return (path / "start.py").is_file() and (path / "runtime").is_dir()
-    return False
+        required_file = relative_root / "api_v2.py"
+    elif provider == "genie-tts":
+        required_file = relative_root / "start.py"
+        required_directory = relative_root / "runtime"
+    if (
+        required_file is None
+        or required_file not in file_identities
+        or (
+            required_directory is not None
+            and required_directory not in directory_identities
+        )
+    ):
+        return None
+
+    bundle_root = path / relative_root
+    current_identity = bundle_root.lstat()
+    if not file_snapshot_is_stable(bundle_identity, current_identity):
+        raise PermissionError(
+            f"installed TTS bundle identity changed: {bundle_root}"
+        )
+    return _InstalledBundleSnapshot(
+        path=bundle_root,
+        identity=bundle_identity,
+    )
 
 
 def _installed_tts_bundle_root_for_key(
     provider: str,
     key: str,
     project_root: str | Path | None = None,
-) -> Path | None:
-    base = INSTALLED_TTS_BUNDLES_PATH
-    bundle_dir = (Path(project_root) / base if project_root else base) / key
+) -> _InstalledBundleSnapshot | None:
+    root = (
+        resolve_project_path(".", root=project_root)
+        if project_root is not None
+        else configured_project_root()
+    )
     try:
-        if not bundle_dir.is_dir():
-            return None
-        root = _resolve_extracted_bundle_root(bundle_dir)
-        if _is_valid_bundle_root(provider, root):
-            return root.resolve()
+        base = managed_project_storage(INSTALLED_TTS_BUNDLES_PATH, root=root)
     except OSError:
+        return None
+    try:
+        bundle_dir = managed_project_directory(
+            INSTALLED_TTS_BUNDLES_PATH,
+            key,
+            root=root,
+        )
+        bundle_snapshot = _inspect_installed_bundle(provider, bundle_dir)
+        if bundle_snapshot is None:
+            return None
+        bundle_root = bundle_snapshot.path
+        if not path_is_within(bundle_dir, base):
+            return None
+        if not path_is_within(bundle_root, bundle_dir):
+            return None
+        current_identity = bundle_root.lstat()
+        if not file_snapshot_is_stable(
+            bundle_snapshot.identity,
+            current_identity,
+        ):
+            raise PermissionError(
+                f"installed TTS bundle identity changed: {bundle_root}"
+            )
+        return bundle_snapshot
+    except (OSError, PermissionError, ValueError):
         return None
     return None
 
@@ -104,14 +185,32 @@ def _installed_tts_bundle_root_for_key(
 def installed_tts_bundle_paths(project_root: str | Path | None = None) -> dict[str, str]:
     paths: dict[str, str] = {}
     for provider, keys in TTS_PROVIDER_BUNDLE_KEYS.items():
-        roots = [
-            root
+        snapshots = [
+            snapshot
             for key in keys
-            if (root := _installed_tts_bundle_root_for_key(provider, key, project_root)) is not None
+            if (
+                snapshot := _installed_tts_bundle_root_for_key(
+                    provider,
+                    key,
+                    project_root,
+                )
+            )
+            is not None
         ]
-        if roots:
-            newest = max(roots, key=lambda root: root.stat().st_mtime)
-            paths[provider] = newest.as_posix()
+        if snapshots:
+            newest = max(
+                snapshots,
+                key=lambda snapshot: snapshot.identity.st_mtime_ns,
+            )
+            try:
+                current_identity = newest.path.lstat()
+            except FileNotFoundError:
+                continue
+            if file_snapshot_is_stable(
+                newest.identity,
+                current_identity,
+            ):
+                paths[provider] = newest.path.as_posix()
     return paths
 
 
@@ -133,7 +232,17 @@ def default_tts_work_path(
     provider_key = normalize_tts_provider(provider)
     if provider_key == "kaggle-gpt-sovits":
         return ""
-    clean_path = str(current_path or "").strip()
-    if clean_path or not requires_tts_work_path(provider_key):
-        return clean_path
+    raw_path = str(current_path or "")
+    if raw_path and (
+        raw_path != raw_path.strip()
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in raw_path
+        )
+    ):
+        raise ValueError("TTS work path contains non-portable characters")
+    if raw_path or not requires_tts_work_path(provider_key):
+        return raw_path
     return installed_tts_bundles_path(provider_key, project_root)


### PR DESCRIPTION
## What changed

Adds exact path validation and safe persistence rules to configuration,
character, proxy, mirror, schema, and provider handling under `config/`.

## Why

Configuration paths need a stable representation before they are saved,
displayed, or consumed by runtime services.

## Impact

Invalid, ambiguous, or unsafe path values fail at the configuration boundary
instead of surfacing later during launch or file access.

## Root cause

Configuration modules previously normalized and validated paths independently,
which allowed saved state and runtime state to diverge.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `config/`.
