### PR TITLE
fix(core): enforce migration-safe path contracts

### DIFF
--- a/core/archive_paths.py
+++ b/core/archive_paths.py
@@ -1,0 +1,10 @@
+"""Compatibility alias for the canonical :mod:`sdk.archive_paths` module."""
+
+from __future__ import annotations
+
+import sys
+
+from sdk import archive_paths as _implementation
+
+
+sys.modules[__name__] = _implementation

--- a/core/bootstrap/frozen_log.py
+++ b/core/bootstrap/frozen_log.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
 from datetime import datetime
-from pathlib import Path
+
+from core.file_transactions import open_text_append_without_links
+from core.paths import (
+    managed_child_path,
+    managed_project_storage,
+    project_root,
+    safe_path_component_with_suffix,
+)
 
 
 def _should_redirect_stdio_to_file() -> bool:
@@ -23,6 +29,22 @@ def _should_redirect_stdio_to_file() -> bool:
         return True
 
 
+def _frozen_log_filename(log_name: str) -> str:
+    safe = "".join(c for c in log_name if c.isalnum() or c in "._-") or "app"
+    try:
+        return safe_path_component_with_suffix(
+            safe,
+            ".log",
+            field="frozen log filename",
+        )
+    except ValueError:
+        return safe_path_component_with_suffix(
+            f"app-{safe}",
+            ".log",
+            field="frozen log filename",
+        )
+
+
 def init_frozen_stdio(log_name: str) -> None:
     """
     在 sys.frozen 为 True 且当前 stdout 非 TTY 时，把 stdout/stderr 指到
@@ -35,15 +57,15 @@ def init_frozen_stdio(log_name: str) -> None:
         or not log_name
     ):
         return
-    safe = "".join(c for c in log_name if c.isalnum() or c in "._-")
-    if not safe:
-        safe = "app"
-    rel = os.environ.get("EASYAI_PROJECT_ROOT")
-    root = Path(rel).resolve() if rel else Path(sys.executable).resolve().parent.parent
-    d = root / "logs"
+    root = project_root()
+    d = managed_project_storage("logs", root=root)
     d.mkdir(parents=True, exist_ok=True)
-    path = d / f"{safe}.log"
-    f = path.open("a", encoding="utf-8", buffering=1)
+    path = managed_child_path(
+        d,
+        _frozen_log_filename(log_name),
+        field="frozen log filename",
+    )
+    f = open_text_append_without_links(path)
     f.write(
         f"\n{'=' * 60}\n{datetime.now().isoformat(sep=' ', timespec='seconds')}  {log_name}  \n"
     )

--- a/core/file_transactions.py
+++ b/core/file_transactions.py
@@ -1,0 +1,10 @@
+"""Compatibility alias for the canonical :mod:`sdk.file_transactions` module."""
+
+from __future__ import annotations
+
+import sys
+
+from sdk import file_transactions as _implementation
+
+
+sys.modules[__name__] = _implementation

--- a/core/media/chat_attachments.py
+++ b/core/media/chat_attachments.py
@@ -2,12 +2,28 @@ from __future__ import annotations
 
 import mimetypes
 import os
-import shutil
+import re
 import uuid
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable, Mapping
+
+from core.file_transactions import (
+    copy_file_exclusive_with_identity,
+    open_binary_read_without_links,
+    remove_directory_without_links,
+)
+from core.paths import (
+    managed_project_storage,
+    path_is_within,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resolve_project_path,
+    resolve_project_read_path,
+    safe_path_component,
+    validate_exact_path_text,
+)
 
 
 MAX_CHAT_ATTACHMENTS = 8
@@ -27,25 +43,32 @@ SUPPORTED_CHAT_IMAGE_MIME_TYPES = frozenset(
 
 @dataclass(frozen=True, slots=True)
 class ResolvedChatAttachment:
+    identity: os.stat_result
     kind: str
     mime_type: str
     name: str
     path: Path
     size: int
+    reference: str = ""
 
     def to_payload(self) -> dict[str, str | int]:
         return {
             "kind": self.kind,
             "mimeType": self.mime_type,
             "name": self.name,
-            "path": str(self.path),
+            "path": self.reference or str(self.path),
             "size": self.size,
         }
 
 
 def _reject_control_characters(value: str, *, field: str) -> str:
-    if any(ord(character) < 32 or ord(character) == 127 for character in value):
-        raise ValueError(f"{field} contains control characters")
+    if any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in value
+    ):
+        raise ValueError(f"{field} contains non-portable characters")
     return value
 
 
@@ -58,46 +81,123 @@ def _attachment_kind(value: Any) -> str:
 
 @lru_cache(maxsize=1)
 def _chat_attachment_root() -> Path:
-    root_value = os.environ.get(CHAT_ATTACHMENTS_ROOT_ENV, "").strip()
+    root_value = os.environ.get(CHAT_ATTACHMENTS_ROOT_ENV, "")
     if not root_value:
         raise ValueError(f"{CHAT_ATTACHMENTS_ROOT_ENV} must be configured")
-    root = Path(root_value).expanduser().resolve(strict=True)
+    if root_value != root_value.strip():
+        raise ValueError(f"{CHAT_ATTACHMENTS_ROOT_ENV} contains non-portable characters")
+    _reject_control_characters(root_value, field=CHAT_ATTACHMENTS_ROOT_ENV)
+    validate_exact_path_text(root_value, field=CHAT_ATTACHMENTS_ROOT_ENV)
+    unresolved = Path(root_value)
+    if not unresolved.is_absolute():
+        raise ValueError(f"{CHAT_ATTACHMENTS_ROOT_ENV} must be an absolute path")
+    root = require_symlink_free_absolute_path(
+        unresolved,
+        field=CHAT_ATTACHMENTS_ROOT_ENV,
+    )
     if not root.is_dir():
         raise ValueError(f"{CHAT_ATTACHMENTS_ROOT_ENV} must point to an existing directory")
     return root
 
 
-def _resolve_selected_file(raw_path: Any) -> Path:
-    value = _reject_control_characters(str(raw_path or "").strip(), field="attachment path")
+def _explicit_chat_attachment_root(
+    value: str | os.PathLike[str],
+) -> Path:
+    raw = os.fspath(value)
+    if raw != raw.strip():
+        raise ValueError("attachment root contains non-portable characters")
+    _reject_control_characters(raw, field="attachment root")
+    validate_exact_path_text(raw, field="attachment root")
+    unresolved = Path(raw)
+    if not unresolved.is_absolute():
+        raise ValueError("attachment root must be an absolute path")
+    root = require_symlink_free_absolute_path(
+        unresolved,
+        field="attachment root",
+    )
+    if not root.is_dir():
+        raise ValueError("attachment root must point to an existing directory")
+    return root
+
+
+def _resolve_selected_file(
+    raw_path: Any,
+    *,
+    root: Path,
+) -> tuple[Path, os.stat_result, str]:
+    value = str(raw_path or "")
     if not value:
         raise ValueError("Attachment path cannot be empty")
+    if value != value.strip():
+        raise ValueError("Attachment path contains surrounding whitespace")
+    value = _reject_control_characters(value, field="attachment path")
     if len(value) > 4096:
         raise ValueError("Attachment path is too long")
     if "\x00" in value:
         raise ValueError("Attachment path contains null bytes")
     if any(part in {".", ".."} for part in value.replace("\\", "/").split("/")):
         raise ValueError("Attachment path contains invalid traversal segments")
-
-    expanded = os.path.expanduser(value)
-    if not os.path.isabs(expanded):
-        raise ValueError("Attachment path must be absolute")
-
-    normalized = os.path.normcase(os.path.realpath(expanded))
-    root = os.path.normcase(os.path.realpath(str(_chat_attachment_root())))
-    root_prefix = root if root.endswith(os.sep) else f"{root}{os.sep}"
-    if not normalized.startswith(root_prefix):
+    validate_exact_path_text(value, field="attachment path")
+    selected = resolve_project_read_path(value, root=root)
+    if selected != root and not path_is_within(selected, root):
+        # Pre-contract histories stored the absolute staging path. Recover
+        # only the exact application-owned shape and only when its matching
+        # file exists under the current attachment root. Arbitrary missing
+        # external paths are never guessed into the sandbox.
+        portable_parts = value.replace("\\", "/").split("/")
+        folded = [part.casefold() for part in portable_parts]
+        marker = ["data", "chat_attachments"]
+        migrated_reference = None
+        for index in range(len(folded) - len(marker), -1, -1):
+            if folded[index : index + len(marker)] != marker:
+                continue
+            tail = portable_parts[index + len(marker) :]
+            if (
+                len(tail) == 2
+                and re.fullmatch(r"[0-9a-fA-F]{32}", tail[0])
+            ):
+                candidate = resolve_project_read_path(
+                    "/".join(tail),
+                    root=root,
+                )
+                if candidate.is_file():
+                    selected = candidate
+                    migrated_reference = candidate.relative_to(root).as_posix()
+            break
+        if migrated_reference is None:
+            raise ValueError("Attachment path is outside the allowed directory")
+    if selected == root or not path_is_within(selected, root):
         raise ValueError("Attachment path is outside the allowed directory")
-
-    selected = Path(normalized).resolve(strict=True)
     if not selected.is_file():
         raise ValueError(f"Attachment is not a file: {selected}")
-    return selected
+    with open_binary_read_without_links(selected) as source:
+        identity = os.fstat(source.fileno())
+    return selected, identity, selected.relative_to(root).as_posix()
 
 
-def resolve_chat_attachments(raw_items: Iterable[Mapping[str, Any]] | None) -> list[ResolvedChatAttachment]:
+def resolve_chat_attachments(
+    raw_items: Iterable[Mapping[str, Any]] | None,
+    *,
+    root: str | os.PathLike[str] | None = None,
+) -> list[ResolvedChatAttachment]:
+    """Resolve attachment references against one explicit sandbox root.
+
+    New payloads use portable paths relative to this root so chat history
+    remains valid when the project is moved. Absolute paths from older
+    histories remain accepted only when they identify the same sandbox.
+    """
+
     items = list(raw_items or [])
     if len(items) > MAX_CHAT_ATTACHMENTS:
         raise ValueError(f"A message can include at most {MAX_CHAT_ATTACHMENTS} attachments")
+    if not items:
+        return []
+
+    attachment_root = (
+        _chat_attachment_root()
+        if root is None
+        else _explicit_chat_attachment_root(root)
+    )
 
     resolved_items: list[ResolvedChatAttachment] = []
     seen_paths: set[str] = set()
@@ -106,14 +206,17 @@ def resolve_chat_attachments(raw_items: Iterable[Mapping[str, Any]] | None) -> l
         if not isinstance(item, Mapping):
             raise ValueError("Chat attachments must be objects")
         kind = _attachment_kind(item.get("kind"))
-        path = _resolve_selected_file(item.get("path"))
-        identity = os.path.normcase(str(path))
-        if identity in seen_paths:
+        path, file_identity, reference = _resolve_selected_file(
+            item.get("path"),
+            root=attachment_root,
+        )
+        path_identity = os.path.normcase(str(path))
+        if path_identity in seen_paths:
             continue
-        seen_paths.add(identity)
+        seen_paths.add(path_identity)
 
         name = _reject_control_characters(path.name, field="attachment name")
-        size = path.stat().st_size
+        size = file_identity.st_size
         limit = MAX_CHAT_IMAGE_BYTES if kind == "image" else MAX_CHAT_ATTACHMENT_BYTES
         if size > limit:
             raise ValueError(f"Attachment is too large: {name}")
@@ -126,11 +229,13 @@ def resolve_chat_attachments(raw_items: Iterable[Mapping[str, Any]] | None) -> l
             raise ValueError(f"Unsupported chat image type: {name}")
         resolved_items.append(
             ResolvedChatAttachment(
+                identity=file_identity,
                 kind=kind,
                 mime_type=mime_type,
                 name=name,
                 path=path,
                 size=size,
+                reference=reference,
             )
         )
     return resolved_items
@@ -147,6 +252,7 @@ CHAT_ATTACHMENT_STAGE_SUBDIR = ("data", "chat_attachments")
 
 @dataclass(frozen=True, slots=True)
 class _UploadedAttachmentCandidate:
+    identity: os.stat_result
     source: Path
     kind: str
     mime_type: str
@@ -154,18 +260,36 @@ class _UploadedAttachmentCandidate:
     size: int
 
 
-def stage_uploaded_chat_attachments(source_paths: Iterable[Any]) -> list[dict[str, str | int]]:
+def stage_uploaded_chat_attachments(
+    source_paths: Iterable[Any],
+    *,
+    project_root: str | os.PathLike[str] | None = None,
+) -> list[dict[str, str | int]]:
     """Copy uploaded files into the attachment root and return payloads.
 
     Files dropped or uploaded from the browser arrive in a temporary directory
     that lives outside the allowed attachment root, so sending them directly is
-    rejected by :func:`resolve_chat_attachments`.  This copies each file under
-    ``<root>/data/chat_attachments/<uuid>/<name>`` — inside the allowed root —
-    and returns attachment payloads whose ``path`` passes that check.  Supported
-    images are tagged ``kind="image"``; every other file is tagged
-    ``kind="file"`` (its text content is read for the model at send time).
+    rejected by :func:`resolve_chat_attachments`. This copies each file under
+    ``<root>/data/chat_attachments/<uuid>/<name>`` and returns a portable path
+    relative to that attachment sandbox. Supported images are tagged
+    ``kind="image"``; every other file is tagged ``kind="file"``.
     """
-    sources = [Path(raw) for raw in source_paths]
+    sources: list[Path] = []
+    for value in source_paths:
+        raw = validate_exact_path_text(value, field="uploaded attachment path")
+        source = Path(raw)
+        if not source.is_absolute():
+            raise ValueError("Uploaded attachment path must be absolute")
+        try:
+            source = require_symlink_free_absolute_path(
+                source,
+                field="uploaded attachment",
+            )
+        except PermissionError as exc:
+            raise PermissionError(
+                "Uploaded attachment must not use a symbolic link or reparse point"
+            ) from exc
+        sources.append(source)
     if not sources:
         raise ValueError("No attachments were uploaded")
     if len(sources) > MAX_CHAT_ATTACHMENTS:
@@ -176,11 +300,16 @@ def stage_uploaded_chat_attachments(source_paths: Iterable[Any]) -> list[dict[st
     for source in sources:
         if not source.is_file():
             raise ValueError(f"Uploaded attachment is not a file: {source.name}")
-        name = _reject_control_characters(source.name, field="attachment name")
+        with open_binary_read_without_links(source) as source_file:
+            source_identity = os.fstat(source_file.fileno())
+        name = safe_path_component(
+            _reject_control_characters(source.name, field="attachment name"),
+            field="attachment name",
+        )
         mime_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
         is_image = mime_type in SUPPORTED_CHAT_IMAGE_MIME_TYPES
         kind = "image" if is_image else "file"
-        size = source.stat().st_size
+        size = source_identity.st_size
         limit = MAX_CHAT_IMAGE_BYTES if is_image else MAX_CHAT_ATTACHMENT_BYTES
         if size > limit:
             raise ValueError(f"Attachment is too large: {name}")
@@ -189,6 +318,7 @@ def stage_uploaded_chat_attachments(source_paths: Iterable[Any]) -> list[dict[st
             raise ValueError("Chat attachments exceed the total size limit")
         candidates.append(
             _UploadedAttachmentCandidate(
+                identity=source_identity,
                 source=source,
                 kind=kind,
                 mime_type=mime_type,
@@ -197,30 +327,69 @@ def stage_uploaded_chat_attachments(source_paths: Iterable[Any]) -> list[dict[st
             )
         )
 
-    root = _chat_attachment_root()
-    stage_root = root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR)
+    if project_root is None:
+        root = _chat_attachment_root()
+    else:
+        root = resolve_project_path(".", root=project_root)
+        if not root.is_dir():
+            raise NotADirectoryError(root)
+    stage_root = managed_project_storage(
+        Path(*CHAT_ATTACHMENT_STAGE_SUBDIR),
+        root=root,
+    )
     stage_root.mkdir(parents=True, exist_ok=True)
-    created_dirs: list[Path] = []
+    stage_root = require_directory_without_links(
+        stage_root,
+        field="chat attachment staging root",
+    )
+    created_dirs: list[tuple[Path, os.stat_result]] = []
     results: list[dict[str, str | int]] = []
+    copied_total_size = 0
     try:
         for candidate in candidates:
             dest_dir = stage_root / uuid.uuid4().hex
             dest_dir.mkdir(parents=True, exist_ok=False)
-            created_dirs.append(dest_dir)
-            dest = dest_dir / candidate.name
-            shutil.copyfile(candidate.source, dest)
+            dest_dir = require_directory_without_links(
+                dest_dir,
+                field="chat attachment staging directory",
+            )
+            created_dirs.append((dest_dir, dest_dir.lstat()))
+            dest, destination_identity = copy_file_exclusive_with_identity(
+                candidate.source,
+                dest_dir,
+                candidate.name,
+                field="attachment filename",
+                expected_source_identity=candidate.identity,
+            )
+            copied_size = destination_identity.st_size
+            copied_limit = (
+                MAX_CHAT_IMAGE_BYTES
+                if candidate.kind == "image"
+                else MAX_CHAT_ATTACHMENT_BYTES
+            )
+            if copied_size > copied_limit:
+                raise ValueError(f"Attachment is too large: {candidate.name}")
+            copied_total_size += copied_size
+            if copied_total_size > MAX_CHAT_ATTACHMENTS_TOTAL_BYTES:
+                raise ValueError("Chat attachments exceed the total size limit")
             results.append(
                 {
                     "kind": candidate.kind,
                     "mimeType": candidate.mime_type,
                     "name": candidate.name,
-                    "path": str(dest),
-                    "size": candidate.size,
+                    "path": dest.relative_to(stage_root).as_posix(),
+                    "size": copied_size,
                 }
             )
     except Exception:
-        for created_dir in reversed(created_dirs):
-            shutil.rmtree(created_dir, ignore_errors=True)
+        for created_dir, identity in reversed(created_dirs):
+            try:
+                remove_directory_without_links(
+                    created_dir,
+                    expected_identity=identity,
+                )
+            except (OSError, ValueError):
+                pass
         raise
 
     return results

--- a/core/media/file_operations.py
+++ b/core/media/file_operations.py
@@ -1,324 +1,994 @@
-"""Host filesystem operations exposed through higher-level adapters."""
+"""Host filesystem operations exposed through higher-level adapters.
+
+Paths preserve exact lexical identity, reject linked traversal, and use
+transactional writes for destructive operations.
+"""
 
 from __future__ import annotations
 
-import mimetypes
+import errno
+import io
 import os
-import platform
-import shutil
-import subprocess
-import tarfile
 import zipfile
-from datetime import datetime
+import tarfile
+import mimetypes
+import subprocess
+import platform
+import stat
+import threading
+import uuid
 from pathlib import Path
 from typing import Any
 
+from sdk.archive_paths import extract_tar_safely, extract_zip_safely
+from sdk.file_transactions import (
+    atomic_write_text,
+    capture_directory_identity,
+    copy_directory_without_links,
+    copy_file_transactionally,
+    create_private_temporary_directory,
+    file_snapshot_is_stable,
+    inspect_portable_directory_tree,
+    open_binary_read_without_links,
+    open_text_append_without_links,
+    private_sibling_path,
+    remove_directory_without_links,
+    remove_empty_directory_without_links,
+    remove_file_without_links,
+    remove_link_without_following,
+    rename_path_without_overwrite,
+    replace_directory_transactionally,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from sdk.path_contract import (
+    _metadata_is_link_or_reparse_point,
+    path_is_link_or_reparse_point,
+    require_symlink_free_absolute_path,
+    resolve_project_path,
+    user_home_directory,
+    validate_exact_path_text,
+)
+from sdk.process_launch import open_with_default_application
 
-FILE_SEARCH_LIMIT = 50
+_FILE_SEARCH_LIMIT = 50
+_FILE_EXTRACTION_LOCK = threading.RLock()
 
 
-def resolve_local_path(path: str) -> Path:
-    candidate = Path(path)
-    if candidate.is_absolute():
-        return candidate.resolve()
-    return (Path.home() / candidate).resolve()
+def _resolve(path_str: str) -> Path:
+    """Resolve an exact user-filesystem path, with relative values under home."""
+
+    return resolve_project_path(path_str, root=user_home_directory())
+
+
+def _resolve_lexical(path_str: str) -> Path:
+    """Keep the leaf identity while rejecting linked parent directories."""
+
+    raw = validate_exact_path_text(path_str, field="filesystem path")
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = user_home_directory().joinpath(*raw.replace("\\", "/").split("/"))
+    return require_symlink_free_absolute_path(
+        candidate,
+        field="filesystem path",
+        include_leaf=False,
+    )
+
+
+def _reject_write_target_link(path: Path) -> None:
+    if path_is_link_or_reparse_point(path):
+        raise PermissionError(f"Write target must not be a symbolic link: {path}")
+
+
+def _copy_file_atomically(
+    source: Path,
+    destination: Path,
+    *,
+    expected_source_identity: os.stat_result | None = None,
+) -> None:
+    """Replace one regular destination without following its final link."""
+
+    _reject_write_target_link(destination)
+    copy_file_transactionally(
+        source,
+        destination,
+        expected_source_identity=expected_source_identity,
+    )
+
+
+def _remove_private_move_path(
+    path: Path,
+    *,
+    expected_identity: os.stat_result,
+) -> None:
+    """Remove only a UUID-named staging/holding path owned by this move."""
+
+    if not os.path.lexists(path):
+        return
+    metadata = path.lstat()
+    if not os.path.samestat(expected_identity, metadata):
+        raise PermissionError(
+            f"private move path identity changed: {path}"
+        )
+    if _metadata_is_link_or_reparse_point(metadata):
+        remove_link_without_following(
+            path,
+            expected_identity=expected_identity,
+        )
+    elif stat.S_ISDIR(metadata.st_mode):
+        remove_directory_without_links(
+            path,
+            expected_identity=expected_identity,
+        )
+    elif stat.S_ISREG(metadata.st_mode):
+        remove_file_without_links(
+            path,
+            expected_identity=expected_identity,
+        )
+    else:
+        raise PermissionError(f"private move path has an unsupported type: {path}")
+
+
+def _restore_cross_volume_source(
+    holding: Path,
+    source: Path,
+    *,
+    expected_holding_identity: os.stat_result,
+) -> None:
+    """Restore a source-side holding name without overwriting a peer path."""
+
+    if not os.path.lexists(holding):
+        return
+    if os.path.lexists(source):
+        raise RuntimeError(
+            "cross-volume move failed and the original source name was reused; "
+            f"the preserved source is at {holding}"
+        )
+    rename_path_without_overwrite(
+        holding,
+        source,
+        expected_identity=expected_holding_identity,
+    )
+
+
+def _move_across_filesystems(
+    source: Path,
+    destination: Path,
+    *,
+    expected_source_identity: os.stat_result,
+) -> None:
+    """Move through private sibling paths without exposing a partial target.
+
+    A raw ``shutil.move`` changes from rename to an in-place copy on ``EXDEV``.
+    That makes a half-copied destination visible if the copy is interrupted.
+    Isolate the source under a source-volume holding name, build a complete
+    destination-volume sibling, publish it, and only then remove the holding
+    copy.  Failure before publication restores the original source identity.
+    """
+
+    if not destination.parent.is_dir():
+        raise NotADirectoryError(destination.parent)
+
+    holding = private_sibling_path(
+        source,
+        f".move-source-{uuid.uuid4().hex}",
+        field="move source holding path",
+    )
+    staging = private_sibling_path(
+        destination,
+        f".move-target-{uuid.uuid4().hex}",
+        field="move destination staging path",
+    )
+    published = False
+    source_metadata = source.lstat()
+    if not os.path.samestat(
+        expected_source_identity,
+        source_metadata,
+    ):
+        raise PermissionError(
+            f"Move source identity changed: {source}"
+        )
+    source_is_link = _metadata_is_link_or_reparse_point(source_metadata)
+    source_link_targets_directory = source.is_dir() if source_is_link else False
+    staging_identity: os.stat_result | None = None
+    build_root: Path | None = None
+    build_root_identity: os.stat_result | None = None
+    holding_identity: os.stat_result | None = None
+
+    rename_path_without_overwrite(
+        source,
+        holding,
+        expected_identity=source_metadata,
+    )
+    try:
+        holding_identity = holding.lstat()
+        if not os.path.samestat(source_metadata, holding_identity):
+            raise PermissionError(
+                f"Move source identity changed while it was isolated: {holding}"
+            )
+        build_root, build_root_identity = create_private_temporary_directory(
+            directory=destination.parent,
+            prefix=f".{destination.name}.move-build-",
+        )
+        payload = build_root / "payload"
+        if source_is_link:
+            link_target = os.readlink(holding)
+            if not os.path.samestat(
+                holding_identity,
+                holding.lstat(),
+            ):
+                raise PermissionError(
+                    f"Move source identity changed: {holding}"
+                )
+            os.symlink(
+                link_target,
+                payload,
+                target_is_directory=source_link_targets_directory,
+            )
+            payload_identity = payload.lstat()
+        elif stat.S_ISREG(source_metadata.st_mode):
+            _copy_file_atomically(
+                holding,
+                payload,
+                expected_source_identity=holding_identity,
+            )
+            payload_identity = payload.lstat()
+        elif stat.S_ISDIR(source_metadata.st_mode):
+            copy_directory_without_links(
+                holding,
+                payload,
+                expected_source_identity=holding_identity,
+            )
+            payload_identity = payload.lstat()
+        else:
+            raise PermissionError(
+                f"Move source must be a regular file, directory, or symbolic link: {source}"
+            )
+
+        rename_path_without_overwrite(
+            payload,
+            staging,
+            expected_identity=payload_identity,
+        )
+        staging_identity = payload_identity
+        remove_directory_without_links(
+            build_root,
+            expected_identity=build_root_identity,
+        )
+        build_root = None
+        build_root_identity = None
+
+        if os.path.lexists(destination):
+            raise FileExistsError(f"Destination already exists: {destination}")
+        if staging_identity is None:
+            raise PermissionError(
+                f"Move staging identity was not established: {staging}"
+            )
+        if (
+            _metadata_is_link_or_reparse_point(staging_identity)
+            or stat.S_ISREG(staging_identity.st_mode)
+        ):
+            rename_path_without_overwrite(
+                staging,
+                destination,
+                expected_identity=staging_identity,
+            )
+        else:
+            replace_directory_transactionally(
+                staging,
+                destination,
+                overwrite=False,
+                expected_staging_identity=staging_identity,
+                expected_destination_identity=None,
+            )
+        published = True
+    except BaseException:
+        if not published:
+            if staging_identity is not None:
+                try:
+                    _remove_private_move_path(
+                        staging,
+                        expected_identity=staging_identity,
+                    )
+                except (OSError, ValueError):
+                    pass
+            if (
+                build_root is not None
+                and build_root_identity is not None
+            ):
+                try:
+                    remove_directory_without_links(
+                        build_root,
+                        expected_identity=build_root_identity,
+                    )
+                except (OSError, ValueError):
+                    pass
+            if holding_identity is None:
+                current_holding_identity = holding.lstat()
+                if not os.path.samestat(
+                    source_metadata,
+                    current_holding_identity,
+                ):
+                    raise PermissionError(
+                        f"Move source identity changed while it was isolated: {holding}"
+                    )
+                holding_identity = current_holding_identity
+            _restore_cross_volume_source(
+                holding,
+                source,
+                expected_holding_identity=holding_identity,
+            )
+        raise
+
+    # At this point the destination is complete.  A cleanup failure leaves the
+    # UUID holding path intact instead of risking loss of the only full copy.
+    if holding_identity is None:
+        raise PermissionError(
+            f"Move holding identity was not established: {holding}"
+        )
+    _remove_private_move_path(
+        holding,
+        expected_identity=holding_identity,
+    )
+
+
+def _safe(name: str, base: Path) -> Path | None:
+    """Resolve and check existence; return None if not found."""
+    p = resolve_project_path(name, root=base)
+    if not p.exists():
+        return None
+    return p
+
+
+def _safe_search_pattern(value: str, *, field: str) -> str:
+    """Return a glob pattern that cannot escape its selected search root."""
+
+    raw = str(value or "")
+    if (
+        not raw
+        or raw != raw.strip()
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in raw
+        )
+    ):
+        raise ValueError(
+            f"{field} is empty or contains surrounding whitespace or control characters"
+        )
+    portable = raw.replace("\\", "/")
+    first = portable.split("/", 1)[0]
+    if (
+        portable.startswith("/")
+        or (len(first) >= 2 and first[0].isalpha() and first[1] == ":")
+        or first.startswith("~")
+    ):
+        raise ValueError(f"{field} must be relative to the selected directory")
+    parts = portable.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise PermissionError(f"{field} escapes the selected directory")
+    return "/".join(parts)
+
+
+def _walk_regular_file_snapshots(
+    base: Path,
+    base_identity: os.stat_result,
+    pattern: str,
+):
+    """Yield one link-free recursive file inventory with pinned parent identities."""
+
+    def walk(
+        relative_directory: Path,
+        expected_directory_identity: os.stat_result,
+    ):
+        directory = base / relative_directory
+        try:
+            (
+                directory,
+                directory_identity,
+                entries,
+            ) = snapshot_directory_entries_without_links(
+                directory,
+                field="file search directory",
+            )
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            return
+        if not os.path.samestat(
+            expected_directory_identity,
+            directory_identity,
+        ):
+            return
+        for child, metadata in sorted(
+            entries,
+            key=lambda item: (
+                item[0].name.casefold(),
+                item[0].name,
+            ),
+        ):
+            relative = relative_directory / child.name
+            if _metadata_is_link_or_reparse_point(metadata):
+                continue
+            if stat.S_ISDIR(metadata.st_mode):
+                yield from walk(relative, metadata)
+            elif (
+                stat.S_ISREG(metadata.st_mode)
+                and relative.match(pattern)
+            ):
+                yield child, metadata, directory_identity
+
+    yield from walk(Path(), base_identity)
+
+
+# ── Read-only tools ──────────────────────────────────────────────────
 
 
 def search_files(pattern: str, directory: str = "~") -> dict[str, Any]:
-    base = Path.home() if directory == "~" else resolve_local_path(directory)
-    if not base.exists():
-        return {"error": f"Directory not found: {base}", "matches": []}
-
-    matches: list[dict[str, Any]] = []
-    for candidate in base.rglob(pattern):
-        if candidate.is_file():
-            matches.append(
-                {
-                    "name": candidate.name,
-                    "path": str(candidate),
-                    "size": candidate.stat().st_size,
-                    "size_human": _human_size(candidate.stat().st_size),
-                }
-            )
-        if len(matches) >= FILE_SEARCH_LIMIT:
-            break
-    return {
-        "pattern": pattern,
-        "directory": str(base),
-        "count": len(matches),
-        "matches": matches,
-    }
-
-
-def list_directory(path: str = ".") -> dict[str, Any]:
-    directory = resolve_local_path(path)
-    if not directory.exists():
-        return {"error": f"Directory not found: {directory}"}
-
-    items: list[dict[str, Any]] = []
+    base = (
+        user_home_directory()
+        if directory == "~"
+        else _resolve_lexical(directory)
+    )
     try:
-        for entry in sorted(
-            directory.iterdir(),
-            key=lambda candidate: (
-                not candidate.is_dir(),
-                candidate.name.lower(),
+        base, base_identity = capture_directory_identity(
+            base,
+            field="file search directory",
+        )
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        return {"error": f"Directory not found: {base}", "matches": []}
+    pattern = _safe_search_pattern(pattern, field="file search pattern")
+    matches = []
+    for candidate, metadata, parent_identity in _walk_regular_file_snapshots(
+        base,
+        base_identity,
+        pattern,
+    ):
+        try:
+            candidate = require_symlink_free_absolute_path(
+                candidate,
+                field="file search result",
+            )
+        except (FileNotFoundError, PermissionError, ValueError):
+            continue
+        try:
+            current_metadata = candidate.lstat()
+            require_directory_identity(
+                candidate.parent,
+                parent_identity,
+                field="file search result parent",
+            )
+            require_directory_identity(
+                base,
+                base_identity,
+                field="file search directory",
+            )
+        except (FileNotFoundError, PermissionError, ValueError):
+            continue
+        if not os.path.samestat(metadata, current_metadata):
+            continue
+        matches.append({
+            "name": candidate.name,
+            "path": str(candidate),
+            "size": metadata.st_size,
+            "size_human": _human_size(metadata.st_size),
+        })
+        if len(matches) >= _FILE_SEARCH_LIMIT:
+            break
+    require_directory_identity(
+        base,
+        base_identity,
+        field="file search directory",
+    )
+    return {"pattern": pattern, "directory": str(base), "count": len(matches), "matches": matches}
+
+
+def list_directory(path: str = "~") -> dict[str, Any]:
+    p = (
+        user_home_directory()
+        if path == "~"
+        else _resolve_lexical(path)
+    )
+    try:
+        p, directory_identity, entries = (
+            snapshot_directory_entries_without_links(
+                p,
+                field="listed directory",
+            )
+        )
+    except (FileNotFoundError, NotADirectoryError):
+        return {"error": f"Directory not found: {p}"}
+    except PermissionError:
+        return {"error": f"Permission denied: {p}", "items": []}
+    items = []
+    try:
+        for entry, metadata in sorted(
+            entries,
+            key=lambda item: (
+                not stat.S_ISDIR(item[1].st_mode),
+                item[0].name.lower(),
             ),
         ):
-            info: dict[str, Any] = {
-                "name": entry.name,
-                "type": "dir" if entry.is_dir() else "file",
-            }
-            if entry.is_file():
-                info["size"] = entry.stat().st_size
-                info["size_human"] = _human_size(entry.stat().st_size)
+            if _metadata_is_link_or_reparse_point(metadata):
+                entry_type = "symbolic-link"
+            elif stat.S_ISDIR(metadata.st_mode):
+                entry_type = "dir"
+            elif stat.S_ISREG(metadata.st_mode):
+                entry_type = "file"
+            else:
+                entry_type = "special"
+            info = {"name": entry.name, "type": entry_type}
+            if entry_type == "file":
+                info["size"] = metadata.st_size
+                info["size_human"] = _human_size(metadata.st_size)
             items.append(info)
+        require_directory_identity(
+            p,
+            directory_identity,
+            field="listed directory",
+        )
     except PermissionError:
-        return {"error": f"Permission denied: {directory}", "items": []}
-    return {"path": str(directory), "count": len(items), "items": items}
+        return {"error": f"Permission denied: {p}", "items": []}
+    return {"path": str(p), "count": len(items), "items": items}
 
 
-def read_text_file(
-    path: str,
-    *,
-    max_chars: int = 5000,
-    line_start: int = 0,
-    line_end: int = 0,
-) -> dict[str, Any]:
-    file_path = resolve_local_path(path)
-    if not file_path.is_file():
-        return {"error": f"File not found: {file_path}"}
+def read_text_file(path: str, max_chars: int = 5000, line_start: int = 0, line_end: int = 0) -> dict[str, Any]:
+    p = _resolve_lexical(path)
     try:
-        with file_path.open("r", encoding="utf-8", errors="replace") as file:
-            content = file.read(max_chars)
+        with open_binary_read_without_links(p) as source:
+            before = os.fstat(source.fileno())
+            size = before.st_size
+            with io.TextIOWrapper(source, encoding="utf-8", errors="replace") as f:
+                content = f.read(max_chars)
+                after = os.fstat(f.buffer.fileno())
+        if not file_snapshot_is_stable(before, after):
+            raise PermissionError(
+                f"File changed while it was being read: {p}"
+            )
         if line_start > 0:
             lines = content.split("\n")
-            start = max(0, line_start - 1)
-            end = min(len(lines), line_end) if line_end > 0 else len(lines)
-            content = "\n".join(lines[start:end])
+            s = max(0, line_start - 1)
+            e = min(len(lines), line_end) if line_end > 0 else len(lines)
+            content = "\n".join(lines[s:e])
             if len(content) > max_chars:
                 content = content[:max_chars]
+        truncated = len(content) >= max_chars
         return {
-            "path": str(file_path),
-            "size": file_path.stat().st_size,
+            "path": str(p),
+            "size": size,
             "content": content,
-            "truncated": len(content) >= max_chars,
+            "truncated": truncated,
         }
-    except Exception as exc:
-        return {"error": str(exc), "path": str(file_path)}
+    except Exception as e:
+        return {"error": str(e), "path": str(p)}
 
 
 def inspect_path(path: str) -> dict[str, Any]:
-    candidate = resolve_local_path(path)
-    if not candidate.exists():
-        return {"error": f"Path not found: {candidate}"}
-
-    stat = candidate.stat()
+    p = _resolve_lexical(path)
+    try:
+        st = p.lstat()
+    except FileNotFoundError:
+        return {"error": f"Path not found: {p}"}
+    if _metadata_is_link_or_reparse_point(st):
+        path_type = "symbolic-link"
+    elif stat.S_ISDIR(st.st_mode):
+        path_type = "directory"
+    elif stat.S_ISREG(st.st_mode):
+        path_type = "file"
+    else:
+        path_type = "special"
     mime, _ = (
-        mimetypes.guess_type(str(candidate)) if candidate.is_file() else (None, None)
+        mimetypes.guess_type(str(p))
+        if path_type == "file"
+        else (None, None)
     )
+    current = p.lstat()
+    if not os.path.samestat(st, current):
+        return {"error": f"Path changed while it was inspected: {p}"}
     return {
-        "name": candidate.name,
-        "path": str(candidate),
-        "type": "directory" if candidate.is_dir() else "file",
-        "size": stat.st_size if candidate.is_file() else None,
-        "size_human": _human_size(stat.st_size) if candidate.is_file() else None,
+        "name": p.name,
+        "path": str(p),
+        "type": path_type,
+        "size": st.st_size if path_type == "file" else None,
+        "size_human": _human_size(st.st_size) if path_type == "file" else None,
         "mime": mime or "unknown",
-        "modified": _timestamp_text(stat.st_mtime),
-        "created": _timestamp_text(stat.st_ctime),
+        "modified": _ts_to_str(st.st_mtime),
+        "created": _ts_to_str(st.st_ctime),
     }
 
 
 def open_local_path(path: str) -> dict[str, Any]:
-    candidate = resolve_local_path(path)
-    if not candidate.exists():
-        return {"error": f"Path not found: {candidate}"}
+    resolved: Path | str = path
     try:
-        if platform.system() == "Windows":
-            os.startfile(str(candidate))
-        elif platform.system() == "Darwin":
-            subprocess.run(["open", str(candidate)], check=True)
-        else:
-            subprocess.run(["xdg-open", str(candidate)], check=True)
-        return {"opened": str(candidate)}
-    except Exception as exc:
-        return {"error": str(exc), "path": str(candidate)}
+        resolved = _resolve_lexical(path)
+        open_with_default_application(
+            resolved,
+            wait=platform.system() != "Windows",
+            check=True,
+            system_name=platform.system(),
+            run_factory=subprocess.run,
+            startfile_factory=getattr(os, "startfile", None),
+        )
+        return {"opened": str(resolved)}
+    except Exception as e:
+        return {"error": str(e), "path": str(resolved)}
 
 
-def search_file_content(
-    keyword: str,
-    *,
-    directory: str = "~",
-    file_pattern: str = "*",
-) -> dict[str, Any]:
-    base = Path.home() if directory == "~" else resolve_local_path(directory)
-    if not base.exists():
+def search_file_content(keyword: str, directory: str = "~", file_pattern: str = "*") -> dict[str, Any]:
+    base = (
+        user_home_directory()
+        if directory == "~"
+        else _resolve_lexical(directory)
+    )
+    try:
+        base, base_identity = capture_directory_identity(
+            base,
+            field="content search directory",
+        )
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
         return {"error": f"Directory not found: {base}"}
-
-    matches: list[dict[str, Any]] = []
-    for candidate in base.rglob(file_pattern):
-        if not candidate.is_file() or candidate.stat().st_size > 2 * 1024 * 1024:
-            continue
+    file_pattern = _safe_search_pattern(
+        file_pattern,
+        field="content search pattern",
+    )
+    results = []
+    count = 0
+    for (
+        candidate,
+        candidate_identity,
+        candidate_parent_identity,
+    ) in _walk_regular_file_snapshots(
+        base,
+        base_identity,
+        file_pattern,
+    ):
+        reached_limit = False
         try:
-            with candidate.open("r", encoding="utf-8", errors="replace") as file:
-                for line_number, line in enumerate(file, 1):
-                    if keyword.lower() in line.lower():
-                        matches.append(
-                            {
+            candidate = require_symlink_free_absolute_path(
+                candidate,
+                field="content search file",
+            )
+        except (FileNotFoundError, NotADirectoryError, PermissionError, ValueError):
+            continue
+        candidate_parent = candidate.parent
+        try:
+            pending_results: list[dict[str, Any]] = []
+            with open_binary_read_without_links(
+                candidate,
+                expected_identity=candidate_identity,
+                expected_parent_identity=candidate_parent_identity,
+            ) as source:
+                before = os.fstat(source.fileno())
+                if before.st_size > 2 * 1024 * 1024:
+                    continue
+                with io.TextIOWrapper(
+                    source,
+                    encoding="utf-8",
+                    errors="replace",
+                ) as f:
+                    for i, line in enumerate(f, 1):
+                        if keyword.lower() in line.lower():
+                            pending_results.append({
                                 "file": str(candidate),
-                                "line": line_number,
+                                "line": i,
                                 "content": line.strip()[:200],
-                            }
-                        )
-                        if len(matches) >= 30:
-                            break
-                if len(matches) >= 30:
-                    break
+                            })
+                            if count + len(pending_results) >= 30:
+                                reached_limit = True
+                                break
+                    after = os.fstat(f.buffer.fileno())
+            if not file_snapshot_is_stable(before, after):
+                continue
+            require_directory_identity(
+                candidate_parent,
+                candidate_parent_identity,
+                field="content search file parent",
+            )
+            require_directory_identity(
+                base,
+                base_identity,
+                field="content search directory",
+            )
+            results.extend(pending_results)
+            count += len(pending_results)
         except Exception:
             continue
-    return {
-        "keyword": keyword,
-        "directory": str(base),
-        "count": len(matches),
-        "matches": matches,
-    }
+        if reached_limit:
+            break
+    require_directory_identity(
+        base,
+        base_identity,
+        field="content search directory",
+    )
+    return {"keyword": keyword, "directory": str(base), "count": len(results), "matches": results}
 
 
-def move_path(source: str, destination: str) -> dict[str, Any]:
-    source_path = resolve_local_path(source)
-    destination_path = resolve_local_path(destination)
-    if not source_path.exists():
-        return {"error": f"Source not found: {source_path}"}
+# ── Write / destructive tools ────────────────────────────────────────
+
+
+def move_path(source: str, dest: str) -> dict[str, Any]:
+    src = _resolve_lexical(source)
+    dst = _resolve_lexical(dest)
+    if not os.path.lexists(src):
+        return {"error": f"Source not found: {src}"}
     try:
-        shutil.move(str(source_path), str(destination_path))
-        return {"moved": str(source_path), "to": str(destination_path)}
-    except Exception as exc:
-        return {
-            "error": str(exc),
-            "source": str(source_path),
-            "dest": str(destination_path),
-        }
+        _reject_write_target_link(dst)
+        if os.path.lexists(dst):
+            raise FileExistsError(f"Destination already exists: {dst}")
+        require_symlink_free_absolute_path(
+            src,
+            field="move source",
+            include_leaf=False,
+        )
+        require_symlink_free_absolute_path(
+            dst,
+            field="move destination",
+            include_leaf=False,
+        )
+        source_identity = src.lstat()
+        try:
+            rename_path_without_overwrite(
+                src,
+                dst,
+                expected_identity=source_identity,
+            )
+        except OSError as exc:
+            if exc.errno != errno.EXDEV:
+                raise
+            _move_across_filesystems(
+                src,
+                dst,
+                expected_source_identity=source_identity,
+            )
+        return {"moved": str(src), "to": str(dst)}
+    except Exception as e:
+        return {"error": str(e), "source": str(src), "dest": str(dst)}
 
 
-def copy_file(source: str, destination: str) -> dict[str, Any]:
-    source_path = resolve_local_path(source)
-    destination_path = resolve_local_path(destination)
-    if not source_path.is_file():
-        return {"error": f"Source file not found: {source_path}"}
+def copy_file(source: str, dest: str) -> dict[str, Any]:
+    src = _resolve(source)
+    dst = _resolve_lexical(dest)
     try:
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(str(source_path), str(destination_path))
-        return {"copied": str(source_path), "to": str(destination_path)}
-    except Exception as exc:
-        return {"error": str(exc)}
+        source_identity = src.lstat()
+    except FileNotFoundError:
+        return {"error": f"Source file not found: {src}"}
+    if (
+        _metadata_is_link_or_reparse_point(source_identity)
+        or not stat.S_ISREG(source_identity.st_mode)
+    ):
+        return {"error": f"Source file not found: {src}"}
+    try:
+        _copy_file_atomically(
+            src,
+            dst,
+            expected_source_identity=source_identity,
+        )
+        return {"copied": str(src), "to": str(dst)}
+    except Exception as e:
+        return {"error": str(e)}
 
 
 def delete_path(path: str) -> dict[str, Any]:
-    candidate = resolve_local_path(path)
-    if not candidate.exists():
-        return {"error": f"Path not found: {candidate}"}
+    p = _resolve_lexical(path)
+    if not os.path.lexists(p):
+        return {"error": f"Path not found: {p}"}
     try:
-        if candidate.is_dir():
-            candidate.rmdir()
-            return {"deleted": str(candidate), "type": "directory"}
-        size = candidate.stat().st_size
-        candidate.unlink()
-        return {
-            "deleted": str(candidate),
-            "type": "file",
-            "size_human": _human_size(size),
-        }
-    except Exception as exc:
-        return {"error": str(exc), "path": str(candidate)}
+        metadata = p.lstat()
+        if _metadata_is_link_or_reparse_point(metadata):
+            size = metadata.st_size
+            remove_link_without_following(p, expected_identity=metadata)
+            return {
+                "deleted": str(p),
+                "type": "symbolic-link",
+                "size_human": _human_size(size),
+            }
+        if stat.S_ISDIR(metadata.st_mode):
+            remove_empty_directory_without_links(
+                p,
+                expected_identity=metadata,
+            )
+            return {"deleted": str(p), "type": "directory"}
+        if stat.S_ISREG(metadata.st_mode):
+            size = metadata.st_size
+            remove_file_without_links(p, expected_identity=metadata)
+            return {"deleted": str(p), "type": "file", "size_human": _human_size(size)}
+        return {"error": f"Unsupported file type: {p}", "path": str(p)}
+    except Exception as e:
+        return {"error": str(e), "path": str(p)}
 
 
-def extract_archive(
-    archive_path: str,
-    *,
-    destination: str = "",
-) -> dict[str, Any]:
-    archive = resolve_local_path(archive_path)
-    if not archive.is_file():
-        return {"error": f"Archive not found: {archive}"}
-
-    target = (
-        resolve_local_path(destination)
-        if destination
-        else archive.parent / archive.stem
-    )
-    target.mkdir(parents=True, exist_ok=True)
+def extract_archive(archive_path: str, destination: str = "") -> dict[str, Any]:
+    p = _resolve(archive_path)
     try:
-        lower_name = archive.name.lower()
-        if lower_name.endswith(".zip"):
-            with zipfile.ZipFile(archive, "r") as zip_file:
-                zip_file.extractall(target)
-        elif lower_name.endswith((".tar.gz", ".tgz")):
-            with tarfile.open(archive, "r:gz") as tar_file:
-                tar_file.extractall(target)
-        elif lower_name.endswith(".tar"):
-            with tarfile.open(archive, "r:") as tar_file:
-                tar_file.extractall(target)
+        archive_identity = p.lstat()
+    except FileNotFoundError:
+        return {"error": f"Archive not found: {p}"}
+    if (
+        _metadata_is_link_or_reparse_point(archive_identity)
+        or not stat.S_ISREG(archive_identity.st_mode)
+    ):
+        return {"error": f"Archive not found: {p}"}
+    dest = _resolve_lexical(destination) if destination else p.parent / p.stem
+    try:
+        name_low = p.name.lower()
+        if name_low.endswith(".zip"):
+            def extract(staging: Path) -> None:
+                with open_binary_read_without_links(
+                    p,
+                    expected_identity=archive_identity,
+                ) as source:
+                    before = os.fstat(source.fileno())
+                    with zipfile.ZipFile(source, "r") as zf:
+                        extract_zip_safely(zf, staging)
+                    after = os.fstat(source.fileno())
+                    if not file_snapshot_is_stable(before, after):
+                        raise PermissionError(
+                            f"archive changed while it was extracted: {p}"
+                        )
+        elif name_low.endswith((".tar.gz", ".tgz")):
+            def extract(staging: Path) -> None:
+                with open_binary_read_without_links(
+                    p,
+                    expected_identity=archive_identity,
+                ) as source:
+                    before = os.fstat(source.fileno())
+                    with tarfile.open(fileobj=source, mode="r:gz") as tf:
+                        extract_tar_safely(tf, staging)
+                    after = os.fstat(source.fileno())
+                    if not file_snapshot_is_stable(before, after):
+                        raise PermissionError(
+                            f"archive changed while it was extracted: {p}"
+                        )
+        elif name_low.endswith(".tar"):
+            def extract(staging: Path) -> None:
+                with open_binary_read_without_links(
+                    p,
+                    expected_identity=archive_identity,
+                ) as source:
+                    before = os.fstat(source.fileno())
+                    with tarfile.open(fileobj=source, mode="r:") as tf:
+                        extract_tar_safely(tf, staging)
+                    after = os.fstat(source.fileno())
+                    if not file_snapshot_is_stable(before, after):
+                        raise PermissionError(
+                            f"archive changed while it was extracted: {p}"
+                        )
         else:
-            return {"error": f"Unsupported archive format: {archive.name}"}
-        extracted = sum(1 for _ in target.rglob("*"))
-        return {
-            "extracted": str(archive),
-            "to": str(target),
-            "files_count": extracted,
-        }
-    except Exception as exc:
-        return {"error": str(exc), "archive": str(archive)}
+            return {"error": f"Unsupported archive format: {p.name}"}
+        _extract_directory_transactionally(dest, extract)
+        # Count extracted files
+        directories, files = inspect_portable_directory_tree(dest)
+        extracted = len(directories) + len(files)
+        return {"extracted": str(p), "to": str(dest), "files_count": extracted}
+    except Exception as e:
+        return {"error": str(e), "archive": str(p)}
+
+
+def _extract_directory_transactionally(dest: Path, extractor) -> None:
+    """Publish a complete extraction and preserve a prior destination on error."""
+
+    with _FILE_EXTRACTION_LOCK:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest = require_symlink_free_absolute_path(
+            dest,
+            field="extraction target",
+            include_leaf=False,
+        )
+        existed = os.path.lexists(dest)
+        if path_is_link_or_reparse_point(dest):
+            raise PermissionError(f"Extraction target is a symbolic link: {dest}")
+        if existed and not dest.is_dir():
+            raise FileExistsError(f"Extraction target is not a directory: {dest}")
+        identity = None
+        destination_identity: os.stat_result | None = None
+        if existed:
+            stat_result = dest.stat()
+            destination_identity = dest.lstat()
+            identity = (
+                stat_result.st_dev,
+                stat_result.st_ino,
+                stat_result.st_mtime_ns,
+            )
+
+        staging = private_sibling_path(
+            dest,
+            f".extract-{uuid.uuid4().hex}",
+            field="extraction staging directory",
+        )
+        staging_identity: os.stat_result | None = None
+        try:
+            if existed:
+                copy_directory_without_links(dest, staging)
+            else:
+                staging.mkdir()
+            staging_identity = staging.lstat()
+            extractor(staging)
+
+            current_exists = os.path.lexists(dest)
+            if current_exists != existed:
+                raise FileExistsError(f"Extraction target changed while extracting: {dest}")
+            dest = require_symlink_free_absolute_path(
+                dest,
+                field="extraction target",
+                include_leaf=False,
+            )
+            if existed:
+                if path_is_link_or_reparse_point(dest) or not dest.is_dir():
+                    raise FileExistsError(f"Extraction target changed while extracting: {dest}")
+                current_stat = dest.stat()
+                current_identity = (
+                    current_stat.st_dev,
+                    current_stat.st_ino,
+                    current_stat.st_mtime_ns,
+                )
+                if current_identity != identity:
+                    raise FileExistsError(f"Extraction target changed while extracting: {dest}")
+            replace_directory_transactionally(
+                staging,
+                dest,
+                overwrite=True,
+                expected_staging_identity=staging_identity,
+                expected_destination_identity=destination_identity,
+            )
+        finally:
+            if staging_identity is not None:
+                try:
+                    remove_directory_without_links(
+                        staging,
+                        expected_identity=staging_identity,
+                    )
+                except OSError:
+                    pass
 
 
 def write_text_file(path: str, content: str) -> dict[str, Any]:
-    file_path = resolve_local_path(path)
-    existed = file_path.exists()
+    p = _resolve_lexical(path)
+    existed = os.path.lexists(p)
     try:
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(content, encoding="utf-8")
-        return {
-            "written": str(file_path),
-            "size": file_path.stat().st_size,
-            "existed": existed,
-        }
-    except Exception as exc:
-        return {"error": str(exc), "path": str(file_path)}
+        atomic_write_text(p, content)
+        return {"written": str(p), "size": p.stat().st_size, "existed": existed}
+    except Exception as e:
+        return {"error": str(e), "path": str(p)}
 
 
 def append_text_file(path: str, content: str) -> dict[str, Any]:
-    file_path = resolve_local_path(path)
-    existed = file_path.exists()
+    p = _resolve_lexical(path)
+    existed = os.path.lexists(p)
     try:
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        with file_path.open("a", encoding="utf-8") as file:
-            file.write(content)
-        return {
-            "appended": str(file_path),
-            "size": file_path.stat().st_size,
-            "existed": existed,
-        }
-    except Exception as exc:
-        return {"error": str(exc), "path": str(file_path)}
+        _reject_write_target_link(p)
+        with open_text_append_without_links(p, encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return {"appended": str(p), "size": p.stat().st_size, "existed": existed}
+    except Exception as e:
+        return {"error": str(e), "path": str(p)}
 
 
 def create_directory(path: str) -> dict[str, Any]:
-    directory = resolve_local_path(path)
-    if directory.exists():
-        return {"error": f"Path already exists: {directory}"}
+    p = _resolve_lexical(path)
+    if os.path.lexists(p):
+        return {"error": f"Path already exists: {p}"}
     try:
-        directory.mkdir(parents=True, exist_ok=False)
-        return {"created": str(directory)}
-    except Exception as exc:
-        return {"error": str(exc), "path": str(directory)}
+        p.mkdir(parents=True, exist_ok=False)
+        p = require_symlink_free_absolute_path(p, field="created directory")
+        if not p.is_dir():
+            raise NotADirectoryError(p)
+        return {"created": str(p)}
+    except Exception as e:
+        return {"error": str(e), "path": str(p)}
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
 
 
 def _human_size(size: int) -> str:
-    value = float(size)
     for unit in ("B", "KB", "MB", "GB"):
-        if value < 1024:
-            return f"{value:.1f}{unit}"
-        value /= 1024
-    return f"{value:.1f}TB"
+        if size < 1024:
+            return f"{size:.1f}{unit}"
+        size /= 1024
+    return f"{size:.1f}TB"
 
 
-def _timestamp_text(timestamp: float) -> str:
-    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+def _ts_to_str(ts: float) -> str:
+    from datetime import datetime
+    return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")

--- a/core/media/snapshots.py
+++ b/core/media/snapshots.py
@@ -1,0 +1,93 @@
+"""Stable byte snapshots for local media consumers.
+
+Qt and pygame accept path strings and reopen those paths internally.  A path
+that was validated by Python can therefore name a different object by the
+time the decoder runs.  Read the selected file once through the no-follow
+descriptor contract and hand decoders the resulting bytes instead.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.file_transactions import (
+    capture_directory_identity,
+    file_snapshot_is_stable,
+    read_bytes_snapshot_without_links,
+    require_directory_identity,
+)
+from core.paths import project_root, resolve_runtime_asset_read_path
+
+
+@dataclass(frozen=True)
+class RuntimeMediaSnapshot:
+    path: Path
+    payload: bytes
+    identity: os.stat_result
+    parent_identity: os.stat_result
+
+    def is_same_content(self, other: "RuntimeMediaSnapshot | None") -> bool:
+        return other is not None and file_snapshot_is_stable(
+            self.identity,
+            other.identity,
+        )
+
+
+def capture_runtime_media(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+) -> RuntimeMediaSnapshot:
+    """Capture one exact runtime-media file and its immutable byte payload."""
+
+    selected_root = project_root() if root is None else root
+    path = resolve_runtime_asset_read_path(value, root=selected_root)
+    parent, parent_identity = capture_directory_identity(
+        path.parent,
+        field="runtime media parent directory",
+    )
+    payload, identity = read_bytes_snapshot_without_links(
+        path,
+        expected_parent_identity=parent_identity,
+    )
+    require_directory_identity(
+        parent,
+        parent_identity,
+        field="runtime media parent directory",
+    )
+    return RuntimeMediaSnapshot(
+        path=path,
+        payload=payload,
+        identity=identity,
+        parent_identity=parent_identity,
+    )
+
+
+def qimage_from_snapshot(snapshot: RuntimeMediaSnapshot):
+    """Decode a snapshot without letting Qt reopen its public pathname."""
+
+    from PySide6.QtGui import QImage
+
+    image = QImage()
+    image.loadFromData(snapshot.payload)
+    return image
+
+
+def qpixmap_from_snapshot(snapshot: RuntimeMediaSnapshot):
+    """Decode a snapshot without letting Qt reopen its public pathname."""
+
+    from PySide6.QtGui import QPixmap
+
+    pixmap = QPixmap()
+    pixmap.loadFromData(snapshot.payload)
+    return pixmap
+
+
+def load_qpixmap_without_links(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+):
+    return qpixmap_from_snapshot(capture_runtime_media(value, root=root))

--- a/core/model_assets/service.py
+++ b/core/model_assets/service.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
 import os
-import shutil
+import stat
 import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Literal
+
+from core.file_transactions import (
+    read_text_without_links,
+    remove_directory_without_links,
+    remove_file_without_links,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from core.paths import (
+    _metadata_is_link_or_reparse_point,
+    managed_project_storage,
+    path_is_within,
+    project_root,
+    resolve_project_output_path,
+    safe_path_component,
+    user_home_directory,
+)
 
 from .downloads import preload_huggingface_snapshot
 
@@ -52,59 +69,258 @@ class ModelAssetSpec:
         return f"{self.asset_id}:{self.source}:{location}"
 
 
-def _huggingface_cache_roots() -> tuple[Path, ...]:
-    """Return the single hub cache root Hugging Face will actually use."""
+def active_huggingface_hub_cache_root(
+    *,
+    root: Path | None = None,
+) -> Path:
+    """Return the one hub cache root used by readiness checks and downloads.
 
+    Environment-variable presence is authoritative.  In particular, an empty
+    current variable must not fall through to a populated legacy variable or
+    to Hugging Face's cwd-relative interpretation of an empty cache path.
+    """
+
+    project = project_root() if root is None else root
     for env_name in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"):
-        raw = str(os.environ.get(env_name) or "").strip()
-        if raw:
-            return (Path(raw).expanduser().resolve(strict=False),)
+        if env_name not in os.environ:
+            continue
+        raw = os.environ[env_name]
+        if not raw:
+            raise ValueError(f"{env_name} must not be empty")
+        return resolve_project_output_path(raw, root=project)
 
-    hf_home_raw = str(os.environ.get("HF_HOME") or "").strip()
-    hf_home = Path(hf_home_raw).expanduser() if hf_home_raw else Path.home() / ".cache" / "huggingface"
-    return ((hf_home / "hub").resolve(strict=False),)
+    if "HF_HOME" in os.environ:
+        hf_home_raw = os.environ["HF_HOME"]
+        if not hf_home_raw:
+            raise ValueError("HF_HOME must not be empty")
+        hf_home = resolve_project_output_path(hf_home_raw, root=project)
+    else:
+        try:
+            home = user_home_directory()
+        except (KeyError, OSError, RuntimeError, ValueError):
+            hf_home = managed_project_storage("data/cache/huggingface", root=project)
+        else:
+            hf_home = home / ".cache" / "huggingface"
+    # A project-owned ``HF_HOME`` must not regain an escape through a linked
+    # ``hub`` child created after the parent was validated.
+    return resolve_project_output_path(hf_home / "hub", root=project)
 
 
-def _is_nonempty_file(path: Path) -> bool:
-    try:
-        return path.is_file() and path.stat().st_size > 0
-    except OSError:
-        return False
+def _huggingface_cache_roots(
+    *,
+    root: Path | None = None,
+) -> tuple[Path, ...]:
+    """Backward-compatible tuple wrapper around the single active cache root."""
+
+    return (active_huggingface_hub_cache_root(root=root),)
 
 
-def _matches_required_pattern(snapshot: Path, pattern: str) -> bool:
+def _normalized_required_pattern(pattern: str) -> str:
     normalized = str(pattern or "").strip().replace("\\", "/")
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or any(part in {"", ".", ".."} for part in normalized.split("/"))
+    ):
+        return ""
+    return normalized
+
+
+def _pattern_matches_relative_path(relative: Path, pattern: str) -> bool:
+    normalized = _normalized_required_pattern(pattern)
     if not normalized:
         return False
-    if any(marker in normalized for marker in ("*", "?", "[")):
-        return any(_is_nonempty_file(candidate) for candidate in snapshot.glob(normalized))
-    return _is_nonempty_file(snapshot / Path(*normalized.split("/")))
+    relative_text = relative.as_posix()
+    if not any(marker in normalized for marker in ("*", "?", "[")):
+        return relative_text == normalized
+    if "/" not in normalized and len(relative.parts) != 1:
+        return False
+    return relative.match(normalized)
+
+
+def _snapshot_regular_paths(
+    snapshot: Path,
+    *,
+    allowed_link_root: Path,
+    expected_snapshot_identity: os.stat_result | None = None,
+) -> set[Path] | None:
+    """Inventory one stable model tree, allowing only bounded file links."""
+
+    try:
+        snapshot, snapshot_identity, root_entries = (
+            snapshot_directory_entries_without_links(
+                snapshot,
+                field="model snapshot directory",
+            )
+        )
+    except (FileNotFoundError, NotADirectoryError, PermissionError, ValueError):
+        return None
+    allowed_root = allowed_link_root.resolve(strict=False)
+    if (
+        expected_snapshot_identity is not None
+        and not os.path.samestat(
+            expected_snapshot_identity,
+            snapshot_identity,
+        )
+    ):
+        return None
+    regular_paths: set[Path] = set()
+    observed_leaves: list[
+        tuple[
+            Path,
+            os.stat_result,
+            Path | None,
+            os.stat_result | None,
+        ]
+    ] = []
+    pending: list[
+        tuple[
+            Path,
+            Path,
+            os.stat_result,
+            list[tuple[Path, os.stat_result]] | None,
+        ]
+    ] = [(snapshot, Path(), snapshot_identity, root_entries)]
+    try:
+        while pending:
+            directory, relative_dir, expected_identity, prefetched = pending.pop()
+            if prefetched is None:
+                directory, directory_identity, entries = (
+                    snapshot_directory_entries_without_links(
+                        directory,
+                        field="model snapshot subdirectory",
+                    )
+                )
+                if not os.path.samestat(
+                    expected_identity,
+                    directory_identity,
+                ):
+                    raise PermissionError(
+                        f"model snapshot directory identity changed: {directory}"
+                    )
+            else:
+                directory_identity = expected_identity
+                entries = prefetched
+            for path, metadata in entries:
+                relative = relative_dir / path.name
+                if _metadata_is_link_or_reparse_point(metadata):
+                    try:
+                        resolved = path.resolve(strict=True)
+                        target_identity = resolved.stat()
+                    except OSError:
+                        continue
+                    if (
+                        not path_is_within(resolved, allowed_root)
+                        or not stat.S_ISREG(target_identity.st_mode)
+                        or target_identity.st_size <= 0
+                    ):
+                        continue
+                    regular_paths.add(relative)
+                    observed_leaves.append(
+                        (path, metadata, resolved, target_identity)
+                    )
+                    continue
+                if stat.S_ISDIR(metadata.st_mode):
+                    pending.append(
+                        (path, relative, metadata, None)
+                    )
+                    continue
+                if stat.S_ISREG(metadata.st_mode) and metadata.st_size > 0:
+                    regular_paths.add(relative)
+                    observed_leaves.append(
+                        (path, metadata, None, None)
+                    )
+            require_directory_identity(
+                directory,
+                directory_identity,
+                field="model snapshot directory",
+            )
+            require_directory_identity(
+                snapshot,
+                snapshot_identity,
+                field="model snapshot directory",
+            )
+
+        for path, identity, resolved, target_identity in observed_leaves:
+            current_identity = path.lstat()
+            if not os.path.samestat(identity, current_identity):
+                raise PermissionError(
+                    f"model snapshot file identity changed: {path}"
+                )
+            if resolved is not None:
+                current_resolved = path.resolve(strict=True)
+                current_target_identity = current_resolved.stat()
+                if (
+                    current_resolved != resolved
+                    or target_identity is None
+                    or not os.path.samestat(
+                        target_identity,
+                        current_target_identity,
+                    )
+                ):
+                    raise PermissionError(
+                        f"model snapshot link target changed: {path}"
+                    )
+        require_directory_identity(
+            snapshot,
+            snapshot_identity,
+            field="model snapshot directory",
+        )
+    except (OSError, PermissionError, ValueError):
+        return None
+    return regular_paths
 
 
 def _snapshot_is_complete(
     snapshot: Path,
     required_file_groups: tuple[tuple[str, ...], ...],
     snapshot_validator: Callable[[Path], bool] | None = None,
+    *,
+    allowed_link_root: Path | None = None,
+    expected_snapshot_identity: os.stat_result | None = None,
 ) -> bool:
-    if not snapshot.is_dir():
+    regular_paths = _snapshot_regular_paths(
+        snapshot,
+        allowed_link_root=(
+            snapshot
+            if allowed_link_root is None
+            else allowed_link_root
+        ),
+        expected_snapshot_identity=expected_snapshot_identity,
+    )
+    if regular_paths is None:
         return False
-    try:
-        files_complete = (
-            all(
-                any(_matches_required_pattern(snapshot, pattern) for pattern in alternatives)
-                for alternatives in required_file_groups
+    files_complete = (
+        all(
+            any(
+                any(
+                    _pattern_matches_relative_path(relative, pattern)
+                    for relative in regular_paths
+                )
+                for pattern in alternatives
             )
-            if required_file_groups
-            else any(snapshot.iterdir())
+            for alternatives in required_file_groups
         )
-        return files_complete and (
-            snapshot_validator is None or bool(snapshot_validator(snapshot))
-        )
+        if required_file_groups
+        else bool(regular_paths)
+    )
+    if not files_complete:
+        return False
+    if snapshot_validator is None:
+        return True
+    try:
+        return bool(snapshot_validator(snapshot))
     except Exception:
         return False
 
 
-def _main_huggingface_snapshots(spec: ModelAssetSpec) -> tuple[Path, ...]:
+def _main_huggingface_snapshots(
+    spec: ModelAssetSpec,
+    *,
+    root: Path | None = None,
+) -> tuple[Path, ...]:
+    """Return only the active ``main`` snapshot under the selected cache root."""
+
     if spec.source != "huggingface":
         return ()
     try:
@@ -112,34 +328,35 @@ def _main_huggingface_snapshots(spec: ModelAssetSpec) -> tuple[Path, ...]:
     except ImportError:
         return ()
 
-    snapshots: list[Path] = []
-    for root in _huggingface_cache_roots():
-        try:
-            resolved_root = root.resolve(strict=False)
-            repo_dir = (
-                resolved_root
-                / repo_folder_name(repo_id=spec.repo_id, repo_type="model")
-            ).resolve(strict=False)
-            if os.path.normcase(
-                os.path.commonpath([str(resolved_root), str(repo_dir)])
-            ) != os.path.normcase(str(resolved_root)):
-                continue
-            revision = (repo_dir / "refs" / "main").read_text(encoding="utf-8").strip()
-            if not revision or revision in {".", ".."} or "/" in revision or "\\" in revision:
-                continue
-            snapshots_dir = (repo_dir / "snapshots").resolve(strict=False)
-            snapshot = snapshots_dir / revision
-            resolved_snapshot = snapshot.resolve(strict=False)
-            if os.path.normcase(
-                os.path.commonpath([str(snapshots_dir), str(resolved_snapshot)])
-            ) == os.path.normcase(str(snapshots_dir)):
-                snapshots.append(snapshot)
-        except (OSError, TypeError, ValueError):
-            continue
-    return tuple(snapshots)
+    try:
+        cache_root = active_huggingface_hub_cache_root(root=root)
+        repo_name = safe_path_component(
+            repo_folder_name(repo_id=spec.repo_id, repo_type="model"),
+            field="Hugging Face repository cache directory",
+        )
+        repo_dir = resolve_project_output_path(repo_name, root=cache_root)
+        revision = safe_path_component(
+            read_text_without_links(repo_dir / "refs" / "main").strip(),
+            field="Hugging Face main revision",
+        )
+        snapshots_dir = resolve_project_output_path(
+            repo_dir / "snapshots",
+            root=cache_root,
+        )
+        snapshot = resolve_project_output_path(
+            snapshots_dir / revision,
+            root=cache_root,
+        )
+    except (FileNotFoundError, ImportError, OSError, PermissionError, TypeError, ValueError):
+        return ()
+    return (snapshot,)
 
 
-def find_cached_huggingface_snapshot(spec: ModelAssetSpec) -> Path | None:
+def find_cached_huggingface_snapshot(
+    spec: ModelAssetSpec,
+    *,
+    root: Path | None = None,
+) -> Path | None:
     """Return the complete snapshot referenced by the cached ``main`` ref.
 
     Hugging Face can retain older complete snapshots after an interrupted
@@ -148,17 +365,23 @@ def find_cached_huggingface_snapshot(spec: ModelAssetSpec) -> Path | None:
     load download again (or fail offline).
     """
 
-    for snapshot in _main_huggingface_snapshots(spec):
+    cache_root = active_huggingface_hub_cache_root(root=root)
+    for snapshot in _main_huggingface_snapshots(spec, root=root):
         if _snapshot_is_complete(
             snapshot,
             spec.required_file_groups,
             spec.snapshot_validator,
+            allowed_link_root=cache_root,
         ):
             return snapshot
     return None
 
 
-def _remove_invalid_main_snapshots(spec: ModelAssetSpec) -> bool:
+def _remove_invalid_main_snapshots(
+    spec: ModelAssetSpec,
+    *,
+    root: Path | None = None,
+) -> bool:
     """Remove only invalid snapshots selected by the cached ``main`` ref.
 
     ``snapshot_download(force_download=True)`` refreshes blobs but deliberately
@@ -169,24 +392,45 @@ def _remove_invalid_main_snapshots(spec: ModelAssetSpec) -> bool:
     """
 
     removed = False
-    for snapshot in _main_huggingface_snapshots(spec):
-        if not snapshot.exists() or _snapshot_is_complete(
+    cache_root = active_huggingface_hub_cache_root(root=root)
+    for snapshot in _main_huggingface_snapshots(spec, root=root):
+        try:
+            metadata = snapshot.lstat()
+        except FileNotFoundError:
+            continue
+        if _snapshot_is_complete(
             snapshot,
             spec.required_file_groups,
             spec.snapshot_validator,
+            allowed_link_root=cache_root,
+            expected_snapshot_identity=metadata,
         ):
             continue
-        if snapshot.is_symlink():
-            snapshot.unlink()
-        elif snapshot.is_dir():
-            shutil.rmtree(snapshot)
+        if _metadata_is_link_or_reparse_point(metadata):
+            raise PermissionError(
+                f"invalid model snapshot is a symbolic link or reparse point: {snapshot}"
+            )
+        if stat.S_ISDIR(metadata.st_mode):
+            remove_directory_without_links(
+                snapshot,
+                expected_identity=metadata,
+            )
+        elif stat.S_ISREG(metadata.st_mode):
+            remove_file_without_links(
+                snapshot,
+                expected_identity=metadata,
+            )
         else:
-            snapshot.unlink()
+            raise PermissionError(f"invalid model snapshot has an unsafe type: {snapshot}")
         removed = True
     return removed
 
 
-def inspect_model_asset(spec: ModelAssetSpec) -> dict[str, object]:
+def inspect_model_asset(
+    spec: ModelAssetSpec,
+    *,
+    root: Path | None = None,
+) -> dict[str, object]:
     """Return the cache/download state consumed by model download UIs."""
 
     result: dict[str, object] = {
@@ -205,6 +449,7 @@ def inspect_model_asset(spec: ModelAssetSpec) -> dict[str, object]:
                 path,
                 spec.required_file_groups,
                 spec.snapshot_validator,
+                allowed_link_root=path,
             )
         )
         result["cached"] = cached
@@ -213,7 +458,7 @@ def inspect_model_asset(spec: ModelAssetSpec) -> dict[str, object]:
         return result
 
     result["repoId"] = spec.repo_id
-    snapshot = find_cached_huggingface_snapshot(spec)
+    snapshot = find_cached_huggingface_snapshot(spec, root=root)
     if snapshot is not None:
         result["cached"] = True
         result["path"] = str(snapshot)
@@ -225,8 +470,11 @@ def _download_model_asset_unlocked(
     *,
     update_task: TaskUpdate,
     token: str = "",
+    root: Path | None = None,
 ) -> dict[str, object]:
-    current = inspect_model_asset(spec)
+    """Ensure a model asset is cached and return its resolved status."""
+
+    current = inspect_model_asset(spec, root=root)
     if spec.source == "local":
         if not current["cached"]:
             raise ValueError(f"Local model directory does not exist: {current.get('path', '')}")
@@ -240,13 +488,14 @@ def _download_model_asset_unlocked(
         )
         return {**current, "downloaded": False}
 
-    snapshot_kwargs: dict[str, object] = {}
-    main_snapshots = _main_huggingface_snapshots(spec)
+    cache_root = active_huggingface_hub_cache_root(root=root)
+    snapshot_kwargs: dict[str, object] = {"cache_dir": str(cache_root)}
+    main_snapshots = _main_huggingface_snapshots(spec, root=root)
     if main_snapshots:
         # The active snapshot exists but failed validation. Redownload the
         # complete allowed artifact set and rebuild its snapshot pointers so no
         # partial or corrupt file survives.
-        _remove_invalid_main_snapshots(spec)
+        _remove_invalid_main_snapshots(spec, root=root)
         snapshot_kwargs["force_download"] = True
     if spec.allow_patterns:
         snapshot_kwargs["allow_patterns"] = list(spec.allow_patterns)
@@ -269,10 +518,15 @@ def _download_model_asset_unlocked(
         )
 
     resolved = Path(snapshot_path).resolve(strict=False)
+    if not path_is_within(resolved, cache_root):
+        raise RuntimeError(
+            f"Downloaded model snapshot is outside the active cache root: {spec.repo_id}"
+        )
     if not _snapshot_is_complete(
         resolved,
         spec.required_file_groups,
         spec.snapshot_validator,
+        allowed_link_root=cache_root,
     ):
         raise RuntimeError(
             f"Downloaded model snapshot is incomplete: {spec.repo_id}"
@@ -295,6 +549,7 @@ def download_model_asset(
     *,
     update_task: TaskUpdate,
     token: str = "",
+    root: Path | None = None,
 ) -> dict[str, object]:
     """Ensure a model asset is cached and return its resolved status.
 
@@ -303,11 +558,17 @@ def download_model_asset(
     """
 
     with _model_asset_download_lock(spec.task_key):
-        return _download_model_asset_unlocked(spec, update_task=update_task, token=token)
+        return _download_model_asset_unlocked(
+            spec,
+            update_task=update_task,
+            token=token,
+            root=root,
+        )
 
 
 __all__ = [
     "ModelAssetSpec",
+    "active_huggingface_hub_cache_root",
     "download_model_asset",
     "find_cached_huggingface_snapshot",
     "inspect_model_asset",

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,49 +1,10 @@
+"""Compatibility alias for the canonical :mod:`sdk.path_contract` module."""
+
 from __future__ import annotations
 
-import os
 import sys
-from pathlib import Path
+
+from sdk import path_contract as _implementation
 
 
-def _resolve(path: Path) -> Path:
-    return path.expanduser().resolve(strict=False)
-
-
-def source_root() -> Path:
-    raw = os.environ.get("SHINSEKAI_SOURCE_ROOT", "").strip()
-    if raw:
-        return _resolve(Path(raw))
-    return _resolve(Path(__file__).parent.parent)
-
-
-def project_root() -> Path:
-    raw = (
-        os.environ.get("SHINSEKAI_PROJECT_ROOT", "").strip()
-        or os.environ.get("EASYAI_PROJECT_ROOT", "").strip()
-    )
-    if raw:
-        return _resolve(Path(raw))
-    return _resolve(Path.cwd())
-
-
-def app_root() -> Path:
-    raw = os.environ.get("SHINSEKAI_APP_ROOT", "").strip()
-    if raw:
-        path = _resolve(Path(raw))
-        if path.exists() and path.is_dir():
-            return path
-    if getattr(sys, "frozen", False):
-        return _resolve(Path(sys.executable).parent.parent)
-    return source_root()
-
-
-def resource_path(path: str | Path) -> Path:
-    candidate = Path(path).expanduser()
-    if candidate.is_absolute():
-        return _resolve(candidate)
-
-    for root in (source_root(), app_root(), project_root()):
-        resolved = _resolve(root / candidate)
-        if resolved.exists():
-            return resolved
-    return _resolve(source_root() / candidate)
+sys.modules[__name__] = _implementation

--- a/core/process_launch.py
+++ b/core/process_launch.py
@@ -1,0 +1,10 @@
+"""Compatibility alias for the canonical :mod:`sdk.process_launch` module."""
+
+from __future__ import annotations
+
+import sys
+
+from sdk import process_launch as _implementation
+
+
+sys.modules[__name__] = _implementation

--- a/core/runtime_env/pip_index.py
+++ b/core/runtime_env/pip_index.py
@@ -8,6 +8,13 @@ import re
 import shlex
 from pathlib import Path
 
+from core.file_transactions import read_text_without_links
+from core.paths import (
+    resolve_project_path,
+    source_root as runtime_source_root,
+    validate_exact_path_text,
+)
+
 # --extra-index-url 也算用户主动声明：只补 extra 源说明作者希望保持默认主源不变，
 # 这时再注入国内镜像当 primary index 会改变包解析来源。
 _PIP_INDEX_FLAGS = frozenset({"-i", "--index-url", "--extra-index-url", "--no-index"})
@@ -137,31 +144,57 @@ def _manifest_pip_indexes(source_root: Path | None) -> tuple[list[str], list[str
 
 def _load_runtime_manifest(source_root: Path | None) -> dict[str, object] | None:
     candidates: list[Path] = []
-    env_path = os.environ.get("SHINSEKAI_RUNTIME_MANIFEST")
-    if env_path:
-        candidates.append(Path(env_path))
+    if "SHINSEKAI_RUNTIME_MANIFEST" in os.environ:
+        env_path = os.environ["SHINSEKAI_RUNTIME_MANIFEST"]
+        validate_exact_path_text(
+            env_path,
+            field="SHINSEKAI_RUNTIME_MANIFEST",
+        )
+        configured_manifest = Path(env_path)
+        if not configured_manifest.is_absolute():
+            raise ValueError("SHINSEKAI_RUNTIME_MANIFEST must be an absolute path")
+        return _read_runtime_manifest(
+            configured_manifest,
+            field="SHINSEKAI_RUNTIME_MANIFEST",
+        )
     for root in _source_root_candidates(source_root):
+        # Packaged Tauri resources stage the manifest directly beside
+        # frontend_bridge.py; source checkouts keep it below frontend/src-tauri.
+        candidates.append(root / "runtime_manifest.json")
         candidates.append(root / "frontend" / "src-tauri" / "runtime_manifest.json")
     for candidate in candidates:
         try:
-            with candidate.expanduser().resolve().open("r", encoding="utf-8") as file:
-                data = json.load(file)
-        except (OSError, json.JSONDecodeError):
+            candidate.lstat()
+        except FileNotFoundError:
             continue
-        if isinstance(data, dict):
-            return data
+        except OSError as exc:
+            raise RuntimeError(f"runtime manifest could not be inspected: {candidate}") from exc
+        return _read_runtime_manifest(candidate, field="runtime manifest")
     return None
+
+
+def _read_runtime_manifest(candidate: Path, *, field: str) -> dict[str, object]:
+    try:
+        data = json.loads(read_text_without_links(candidate))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{field} is not valid JSON: {candidate}") from exc
+    except OSError as exc:
+        raise RuntimeError(f"{field} could not be read: {candidate}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{field} must contain a JSON object: {candidate}")
+    return data
 
 
 def _source_root_candidates(source_root: Path | None) -> list[Path]:
     candidates: list[Path] = []
     if source_root is not None:
-        candidates.append(source_root)
-    for env_name in ("SHINSEKAI_SOURCE_ROOT", "SHINSEKAI_PROJECT_ROOT", "EASYAI_PROJECT_ROOT"):
-        value = os.environ.get(env_name)
-        if value:
-            candidates.append(Path(value))
-    candidates.append(Path.cwd())
+        configured_source = resolve_project_path(".", root=source_root)
+        candidates.append(configured_source)
+    candidates.append(runtime_source_root())
+
+    # The writable project root and process cwd are deliberately absent.
+    # They can be relocated independently from application resources and must
+    # never be allowed to override executable dependency policy.
     candidates.append(Path(__file__).resolve().parents[2])
     return _unique_paths(candidates)
 
@@ -204,10 +237,7 @@ def _unique_paths(paths: list[Path]) -> list[Path]:
     unique: list[Path] = []
     seen: set[str] = set()
     for path in paths:
-        try:
-            key = str(path.expanduser().resolve())
-        except OSError:
-            key = str(path)
+        key = os.path.normcase(os.path.normpath(os.fspath(path)))
         if key in seen:
             continue
         seen.add(key)

--- a/core/runtime_env/pip_runner.py
+++ b/core/runtime_env/pip_runner.py
@@ -12,11 +12,28 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import IO
+from urllib.parse import urlparse
 
+from sdk.file_transactions import read_text_without_links
+from sdk.path_contract import (
+    require_symlink_free_absolute_path,
+    resolve_project_read_path,
+    validate_exact_path_text,
+)
+from sdk.process_launch import (
+    LaunchDirectorySnapshot,
+    LaunchFileSnapshot,
+    capture_launch_directory,
+    capture_launch_file,
+    isolated_python_environment,
+    popen_with_stable_paths,
+    require_launch_snapshots,
+)
 from core.runtime_env.pip_index import (
     has_explicit_pip_index as _has_explicit_pip_index,
     pip_index_args as _pip_index_args,
     requirements_lines_define_index as _requirements_lines_define_index,
+    strip_inline_requirement_comment as _strip_inline_requirement_comment,
 )
 
 logger = logging.getLogger(__name__)
@@ -28,6 +45,30 @@ _PIP_CONFLICT_RE = re.compile(
 )
 _URL_CREDENTIAL_RE = re.compile(
     r"(?P<scheme>https?://)(?P<user>[^:/\s@]+)(?::(?P<password>[^@\s/]+))?@"
+)
+_PIP_INPUT_FILE_FLAGS = frozenset(
+    {"-r", "--requirement", "-c", "--constraint"}
+)
+_PIP_INPUT_FILE_PREFIXES = ("--requirement=", "--constraint=")
+_MAX_PIP_INPUT_FILES = 256
+_PIP_ENVIRONMENT_FILE_PATHS = (
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "PIP_CERT",
+    "PIP_CLIENT_CERT",
+    "PIP_CONFIG_FILE",
+    "PIP_REQUIREMENT",
+    "PIP_CONSTRAINT",
+)
+_PIP_ENVIRONMENT_OUTPUT_PATHS = (
+    "PIP_CACHE_DIR",
+    "PIP_SRC",
+    "PIP_TARGET",
+    "PIP_PREFIX",
+    "PIP_ROOT",
+    "PIP_BUILD_TRACKER",
+    "PIP_LOG",
 )
 
 
@@ -46,11 +87,88 @@ def pip_win_creationflags() -> int:
 
 
 def pip_subprocess_env() -> dict[str, str]:
-    env = dict(os.environ)
+    env = isolated_python_environment()
     env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
     env.setdefault("PYTHONUTF8", "1")
     env.setdefault("PYTHONUNBUFFERED", "1")
     return env
+
+
+def _capture_environment_file_alias(
+    value: str,
+    *,
+    field: str,
+) -> LaunchFileSnapshot:
+    raw = validate_exact_path_text(value, field=field)
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        raise ValueError(
+            f"{field} must be absolute and must not depend on the pip working directory"
+        )
+    canonical = candidate.resolve(strict=True)
+    snapshot = capture_launch_file(canonical, field=field)
+    verification = candidate.resolve(strict=True)
+    if verification != snapshot.path:
+        raise PermissionError(f"{field} alias changed while it was resolved")
+    return snapshot
+
+
+def _capture_pip_environment_paths(
+    env: dict[str, str],
+) -> tuple[
+    tuple[LaunchFileSnapshot, ...],
+    tuple[LaunchDirectorySnapshot, ...],
+]:
+    files: list[LaunchFileSnapshot] = []
+    directories: list[LaunchDirectorySnapshot] = []
+    for name in _PIP_ENVIRONMENT_FILE_PATHS:
+        if name not in env:
+            continue
+        value = env[name]
+        if name == "PIP_CONFIG_FILE" and os.path.normcase(value) == os.path.normcase(
+            os.devnull
+        ):
+            env[name] = os.devnull
+            continue
+        snapshot = _capture_environment_file_alias(
+            value,
+            field=f"{name} environment file",
+        )
+        env[name] = os.fspath(snapshot.path)
+        files.append(snapshot)
+
+    if "SSL_CERT_DIR" in env:
+        raw = validate_exact_path_text(
+            env["SSL_CERT_DIR"],
+            field="SSL_CERT_DIR environment directory",
+        )
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            raise ValueError(
+                "SSL_CERT_DIR must be absolute and must not depend on the pip working directory"
+            )
+        canonical = candidate.resolve(strict=True)
+        snapshot = capture_launch_directory(
+            canonical,
+            field="SSL_CERT_DIR environment directory",
+        )
+        if candidate.resolve(strict=True) != snapshot.path:
+            raise PermissionError(
+                "SSL_CERT_DIR environment directory alias changed while it was resolved"
+            )
+        env["SSL_CERT_DIR"] = os.fspath(snapshot.path)
+        directories.append(snapshot)
+
+    for name in _PIP_ENVIRONMENT_OUTPUT_PATHS:
+        if name not in env:
+            continue
+        path = require_symlink_free_absolute_path(
+            env[name],
+            field=f"{name} environment path",
+            include_leaf=False,
+        )
+        env[name] = os.fspath(path)
+    return tuple(files), tuple(directories)
 
 
 def extra_pip_install_args() -> list[str]:
@@ -84,6 +202,84 @@ def apply_pip_index_and_extra_args(
     return final_cmd
 
 
+def _pip_input_file_references(tokens: list[str]) -> list[str]:
+    references: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in _PIP_INPUT_FILE_FLAGS:
+            if index + 1 < len(tokens):
+                references.append(tokens[index + 1])
+                index += 2
+                continue
+        matched_prefix = next(
+            (
+                prefix
+                for prefix in _PIP_INPUT_FILE_PREFIXES
+                if token.startswith(prefix)
+            ),
+            None,
+        )
+        if matched_prefix is not None:
+            references.append(token[len(matched_prefix) :])
+        elif token.startswith(("-r", "-c")) and token not in {"-r", "-c"}:
+            references.append(token[2:])
+        index += 1
+    return [reference for reference in references if reference]
+
+
+def _capture_pip_input_files(
+    command: list[str],
+    *,
+    cwd: Path,
+) -> tuple[LaunchFileSnapshot, ...]:
+    snapshots: list[LaunchFileSnapshot] = []
+    seen: set[str] = set()
+
+    def capture(raw: str, base: Path) -> None:
+        parsed = urlparse(raw)
+        if parsed.scheme.lower() in {"http", "https"}:
+            # pip itself owns the identity and transport semantics of remote
+            # requirements.  Only local path inputs can be bound to a host
+            # filesystem snapshot here.
+            return
+        if parsed.scheme:
+            raise ValueError(
+                f"unsupported pip requirements input URI scheme: {parsed.scheme}"
+            )
+        path = resolve_project_read_path(raw, root=base)
+        key = os.path.normcase(os.path.normpath(os.fspath(path)))
+        if key in seen:
+            return
+        if len(snapshots) >= _MAX_PIP_INPUT_FILES:
+            raise ValueError("pip requirements include too many nested input files")
+        snapshot = capture_launch_file(
+            path,
+            field="pip requirements input",
+        )
+        seen.add(key)
+        snapshots.append(snapshot)
+        text = read_text_without_links(
+            snapshot.path,
+            expected_identity=snapshot.identity,
+            expected_parent_identity=snapshot.parent.identity,
+        )
+        for raw_line in text.splitlines():
+            line = _strip_inline_requirement_comment(raw_line)
+            if not line:
+                continue
+            try:
+                tokens = shlex.split(line)
+            except ValueError:
+                continue
+            for nested in _pip_input_file_references(tokens):
+                capture(nested, snapshot.path.parent)
+
+    for reference in _pip_input_file_references(command[1:]):
+        capture(reference, cwd)
+    return tuple(snapshots)
+
+
 def classify_pip_result(result: tuple[str, str]) -> tuple[str, str]:
     # 依赖求解冲突单独分类，前端可以提示“版本冲突”，而不是笼统显示 pip failed。
     code, detail = result
@@ -108,20 +304,55 @@ def run_pip_install(
     credential-redacted output tail for failures (empty on success). Lines
     forwarded to ``on_output_line`` are redacted the same way.
     """
+    try:
+        if not cmd:
+            raise ValueError("pip command is empty")
+        executable_snapshot = capture_launch_file(
+            cmd[0],
+            field="pip Python executable",
+            executable=True,
+        )
+        working_directory_snapshot = capture_launch_directory(
+            cwd,
+            field="pip working directory",
+        )
+        safe_cmd = [str(executable_snapshot.path), *cmd[1:]]
+        input_file_snapshots = _capture_pip_input_files(
+            safe_cmd,
+            cwd=working_directory_snapshot.path,
+        )
+        child_env = pip_subprocess_env()
+        environment_file_snapshots, environment_directory_snapshots = (
+            _capture_pip_environment_paths(child_env)
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning("pip install path validation failed: %s", exc)
+        return ("pip_exception", str(exc))
+
     pop_kw: dict[str, object] = {
-        "cwd": str(cwd),
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
-        "env": pip_subprocess_env(),
+        "env": child_env,
     }
     flags = pip_win_creationflags()
     if sys.platform == "win32" and flags:
         pop_kw["creationflags"] = flags
     try:
-        proc = subprocess.Popen(cmd, **pop_kw)
-    except OSError as exc:
-        logger.warning("pip install could not run (cmd=%s): %s", cmd[:8], exc)
+        proc = popen_with_stable_paths(
+            safe_cmd,
+            cwd=working_directory_snapshot,
+            executable=executable_snapshot,
+            required_directories=environment_directory_snapshots,
+            required_files=(
+                *input_file_snapshots,
+                *environment_file_snapshots,
+            ),
+            popen_factory=subprocess.Popen,
+            **pop_kw,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning("pip install could not run (cmd=%s): %s", safe_cmd[:8], exc)
         return ("pip_exception", str(exc))
 
     combined_chunks: list[str] = []
@@ -153,6 +384,21 @@ def run_pip_install(
         proc.kill()
         t_out.join(timeout=3.0)
         t_err.join(timeout=3.0)
+        try:
+            require_launch_snapshots(
+                directories=(
+                    working_directory_snapshot,
+                    *environment_directory_snapshots,
+                ),
+                files=(
+                    executable_snapshot,
+                    *input_file_snapshots,
+                    *environment_file_snapshots,
+                ),
+            )
+        except (OSError, PermissionError, ValueError) as exc:
+            logger.warning("pip install paths changed during timeout handling: %s", exc)
+            return ("pip_exception", str(exc))
         combined = "".join(combined_chunks)
         tail = combined.strip()[-max(1, detail_max):]
         logger.warning("pip install timed out (timeout_sec=%s)", timeout_sec)
@@ -160,6 +406,21 @@ def run_pip_install(
 
     t_out.join()
     t_err.join()
+    try:
+        require_launch_snapshots(
+            directories=(
+                working_directory_snapshot,
+                *environment_directory_snapshots,
+            ),
+            files=(
+                executable_snapshot,
+                *input_file_snapshots,
+                *environment_file_snapshots,
+            ),
+        )
+    except (OSError, PermissionError, ValueError) as exc:
+        logger.warning("pip install paths changed while pip was running: %s", exc)
+        return ("pip_exception", str(exc))
     combined = "".join(combined_chunks).strip()
     if proc.returncode == 0:
         logger.info("pip install ok")

--- a/core/sprite/chat_branch_storage.py
+++ b/core/sprite/chat_branch_storage.py
@@ -2,13 +2,42 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import re
+import stat
+import threading
 from pathlib import Path
 from typing import Any
+
+from core.file_transactions import (
+    atomic_write_text,
+    read_text_without_links,
+    remove_empty_directory_without_links,
+    remove_file_without_links,
+    snapshot_directory_entries_without_links,
+)
+from core.paths import (
+    _metadata_is_link_or_reparse_point,
+    path_is_link_or_reparse_point,
+    path_is_within,
+    project_root,
+    resolve_managed_project_path,
+    resolve_project_path,
+    resolve_project_read_path,
+    validate_exact_path_text,
+)
 
 ACTIVE_HISTORY_FILENAME = "active.json"
 BRANCH_TREE_FILENAME = "branches.json"
 BRANCH_TREE_VERSION = 1
+_BRANCH_STORAGE_LOCK = threading.RLock()
+
+
+def _exact_history_path(path: str | Path) -> Path:
+    """Preserve a history reference's lexical identity at the storage boundary."""
+
+    raw = validate_exact_path_text(path, field="chat history path")
+    return resolve_project_read_path(raw, root=project_root())
 
 
 def _is_branch_file(path: Path) -> bool:
@@ -16,7 +45,7 @@ def _is_branch_file(path: Path) -> bool:
 
 
 def is_legacy_history_file(path: str | Path) -> bool:
-    candidate = Path(path)
+    candidate = _exact_history_path(path)
     if candidate.suffix.lower() != ".json" or _is_branch_file(candidate):
         return False
     session_dir = candidate.with_suffix("")
@@ -24,7 +53,7 @@ def is_legacy_history_file(path: str | Path) -> bool:
 
 
 def chat_history_session_dir(path: str | Path) -> Path:
-    candidate = Path(path)
+    candidate = _exact_history_path(path)
     if candidate.suffix.lower() == ".json":
         if _is_branch_file(candidate):
             return candidate.parent
@@ -33,7 +62,7 @@ def chat_history_session_dir(path: str | Path) -> Path:
 
 
 def chat_history_active_path(path: str | Path) -> Path:
-    candidate = Path(path)
+    candidate = _exact_history_path(path)
     if is_legacy_history_file(candidate):
         return candidate
     return chat_history_session_dir(candidate) / ACTIVE_HISTORY_FILENAME
@@ -50,39 +79,177 @@ def chat_history_download_path(path: str | Path) -> Path:
     return chat_history_active_path(path)
 
 
-def remove_chat_history_storage(path: str | Path) -> None:
-    candidate = Path(path)
-    if candidate.suffix.lower() == ".json" and not _is_branch_file(candidate):
-        file_targets = [candidate, Path(str(candidate) + ".tmp")]
-        directory_targets = [candidate.with_suffix("")]
-    elif _is_branch_file(candidate):
-        file_targets = []
-        directory_targets = [candidate.parent]
-    else:
-        file_targets = []
-        directory_targets = [chat_history_session_dir(candidate)]
+def _history_session_directory_identity(
+    path: Path,
+) -> os.stat_result | None:
+    try:
+        _directory, identity, entries = (
+            snapshot_directory_entries_without_links(
+                path,
+                field="chat history session directory",
+            )
+        )
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        return None
+    reserved = {
+        ACTIVE_HISTORY_FILENAME,
+        BRANCH_TREE_FILENAME,
+        f"{ACTIVE_HISTORY_FILENAME}.tmp",
+    }
+    if any(
+        child.name in reserved
+        and not _metadata_is_link_or_reparse_point(metadata)
+        and stat.S_ISREG(metadata.st_mode)
+        for child, metadata in entries
+    ):
+        return identity
+    return None
 
-    # A history directory is not an ownership boundary. Remove only files
-    # created by chat storage, then remove the directory if it is empty.
-    # Never recursively delete unrelated content from an external directory.
+
+def _looks_like_history_session_dir(path: Path) -> bool:
+    return _history_session_directory_identity(path) is not None
+
+
+def validate_chat_history_removal_target(
+    target: str | Path,
+    root: str | Path,
+) -> Path:
+    """Return a resolved strict descendant suitable for destructive actions."""
+
+    raw_root = os.fspath(root)
+    raw_target = os.fspath(target)
+    try:
+        active_project_root = project_root()
+        resolved_root = resolve_project_path(raw_root, root=active_project_root)
+        unresolved_root = Path(raw_root).expanduser()
+        if not unresolved_root.is_absolute():
+            unresolved_root = active_project_root / unresolved_root
+        if path_is_link_or_reparse_point(unresolved_root):
+            raise PermissionError("chat history root must not be a symbolic link")
+        project_candidate = resolve_project_path(raw_target, root=active_project_root)
+        raw_target_path = Path(raw_target).expanduser()
+        if raw_target_path.is_absolute():
+            unresolved_target = raw_target_path
+        elif path_is_within(project_candidate, resolved_root):
+            # Preserve unresolved components for the managed resolver so it
+            # can detect an in-boundary symbolic-link hop.
+            unresolved_target = active_project_root / raw_target_path
+        else:
+            # A shorthand such as ``session`` is relative to the explicitly
+            # declared history collection, never to process cwd.
+            resolve_project_path(raw_target, root=resolved_root)
+            unresolved_target = resolved_root / raw_target_path
+        resolved_target = resolve_managed_project_path(
+            unresolved_target,
+            root=resolved_root,
+        )
+    except PermissionError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError("chat history removal target could not be resolved") from exc
+    removal_container = (
+        resolved_target.parent
+        if _is_branch_file(resolved_target)
+        else resolved_target
+    )
+    if removal_container == resolved_root:
+        raise PermissionError("refusing to remove the chat history collection root")
+    return resolved_target
+
+
+def remove_chat_history_storage(
+    path: str | Path,
+    *,
+    root: str | Path | None = None,
+) -> None:
+    """Remove one history session, optionally enforcing its managed boundary.
+
+    A legacy ``session.json`` may have a companion ``session/`` branch store.
+    Only remove that companion when it actually has the reserved history
+    layout; an unrelated same-named directory must survive.
+    """
+
+    managed_root = Path(root) if root is not None else None
+    candidate = (
+        validate_chat_history_removal_target(path, managed_root)
+        if managed_root is not None
+        else _exact_history_path(path)
+    )
+    with _BRANCH_STORAGE_LOCK:
+        default_history_root = resolve_managed_project_path(
+            "data/chat_history",
+            root=project_root(),
+        )
+        managed = managed_root is not None or path_is_within(
+            candidate,
+            default_history_root,
+        )
+        removal_container = candidate.parent if _is_branch_file(candidate) else candidate
+        if managed and managed_root is None and removal_container == default_history_root:
+            raise PermissionError(
+                "refusing to remove the chat history collection root"
+            )
+        _remove_reserved_history_storage(candidate)
+
+
+def _remove_regular_history_file(path: Path) -> None:
+    """Remove one reserved file without following or deleting an alias."""
+
+    try:
+        identity = path.lstat()
+    except FileNotFoundError:
+        return
+    if _metadata_is_link_or_reparse_point(identity):
+        raise PermissionError(f"chat history file must not be a symbolic link: {path}")
+    if not stat.S_ISREG(identity.st_mode):
+        raise PermissionError(f"chat history file has an unsafe type: {path}")
+    remove_file_without_links(path, expected_identity=identity)
+
+
+def _remove_reserved_history_storage(candidate: Path) -> None:
+    """Clear reserved chat files without treating a directory as fully owned."""
+
+    if candidate.suffix.lower() == ".json" and not _is_branch_file(candidate):
+        file_targets = (candidate, Path(f"{candidate}.tmp"))
+        directory_targets = (candidate.with_suffix(""),)
+    elif _is_branch_file(candidate):
+        file_targets = ()
+        directory_targets = (candidate.parent,)
+    else:
+        file_targets = ()
+        directory_targets = (chat_history_session_dir(candidate),)
+
     for directory in directory_targets:
+        try:
+            directory_identity = directory.lstat()
+        except FileNotFoundError:
+            continue
+        if (
+            _metadata_is_link_or_reparse_point(directory_identity)
+            or not stat.S_ISDIR(directory_identity.st_mode)
+        ):
+            raise PermissionError(
+                f"chat history session must be a regular directory: {directory}"
+            )
+        # Metadata goes first and the authoritative active history last. If a
+        # locked file aborts cleanup, the readable conversation stays intact.
         for name in (
             BRANCH_TREE_FILENAME,
             f"{ACTIVE_HISTORY_FILENAME}.tmp",
             ACTIVE_HISTORY_FILENAME,
         ):
-            target = directory / name
-            target.unlink(missing_ok=True)
+            _remove_regular_history_file(directory / name)
         try:
-            directory.rmdir()
+            remove_empty_directory_without_links(
+                directory,
+                expected_identity=directory_identity,
+            )
         except OSError:
+            # Unrelated external content deliberately keeps the directory alive.
             pass
 
-    # Legacy aliases are removed last. If branch metadata is locked, the
-    # authoritative active history remains intact and the clear is reported as
-    # failed instead of leaving a partially-cleared session.
     for target in file_targets:
-        target.unlink(missing_ok=True)
+        _remove_regular_history_file(target)
 
 
 def sanitize_branch_id(value: str) -> str:
@@ -145,8 +312,7 @@ def load_branch_state(path: str | Path) -> dict[str, Any] | None:
     if not tree_path.is_file():
         return None
     try:
-        with tree_path.open(encoding="utf-8") as file:
-            return normalize_branch_state(json.load(file))
+        return normalize_branch_state(json.loads(read_text_without_links(tree_path)))
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -202,7 +368,17 @@ def branch_state_payload(branch_state: dict[str, Any]) -> dict[str, Any]:
 
 def save_branch_state(path: str | Path, branch_state: dict[str, Any]) -> Path:
     tree_path = chat_history_branch_tree_path(path)
-    tree_path.parent.mkdir(parents=True, exist_ok=True)
-    with tree_path.open("w", encoding="utf-8") as file:
-        json.dump(branch_state_payload(branch_state), file, ensure_ascii=False, indent=2)
+    with _BRANCH_STORAGE_LOCK:
+        if path_is_link_or_reparse_point(tree_path.parent):
+            raise PermissionError("chat history session must not be a symbolic link")
+        tree_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(
+            tree_path,
+            json.dumps(
+                branch_state_payload(branch_state),
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+        )
     return tree_path

--- a/core/sprite/initial_sprite.py
+++ b/core/sprite/initial_sprite.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Any
 
-from sdk.path_utils import normalize_path_identity
+from sdk.path_contract import (
+    project_root as configured_project_root,
+    resolve_project_path,
+    resolve_runtime_asset_path,
+    validate_exact_path_text,
+)
+
+
+_WINDOWS_ABSOLUTE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_DRIVE_RELATIVE_RE = re.compile(r"^[A-Za-z]:[^\\/]")
 
 
 def sprite_entry_path(sprite: object) -> str:
@@ -24,28 +34,66 @@ def _character_sprites(character: object) -> list[Any]:
     return list(sprites) if isinstance(sprites, (list, tuple)) else []
 
 
-def resolve_runtime_path(raw_path: str) -> Path:
-    return normalize_path_identity(raw_path, field="initial sprite path")
+def resolve_runtime_path(raw_path: str, *, project_root: str | Path | None = None) -> Path:
+    root = (
+        resolve_project_path(".", root=project_root)
+        if project_root is not None
+        else configured_project_root()
+    )
+    return resolve_runtime_asset_path(raw_path, root=root)
 
 
-def _sprite_path_key(raw_path: str) -> str:
+def _sprite_path_key(raw_path: str, *, project_root: str | Path | None = None) -> str:
     """Normalize path identity using the host filesystem's case semantics."""
-    return os.path.normcase(str(resolve_runtime_path(raw_path))).replace("\\", "/")
+    raw = str(raw_path or "")
+    if (
+        not raw
+        or raw != raw.strip()
+        or _WINDOWS_DRIVE_RELATIVE_RE.match(raw)
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in raw
+        )
+    ):
+        raise ValueError("sprite path is empty, ambiguous, or non-portable")
+    validate_exact_path_text(
+        raw,
+        field="sprite path",
+        allow_non_native_absolute=True,
+    )
+    if _WINDOWS_ABSOLUTE_RE.match(raw) or raw.startswith(("\\\\", "//")):
+        # A persisted Windows path can still be compared on another host
+        # without anchoring it to that host's cwd.  Operational access remains
+        # strict in ``resolve_runtime_path``.
+        return os.path.normcase(raw).replace("\\", "/")
+    return os.path.normcase(
+        str(resolve_runtime_path(raw, project_root=project_root))
+    ).replace("\\", "/")
 
 
 def find_character_sprite_by_path(
     config: Any,
     raw_path: str,
+    *,
+    project_root: str | Path | None = None,
 ) -> tuple[str, int] | None:
     if not raw_path:
         return None
-    target_key = _sprite_path_key(raw_path)
+    target_key = _sprite_path_key(raw_path, project_root=project_root)
     for character in getattr(config.config, "characters", None) or []:
         for index, sprite in enumerate(_character_sprites(character)):
             sprite_path = sprite_entry_path(sprite)
             if not sprite_path:
                 continue
-            candidate_key = _sprite_path_key(sprite_path)
+            try:
+                candidate_key = _sprite_path_key(
+                    sprite_path,
+                    project_root=project_root,
+                )
+            except (OSError, RuntimeError, ValueError):
+                continue
             if candidate_key == target_key:
                 return _character_name(character), index
     return None
@@ -55,6 +103,8 @@ def initial_sprite_path_for_characters(
     config: Any,
     raw_path: str,
     character_names: list[str] | None,
+    *,
+    project_root: str | Path | None = None,
 ) -> str:
     selected_names = [name.strip() for name in (character_names or []) if isinstance(name, str) and name.strip()]
     default_path = ""
@@ -64,10 +114,10 @@ def initial_sprite_path_for_characters(
         if sprites:
             default_path = sprite_entry_path(sprites[0])
 
-    requested_path = str(raw_path or "").strip()
+    requested_path = str(raw_path or "")
     if not requested_path:
         return default_path
-    matched = find_character_sprite_by_path(config, requested_path)
+    matched = find_character_sprite_by_path(config, requested_path, project_root=project_root)
     if matched is not None and matched[0] not in selected_names:
         return default_path
     return requested_path

--- a/core/tts_bundle_catalog.py
+++ b/core/tts_bundle_catalog.py
@@ -1,0 +1,378 @@
+"""TTS bundle metadata and hardware recommendation for non-UI runtimes."""
+
+from __future__ import annotations
+
+import json
+import platform
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from core.file_transactions import (
+    portable_name_key,
+    read_text_snapshot_without_links,
+)
+from core.paths import (
+    require_regular_file_without_links,
+    resource_path,
+    safe_path_component,
+)
+from core.process_launch import (
+    capture_command_executable,
+    run_with_stable_paths,
+)
+
+try:
+    from gpu_list import get_info as _gpu_get_info
+except ImportError:  # pragma: no cover - optional dependency
+    _gpu_get_info = None  # type: ignore[misc, assignment]
+
+
+MIN_VRAM_GB_GPT = 6.0
+
+
+@dataclass(frozen=True)
+class TtsBundleManifestEntry:
+    kind: str
+    bundle_dir_key: str
+    filename: str
+    download_url: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class TtsBundleChoice:
+    kind: str
+    download_url: str
+    bundle_dir_key: str
+
+
+def _manifest_path() -> Path:
+    return require_regular_file_without_links(
+        resource_path("core/model_assets/tts_bundle_manifest.json"),
+        field="TTS bundle manifest",
+    )
+
+
+def _validated_download_url(value: object) -> str:
+    raw = str(value)
+    if (
+        not raw
+        or raw != raw.strip()
+        or "\\" in raw
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in raw
+        )
+    ):
+        raise ValueError("TTS bundle URL is empty or contains non-portable characters")
+    try:
+        parsed = urlsplit(raw)
+        # Python defers malformed and out-of-range port validation until the
+        # property is read.  Validate it while loading the catalog rather than
+        # after a user has already started a download.
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("TTS bundle URL is malformed") from exc
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+        or "%" in parsed.netloc
+        or any(character.isspace() for character in parsed.netloc)
+    ):
+        raise ValueError(
+            "TTS bundle URL must be an absolute HTTP(S) URL without "
+            "credentials, an ambiguous authority, or a fragment"
+        )
+    return raw
+
+
+def _entry_from_dict(raw: dict[str, Any]) -> TtsBundleManifestEntry:
+    kind = safe_path_component(str(raw["kind"]), field="TTS bundle kind")
+    bundle_dir_key = safe_path_component(
+        str(raw["bundle_dir_key"]),
+        field="TTS bundle directory key",
+    )
+    filename = safe_path_component(
+        str(raw["filename"]),
+        field="TTS bundle filename",
+    )
+    download_url = _validated_download_url(raw["download_url"])
+    size = int(raw["size"])
+    if size <= 0:
+        raise ValueError("TTS bundle size must be positive")
+    sha256 = str(raw["sha256"]).lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", sha256):
+        raise ValueError("TTS bundle sha256 must contain exactly 64 hex digits")
+    return TtsBundleManifestEntry(
+        kind=kind,
+        bundle_dir_key=bundle_dir_key,
+        filename=filename,
+        download_url=download_url,
+        size=size,
+        sha256=sha256,
+    )
+
+
+def load_tts_bundle_manifest(
+    path: Path | None = None,
+) -> dict[str, TtsBundleManifestEntry]:
+    source = require_regular_file_without_links(
+        path if path is not None else _manifest_path(),
+        field="TTS bundle manifest",
+    )
+    payload_text, _identity = read_text_snapshot_without_links(source)
+    payload = json.loads(payload_text)
+    if not isinstance(payload, dict) or not isinstance(payload.get("bundles"), list):
+        raise ValueError("TTS bundle manifest must contain a bundles list")
+
+    by_kind: dict[str, TtsBundleManifestEntry] = {}
+    directory_keys: set[str] = set()
+    filenames: set[str] = set()
+    for raw_entry in payload["bundles"]:
+        if not isinstance(raw_entry, dict):
+            raise ValueError("TTS bundle manifest entries must be objects")
+        entry = _entry_from_dict(raw_entry)
+        if entry.kind in by_kind:
+            raise ValueError(f"duplicate TTS bundle kind: {entry.kind}")
+        directory_key = portable_name_key(entry.bundle_dir_key)
+        filename_key = portable_name_key(entry.filename)
+        if directory_key in directory_keys:
+            raise ValueError(
+                f"duplicate TTS bundle directory key: {entry.bundle_dir_key}"
+            )
+        if filename_key in filenames:
+            raise ValueError(f"duplicate TTS bundle filename: {entry.filename}")
+        by_kind[entry.kind] = entry
+        directory_keys.add(directory_key)
+        filenames.add(filename_key)
+    return by_kind
+
+
+TTS_BUNDLE_MANIFEST = load_tts_bundle_manifest()
+_TTS_BUNDLE_MANIFEST_BY_KEY = {
+    entry.bundle_dir_key: entry for entry in TTS_BUNDLE_MANIFEST.values()
+}
+
+
+def bundle_manifest_for_kind(kind: str) -> TtsBundleManifestEntry | None:
+    return TTS_BUNDLE_MANIFEST.get(kind)
+
+
+def bundle_manifest_for_key(
+    bundle_dir_key: str,
+) -> TtsBundleManifestEntry | None:
+    return _TTS_BUNDLE_MANIFEST_BY_KEY.get(bundle_dir_key)
+
+
+def bundle_choice_for_kind(kind: str) -> TtsBundleChoice:
+    entry = bundle_manifest_for_kind(kind)
+    if entry is None:
+        entry = bundle_manifest_for_kind("genie")
+    if entry is None:
+        raise RuntimeError("TTS bundle manifest does not define the genie fallback")
+    return TtsBundleChoice(
+        kind=entry.kind,
+        download_url=entry.download_url,
+        bundle_dir_key=entry.bundle_dir_key,
+    )
+
+
+def is_nvidia_vendor(info: dict[str, Any]) -> bool:
+    vendor = str(info.get("vendor", "") or "").lower()
+    vendor_id = str(info.get("vendor_id", "") or "").lower()
+    return "nvidia" in vendor or vendor_id in {"10de", "0x10de"}
+
+
+def _vram_gb(info: dict[str, Any]) -> float:
+    try:
+        return float(info.get("vram_gb", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _needs_display_enrichment(info: dict[str, Any]) -> bool:
+    def missing(value: object) -> bool:
+        return str(value or "").strip().lower() in {
+            "",
+            "unknown",
+            "generic",
+            "?",
+            "n/a",
+            "na",
+            "other",
+        }
+
+    return missing(info.get("vendor")) or missing(info.get("device"))
+
+
+def _nvidia_smi_query_gpus() -> list[tuple[str, float]]:
+    try:
+        executable = capture_command_executable(
+            "nvidia-smi",
+            field="NVIDIA SMI executable",
+        )
+    except (OSError, PermissionError, RuntimeError, ValueError):
+        return []
+
+    kwargs: dict[str, Any] = {
+        "capture_output": True,
+        "text": True,
+        "timeout": 8,
+    }
+    if sys.platform == "win32":
+        creation_flags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        if creation_flags:
+            kwargs["creationflags"] = creation_flags
+    try:
+        process = run_with_stable_paths(
+            [
+                executable.path,
+                "--query-gpu=name,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            cwd=executable.parent,
+            executable=executable,
+            **kwargs,
+        )
+    except (OSError, PermissionError, subprocess.TimeoutExpired):
+        return []
+    if process.returncode != 0:
+        return []
+
+    rows: list[tuple[str, float]] = []
+    for raw_line in str(process.stdout or "").splitlines():
+        parts = [part.strip() for part in raw_line.strip().split(",", 1)]
+        if len(parts) != 2 or not parts[0]:
+            continue
+        try:
+            memory_mib = float(re.sub(r"[^\d.]", "", parts[1]) or "nan")
+        except ValueError:
+            continue
+        if memory_mib != memory_mib:
+            continue
+        rows.append((parts[0], memory_mib / 1024.0))
+    return rows
+
+
+def _enrich_gpu_entries_with_nvidia_smi(
+    gpus: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    rows = _nvidia_smi_query_gpus()
+    if not rows:
+        return list(gpus)
+
+    output = [dict(gpu) for gpu in gpus]
+    missing_indexes = [
+        index for index, gpu in enumerate(output) if _needs_display_enrichment(gpu)
+    ]
+    used_rows: set[int] = set()
+    for index in missing_indexes:
+        vram = _vram_gb(output[index])
+        candidates = [
+            (abs(vram - row_vram) if vram > 0.15 else 0.0, row_index)
+            for row_index, (_name, row_vram) in enumerate(rows)
+            if row_index not in used_rows
+        ]
+        if not candidates:
+            continue
+        difference, row_index = min(candidates)
+        if vram > 0.15 and difference > 2.25:
+            continue
+        if vram <= 0.15 and len(rows) > 1 and len(missing_indexes) > 1:
+            continue
+        used_rows.add(row_index)
+        name, row_vram = rows[row_index]
+        output[index]["vendor"] = "NVIDIA"
+        output[index]["device"] = name
+        if vram <= 0.15:
+            output[index]["vram_gb"] = round(row_vram, 2)
+    return output
+
+
+def is_rtx_50_series(device: str) -> bool:
+    return bool(
+        device
+        and re.search(r"(?:GeForce\s*)?RTX\s*50[0-9]{2}\b", device, re.IGNORECASE)
+    )
+
+
+def pick_nvidia_gpus(gpus: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [gpu for gpu in gpus if is_nvidia_vendor(gpu)]
+
+
+def pick_best_nvidia(gpus: list[dict[str, Any]]) -> dict[str, Any] | None:
+    nvidia_gpus = pick_nvidia_gpus(gpus)
+    return max(nvidia_gpus, key=_vram_gb) if nvidia_gpus else None
+
+
+def recommend_tts_bundle(
+    gpus: list[dict[str, Any]] | None,
+) -> TtsBundleChoice:
+    best = pick_best_nvidia(gpus or [])
+    if best is not None and _vram_gb(best) >= MIN_VRAM_GB_GPT:
+        return bundle_choice_for_kind(
+            "gptso50"
+            if is_rtx_50_series(str(best.get("device", "") or ""))
+            else "gptso"
+        )
+    return bundle_choice_for_kind("genie")
+
+
+def get_gpu_list() -> list[dict[str, Any]]:
+    if _gpu_get_info is None:
+        rows = _nvidia_smi_query_gpus()
+        return [
+            {
+                "vendor": "NVIDIA",
+                "device": name,
+                "vram_gb": round(vram, 2),
+            }
+            for name, vram in rows
+        ]
+    try:
+        detected = _gpu_get_info()
+    except Exception:  # pragma: no cover - third-party probe
+        return []
+    gpus = detected if isinstance(detected, list) else []
+    enriched = _enrich_gpu_entries_with_nvidia_smi(gpus)
+    if enriched:
+        return enriched
+    return [
+        {
+            "vendor": "NVIDIA",
+            "device": name,
+            "vram_gb": round(vram, 2),
+        }
+        for name, vram in _nvidia_smi_query_gpus()
+    ]
+
+
+def format_platform() -> str:
+    try:
+        return platform.platform(aliased=True, terse=True)
+    except Exception:  # pragma: no cover
+        return f"{platform.system()} {platform.release()}"
+
+
+__all__ = [
+    "TtsBundleChoice",
+    "TtsBundleManifestEntry",
+    "bundle_choice_for_kind",
+    "bundle_manifest_for_key",
+    "bundle_manifest_for_kind",
+    "format_platform",
+    "get_gpu_list",
+    "load_tts_bundle_manifest",
+    "recommend_tts_bundle",
+]

--- a/core/tts_bundle_io.py
+++ b/core/tts_bundle_io.py
@@ -1,0 +1,636 @@
+"""Identity-bound download, extraction, and publication of TTS bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import os
+import re
+import stat
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote_to_bytes, urlsplit
+
+import requests
+
+from core.archive_paths import validate_archive_member_names
+from core.file_transactions import (
+    atomic_binary_writer,
+    capture_directory_identity,
+    clear_directory_without_links,
+    file_snapshot_is_stable,
+    inspect_portable_directory_tree,
+    open_binary_read_without_links,
+    remove_directory_without_links,
+    replace_directory_transactionally,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from core.paths import (
+    _metadata_is_link_or_reparse_point,
+    app_root,
+    managed_child_path,
+    managed_project_storage,
+    require_directory_without_links,
+    safe_path_component,
+    source_root,
+)
+from core.process_launch import (
+    LaunchDirectorySnapshot,
+    LaunchFileSnapshot,
+    capture_command_executable,
+    capture_launch_directory,
+    capture_launch_file,
+    popen_with_stable_paths,
+    require_launch_snapshots,
+)
+from core.tts_bundle_catalog import (
+    TtsBundleManifestEntry,
+    _validated_download_url,
+)
+
+_WIN_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+_DOWNLOAD_CHUNK_SIZE = 128 * 1024
+_HASH_CHUNK_SIZE = 4 * 1024 * 1024
+_SEVEN_ZIP_COMMANDS = (
+    "7zz.exe",
+    "7za.exe",
+    "7z.exe",
+    "7zz",
+    "7za",
+    "7z",
+)
+
+_BUNDLE_IO_LOCK = threading.RLock()
+_ENCODED_PATH_SEPARATOR_RE = re.compile(r"%(?:2f|5c)", re.IGNORECASE)
+_INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+
+
+class _DownloadInterrupted(Exception):
+    pass
+
+
+class _ExtractionInterrupted(Exception):
+    pass
+
+
+def _archive_filename(url: str) -> str:
+    parsed = urlsplit(_validated_download_url(url))
+    encoded_name = parsed.path.rsplit("/", 1)[-1]
+    if not encoded_name:
+        return "bundle.7z"
+    if (
+        _ENCODED_PATH_SEPARATOR_RE.search(encoded_name)
+        or _INVALID_PERCENT_ESCAPE_RE.search(encoded_name)
+    ):
+        raise ValueError("TTS archive filename contains ambiguous URL encoding")
+    try:
+        filename = unquote_to_bytes(encoded_name).decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise ValueError("TTS archive filename contains invalid UTF-8") from exc
+    return safe_path_component(filename, field="TTS archive filename")
+
+
+def _bundle_storage_paths(
+    project_root: Path,
+    bundle_dir_key: str,
+) -> tuple[Path, Path]:
+    downloads = managed_project_storage(
+        "data/tts_bundles/downloads",
+        root=project_root,
+    )
+    installed = managed_project_storage(
+        "data/tts_bundles/installed",
+        root=project_root,
+    )
+    destination = managed_child_path(
+        installed,
+        safe_path_component(
+            bundle_dir_key,
+            field="TTS bundle directory key",
+        ),
+        field="TTS bundle directory",
+    )
+    return downloads, destination
+
+
+def _archive_verification_error(
+    archive: Path,
+    manifest: TtsBundleManifestEntry,
+    *,
+    is_interrupted: Any | None = None,
+) -> str | None:
+    try:
+        metadata = archive.lstat()
+    except FileNotFoundError:
+        return "archive is missing"
+    if (
+        _metadata_is_link_or_reparse_point(metadata)
+        or not stat.S_ISREG(metadata.st_mode)
+    ):
+        raise PermissionError(f"TTS archive must be a regular file: {archive}")
+
+    parent, parent_identity = capture_directory_identity(
+        archive.parent,
+        field="TTS archive directory",
+    )
+    if archive.parent != parent:
+        raise PermissionError("TTS archive directory changed identity")
+    hasher = hashlib.sha256()
+    with open_binary_read_without_links(
+        archive,
+        expected_identity=metadata,
+        expected_parent_identity=parent_identity,
+    ) as handle:
+        before = os.fstat(handle.fileno())
+        if before.st_size != manifest.size:
+            return (
+                f"size mismatch: expected {manifest.size}, "
+                f"got {before.st_size}"
+            )
+        while True:
+            if is_interrupted is not None and is_interrupted():
+                raise _DownloadInterrupted()
+            chunk = handle.read(_HASH_CHUNK_SIZE)
+            if not chunk:
+                break
+            hasher.update(chunk)
+        after = os.fstat(handle.fileno())
+    if not file_snapshot_is_stable(before, after):
+        raise PermissionError(f"TTS archive changed while it was verified: {archive}")
+    require_directory_identity(
+        parent,
+        parent_identity,
+        field="TTS archive directory",
+    )
+    actual_sha256 = hasher.hexdigest()
+    if actual_sha256.lower() != manifest.sha256.lower():
+        return (
+            "sha256 mismatch: expected "
+            f"{manifest.sha256}, got {actual_sha256}"
+        )
+    return None
+
+
+def _download_archive(
+    url: str,
+    archive: Path,
+    headers: dict[str, str],
+    *,
+    expected_size: int | None = None,
+    expected_sha256: str | None = None,
+    is_interrupted: Any | None = None,
+    on_progress: Any | None = None,
+    timeout: tuple[float, float] = (15, 600),
+) -> None:
+    download_url = _validated_download_url(url)
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    parent, parent_identity = capture_directory_identity(
+        archive.parent,
+        field="TTS download directory",
+    )
+    if archive.parent != parent:
+        raise PermissionError("TTS download directory changed identity")
+    hasher = hashlib.sha256() if expected_sha256 is not None else None
+    received = 0
+
+    try:
+        with requests.get(
+            download_url,
+            stream=True,
+            timeout=timeout,
+            headers=headers,
+        ) as response:
+            response.raise_for_status()
+            final_url = str(getattr(response, "url", "") or "")
+            if final_url:
+                _validated_download_url(final_url)
+            raw_total = str(response.headers.get("Content-Length", "0") or "0")
+            try:
+                total = int(raw_total)
+            except ValueError:
+                total = 0
+            if total <= 0 and expected_size is not None:
+                total = expected_size
+
+            with atomic_binary_writer(
+                archive,
+                expected_parent_identity=parent_identity,
+            ) as handle:
+                for chunk in response.iter_content(_DOWNLOAD_CHUNK_SIZE):
+                    if is_interrupted is not None and is_interrupted():
+                        raise _DownloadInterrupted()
+                    if not chunk:
+                        continue
+                    received += len(chunk)
+                    if expected_size is not None and received > expected_size:
+                        raise ValueError(
+                            "verification failed: size exceeds expected "
+                            f"{expected_size} bytes"
+                        )
+                    handle.write(chunk)
+                    if hasher is not None:
+                        hasher.update(chunk)
+                    if on_progress is None:
+                        continue
+                    if total > 0:
+                        on_progress(min(70, int(70 * received / total)))
+                    else:
+                        on_progress(
+                            min(35, received // (10 * 1024 * 1024))
+                        )
+                if expected_size is not None and received != expected_size:
+                    raise ValueError(
+                        "verification failed: size mismatch: "
+                        f"expected {expected_size}, got {received}"
+                    )
+                if hasher is not None:
+                    actual_sha256 = hasher.hexdigest()
+                    if actual_sha256.lower() != str(expected_sha256).lower():
+                        raise ValueError(
+                            "verification failed: sha256 mismatch: expected "
+                            f"{expected_sha256}, got {actual_sha256}"
+                        )
+    except requests.exceptions.ReadTimeout:
+        if is_interrupted is not None and is_interrupted():
+            raise _DownloadInterrupted() from None
+        raise
+
+    require_directory_identity(
+        parent,
+        parent_identity,
+        field="TTS download directory",
+    )
+
+
+def _load_py7zz() -> Any | None:
+    try:
+        return importlib.import_module("py7zz")
+    except ImportError:  # pragma: no cover - optional dependency
+        return None
+
+
+def _load_py7zr() -> Any | None:
+    try:
+        return importlib.import_module("py7zr")
+    except ImportError:  # pragma: no cover - optional dependency
+        return None
+
+
+def _direct_seven_zip_candidates() -> list[Path]:
+    candidates: list[Path] = []
+    if getattr(sys, "frozen", False):
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            for name in _SEVEN_ZIP_COMMANDS:
+                candidates.append(Path(meipass) / "7za" / name)
+    roots: list[Path] = []
+    for root_factory in (app_root, source_root):
+        try:
+            root = root_factory()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if root not in roots:
+            roots.append(root)
+    for root in roots:
+        for name in _SEVEN_ZIP_COMMANDS:
+            candidates.append(root / "build_exe" / name)
+    return candidates
+
+
+def _seven_zip_executable() -> LaunchFileSnapshot | None:
+    for candidate in _direct_seven_zip_candidates():
+        try:
+            return capture_launch_file(
+                candidate,
+                field="7-Zip executable",
+                executable=True,
+            )
+        except (OSError, PermissionError, RuntimeError, ValueError):
+            continue
+    for name in _SEVEN_ZIP_COMMANDS:
+        try:
+            return capture_command_executable(
+                name,
+                field="7-Zip executable",
+            )
+        except (OSError, PermissionError, RuntimeError, ValueError):
+            continue
+    return None
+
+
+def _extract_7za(
+    executable: LaunchFileSnapshot,
+    archive: LaunchFileSnapshot,
+    output: LaunchDirectorySnapshot,
+    *,
+    is_interrupted: Any | None = None,
+) -> str | None:
+    output_text = str(output.path)
+    if not output_text.endswith(("/", "\\")):
+        output_text += "\\" if sys.platform == "win32" else "/"
+    kwargs: dict[str, Any] = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = _WIN_NO_WINDOW
+    try:
+        process = popen_with_stable_paths(
+            [
+                executable.path,
+                "x",
+                "-y",
+                f"-o{output_text}",
+                archive.path,
+            ],
+            cwd=output,
+            executable=executable,
+            required_files=(archive,),
+            **kwargs,
+        )
+    except OSError as exc:  # pragma: no cover - host executable failure
+        return str(exc)[:2000]
+
+    while True:
+        try:
+            stdout, stderr = process.communicate(timeout=0.25)
+            break
+        except subprocess.TimeoutExpired:
+            if is_interrupted is None or not is_interrupted():
+                continue
+            process.terminate()
+            try:
+                process.communicate(timeout=3)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+            raise _ExtractionInterrupted()
+    require_launch_snapshots(directories=(output,), files=(archive, executable))
+    if process.returncode != 0:
+        error = (stderr or stdout or "").strip() or f"exit {process.returncode}"
+        return error[:2000]
+    return None
+
+
+def _validate_extracted_tree(
+    output: LaunchDirectorySnapshot,
+    archive: LaunchFileSnapshot,
+) -> None:
+    require_launch_snapshots(directories=(output,), files=(archive,))
+    inspect_portable_directory_tree(output.path)
+    require_launch_snapshots(directories=(output,), files=(archive,))
+
+
+def _clear_extraction_output(output: LaunchDirectorySnapshot) -> None:
+    clear_directory_without_links(
+        output.path,
+        expected_identity=output.identity,
+    )
+
+
+def _extract_py7zz(
+    archive: LaunchFileSnapshot,
+    output: LaunchDirectorySnapshot,
+) -> str | None:
+    py7zz = _load_py7zz()
+    if py7zz is None:
+        return "missing"
+    require_launch_snapshots(directories=(output,), files=(archive,))
+    try:
+        py7zz.extract_archive(str(archive.path), str(output.path))
+    except Exception as exc:
+        return str(exc)[:2000]
+    _validate_extracted_tree(output, archive)
+    return None
+
+
+def _py7zr_targets(archive_reader: Any) -> list[str]:
+    try:
+        names = archive_reader.getnames()
+    except Exception as exc:
+        raise ValueError("py7zr could not enumerate archive members") from exc
+    if not isinstance(names, list):
+        names = list(names or ())
+    normalized = [str(name) for name in names if str(name)]
+    validate_archive_member_names(normalized)
+    return [name for name in normalized if not name.endswith(("/", "\\"))]
+
+
+def _extract_py7zr(
+    py7zr: Any,
+    archive: LaunchFileSnapshot,
+    output: LaunchDirectorySnapshot,
+    *,
+    is_interrupted: Any | None = None,
+    on_progress: Any | None = None,
+) -> None:
+    require_launch_snapshots(directories=(output,), files=(archive,))
+    with py7zr.SevenZipFile(archive.path, "r") as reader:
+        targets = _py7zr_targets(reader)
+        if not targets:
+            raise ValueError("TTS archive contains no extractable files")
+        for index, name in enumerate(targets):
+            if is_interrupted is not None and is_interrupted():
+                raise _ExtractionInterrupted()
+            reader.extract(path=output.path, targets=[name])
+            if on_progress is not None:
+                on_progress(70 + int(30 * (index + 1) / len(targets)))
+    _validate_extracted_tree(output, archive)
+
+
+def _extract_archive(
+    archive: Path,
+    out_dir: Path,
+    *,
+    is_interrupted: Any | None = None,
+    on_progress: Any | None = None,
+) -> str | None:
+    archive_snapshot = capture_launch_file(
+        archive,
+        field="TTS archive",
+    )
+    output_snapshot = capture_launch_directory(
+        out_dir,
+        field="TTS extraction directory",
+    )
+    seven_zip = _seven_zip_executable()
+
+    if is_interrupted is not None and seven_zip is not None:
+        cli_error = _extract_7za(
+            seven_zip,
+            archive_snapshot,
+            output_snapshot,
+            is_interrupted=is_interrupted,
+        )
+        if cli_error is None:
+            _validate_extracted_tree(output_snapshot, archive_snapshot)
+            if on_progress is not None:
+                on_progress(100)
+            return None
+        _clear_extraction_output(output_snapshot)
+
+    py7zz_error = _extract_py7zz(archive_snapshot, output_snapshot)
+    if py7zz_error is None:
+        if on_progress is not None:
+            on_progress(100)
+        return None
+
+    if seven_zip is not None:
+        if py7zz_error != "missing":
+            _clear_extraction_output(output_snapshot)
+        cli_error = _extract_7za(
+            seven_zip,
+            archive_snapshot,
+            output_snapshot,
+            is_interrupted=is_interrupted,
+        )
+        if cli_error is None:
+            _validate_extracted_tree(output_snapshot, archive_snapshot)
+            if on_progress is not None:
+                on_progress(100)
+            return None
+        if py7zz_error != "missing":
+            return f"py7zz: {py7zz_error}\n7-Zip: {cli_error}"[:2000]
+        return cli_error
+
+    py7zr = _load_py7zr()
+    if py7zr is None:
+        return "7za"
+    if py7zz_error != "missing":
+        _clear_extraction_output(output_snapshot)
+    try:
+        _extract_py7zr(
+            py7zr,
+            archive_snapshot,
+            output_snapshot,
+            is_interrupted=is_interrupted,
+            on_progress=on_progress,
+        )
+    except _ExtractionInterrupted:
+        raise
+    except Exception as exc:
+        return (
+            "external 7-Zip CLI is required for this archive; "
+            f"py7zr fallback failed: {exc}"
+        )[:2000]
+    return None
+
+
+def _resolve_extracted_root(
+    extract_to: Path,
+    *,
+    expected_root_identity: os.stat_result | None = None,
+) -> Path:
+    root = require_directory_without_links(
+        extract_to,
+        field="TTS extraction root",
+    )
+    if expected_root_identity is not None:
+        require_directory_identity(
+            root,
+            expected_root_identity,
+            field="TTS extraction root",
+        )
+    inspect_portable_directory_tree(root)
+    root, root_identity, entries = snapshot_directory_entries_without_links(
+        root,
+        field="TTS extraction root",
+    )
+    if (
+        expected_root_identity is not None
+        and not os.path.samestat(expected_root_identity, root_identity)
+    ):
+        raise PermissionError(f"TTS extraction root identity changed: {root}")
+
+    visible_directories: list[tuple[Path, os.stat_result]] = []
+    for entry, metadata in entries:
+        if entry.name.startswith("."):
+            continue
+        if stat.S_ISDIR(metadata.st_mode):
+            visible_directories.append((entry, metadata))
+    if len(visible_directories) != 1:
+        return root
+
+    candidate, expected_identity = visible_directories[0]
+    selected = require_directory_without_links(
+        candidate,
+        field="extracted TTS bundle root",
+    )
+    if not os.path.samestat(expected_identity, selected.lstat()):
+        raise PermissionError(
+            f"extracted TTS bundle root identity changed: {selected}"
+        )
+    require_directory_identity(
+        root,
+        root_identity,
+        field="TTS extraction root",
+    )
+    return selected
+
+
+def _publish_extracted_bundle(
+    staging: Path,
+    destination: Path,
+    *,
+    expected_staging_identity: os.stat_result,
+    expected_destination_identity: os.stat_result | None,
+) -> Path:
+    parent, parent_identity = capture_directory_identity(
+        destination.parent,
+        field="TTS installation directory",
+    )
+    if staging.parent != parent or destination.parent != parent:
+        raise PermissionError("TTS publication paths changed parent")
+    inspect_portable_directory_tree(staging)
+    return replace_directory_transactionally(
+        staging,
+        destination,
+        expected_staging_identity=expected_staging_identity,
+        expected_destination_identity=expected_destination_identity,
+        expected_parent_identity=parent_identity,
+    )
+
+
+def _rmtree(
+    path: Path,
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    if (
+        _metadata_is_link_or_reparse_point(metadata)
+        or not stat.S_ISDIR(metadata.st_mode)
+    ):
+        raise NotADirectoryError(path)
+    if expected_identity is not None and not os.path.samestat(
+        expected_identity,
+        metadata,
+    ):
+        raise PermissionError(f"directory removal target identity changed: {path}")
+    remove_directory_without_links(
+        path,
+        expected_identity=metadata,
+    )
+
+
+__all__ = [
+    "_BUNDLE_IO_LOCK",
+    "_DownloadInterrupted",
+    "_ExtractionInterrupted",
+    "_archive_filename",
+    "_archive_verification_error",
+    "_bundle_storage_paths",
+    "_download_archive",
+    "_extract_archive",
+    "_publish_extracted_bundle",
+    "_resolve_extracted_root",
+    "_rmtree",
+]


### PR DESCRIPTION
## What changed

Adds shared archive, file-transaction, process-launch, media, model-asset,
runtime-environment, sprite, and TTS bundle path contracts under `core/`.

## Why

Low-level filesystem and process code needs reusable containment, identity,
and no-link guarantees rather than subsystem-specific checks.

## Impact

Core operations gain consistent protections against traversal, link swaps,
ambiguous roots, and unsafe executable or archive paths.

## Root cause

Security-sensitive path handling was spread across callers and often checked
textual paths separately from the filesystem object eventually used.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `core/`.
