### PR TITLE
fix(frontend-bridge): enforce migration-safe path contracts

### DIFF
--- a/frontend_bridge_core/backgrounds.py
+++ b/frontend_bridge_core/backgrounds.py
@@ -11,7 +11,7 @@ def _save_background(state: BridgeState, payload: dict[str, Any]) -> dict[str, A
     if not isinstance(body, dict):
         raise ValueError("background payload must be an object")
     name = str(body.get("name") or "").strip()
-    prefix = str(body.get("sprite_prefix") or "temp").strip() or "temp"
+    prefix = str(body.get("sprite_prefix") or "temp")
     original_name = str(payload.get("originalName") or "").strip()
     message, _names = state.background_manager.add_background(
         name,
@@ -20,7 +20,13 @@ def _save_background(state: BridgeState, payload: dict[str, Any]) -> dict[str, A
         bg_tags=str(body.get("bg_tags") or ""),
         bgm_tags=str(body.get("bgm_tags") or ""),
     )
-    if message.startswith("名称") or "重复" in message or message.startswith("找不到"):
+    if (
+        message.startswith("名称")
+        or "重复" in message
+        or "目录名" in message
+        or "已被背景组" in message
+        or message.startswith("找不到")
+    ):
         raise RuntimeError(message)
     state.config_manager.reload()
     saved = state.config_manager.get_background_by_name(name)
@@ -83,9 +89,11 @@ def _upload_background_bgm(state: BridgeState, payload: dict[str, Any]) -> dict[
     name = str(payload.get("name") or "").strip()
     files = _path_namespace_list(payload.get("paths") or [])
     background = _background_by_name(state, name)
-    background.bgm_tags = str(payload.get("bgmTags") or background.bgm_tags or "")
-    state.config_manager.save_background_config()
-    message, _df, _tags = state.background_manager.upload_bgms(name, files)
+    message, _df, _tags = state.background_manager.upload_bgms(
+        name,
+        files,
+        bgm_tags=str(payload.get("bgmTags") or background.bgm_tags or ""),
+    )
     if message.startswith("找不到") or message.startswith("请选择") or message.startswith("请先"):
         raise RuntimeError(message)
     return _background_json_after_reload(state, name)

--- a/frontend_bridge_core/characters.py
+++ b/frontend_bridge_core/characters.py
@@ -5,7 +5,14 @@ from typing import Any
 from urllib.parse import urlparse
 
 from frontend_bridge_core.media_utils import _optional_suffix_check, _path_namespace_list
+from sdk.path_references import (
+    make_path_reference,
+    path_reference_value,
+    state_project_root,
+)
 from application.runtime.state import BridgeState, _jsonify
+from frontend_bridge_core.security import portable_path_text
+from sdk.path_contract import resolve_runtime_asset_read_path, safe_path_component
 
 
 def _validate_reference_audio(voice_path: str) -> None:
@@ -29,9 +36,13 @@ def _normalize_sprite_voice_type(value: Any, *, allow_empty: bool = False) -> st
 
 
 def _has_gpt_sovits_model(character: Any) -> bool:
+    gpt_path = str(getattr(character, "gpt_model_path", "") or "")
+    sovits_path = str(getattr(character, "sovits_model_path", "") or "")
     return bool(
-        str(getattr(character, "gpt_model_path", "") or "").strip()
-        and str(getattr(character, "sovits_model_path", "") or "").strip()
+        gpt_path
+        and gpt_path == gpt_path.strip()
+        and sovits_path
+        and sovits_path == sovits_path.strip()
     )
 
 
@@ -59,7 +70,12 @@ def _uses_remote_gpt_sovits(state: BridgeState) -> bool:
     )
 
 
-def _validate_character_payload(body: dict[str, Any], *, allow_remote_voice_paths: bool = False) -> None:
+def _validate_character_payload(
+    body: dict[str, Any],
+    *,
+    allow_remote_voice_paths: bool = False,
+    project_root: Path | None = None,
+) -> None:
     from sdk.ui.validators import (
         ascii_only,
         audio_duration_between,
@@ -69,10 +85,24 @@ def _validate_character_payload(body: dict[str, Any], *, allow_remote_voice_path
         not_empty,
     )
 
-    sprite_prefix = str(body.get("sprite_prefix") or "").strip()
-    gpt_model_path = str(body.get("gpt_model_path") or "").strip()
-    sovits_model_path = str(body.get("sovits_model_path") or "").strip()
-    refer_audio_path = str(body.get("refer_audio_path") or "").strip()
+    sprite_prefix = str(body.get("sprite_prefix") or "")
+    try:
+        safe_path_component(sprite_prefix, field="sprite_prefix")
+    except ValueError as exc:
+        raise ValueError("立绘目录名无效") from exc
+    gpt_model_path = str(body.get("gpt_model_path") or "")
+    sovits_model_path = str(body.get("sovits_model_path") or "")
+    refer_audio_path = str(body.get("refer_audio_path") or "")
+    if gpt_model_path:
+        gpt_model_path = portable_path_text(gpt_model_path, field="GPT model path")
+    if sovits_model_path:
+        sovits_model_path = portable_path_text(sovits_model_path, field="SoVITS model path")
+    if refer_audio_path:
+        refer_audio_path = portable_path_text(refer_audio_path, field="reference audio path")
+    if project_root is not None:
+        gpt_model_path = _resolved_character_path(gpt_model_path, project_root)
+        sovits_model_path = _resolved_character_path(sovits_model_path, project_root)
+        refer_audio_path = _resolved_character_path(refer_audio_path, project_root)
     checks = [
         not_empty(sprite_prefix, "立绘目录"),
         ascii_only(sprite_prefix, "立绘目录"),
@@ -92,6 +122,36 @@ def _validate_character_payload(body: dict[str, Any], *, allow_remote_voice_path
     ok, errors = check_all(*checks)
     if not ok:
         raise ValueError("\n".join(errors))
+
+
+def _resolved_character_path(value: str, project_root: Path) -> str:
+    if not value:
+        return ""
+    return resolve_runtime_asset_read_path(value, root=project_root).as_posix()
+
+
+def _stored_character_path(value: Any, project_root: Path) -> str:
+    raw = str(value or "")
+    if not raw:
+        return ""
+    raw = portable_path_text(raw, field="character asset path")
+    reference = make_path_reference(
+        raw,
+        project_root,
+        legacy_project_prefixes=(
+            ("data", "models"),
+            ("data", "speech"),
+        ),
+        resource_prefixes=(
+            ("assets", "system", "models"),
+            ("assets", "system", "sound"),
+        ),
+        recover_legacy_absolute=False,
+    )
+    stored = path_reference_value(reference)
+    if stored is None:
+        raise ValueError("character asset path could not be classified")
+    return stored
 
 
 def _sprite_voice_path(sprite: Any) -> str:
@@ -115,20 +175,28 @@ def _validate_sprite_voice_duration(voice_path: str, voice_text: str) -> None:
 def _save_character(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
     from config.schema import Character
 
-    body = payload.get("character", payload)
-    if not isinstance(body, dict):
+    raw_body = payload.get("character", payload)
+    if not isinstance(raw_body, dict):
         raise ValueError("character payload must be an object")
+    body = dict(raw_body)
     original_name = str(payload.get("originalName") or body.get("name") or "").strip()
-    _validate_character_payload(body, allow_remote_voice_paths=_uses_remote_gpt_sovits(state))
+    root = state_project_root(state)
+    _validate_character_payload(
+        body,
+        allow_remote_voice_paths=_uses_remote_gpt_sovits(state),
+        project_root=root,
+    )
+    for field in ("gpt_model_path", "sovits_model_path", "refer_audio_path"):
+        body[field] = _stored_character_path(body.get(field), root)
     character = Character.model_validate(body)
     saved_name = character.name.strip()
     message, _names = state.character_manager.add_character(
         saved_name,
         str(character.color or "").strip() or "#d07d7d",
-        character.sprite_prefix.strip() or "temp",
-        str(character.gpt_model_path or "").strip(),
-        str(character.sovits_model_path or "").strip(),
-        str(character.refer_audio_path or "").strip(),
+        str(character.sprite_prefix or ""),
+        str(character.gpt_model_path or ""),
+        str(character.sovits_model_path or ""),
+        str(character.refer_audio_path or ""),
         str(character.prompt_text or "").strip(),
         str(character.prompt_lang or "").strip(),
         str(character.character_setting or "").strip(),
@@ -138,7 +206,13 @@ def _save_character(state: BridgeState, payload: dict[str, Any]) -> dict[str, An
         edit_as_name=original_name,
         emotion_tags=str(character.emotion_tags or ""),
     )
-    if message.startswith("名称不能为空") or "已与其他角色重复" in message or message.startswith("保存失败"):
+    if (
+        message.startswith("名称不能为空")
+        or "已与其他角色重复" in message
+        or "目录名" in message
+        or "已被角色" in message
+        or message.startswith("保存失败")
+    ):
         raise RuntimeError(message)
     state.config_manager.reload()
     if original_name and original_name != saved_name:
@@ -196,7 +270,7 @@ def _translate_character_fields(state: BridgeState, payload: dict[str, Any]) -> 
 def _upload_sprite_voice(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
     name = str(payload.get("name") or "").strip()
     sprite_index = int(payload.get("spriteIndex") or 0)
-    voice_path = str(payload.get("voicePath") or "").strip()
+    voice_path = str(payload.get("voicePath") or "")
     voice_text = str(payload.get("voiceText") or "").strip()
     character = _character_by_name(state, name)
     voice_type = _normalize_sprite_voice_type(payload.get("voiceType"), allow_empty=True)
@@ -204,6 +278,8 @@ def _upload_sprite_voice(state: BridgeState, payload: dict[str, Any]) -> dict[st
         voice_type = _default_sprite_voice_type(character)
     if not voice_path:
         raise ValueError("voice path is required")
+    voice_path = portable_path_text(voice_path, field="voice path")
+    voice_path = _resolved_character_path(voice_path, state_project_root(state))
     if voice_type == "reference":
         _validate_reference_audio(voice_path)
     message, _path = state.character_manager.upload_voice(name, sprite_index, voice_path, voice_text, voice_type)
@@ -283,8 +359,13 @@ def _save_sprite_voice_text(state: BridgeState, payload: dict[str, Any]) -> dict
             _vt = _s.get("voice_type") if isinstance(_s, dict) else None
         if _vt == "reference":
             voice_path = _sprite_voice_path(_s)
-            if voice_path and Path(voice_path).is_file():
-                _validate_sprite_voice_duration(voice_path, voice_text)
+            if voice_path:
+                resolved_voice = _resolved_character_path(
+                    voice_path,
+                    state_project_root(state),
+                )
+                if Path(resolved_voice).is_file():
+                    _validate_sprite_voice_duration(resolved_voice, voice_text)
     message = state.character_manager.save_sprite_voice_text(name, sprite_index, voice_text)
     if message.startswith("找不到") or message.startswith("立绘不存在") or message.startswith("请先"):
         raise RuntimeError(message)
@@ -300,6 +381,10 @@ def _save_sprite_voice_type(state: BridgeState, payload: dict[str, Any]) -> dict
     if voice_type == "reference" and 0 <= sprite_index < len(sprites):
         voice_path = _sprite_voice_path(sprites[sprite_index])
         if voice_path:
+            voice_path = _resolved_character_path(
+                voice_path,
+                state_project_root(state),
+            )
             if not Path(voice_path).is_file():
                 raise ValueError("reference audio file does not exist")
             _validate_reference_audio(voice_path)

--- a/frontend_bridge_core/chat_stream.py
+++ b/frontend_bridge_core/chat_stream.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import json
 import secrets
+import sys
 import threading
 import time
 import uuid
@@ -14,16 +15,25 @@ from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import parse_qs, quote, urlparse
 
+from sdk.path_contract import (
+    runtime_media_reference_is_direct,
+    validate_runtime_media_reference,
+)
 from application.runtime.event_sink import (
     EVENT_PROTOCOL_VERSION,
     build_event,
     fold_event_into_snapshot,
     make_empty_chat_snapshot,
 )
+from application.runtime.restart_debug import write_restart_debug_log
 from frontend_bridge_core.media_paths import (
     is_absolute_local_media_path_text,
     is_supported_media_path_text,
 )
+
+
+def _stream_debug_log(message: str) -> None:
+    write_restart_debug_log("chat_stream", message)
 
 
 _MEDIA_EVENT_TYPES = {
@@ -52,10 +62,6 @@ def _http_base(host: str, port: int) -> str:
 
 def _ws_base(host: str, port: int) -> str:
     return f"ws://{_external_host(host)}:{int(port)}/ws"
-
-
-def _is_direct_media_path(raw_path: str) -> bool:
-    return raw_path.startswith(("http://", "https://", "blob:", "data:", "/assets/"))
 
 
 def _append_query(url: str, params: dict[str, str]) -> str:
@@ -167,30 +173,38 @@ class ChatStreamService:
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
+            _stream_debug_log("start skipped reason=already_running")
             return
+        _stream_debug_log(f"start requested host={self.host} bridge_port={self.bridge_port} ws_port={self.ws_port}")
         self._ready.clear()
         self._start_error = None
         self._thread = threading.Thread(target=self._run_loop, name="shinsekai-chat-stream", daemon=True)
         self._thread.start()
         self._ready.wait(timeout=5.0)
         if self._start_error is not None:
+            _stream_debug_log(f"start failed error_type={self._start_error.__class__.__name__} error={self._start_error}")
             raise self._start_error
+        _stream_debug_log(f"start ready thread_alive={self._thread.is_alive() if self._thread else False}")
 
     def stop(self) -> None:
         loop = self._loop
         if loop is None:
+            _stream_debug_log("stop skipped reason=no_loop")
             return
+        _stream_debug_log("stop requested")
         try:
             future = asyncio.run_coroutine_threadsafe(self._shutdown_async(), loop)
             future.result(timeout=5.0)
-        except Exception:
-            pass
+            _stream_debug_log("shutdown_async completed")
+        except Exception as exc:
+            _stream_debug_log(f"shutdown_async failed error_type={exc.__class__.__name__} error={exc}")
         try:
             loop.call_soon_threadsafe(loop.stop)
         except RuntimeError:
             pass
         if self._thread is not None:
             self._thread.join(timeout=5.0)
+            _stream_debug_log(f"thread joined alive={self._thread.is_alive()}")
         self._loop = None
         self._thread = None
         self._server = None
@@ -245,6 +259,9 @@ class ChatStreamService:
         )
         with self._lock:
             self._sessions[session_id] = session
+        _stream_debug_log(
+            f"session_created session={session_id} snapshot_keys={','.join(sorted(str(key) for key in snapshot.keys()))}"
+        )
         producer_endpoint = f"{self.ws_base}?sessionId={quote(session_id)}&role=producer"
         producer_endpoint = _append_query(
             producer_endpoint,
@@ -277,17 +294,23 @@ class ChatStreamService:
 
     def delete_session(self, session_id: str) -> None:
         with self._lock:
-            self._sessions.pop(session_id, None)
+            removed = self._sessions.pop(session_id, None) is not None
+        _stream_debug_log(f"session_deleted session={session_id} removed={removed}")
 
     def wait_for_producer(self, session_id: str, *, timeout: float = 5.0) -> bool:
         with self._lock:
             session = self._sessions.get(session_id)
             if session is None:
+                _stream_debug_log(f"producer_wait skipped session={session_id} reason=missing_session")
                 return False
             if session.producer is not None:
+                _stream_debug_log(f"producer_wait ready session={session_id} reason=already_connected")
                 return True
             ready = session.producer_ready
-        return ready.wait(timeout=max(float(timeout), 0.0))
+        _stream_debug_log(f"producer_wait start session={session_id} timeout={timeout:.3f}")
+        result = ready.wait(timeout=max(float(timeout), 0.0))
+        _stream_debug_log(f"producer_wait done session={session_id} ready={result}")
+        return result
 
     def close_session(self, session_id: str, *, reason: str = "聊天会话已结束。") -> None:
         event: dict[str, Any] | None = None
@@ -296,6 +319,7 @@ class ChatStreamService:
             if session is None:
                 return
             event = build_event(session.last_seq + 1, {"type": "session.closed", "reason": reason})
+        _stream_debug_log(f"close_session publish session={session_id} reason={reason}")
 
         loop = self._loop
         if loop is None:
@@ -312,7 +336,10 @@ class ChatStreamService:
         future = asyncio.run_coroutine_threadsafe(self._publish_event(session_id, event), loop)
         try:
             future.result(timeout=0.35)
-        except Exception:
+        except Exception as exc:
+            _stream_debug_log(
+                f"close_session publish fallback session={session_id} error_type={exc.__class__.__name__} error={exc}"
+            )
             with self._lock:
                 session = self._sessions.get(session_id)
                 if session is None:
@@ -339,6 +366,9 @@ class ChatStreamService:
             session.last_seq = max(session.last_seq, snapshot_seq)
             next_snapshot["eventSeq"] = session.last_seq
             session.snapshot = next_snapshot
+        _stream_debug_log(
+            f"session_snapshot_updated session={session_id} keys={','.join(sorted(str(key) for key in snapshot.keys()))}"
+        )
 
     def publish_event(self, session_id: str, event: dict[str, Any]) -> bool:
         """Publish one trusted bridge-local event to a Chat session."""
@@ -375,17 +405,23 @@ class ChatStreamService:
             future = asyncio.run_coroutine_threadsafe(self._send_command(session_id, command), loop)
             try:
                 if bool(future.result(timeout=0.5)):
+                    _stream_debug_log(
+                        f"command_sent session={session_id} type={command.get('type', 'unknown')} cmd_id={command.get('cmdId', '')}"
+                    )
                     return True
-            except Exception:
-                pass
+            except Exception as exc:
+                _stream_debug_log(
+                    f"command_send_failed session={session_id} type={command.get('type', 'unknown')} error_type={exc.__class__.__name__} error={exc}"
+                )
             time.sleep(0.1)
+        _stream_debug_log(f"command_send_timeout session={session_id} type={command.get('type', 'unknown')}")
         return False
 
     def media_url(self, raw_path: str) -> str:
-        path = str(raw_path or "").strip()
+        path = validate_runtime_media_reference(raw_path)
         if not path:
             return ""
-        if _is_direct_media_path(path):
+        if runtime_media_reference_is_direct(path):
             return path
         self.approve_external_media_path(path)
         return _append_query(
@@ -394,7 +430,13 @@ class ChatStreamService:
         )
 
     def approve_external_media_path(self, raw_path: str) -> bool:
-        path = str(raw_path or "").strip()
+        try:
+            path = validate_runtime_media_reference(
+                raw_path,
+                allow_empty=False,
+            )
+        except (TypeError, ValueError):
+            return False
         if not (
             is_absolute_local_media_path_text(path)
             and is_supported_media_path_text(path)
@@ -502,17 +544,18 @@ class ChatStreamService:
     def _approve_event_media_path(self, event: dict[str, Any]) -> None:
         if str(event.get("type") or "") not in _MEDIA_EVENT_TYPES:
             return
-        media_url = str(event.get("url") or "").strip()
-        if not media_url:
+        media_url = str(event.get("url") or "")
+        if not media_url or media_url != media_url.strip():
             return
         parsed = urlparse(media_url)
         if parsed.path != "/api/media":
             return
         query = parse_qs(parsed.query)
-        raw_path = str((query.get("path") or [""])[0]).strip()
+        raw_path = str((query.get("path") or [""])[0])
         self.approve_external_media_path(raw_path)
 
     async def _shutdown_async(self) -> None:
+        _stream_debug_log("shutdown_async start")
         await self._stop_mobile_listener_async()
         server = self._server
         if server is not None:
@@ -535,6 +578,7 @@ class ChatStreamService:
                 session.viewers.clear()
                 session.producer = None
                 session.producer_ready.clear()
+        _stream_debug_log(f"shutdown_async done sessions={len(sessions)}")
 
     async def _start_mobile_listener_async(self, websocket_url: str, port: int) -> str:
         if self._mobile_server is not None:
@@ -576,19 +620,36 @@ class ChatStreamService:
             await self._detach(viewer)
 
     def _run_loop(self) -> None:
-        loop = asyncio.new_event_loop()
+        if sys.platform == "win32":
+            default_loop = asyncio.new_event_loop()
+            default_loop_type = type(default_loop).__name__
+            default_loop.close()
+            loop = asyncio.SelectorEventLoop()
+            loop_strategy = "selector"
+        else:
+            loop = asyncio.new_event_loop()
+            default_loop_type = type(loop).__name__
+            loop_strategy = "default"
+        _stream_debug_log(
+            f"event_loop_created platform={sys.platform} default_loop_type={default_loop_type} active_loop_type={type(loop).__name__} strategy={loop_strategy}"
+        )
         self._loop = loop
         asyncio.set_event_loop(loop)
         try:
+            _stream_debug_log(f"binding ws://{self.host}:{self.ws_port}")
             self._server = loop.run_until_complete(asyncio.start_server(self._handle_client, self.host, self.ws_port))
+            _stream_debug_log("server_bound ok")
         except Exception as exc:  # pragma: no cover - startup failure path
             self._start_error = exc
             self._ready.set()
+            _stream_debug_log(f"server_bound failed error_type={exc.__class__.__name__} error={exc}")
             return
         self._ready.set()
+        _stream_debug_log("run_forever enter")
         try:
             loop.run_forever()
         finally:  # pragma: no cover - shutdown path
+            _stream_debug_log("run_forever exit")
             pending = asyncio.all_tasks(loop)
             for task in pending:
                 task.cancel()
@@ -596,6 +657,7 @@ class ChatStreamService:
                 with contextlib.suppress(Exception):
                     loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             loop.close()
+            _stream_debug_log(f"event_loop_closed pending_tasks={len(pending)}")
 
     async def _handle_client(
         self,
@@ -618,9 +680,9 @@ class ChatStreamService:
                 await self._send_snapshot(connection)
             await self._receive_loop(connection)
         except asyncio.IncompleteReadError:
-            pass
-        except Exception:
-            pass
+            _stream_debug_log("client_disconnected reason=incomplete_read")
+        except Exception as exc:
+            _stream_debug_log(f"client_error error_type={exc.__class__.__name__} error={exc}")
         finally:
             if connection is not None:
                 await self._detach(connection)
@@ -708,11 +770,17 @@ class ChatStreamService:
                     old_producer = session.producer
                 session.producer = connection
                 session.producer_ready.set()
+                producer_count = 1
+                viewer_count = len(session.viewers)
             else:
                 session.viewers.add(connection)
                 self._remember_renderer_locked(session, connection.renderer_id)
+                producer_count = 1 if session.producer is not None else 0
+                viewer_count = len(session.viewers)
+        _stream_debug_log(f"{role}_connected session={session_id} producers={producer_count} viewers={viewer_count}")
         if old_producer is not None:
             await old_producer.close()
+            _stream_debug_log(f"producer_replaced session={session_id}")
         return connection
 
     async def _receive_loop(self, connection: _WebSocketConnection) -> None:
@@ -730,6 +798,9 @@ class ChatStreamService:
                 continue
             event = json.loads(payload.decode("utf-8"))
             if isinstance(event, dict):
+                _stream_debug_log(
+                    f"producer_event_received session={connection.session_id} type={event.get('type', 'unknown')} seq={event.get('seq', 0)}"
+                )
                 await self._publish_event(connection.session_id, event)
 
     async def _publish_event(self, session_id: str, event: dict[str, Any]) -> None:
@@ -753,11 +824,18 @@ class ChatStreamService:
             session.snapshot["sessionId"] = session_id
             session.snapshot["wsUrl"] = self.ws_base
             viewers = list(session.viewers)
+            event_seq = session.last_seq
+        _stream_debug_log(
+            f"publish_event session={session_id} type={event.get('type', 'unknown')} seq={event_seq} viewers={len(viewers)}"
+        )
         stale: list[_WebSocketConnection] = []
         for viewer in viewers:
             try:
                 await viewer.send_json(normalized_event)
-            except Exception:
+            except Exception as exc:
+                _stream_debug_log(
+                    f"viewer_send_failed session={session_id} type={event.get('type', 'unknown')} error_type={exc.__class__.__name__} error={exc}"
+                )
                 stale.append(viewer)
         for viewer in stale:
             await self._detach(viewer)
@@ -772,6 +850,7 @@ class ChatStreamService:
             seq = session.last_seq
         if connection.advertised_ws_url:
             snapshot["wsUrl"] = connection.advertised_ws_url
+        _stream_debug_log(f"snapshot_sent session={connection.session_id} seq={seq}")
         await connection.send_json(
             {
                 "v": 1,
@@ -840,6 +919,7 @@ class ChatStreamService:
                 if session.producer is connection:
                     session.producer = None
                     session.producer_ready.clear()
+                    _stream_debug_log(f"producer_detached session={connection.session_id}")
             else:
                 session.viewers.discard(connection)
                 renderer_id = str(getattr(connection, "renderer_id", "") or "")
@@ -866,6 +946,9 @@ class ChatStreamService:
                         ),
                         None,
                     )
+                _stream_debug_log(
+                    f"viewer_detached session={connection.session_id} viewers={len(session.viewers)}"
+                )
         if replacement is not None:
             try:
                 await self._send_snapshot(replacement)

--- a/frontend_bridge_core/chat_themes.py
+++ b/frontend_bridge_core/chat_themes.py
@@ -14,11 +14,38 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
-import tempfile
+import stat
 import threading
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from sdk.file_transactions import (
+    atomic_write_text,
+    copy_directory_without_links,
+    private_temporary_directory,
+    inspect_portable_directory_tree_with_metadata,
+    private_sibling_path,
+    read_bytes_snapshot_without_links,
+    read_text_without_links,
+    remove_directory_without_links,
+    remove_file_without_links,
+    rename_path_without_overwrite,
+    replace_directory_transactionally,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from sdk.path_contract import (
+    _metadata_is_link_or_reparse_point,
+    managed_child_path,
+    managed_project_storage,
+    path_is_link_or_reparse_point,
+    project_root as configured_project_root,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resource_path,
+)
 
 from .builtin_chat_themes import (
     BUILTIN_THEME_IDS,
@@ -34,10 +61,11 @@ from sdk.chat_ui_theme import (
     validate_theme_dir,
 )
 
+from sdk.path_references import state_project_root
+from .security import safe_child_path, safe_existing_file_path
 from application.runtime.state import BridgeState
-from sdk.path_utils import safe_child_path, safe_existing_file_path
 
-#: 用户可写主题目录（相对项目根 / cwd）。
+#: 用户可写主题目录（只相对权威项目根）。
 USER_THEMES_DIR = Path("data") / "chat_ui_themes"
 BUILTIN_THEMES_DIR = Path("assets") / "chat_ui_themes"
 RETIRED_BUILTIN_THEME_IDS = {"classic-dark", "light-paper"}
@@ -45,49 +73,91 @@ RETIRED_BUILTIN_THEME_IDS = {"classic-dark", "light-paper"}
 #: manifest schema 版本，与前端 CHAT_THEME_SCHEMA 一致。
 CHAT_THEME_SCHEMA = 1
 BUILTIN_THEME_OWNER_MARKER = ".shinsekai-builtin-theme"
-_THEME_PUBLICATION_LOCK = threading.Lock()
+_THEME_PUBLICATION_LOCK = threading.RLock()
 
 
-def _themes_root() -> Path:
-    root = USER_THEMES_DIR
-    if not root.is_absolute():
-        root = Path.cwd() / root
-    return root
+@dataclass(frozen=True)
+class _ThemeManifestSnapshot:
+    identity: os.stat_result
+    files: tuple[tuple[Path, os.stat_result], ...]
+    manifest: Dict[str, Any]
+
+
+def _themes_root(state: BridgeState | None = None) -> Path:
+    base = state_project_root(state) if state is not None else configured_project_root()
+    return managed_project_storage(USER_THEMES_DIR, root=base)
+
+
+def _prepare_themes_root(state: BridgeState | None = None) -> Path:
+    """Create and revalidate the exact writable theme directory."""
+
+    root = _themes_root(state)
+    root.mkdir(parents=True, exist_ok=True)
+    return require_directory_without_links(
+        root,
+        field="chat theme directory",
+    )
 
 
 def _builtin_themes_root() -> Path:
-    return (Path(__file__).resolve().parents[1] / BUILTIN_THEMES_DIR).resolve()
+    return resource_path(BUILTIN_THEMES_DIR)
 
 
-def _registered_builtin_theme(theme_id: str) -> Optional[tuple[str, Path]]:
+def _registered_builtin_theme(
+    theme_id: str,
+    state: BridgeState | None = None,
+) -> Optional[tuple[str, Path]]:
     """Return a trusted registry ID and its canonical user-data directory."""
     for registered_id in BUILTIN_THEME_IDS:
         if theme_id == registered_id:
-            return registered_id, safe_child_path(_themes_root(), registered_id)
+            return registered_id, managed_child_path(
+                _themes_root(state),
+                registered_id,
+                field="theme id",
+            )
     return None
 
 
-def _is_builtin_theme_dir(theme_id: str) -> bool:
+def _is_builtin_theme_dir(theme_id: str, state: BridgeState | None = None) -> bool:
     try:
-        registered = _registered_builtin_theme(theme_id)
+        registered = _registered_builtin_theme(theme_id, state)
         if registered is None:
             return False
         theme_id, registered_dir = registered
+        unresolved = _themes_root(state) / theme_id
+        if path_is_link_or_reparse_point(unresolved):
+            return False
         if theme_id in LEGACY_UNMARKED_BUILTIN_THEME_IDS:
-            return True
-        marker = safe_child_path(registered_dir, BUILTIN_THEME_OWNER_MARKER)
-        return marker.read_text(encoding="utf-8").strip() == theme_id
+            # Missing legacy built-ins are still registry-owned so manifest
+            # lookup can fall back to the default.  Existing symlinks were
+            # rejected above and existing non-directories are never owned.
+            return not unresolved.exists() or registered_dir.is_dir()
+        if not registered_dir.is_dir():
+            return False
+        marker = managed_child_path(
+            registered_dir,
+            BUILTIN_THEME_OWNER_MARKER,
+            field="built-in theme marker",
+        )
+        return read_text_without_links(marker).strip() == theme_id
     except (OSError, ValueError):
         return False
 
 
-def _mark_builtin_theme_owned(theme_id: str) -> None:
-    registered = _registered_builtin_theme(theme_id)
+def _mark_builtin_theme_owned(theme_id: str, state: BridgeState | None = None) -> None:
+    registered = _registered_builtin_theme(theme_id, state)
     if registered is None:
         raise ValueError(f"unknown built-in theme id: {theme_id}")
     registered_id, registered_dir = registered
-    marker = safe_child_path(registered_dir, BUILTIN_THEME_OWNER_MARKER)
-    marker.write_text(f"{registered_id}\n", encoding="utf-8")
+    unresolved = _themes_root(state) / registered_id
+    if path_is_link_or_reparse_point(unresolved) or not registered_dir.is_dir():
+        raise PermissionError("内置主题目录不能是符号链接")
+    marker = managed_child_path(
+        registered_dir,
+        BUILTIN_THEME_OWNER_MARKER,
+        field="built-in theme marker",
+    )
+    atomic_write_text(marker, f"{registered_id}\n")
 
 
 def _is_retired_builtin_theme_id(theme_id: str) -> bool:
@@ -95,107 +165,236 @@ def _is_retired_builtin_theme_id(theme_id: str) -> bool:
 
 
 def _safe_theme_id(theme_id: str) -> str:
-    raw = str(theme_id or "").strip()
+    raw = str(theme_id or "")
     safe_id = slugify_theme_id(raw)
     if not safe_id or safe_id != raw:
         raise ValueError("主题 id 无效")
     return safe_id
 
 
-def _copy_theme_source(source: Path, staging: Path, root: Path) -> None:
-    """Copy a theme only after its canonical path is contained by ``root``."""
-    canonical_root = os.path.normcase(os.path.realpath(os.fspath(root)))
-    canonical_source = os.path.normcase(os.path.realpath(os.fspath(source)))
-    root_prefix = os.path.join(canonical_root, "")
-    if not canonical_source.startswith(root_prefix):
-        raise PermissionError("基础主题路径超出主题目录")
-    shutil.copytree(canonical_source, staging)
-
-
-def _atomic_write_manifest(theme_dir: Path, manifest: Dict[str, Any]) -> None:
-    pending: Optional[Path] = None
+def _copy_theme_source(
+    source: Path,
+    staging: Path,
+    root: Path,
+    *,
+    expected_source_identity: os.stat_result | None = None,
+) -> None:
+    """Copy a real theme directory that is strictly contained by ``root``."""
+    if path_is_link_or_reparse_point(root) or path_is_link_or_reparse_point(source):
+        raise PermissionError("基础主题路径不能是符号链接")
+    canonical_root = root.resolve(strict=True)
+    canonical_source = source.resolve(strict=True)
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=theme_dir,
-            prefix=f".{MANIFEST_NAME}.",
-            suffix=".tmp",
-            delete=False,
-        ) as handle:
-            json.dump(manifest, handle, ensure_ascii=False, indent=2)
-            handle.write("\n")
-            pending = Path(handle.name)
-        pending.replace(theme_dir / MANIFEST_NAME)
-    finally:
-        if pending is not None:
-            pending.unlink(missing_ok=True)
+        relative = canonical_source.relative_to(canonical_root)
+    except ValueError as exc:
+        raise PermissionError("基础主题路径超出主题目录") from exc
+    if not relative.parts:
+        raise PermissionError("基础主题路径超出主题目录")
+    # Preserve the unresolved source for the copy helper.  Replacing the
+    # selected directory with a link between validation and copying must be
+    # rejected, not silently dereferenced to another theme.
+    copy_directory_without_links(
+        source,
+        staging,
+        expected_source_identity=expected_source_identity,
+    )
+
+
+def _atomic_write_manifest(
+    theme_dir: Path,
+    manifest: Dict[str, Any],
+    *,
+    expected_theme_identity: os.stat_result | None = None,
+) -> None:
+    theme_metadata = theme_dir.lstat()
+    if (
+        _metadata_is_link_or_reparse_point(theme_metadata)
+        or not stat.S_ISDIR(theme_metadata.st_mode)
+    ):
+        raise NotADirectoryError(theme_dir)
+    if (
+        expected_theme_identity is not None
+        and not os.path.samestat(expected_theme_identity, theme_metadata)
+    ):
+        raise PermissionError(f"主题目录身份已变化：{theme_dir.name}")
+    manifest_path = managed_child_path(
+        theme_dir,
+        MANIFEST_NAME,
+        field="theme manifest filename",
+    )
+    atomic_write_text(
+        manifest_path,
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        expected_parent_identity=theme_metadata,
+    )
+    final_theme_metadata = theme_dir.lstat()
+    if not os.path.samestat(theme_metadata, final_theme_metadata):
+        raise PermissionError(f"主题目录身份在保存期间发生变化：{theme_dir.name}")
 
 
 def _publish_new_theme(staging: Path, target: Path, theme_id: str) -> None:
     """Atomically publish a complete staged directory without replacing a peer."""
+
+    publication_staging = private_sibling_path(
+        target,
+        f".publish-{uuid.uuid4().hex}",
+        field="theme publication staging directory",
+    )
+    publication_identity: os.stat_result | None = None
     with _THEME_PUBLICATION_LOCK:
-        if target.exists():
-            raise FileExistsError(f"主题已存在：{theme_id}")
         try:
-            staging.rename(target)
-        except OSError as error:
-            if target.exists():
+            if target.exists() or path_is_link_or_reparse_point(target):
+                raise FileExistsError(f"主题已存在：{theme_id}")
+            copy_directory_without_links(staging, publication_staging)
+            publication_identity = publication_staging.lstat()
+            replace_directory_transactionally(
+                publication_staging,
+                target,
+                overwrite=False,
+                expected_staging_identity=publication_identity,
+                expected_destination_identity=None,
+            )
+        except FileExistsError as error:
+            if target.exists() or path_is_link_or_reparse_point(target):
                 raise FileExistsError(f"主题已存在：{theme_id}") from error
             raise
+        finally:
+            if publication_identity is not None:
+                try:
+                    remove_directory_without_links(
+                        publication_staging,
+                        expected_identity=publication_identity,
+                    )
+                except OSError:
+                    pass
 
 
 def _theme_version(theme_dir: Path) -> str:
-    try:
-        data = json.loads((theme_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    snapshot = _read_theme_manifest_snapshot(theme_dir)
+    if snapshot is None:
         return ""
-    if not isinstance(data, dict):
-        return ""
-    return str(data.get("version") or "").strip()
+    return str(snapshot.manifest.get("version") or "").strip()
 
 
-def _seed_builtin_themes() -> None:
-    root = _themes_root()
+def _seed_builtin_themes(state: BridgeState | None = None) -> None:
+    root = _prepare_themes_root(state)
     builtin_root = _builtin_themes_root()
-    root.mkdir(parents=True, exist_ok=True)
-    for theme_id in BUILTIN_THEME_IDS:
-        source = builtin_root / theme_id
-        target = root / theme_id
-        if not source.is_dir():
-            continue
-        if not target.exists():
-            shutil.copytree(source, target)
-            _mark_builtin_theme_owned(theme_id)
-            continue
-        if not target.is_dir() or not _is_builtin_theme_dir(theme_id):
-            continue
-        source_version = _theme_version(source)
-        if target.is_dir() and source_version and source_version != _theme_version(target):
-            shutil.copytree(source, target, dirs_exist_ok=True)
-        _mark_builtin_theme_owned(theme_id)
+    with _THEME_PUBLICATION_LOCK:
+        for theme_id in BUILTIN_THEME_IDS:
+            source = builtin_root / theme_id
+            target = root / theme_id
+            if path_is_link_or_reparse_point(source) or not source.is_dir():
+                continue
+            if path_is_link_or_reparse_point(target):
+                # Never refresh through a user-created link, including the two
+                # legacy IDs that predate ownership markers.
+                continue
+
+            target_exists = target.exists()
+            if target_exists and (
+                not target.is_dir() or not _is_builtin_theme_dir(theme_id, state)
+            ):
+                continue
+            target_identity = target.lstat() if target_exists else None
+
+            source_version = _theme_version(source)
+            refresh = not target_exists or (
+                bool(source_version) and source_version != _theme_version(target)
+            )
+            if not refresh:
+                _mark_builtin_theme_owned(theme_id, state)
+                continue
+
+            staging = private_sibling_path(
+                root / theme_id,
+                f".seed-{uuid.uuid4().hex}",
+                field="theme seed staging directory",
+            )
+            staging_identity: os.stat_result | None = None
+            try:
+                copy_directory_without_links(source, staging)
+                staging_identity = staging.lstat()
+                atomic_write_text(
+                    managed_child_path(
+                        staging,
+                        BUILTIN_THEME_OWNER_MARKER,
+                        field="theme marker filename",
+                    ),
+                    f"{theme_id}\n",
+                )
+                result = validate_theme_dir(staging)
+                if not result.ok:
+                    raise ValueError("内置主题校验失败：\n" + "\n".join(result.errors))
+                _replace_theme_directory(
+                    staging,
+                    target,
+                    overwrite=target_exists,
+                    expected_staging_identity=staging_identity,
+                    expected_destination_identity=target_identity,
+                )
+            finally:
+                if staging_identity is not None:
+                    try:
+                        remove_directory_without_links(
+                            staging,
+                            expected_identity=staging_identity,
+                        )
+                    except OSError:
+                        pass
 
 
-def _read_manifest(theme_dir: Path) -> Optional[Dict[str, Any]]:
+def _read_theme_manifest_snapshot(
+    theme_dir: Path,
+    *,
+    expected_theme_identity: os.stat_result | None = None,
+) -> _ThemeManifestSnapshot | None:
+    manifest_path = theme_dir / "theme.json"
     try:
-        manifest_path = safe_existing_file_path(
-            theme_dir / MANIFEST_NAME,
-            roots=[_themes_root(), _builtin_themes_root()],
-            field="chat theme manifest",
+        theme_identity, _directories, files = (
+            inspect_portable_directory_tree_with_metadata(theme_dir)
         )
-    except (OSError, PermissionError, ValueError):
-        return None
-    try:
-        with manifest_path.open(encoding="utf-8") as file:
-            data = json.load(file)
-    except (OSError, json.JSONDecodeError):
+        if (
+            expected_theme_identity is not None
+            and not os.path.samestat(
+                expected_theme_identity,
+                theme_identity,
+            )
+        ):
+            raise PermissionError(
+                f"chat theme directory identity changed: {theme_dir}"
+            )
+        file_identities = dict(files)
+        manifest_identity = file_identities.get(Path(MANIFEST_NAME))
+        if manifest_identity is None:
+            return None
+        payload, _manifest_snapshot = read_bytes_snapshot_without_links(
+            manifest_path,
+            expected_identity=manifest_identity,
+            expected_parent_identity=theme_identity,
+        )
+        data = json.loads(payload.decode("utf-8"))
+        require_directory_identity(
+            theme_dir,
+            theme_identity,
+            field="chat theme directory",
+        )
+    except (OSError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         return None
     if not isinstance(data, dict):
         return None
     result = validate_manifest({**data, "id": theme_dir.name})
     if not result.ok:
         return None
-    return result.normalized
+    return _ThemeManifestSnapshot(
+        identity=theme_identity,
+        files=tuple(files),
+        manifest=result.normalized,
+    )
+
+
+def _read_manifest(theme_dir: Path) -> Optional[Dict[str, Any]]:
+    snapshot = _read_theme_manifest_snapshot(theme_dir)
+    return snapshot.manifest if snapshot is not None else None
 
 
 def _media_url(rel_path: Path) -> str:
@@ -206,51 +405,109 @@ def _media_url(rel_path: Path) -> str:
     return f"/api/media?path={quote(posix)}"
 
 
-def _summary(theme_dir: Path, manifest: Dict[str, Any]) -> Dict[str, Any]:
+def _summary(
+    theme_dir: Path,
+    snapshot: _ThemeManifestSnapshot,
+    state: BridgeState | None = None,
+) -> Dict[str, Any]:
+    manifest = snapshot.manifest
     preview = manifest.get("preview")
     preview_url = None
     if isinstance(preview, str) and preview:
-        candidate = safe_child_path(theme_dir, preview)
-        if candidate.is_file():
+        try:
+            candidate = safe_child_path(theme_dir, preview)
+            relative = candidate.relative_to(theme_dir)
+            expected_preview_identity = dict(snapshot.files).get(relative)
+            current_preview_identity = candidate.lstat()
+        except (FileNotFoundError, OSError, ValueError):
+            expected_preview_identity = None
+        if (
+            expected_preview_identity is not None
+            and stat.S_ISREG(expected_preview_identity.st_mode)
+            and os.path.samestat(
+                expected_preview_identity,
+                current_preview_identity,
+            )
+        ):
             preview_url = _media_url(USER_THEMES_DIR / theme_dir.name / preview)
+    require_directory_identity(
+        theme_dir,
+        snapshot.identity,
+        field="chat theme directory",
+    )
+    source = (
+        "builtin"
+        if _is_builtin_theme_dir(theme_dir.name, state)
+        else "user"
+    )
+    require_directory_identity(
+        theme_dir,
+        snapshot.identity,
+        field="chat theme directory",
+    )
     return {
         "id": theme_dir.name,
         "name": manifest.get("name") or {"zh_CN": theme_dir.name},
         "author": manifest.get("author"),
         "version": manifest.get("version"),
         "previewUrl": preview_url,
-        "source": "builtin" if _is_builtin_theme_dir(theme_dir.name) else "user",
+        "source": source,
     }
 
 
 def list_chat_themes(state: BridgeState) -> List[Dict[str, Any]]:
     """扫描主题目录，返回 ChatThemeSummary[]。"""
-    _seed_builtin_themes()
-    root = _themes_root()
-    if not root.is_dir():
+    _seed_builtin_themes(state)
+    root = _themes_root(state)
+    try:
+        root, root_identity, entries = snapshot_directory_entries_without_links(
+            root,
+            field="chat theme directory",
+        )
+    except (FileNotFoundError, NotADirectoryError):
         return []
     summaries: List[Dict[str, Any]] = []
-    for child in sorted(root.iterdir()):
-        if not child.is_dir():
+    for child, child_identity in sorted(
+        entries,
+        key=lambda item: (
+            item[0].name.casefold(),
+            item[0].name,
+        ),
+    ):
+        if (
+            _metadata_is_link_or_reparse_point(child_identity)
+            or not stat.S_ISDIR(child_identity.st_mode)
+        ):
             continue
         if _is_retired_builtin_theme_id(child.name):
             continue
-        manifest = _read_manifest(child)
-        if manifest is None:
+        snapshot = _read_theme_manifest_snapshot(
+            child,
+            expected_theme_identity=child_identity,
+        )
+        if snapshot is None:
             continue
-        summaries.append(_summary(child, manifest))
+        try:
+            summaries.append(_summary(child, snapshot, state))
+        except (FileNotFoundError, PermissionError):
+            continue
+    require_directory_identity(
+        root,
+        root_identity,
+        field="chat theme directory",
+    )
     return summaries
 
 
 def get_chat_theme_manifest(state: BridgeState, theme_id: str) -> Dict[str, Any]:
     """读取并返回单个主题的完整 manifest。"""
-    _seed_builtin_themes()
+    _seed_builtin_themes(state)
     safe_id = _safe_theme_id(theme_id)
     if _is_retired_builtin_theme_id(safe_id):
         raise FileNotFoundError(f"主题不存在或 theme.json 无效: {theme_id}")
-    root = _themes_root()
+    root = _themes_root(state)
     manifest = _read_manifest(root / safe_id)
-    if manifest is None and safe_id != DEFAULT_BUILTIN_CHAT_THEME_ID and _is_builtin_theme_dir(safe_id):
+    if manifest is None and safe_id != DEFAULT_BUILTIN_CHAT_THEME_ID and _is_builtin_theme_dir(safe_id, state):
         manifest = _read_manifest(root / DEFAULT_BUILTIN_CHAT_THEME_ID)
     if manifest is None:
         raise FileNotFoundError(f"主题不存在或 theme.json 无效: {theme_id}")
@@ -261,35 +518,70 @@ def get_active_chat_theme_id(state: BridgeState) -> Dict[str, str]:
     """返回当前激活主题 id（存于 system_config.chat_ui_theme_id）。"""
     system_config = state.config_manager.config.system_config
     theme_id = str(getattr(system_config, "chat_ui_theme_id", "") or "")
-    if not theme_id or _is_retired_builtin_theme_id(Path(theme_id).name):
-        theme_id = DEFAULT_BUILTIN_CHAT_THEME_ID
-    return {"id": theme_id}
+    try:
+        safe_id = _safe_theme_id(theme_id)
+    except ValueError:
+        safe_id = DEFAULT_BUILTIN_CHAT_THEME_ID
+    if _is_retired_builtin_theme_id(safe_id):
+        safe_id = DEFAULT_BUILTIN_CHAT_THEME_ID
+    return {"id": safe_id}
 
 
 def set_active_chat_theme(state: BridgeState, body: Dict[str, Any]) -> Dict[str, str]:
     """设置激活主题 id 并持久化。"""
-    theme_id = str((body or {}).get("id") or "").strip()
+    theme_id = str((body or {}).get("id") or "")
     if not theme_id:
         raise ValueError("缺少主题 id")
-    _seed_builtin_themes()
+    _seed_builtin_themes(state)
     safe_id = _safe_theme_id(theme_id)
     if _is_retired_builtin_theme_id(safe_id):
         raise FileNotFoundError(f"主题不存在：{theme_id}")
-    if _read_manifest(_themes_root() / safe_id) is None:
+    if _read_manifest(_themes_root(state) / safe_id) is None:
         raise FileNotFoundError(f"主题不存在：{theme_id}")
     system_config = state.config_manager.config.system_config
+    previous_id = str(getattr(system_config, "chat_ui_theme_id", "") or "")
     setattr(system_config, "chat_ui_theme_id", safe_id)
     save = (
         getattr(state.config_manager, "save_system_config", None)
         or getattr(state.config_manager, "save_config", None)
         or getattr(state.config_manager, "save", None)
     )
-    if callable(save):
-        try:
-            save()
-        except Exception:
-            pass
+    if not callable(save):
+        setattr(system_config, "chat_ui_theme_id", previous_id)
+        raise RuntimeError("主题配置无法持久化")
+    try:
+        save()
+    except Exception:
+        setattr(system_config, "chat_ui_theme_id", previous_id)
+        raise
     return {"id": safe_id}
+
+
+def _replace_theme_directory(
+    staging: Path,
+    target: Path,
+    *,
+    overwrite: bool,
+    expected_staging_identity: os.stat_result | None,
+    expected_destination_identity: os.stat_result | None,
+) -> None:
+    """Publish one complete theme tree and restore the old tree on failure."""
+
+    with _THEME_PUBLICATION_LOCK:
+        if path_is_link_or_reparse_point(target):
+            raise PermissionError("主题安装目标不能是符号链接")
+        if target.exists() and not target.is_dir():
+            raise FileExistsError(f"主题路径不是目录：{target.name}")
+        try:
+            replace_directory_transactionally(
+                staging,
+                target,
+                overwrite=overwrite,
+                expected_staging_identity=expected_staging_identity,
+                expected_destination_identity=expected_destination_identity,
+            )
+        except FileExistsError as exc:
+            raise FileExistsError(f"主题已存在：{target.name}") from exc
 
 
 def install_theme_from_zip(
@@ -299,18 +591,13 @@ def install_theme_from_zip(
 
     返回安装后的 ChatThemeSummary。校验不通过会抛 ``ValueError``，把错误清单返回给前端。
     """
-    root = _themes_root()
-    root.mkdir(parents=True, exist_ok=True)
-    _seed_builtin_themes()
+    root = _prepare_themes_root(state)
+    _seed_builtin_themes(state)
 
-    with tempfile.TemporaryDirectory(prefix="chat_theme_") as tmp:
+    with private_temporary_directory(prefix="chat_theme_") as temp_root:
         extracted = safe_extract(
-            safe_existing_file_path(
-                zip_path,
-                roots=[Path(tempfile.gettempdir())],
-                field="theme zip path",
-            ),
-            Path(tmp),
+            safe_existing_file_path(zip_path, field="theme zip path"),
+            temp_root,
         )
         manifest_root = locate_manifest_root(extracted)
         if manifest_root is None:
@@ -321,21 +608,56 @@ def install_theme_from_zip(
             raise ValueError("主题校验失败：\n" + "\n".join(result.errors))
 
         theme_id = slugify_theme_id(result.normalized.get("id") or manifest_root.name)
-        target = safe_child_path(root, theme_id)
-        if target.exists():
-            if not overwrite:
-                raise FileExistsError(f"主题已存在：{theme_id}（如需覆盖请传 overwrite=true）")
-            shutil.rmtree(target, ignore_errors=True)
+        theme_id = _safe_theme_id(theme_id)
+        # The installed directory, persisted manifest, and API identity must
+        # remain one value even when a portable-filesystem rewrite was needed.
+        result.normalized["id"] = theme_id
+        target = managed_child_path(root, theme_id, field="theme id")
+        if target.exists() and _is_builtin_theme_dir(theme_id, state):
+            raise PermissionError(f"内置主题不可覆盖：{theme_id}")
+        if target.exists() and not overwrite:
+            raise FileExistsError(f"主题已存在：{theme_id}（如需覆盖请传 overwrite=true）")
+        try:
+            target_identity = target.lstat()
+        except FileNotFoundError:
+            target_identity = None
 
         # 以校验后规整的 manifest 落地（剔除非法字段），其余资源原样拷贝。
-        shutil.copytree(manifest_root, target)
-        safe_child_path(target, BUILTIN_THEME_OWNER_MARKER).unlink(missing_ok=True)
-        (target / MANIFEST_NAME).write_text(
-            json.dumps(result.normalized, ensure_ascii=False, indent=2), encoding="utf-8"
+        staging = private_sibling_path(
+            root / theme_id,
+            f".install-{uuid.uuid4().hex}",
+            field="theme installation staging directory",
         )
+        staging_identity: os.stat_result | None = None
+        try:
+            copy_directory_without_links(manifest_root, staging)
+            staging_identity = staging.lstat()
+            remove_file_without_links(
+                safe_child_path(staging, BUILTIN_THEME_OWNER_MARKER),
+                missing_ok=True,
+            )
+            _atomic_write_manifest(staging, result.normalized)
+            _replace_theme_directory(
+                staging,
+                target,
+                overwrite=overwrite,
+                expected_staging_identity=staging_identity,
+                expected_destination_identity=target_identity,
+            )
+        finally:
+            if staging_identity is not None:
+                try:
+                    remove_directory_without_links(
+                        staging,
+                        expected_identity=staging_identity,
+                    )
+                except OSError:
+                    pass
 
-    manifest = _read_manifest(target)
-    return _summary(target, manifest or {})
+    snapshot = _read_theme_manifest_snapshot(target)
+    if snapshot is None:
+        raise ValueError(f"安装后的主题无效：{theme_id}")
+    return _summary(target, snapshot, state)
 
 
 def save_chat_theme(state: BridgeState, body: Dict[str, Any]) -> Dict[str, Any]:
@@ -345,9 +667,8 @@ def save_chat_theme(state: BridgeState, body: Dict[str, Any]) -> Dict[str, Any]:
     and background assets keep working. Existing user themes retain their own
     assets and only replace ``theme.json``. Built-in ownership is never changed.
     """
-    _seed_builtin_themes()
-    root = _themes_root()
-    root.mkdir(parents=True, exist_ok=True)
+    _seed_builtin_themes(state)
+    root = _prepare_themes_root(state)
 
     raw_manifest = (body or {}).get("manifest")
     result = validate_manifest(raw_manifest)
@@ -357,80 +678,191 @@ def save_chat_theme(state: BridgeState, body: Dict[str, Any]) -> Dict[str, Any]:
     theme_id = _safe_theme_id(str(manifest.get("id") or ""))
     base_id = _safe_theme_id(str((body or {}).get("baseId") or DEFAULT_BUILTIN_CHAT_THEME_ID))
     creating = base_id != theme_id
-    target = safe_child_path(root, theme_id)
+    target = managed_child_path(root, theme_id, field="theme id")
 
-    if target.exists() and _is_builtin_theme_dir(theme_id):
+    if target.exists() and _is_builtin_theme_dir(theme_id, state):
         raise PermissionError(f"内置主题不可编辑：{theme_id}")
     if target.exists() and not target.is_dir():
         raise FileExistsError(f"主题路径不是目录：{theme_id}")
 
+    source_identity: os.stat_result
     if creating:
         if target.exists():
             raise FileExistsError(f"主题已存在：{theme_id}")
         if _is_retired_builtin_theme_id(base_id):
             raise FileNotFoundError(f"基础主题不存在：{base_id}")
-        source = safe_child_path(root, base_id)
+        source = managed_child_path(root, base_id, field="base theme id")
+        source_identity = source.lstat()
+        if (
+            _metadata_is_link_or_reparse_point(source_identity)
+            or not stat.S_ISDIR(source_identity.st_mode)
+        ):
+            raise FileNotFoundError(f"基础主题不存在或无效：{base_id}")
         if _read_manifest(source) is None:
             raise FileNotFoundError(f"基础主题不存在或无效：{base_id}")
+        if not os.path.samestat(source_identity, source.lstat()):
+            raise PermissionError(f"基础主题目录身份已变化：{base_id}")
     else:
         if not target.is_dir():
             raise FileNotFoundError(f"主题不存在：{theme_id}")
         source = target
+        source_identity = source.lstat()
+        if (
+            _metadata_is_link_or_reparse_point(source_identity)
+            or not stat.S_ISDIR(source_identity.st_mode)
+        ):
+            raise FileNotFoundError(f"主题不存在：{theme_id}")
 
-    with tempfile.TemporaryDirectory(prefix="chat_theme_save_", dir=root) as tmp:
+    with private_temporary_directory(
+        prefix="chat_theme_save_",
+        directory=root,
+    ) as tmp:
         # The temporary directory is unique already. Keep its child name
         # server-controlled so request data is never used in this copy path.
-        staging = Path(tmp) / "working-theme"
-        _copy_theme_source(source, staging, root)
-        safe_child_path(staging, BUILTIN_THEME_OWNER_MARKER).unlink(missing_ok=True)
-        (staging / MANIFEST_NAME).write_text(
-            json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+        staging = tmp / "working-theme"
+        _copy_theme_source(
+            source,
+            staging,
+            root,
+            expected_source_identity=source_identity,
+        )
+        remove_file_without_links(
+            safe_child_path(staging, BUILTIN_THEME_OWNER_MARKER),
+            missing_ok=True,
+        )
+        atomic_write_text(
+            managed_child_path(
+                staging,
+                MANIFEST_NAME,
+                field="theme manifest filename",
+            ),
+            json.dumps(manifest, ensure_ascii=False, indent=2),
         )
         staged_result = validate_theme_dir(staging)
         if not staged_result.ok:
             raise ValueError("主题资源校验失败：\n" + "\n".join(staged_result.errors))
         normalized_manifest = staged_result.normalized
-        (staging / MANIFEST_NAME).write_text(
-            json.dumps(normalized_manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+        atomic_write_text(
+            managed_child_path(
+                staging,
+                MANIFEST_NAME,
+                field="theme manifest filename",
+            ),
+            json.dumps(normalized_manifest, ensure_ascii=False, indent=2),
         )
 
         if creating:
             _publish_new_theme(staging, target, theme_id)
         else:
-            _atomic_write_manifest(target, normalized_manifest)
+            with _THEME_PUBLICATION_LOCK:
+                _atomic_write_manifest(
+                    target,
+                    normalized_manifest,
+                    expected_theme_identity=source_identity,
+                )
 
-    saved_manifest = _read_manifest(target)
-    if saved_manifest is None:
+    saved_snapshot = _read_theme_manifest_snapshot(target)
+    if saved_snapshot is None:
         raise ValueError(f"保存后的主题无效：{theme_id}")
-    return _summary(target, saved_manifest)
+    return _summary(target, saved_snapshot, state)
 
 
 def delete_chat_theme(state: BridgeState, theme_id: str) -> Dict[str, Any]:
     """删除一个用户主题目录。内置主题（M5 种子化后只读）不可删。"""
     safe_id = _safe_theme_id(theme_id)
-    target = safe_child_path(_themes_root(), safe_id)
-    if _is_builtin_theme_dir(safe_id):
+    target = managed_child_path(_themes_root(state), safe_id, field="theme id")
+    if _is_builtin_theme_dir(safe_id, state):
         raise PermissionError(f"内置主题不可删除：{theme_id}")
+    if path_is_link_or_reparse_point(target):
+        raise PermissionError(f"主题目录不能是符号链接：{theme_id}")
     if not target.is_dir():
         raise FileNotFoundError(f"主题不存在：{theme_id}")
-    shutil.rmtree(target, ignore_errors=True)
-    # 若删除的是当前激活主题，清空激活态。
-    active = get_active_chat_theme_id(state).get("id")
-    if active == safe_id:
-        _clear_active(state)
+    with _THEME_PUBLICATION_LOCK:
+        root = _themes_root(state)
+        target = managed_child_path(root, safe_id, field="theme id")
+        target_metadata = target.lstat()
+        if (
+            _metadata_is_link_or_reparse_point(target_metadata)
+            or not stat.S_ISDIR(target_metadata.st_mode)
+        ):
+            raise NotADirectoryError(target)
+        trash = require_symlink_free_absolute_path(
+            private_sibling_path(
+                root / safe_id,
+                f".delete-{uuid.uuid4().hex}",
+                field="theme deletion staging directory",
+            ),
+            field="theme deletion staging directory",
+        )
+        if os.path.lexists(trash):
+            raise FileExistsError(trash)
+        rename_path_without_overwrite(
+            target,
+            trash,
+            expected_identity=target_metadata,
+        )
+        active_cleared = False
+        try:
+            trash = require_symlink_free_absolute_path(
+                trash,
+                field="theme deletion staging directory",
+            )
+            trash_metadata = trash.lstat()
+            if (
+                _metadata_is_link_or_reparse_point(trash_metadata)
+                or not stat.S_ISDIR(trash_metadata.st_mode)
+                or not os.path.samestat(target_metadata, trash_metadata)
+            ):
+                raise PermissionError(
+                    f"theme directory identity changed before deletion: {safe_id}"
+                )
+            # 若删除的是当前激活主题，先持久化清空；失败则恢复目录。
+            active = get_active_chat_theme_id(state).get("id")
+            if active == safe_id:
+                _clear_active(state)
+                active_cleared = True
+            remove_directory_without_links(
+                trash,
+                expected_identity=target_metadata,
+            )
+        except BaseException as exc:
+            restored = False
+            try:
+                if os.path.lexists(trash) and not os.path.lexists(target):
+                    rollback_metadata = trash.lstat()
+                    if not os.path.samestat(target_metadata, rollback_metadata):
+                        raise PermissionError("主题删除回滚目录身份已变化")
+                    rename_path_without_overwrite(
+                        trash,
+                        target,
+                        expected_identity=target_metadata,
+                    )
+                    restored = True
+            except BaseException as rollback_error:
+                raise RuntimeError("主题删除回滚目录失败") from rollback_error
+            if active_cleared and restored:
+                try:
+                    set_active_chat_theme(state, {"id": safe_id})
+                except BaseException as rollback_error:
+                    raise RuntimeError("主题删除回滚配置失败") from rollback_error
+            raise
     return {"id": safe_id, "deleted": True}
 
 
 def _clear_active(state: BridgeState) -> None:
     system_config = state.config_manager.config.system_config
+    previous_id = str(getattr(system_config, "chat_ui_theme_id", "") or "")
     setattr(system_config, "chat_ui_theme_id", "")
     save = (
         getattr(state.config_manager, "save_system_config", None)
         or getattr(state.config_manager, "save_config", None)
         or getattr(state.config_manager, "save", None)
     )
-    if callable(save):
-        try:
-            save()
-        except Exception:
-            pass
+    if not callable(save):
+        setattr(system_config, "chat_ui_theme_id", previous_id)
+        raise RuntimeError("主题配置无法持久化")
+    try:
+        save()
+    except Exception:
+        setattr(system_config, "chat_ui_theme_id", previous_id)
+        raise

--- a/frontend_bridge_core/config.py
+++ b/frontend_bridge_core/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -17,12 +16,18 @@ from config.tts_provider_config import (
     tts_server_url_or_default,
     uses_shared_tts_server_config,
 )
+from config.api_path_validation import validate_t2i_paths_for_save
+from sdk.path_contract import (
+    project_root as configured_project_root,
+    resolve_runtime_asset_read_path,
+)
 from application.model_providers import (
-    adapter_catalog as _adapter_catalog,
+    adapter_catalog as _application_adapter_catalog,
     claude_messages_endpoint_url,
     claude_models_endpoint_url,
-    normalize_t2i_provider as _normalize_t2i_provider,
+    normalize_t2i_provider as _application_normalize_t2i_provider,
 )
+from sdk.path_references import state_project_root
 from .security import host_matches, validated_http_url
 from application.runtime.state import BridgeState, _jsonify
 
@@ -41,6 +46,16 @@ _IMAGE_ONLY_MODEL_MARKERS = (
     "sdxl",
     "stable-diffusion",
 )
+_TTS_LABEL_PREFS: tuple[tuple[str, str], ...] = (
+    ("genie-tts", "Genie TTS"),
+    ("kaggle-gpt-sovits", "Kaggle GPT-SoVITS"),
+    ("gpt-sovits", "GPT SoVITS"),
+    ("index-tts", "IndexTTS"),
+    ("cosyvoice", "CosyVoice"),
+)
+_PREFERRED_T2I_KEYS_LOWER: tuple[str, ...] = ("comfyui", "stable diffusion")
+
+
 class LlmModelDiscoveryHttpError(RuntimeError):
     def __init__(self, status_code: int, url: str, detail: str) -> None:
         self.status_code = status_code
@@ -57,23 +72,33 @@ class LlmModelDiscoveryConnectionError(RuntimeError):
 
 def _state_project_root(state: BridgeState) -> Path:
     """Resolve the writable project/data root without falling back to the app install root."""
-    candidates = (
-        getattr(state, "project_root_dir", ""),
-        os.environ.get("SHINSEKAI_PROJECT_ROOT", ""),
-        os.environ.get("EASYAI_PROJECT_ROOT", ""),
-    )
-    for candidate in candidates:
-        raw = str(candidate or "").strip()
-        if not raw:
-            continue
-        try:
-            return Path(raw).expanduser().resolve(strict=False)
-        except (OSError, RuntimeError, ValueError):
-            continue
+    return state_project_root(state)
+
+
+def _adapter_schema(adapter_class: Any | None) -> dict[str, Any]:
+    if adapter_class is None:
+        return {}
+    getter = getattr(adapter_class, "get_config_schema", None)
+    if not callable(getter):
+        return {}
     try:
-        return Path.cwd().resolve(strict=False)
-    except (OSError, RuntimeError, ValueError):
-        return Path(".")
+        schema = getter()
+    except Exception:
+        return {}
+    return _jsonify(schema) if isinstance(schema, dict) else {}
+
+
+def _adapter_option(value: str, label: str, adapter_class: Any | None = None) -> dict[str, Any]:
+    return {
+        "label": str(label or value),
+        "schema": _adapter_schema(adapter_class),
+        "value": str(value),
+    }
+
+
+def _adapter_catalog() -> dict[str, list[dict[str, Any]]]:
+    """Expose registered choices without importing AI modules in the bridge."""
+    return _application_adapter_catalog()
 
 
 def _app_config_response(state: BridgeState) -> dict[str, Any]:
@@ -127,7 +152,15 @@ def _provider_map_value(mapping: dict[str, str], provider: str) -> str:
     return str((mapping or {}).get(provider, "") or "").strip()
 
 
-def _validate_api_config_for_save(config: Any) -> None:
+def _normalize_t2i_provider(value: str) -> str:
+    return _application_normalize_t2i_provider(value)
+
+
+def _validate_api_config_for_save(
+    config: Any,
+    *,
+    project_root: Path | None = None,
+) -> None:
     provider = str(config.llm_provider or "").strip()
     base_url = str(config.llm_base_url or "").strip()
     api_key = _provider_map_value(config.llm_api_key, provider)
@@ -137,12 +170,15 @@ def _validate_api_config_for_save(config: Any) -> None:
     if _contains_quotes(base_url):
         raise ValueError("LLM API 基础网址不能包含引号。")
 
+    validation_root = project_root or configured_project_root()
+    validate_t2i_paths_for_save(config, project_root=validation_root)
+
     tts_provider = normalize_tts_provider(config.tts_provider)
     if not uses_shared_tts_server_config(tts_provider):
         return
 
     tts_url = str(config.gpt_sovits_url or "").strip()
-    tts_path = str(config.gpt_sovits_api_path or "").strip()
+    tts_path = str(config.gpt_sovits_api_path or "")
     if not tts_url:
         raise ValueError("当前 TTS 引擎需要填写 URL。")
     if _contains_quotes(tts_url) or _contains_quotes(tts_path):
@@ -151,7 +187,15 @@ def _validate_api_config_for_save(config: Any) -> None:
         raise ValueError("TTS URL 必须是有效的 http(s) URL。")
     if requires_tts_work_path(tts_provider) and not tts_path:
         raise ValueError("本地 TTS 引擎需要填写服务启动路径。")
-    if tts_path and tts_provider != "kaggle-gpt-sovits" and not Path(tts_path).expanduser().is_dir():
+    if (
+        tts_path
+        and tts_provider != "kaggle-gpt-sovits"
+        and not resolve_runtime_asset_read_path(
+            tts_path,
+            root=validation_root,
+            resource_prefixes=(),
+        ).is_dir()
+    ):
         raise ValueError("TTS 服务启动路径必须是已存在的目录。")
 
 
@@ -170,9 +214,15 @@ def _save_api_config(state: BridgeState, payload: dict[str, Any]) -> Any:
             config.gpt_sovits_api_path,
             _state_project_root(state),
         )
-    _validate_api_config_for_save(config)
+    root = _state_project_root(state)
+    _validate_api_config_for_save(config, project_root=root)
+    previous = state.config_manager.config.api_config
     state.config_manager.config.api_config = config
-    state.config_manager.save_api_config()
+    try:
+        state.config_manager.save_api_config()
+    except BaseException:
+        state.config_manager.config.api_config = previous
+        raise
     return config
 
 

--- a/frontend_bridge_core/effects.py
+++ b/frontend_bridge_core/effects.py
@@ -1,20 +1,77 @@
 from __future__ import annotations
 
 import os
-import shutil
+import threading
+from copy import deepcopy
+from functools import wraps
 from pathlib import Path, PureWindowsPath
 from typing import Any
 
-from .tools import _local_file_access_roots
+from sdk.file_transactions import (
+    copy_file_exclusive_with_identity,
+    portable_name_key,
+    remove_directory_without_links,
+    remove_empty_directory_without_links,
+    remove_file_without_links,
+    replace_directory_transactionally,
+)
+from sdk.path_contract import (
+    managed_project_directory,
+    managed_project_storage,
+    path_is_link_or_reparse_point,
+    project_root as runtime_project_root,
+    require_directory_without_links,
+    resolve_managed_project_path,
+    resolve_runtime_asset_read_path,
+    safe_path_component,
+    safe_path_component_with_suffix,
+)
+
+from sdk.path_references import (
+    make_path_reference,
+    path_reference_value,
+    project_relative_path,
+    resolved_path_is_within,
+    state_project_root,
+)
+from .security import portable_path_text, safe_existing_file_path
 from application.runtime.state import BridgeState, _jsonify
-from sdk.path_utils import safe_child_path, safe_existing_file_path
 
 EFFECT_UPLOAD_DIR = "data/effects"
+_EFFECT_MUTATION_LOCK = threading.RLock()
+
+
+def _serialized_effect_mutation(function):
+    @wraps(function)
+    def wrapped(*args, **kwargs):
+        with _EFFECT_MUTATION_LOCK:
+            return function(*args, **kwargs)
+
+    return wrapped
+
+
+def _restore_model(target: Any, snapshot: Any) -> None:
+    for field_name in type(target).model_fields:
+        setattr(target, field_name, deepcopy(getattr(snapshot, field_name)))
+
+
+def _unlink_created_files(
+    paths: list[tuple[Path, os.stat_result]],
+) -> None:
+    for path, identity in reversed(paths):
+        try:
+            remove_file_without_links(
+                path,
+                missing_ok=True,
+                expected_identity=identity,
+            )
+        except (OSError, ValueError):
+            pass
 
 
 def _validate_effect_storage_name(name: str) -> str:
     """Validate that an effect name can only address one managed directory."""
-    value = str(name or "").strip()
+    value = str(name or "")
     if not value:
         raise ValueError("effect name is required")
     if "\x00" in value:
@@ -28,54 +85,167 @@ def _validate_effect_storage_name(name: str) -> str:
         raise ValueError("effect name must not be an absolute path")
     if value in {".", ".."} or any(part in {".", ".."} for part in path.parts):
         raise ValueError("effect name must not contain relative path segments")
+    return safe_path_component(value, field="effect name")
+
+
+def _effect_root(state: BridgeState | None = None) -> Path:
+    project_root = state_project_root(state) if state is not None else runtime_project_root()
+    return managed_project_storage(EFFECT_UPLOAD_DIR, root=project_root)
+
+
+def _effect_dir(name: str, state: BridgeState | None = None) -> Path:
+    """Get the managed directory for an effect's audio files."""
+    safe_name = _validate_effect_storage_name(name)
+    project_root = state_project_root(state) if state is not None else runtime_project_root()
+    return managed_project_directory(EFFECT_UPLOAD_DIR, safe_name, root=project_root)
+
+
+def _canonical_effect_audio_value(
+    state: BridgeState,
+    effect_name: str,
+    raw_path: str,
+) -> str:
+    raw = str(raw_path or "")
+    if not raw:
+        return ""
+    raw = portable_path_text(raw, field="effect audio path")
+    root = state_project_root(state)
+    try:
+        reference = make_path_reference(
+            raw,
+            root,
+            legacy_project_prefixes=(("data", "effects"),),
+            resource_prefixes=(("assets", "system", "sound"),),
+            # This is the non-destructive launch-time repair path.  Recover
+            # absolute references left by a moved pre-contract installation
+            # before the child runtime reads effect.yaml.  Destructive effect
+            # operations deliberately keep recovery disabled below so a
+            # missing external file can never retarget a deletion.
+            recover_legacy_absolute=True,
+        )
+        value = path_reference_value(reference) or raw
+        if reference is not None and reference.get("scope") == "project":
+            target = resolve_managed_project_path(value, root=root)
+            if resolved_path_is_within(target, _effect_dir(effect_name, state)):
+                return project_relative_path(target, root) or value
+    except (OSError, RuntimeError, ValueError):
+        return raw
     return value
 
 
-def _effect_root() -> Path:
-    return Path(EFFECT_UPLOAD_DIR).resolve()
+def _managed_effect_audio_target(
+    state: BridgeState,
+    effect_name: str,
+    raw_path: str,
+) -> Path | None:
+    root = state_project_root(state)
+    try:
+        reference = make_path_reference(
+            str(raw_path or ""),
+            root,
+            legacy_project_prefixes=(("data", "effects"),),
+            resource_prefixes=(("assets", "system", "sound"),),
+            recover_legacy_absolute=False,
+        )
+        if reference is None or reference.get("scope") != "project":
+            return None
+        value = path_reference_value(reference)
+        if not value:
+            return None
+        target = resolve_managed_project_path(value, root=root)
+    except (OSError, PermissionError, ValueError):
+        return None
+    return target if resolved_path_is_within(target, _effect_dir(effect_name, state)) else None
 
 
-def _effect_dir(name: str) -> Path:
-    """Get the managed directory for an effect's audio files."""
-    safe_name = _validate_effect_storage_name(name)
-    root = _effect_root()
-    candidate = safe_child_path(root, safe_name)
-    if candidate == root:
-        raise ValueError("effect directory escapes managed storage")
-    return candidate
+def _effect_audio_path_in_use(state: BridgeState, raw_path: str) -> bool:
+    root = state_project_root(state)
+    try:
+        reference = make_path_reference(
+            str(raw_path or ""),
+            root,
+            legacy_project_prefixes=(("data", "effects"),),
+            recover_legacy_absolute=False,
+        )
+        value = path_reference_value(reference)
+        if reference is None or reference.get("scope") != "project" or not value:
+            return False
+        target = resolve_managed_project_path(value, root=root)
+        if not resolved_path_is_within(target, _effect_root(state)):
+            return False
+    except (OSError, PermissionError, ValueError):
+        return False
+
+    for effect in state.config_manager.config.effect_list:
+        for candidate_raw in effect.audio_list or []:
+            try:
+                candidate_reference = make_path_reference(
+                    str(candidate_raw or ""),
+                    root,
+                    legacy_project_prefixes=(("data", "effects"),),
+                    recover_legacy_absolute=False,
+                )
+                candidate_value = path_reference_value(candidate_reference)
+                if (
+                    candidate_reference is None
+                    or candidate_reference.get("scope") != "project"
+                    or not candidate_value
+                ):
+                    continue
+                candidate = resolve_managed_project_path(candidate_value, root=root)
+            except (OSError, PermissionError, ValueError):
+                continue
+            if candidate == target:
+                return True
+    return False
 
 
-def _unlink_managed_effect_file(effect_name: str, raw_path: str) -> None:
+def _unlink_managed_effect_file(
+    state: BridgeState,
+    effect_name: str,
+    raw_path: str,
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
     """Remove an audio file only when it is inside the effect's managed dir."""
     if not raw_path:
         return
     try:
-        root = _effect_dir(effect_name).resolve()
-        target = safe_existing_file_path(
-            str(raw_path),
-            roots=[root],
-            field="effect audio path",
-        )
+        target = _managed_effect_audio_target(state, effect_name, raw_path)
     except (OSError, ValueError, FileNotFoundError):
         return
-    if os.path.commonpath([str(root), str(target)]) != str(root):
+    if target is None or not target.is_file():
+        return
+    current_identity = target.lstat()
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, current_identity)
+    ):
         return
     try:
-        if target.is_file():
-            target.unlink()
-    except OSError:
+        remove_file_without_links(
+            target,
+            expected_identity=current_identity,
+        )
+    except (OSError, ValueError):
         pass
 
 
-def _copy_effect_dir(src: Path, dst: Path) -> None:
-    """Copy an effect's managed audio directory from src to dst."""
-    if not src.is_dir():
-        return
-    dst.mkdir(parents=True, exist_ok=True)
-    for item in src.iterdir():
-        dest = dst / item.name
-        if item.is_file():
-            shutil.copy2(item, dest)
+def _managed_effect_file_snapshot(
+    state: BridgeState,
+    effect_name: str,
+    raw_path: str,
+) -> tuple[Path, os.stat_result] | None:
+    if not raw_path:
+        return None
+    try:
+        target = _managed_effect_audio_target(state, effect_name, raw_path)
+        if target is None:
+            return None
+        identity = target.lstat()
+    except (OSError, ValueError, FileNotFoundError):
+        return None
+    return (target, identity) if target.is_file() else None
 
 
 def _effect_by_name(state: BridgeState, name: str) -> Any:
@@ -91,11 +261,16 @@ def _effect_json_after_reload(state: BridgeState, name: str) -> dict[str, Any]:
 
 
 def _save_effect(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
+    with _EFFECT_MUTATION_LOCK:
+        return _save_effect_unlocked(state, payload)
+
+
+def _save_effect_unlocked(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
     body = payload.get("effect", payload)
     if not isinstance(body, dict):
         raise ValueError("effect payload must be an object")
-    name = str(body.get("name") or "").strip()
-    original_name = str(payload.get("originalName") or "").strip()
+    name = str(body.get("name") or "")
+    original_name = str(payload.get("originalName") or "")
     _validate_effect_storage_name(name)
     if original_name:
         _validate_effect_storage_name(original_name)
@@ -104,70 +279,147 @@ def _save_effect(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("特效方案名称不能为空。")
 
     effect_list = state.config_manager.config.effect_list
+    original_effects = list(effect_list)
     from config.schema import Effect as EffectModel
 
-    if original_name:
-        original = state.config_manager.get_effect_by_name(original_name)
-        if original is None:
-            raise KeyError(f"effect not found: {original_name}")
-        # Remove the original effect from the list
-        effect_list[:] = [e for e in effect_list if e.name.lower() != original_name.lower()]
-        # If renaming to a name that already exists, auto-suffix
-        existing_names = {e.name.lower() for e in effect_list}
-        base_name = name
-        counter = 1
-        while name.lower() in existing_names:
-            name = f"{base_name}_{counter}"
-            counter += 1
-        if name != base_name:
-            body["name"] = name
-            print(f"[Effect] 重命名冲突，自动更名为: {name}")
-        # Rename directory if it exists, and update paths
-        old_dir = _effect_dir(original_name)
-        new_dir = _effect_dir(name)
-        if old_dir.is_dir() and old_dir != new_dir:
-            new_dir.parent.mkdir(parents=True, exist_ok=True)
-            # Update audio_list paths from old dir to new dir
-            old_prefix = old_dir.as_posix()
-            new_prefix = new_dir.as_posix()
-            if "audio_list" in body and isinstance(body["audio_list"], list):
-                body["audio_list"] = [
-                    p.replace(old_prefix, new_prefix) if isinstance(p, str) and p.startswith(old_prefix) else p
-                    for p in body["audio_list"]
+    renamed_directory: tuple[Path, Path, os.stat_result] | None = None
+    created_directory: tuple[Path, os.stat_result] | None = None
+    saved_name = name
+    try:
+        if original_name:
+            original = state.config_manager.get_effect_by_name(original_name)
+            if original is None:
+                raise KeyError(f"effect not found: {original_name}")
+            retained = [e for e in effect_list if e is not original]
+            original_key = portable_name_key(original.name)
+            if portable_name_key(name) == original_key and name != original.name:
+                # A case/normalization-only rename is not portable: it is the
+                # same directory on Windows/macOS but a different one on Linux.
+                name = original.name
+                body["name"] = name
+
+            existing_names = {portable_name_key(e.name) for e in retained}
+            base_name = name
+            counter = 1
+            while portable_name_key(name) in existing_names or (
+                portable_name_key(name) != original_key
+                and _effect_dir(name, state).exists()
+            ):
+                name = safe_path_component_with_suffix(
+                    base_name,
+                    f"_{counter}",
+                    field="effect name",
+                )
+                counter += 1
+            if name != base_name:
+                body["name"] = name
+                print(f"[Effect] 重命名冲突，自动更名为: {name}")
+
+            old_dir = _effect_dir(original.name, state)
+            new_dir = _effect_dir(name, state)
+            if old_dir.is_dir() and old_dir != new_dir:
+                if new_dir.exists() or path_is_link_or_reparse_point(new_dir):
+                    raise FileExistsError(f"effect storage already exists: {name}")
+                if "audio_list" in body and isinstance(body["audio_list"], list):
+                    updated_audio_list: list[Any] = []
+                    for raw_audio in body["audio_list"]:
+                        target = _managed_effect_audio_target(
+                            state,
+                            original.name,
+                            str(raw_audio or ""),
+                        )
+                        if target is None:
+                            updated_audio_list.append(raw_audio)
+                            continue
+                        try:
+                            relative_audio = target.relative_to(old_dir)
+                        except ValueError:
+                            updated_audio_list.append(raw_audio)
+                            continue
+                        updated_audio_list.append(
+                            project_relative_path(
+                                new_dir / relative_audio,
+                                state_project_root(state),
+                            )
+                            or str(raw_audio or "")
+                        )
+                    body["audio_list"] = updated_audio_list
+
+            updated = EffectModel.model_validate(body)
+            if old_dir.is_dir() and old_dir != new_dir:
+                new_dir.parent.mkdir(parents=True, exist_ok=True)
+                old_dir_identity = old_dir.lstat()
+                replace_directory_transactionally(
+                    old_dir,
+                    new_dir,
+                    overwrite=False,
+                    expected_staging_identity=old_dir_identity,
+                    expected_destination_identity=None,
+                )
+                renamed_directory = (new_dir, old_dir, old_dir_identity)
+            elif not new_dir.exists():
+                new_dir.mkdir(parents=True)
+                created_path = require_directory_without_links(
+                    new_dir,
+                    field="effect storage directory",
+                )
+                created_directory = (created_path, created_path.lstat())
+            effect_list[:] = [*retained, updated]
+            saved_name = updated.name
+        else:
+            existing = state.config_manager.get_effect_by_name(name)
+            updated = EffectModel.model_validate(body)
+            target_dir = _effect_dir(name, state)
+            if existing is None and target_dir.exists():
+                raise FileExistsError(f"effect storage already exists: {name}")
+            if not target_dir.exists():
+                target_dir.mkdir(parents=True)
+                created_path = require_directory_without_links(
+                    target_dir,
+                    field="effect storage directory",
+                )
+                created_directory = (created_path, created_path.lstat())
+            if existing is None:
+                effect_list.append(updated)
+            else:
+                effect_list[:] = [
+                    updated if effect is existing else effect
+                    for effect in effect_list
                 ]
+            saved_name = updated.name
+
+        state.config_manager.save_effect_config()
+    except BaseException:
+        effect_list[:] = original_effects
+        if renamed_directory is not None:
+            new_dir, old_dir, renamed_identity = renamed_directory
             try:
-                old_dir.rename(new_dir)
-            except OSError:
-                # If rename fails (e.g. target already exists), copy instead
-                if old_dir.is_dir():
-                    _copy_effect_dir(old_dir, new_dir)
-                    shutil.rmtree(old_dir, ignore_errors=True)
-        updated = EffectModel.model_validate(body)
-        effect_list.append(updated)
-        state.config_manager.save_effect_config()
-        _effect_dir(name).mkdir(parents=True, exist_ok=True)
-        state.config_manager.reload()
-        return _jsonify(_effect_by_name(state, updated.name))
+                if new_dir.exists() and not old_dir.exists():
+                    replace_directory_transactionally(
+                        new_dir,
+                        old_dir,
+                        overwrite=False,
+                        expected_staging_identity=renamed_identity,
+                        expected_destination_identity=None,
+                    )
+            except OSError as rollback_error:
+                raise RuntimeError("effect directory rollback failed") from rollback_error
+        if created_directory is not None:
+            created_path, created_identity = created_directory
+            try:
+                remove_empty_directory_without_links(
+                    created_path,
+                    expected_identity=created_identity,
+                )
+            except (OSError, ValueError):
+                pass
+        raise
 
-    existing = state.config_manager.get_effect_by_name(name)
-    if existing is not None:
-        effect_list[:] = [e for e in effect_list if e.name.lower() != name.lower()]
-        updated = EffectModel.model_validate(body)
-        effect_list.append(updated)
-        state.config_manager.save_effect_config()
-        _effect_dir(name).mkdir(parents=True, exist_ok=True)
-        state.config_manager.reload()
-        return _jsonify(_effect_by_name(state, updated.name))
-
-    new_effect = EffectModel.model_validate(body)
-    effect_list.append(new_effect)
-    state.config_manager.save_effect_config()
-    # Ensure the managed audio directory exists
-    _effect_dir(name).mkdir(parents=True, exist_ok=True)
     state.config_manager.reload()
-    return _jsonify(_effect_by_name(state, new_effect.name))
+    return _jsonify(_effect_by_name(state, saved_name))
 
 
+@_serialized_effect_mutation
 def _delete_effect(state: BridgeState, name: str) -> dict[str, Any]:
     _validate_effect_storage_name(name)
     effect_list = state.config_manager.config.effect_list
@@ -178,61 +430,107 @@ def _delete_effect(state: BridgeState, name: str) -> dict[str, Any]:
             break
     if match is None:
         raise KeyError(f"effect not found: {name}")
+    try:
+        ef_dir = _effect_dir(match.name, state)
+        ef_dir_identity = ef_dir.lstat() if ef_dir.is_dir() else None
+    except (OSError, PermissionError, ValueError):
+        ef_dir = None
+        ef_dir_identity = None
+    original_index = effect_list.index(match)
     effect_list.remove(match)
-    state.config_manager.save_effect_config()
+    try:
+        state.config_manager.save_effect_config()
+    except BaseException:
+        effect_list.insert(original_index, match)
+        raise
     # Clean up managed audio directory
-    ef_dir = _effect_dir(name)
-    if ef_dir.is_dir():
-        shutil.rmtree(ef_dir, ignore_errors=True)
+    storage_key = portable_name_key(match.name)
+    storage_in_use = any(
+        portable_name_key(effect.name) == storage_key
+        for effect in effect_list
+    )
+    if (
+        not storage_in_use
+        and ef_dir is not None
+        and ef_dir_identity is not None
+    ):
+        try:
+            remove_directory_without_links(
+                ef_dir,
+                expected_identity=ef_dir_identity,
+            )
+        except OSError:
+            pass
     return {}
 
 
+@_serialized_effect_mutation
 def _upload_effect_audio(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
-    name = str(payload.get("name") or "").strip()
+    name = str(payload.get("name") or "")
     paths = list(payload.get("paths") or [])
     _validate_effect_storage_name(name)
     if not name:
         raise ValueError("特效方案名称不能为空。")
     effect = _effect_by_name(state, name)
 
-    # Ensure managed directory exists
-    ef_dir = _effect_dir(name)
-    ef_dir.mkdir(parents=True, exist_ok=True)
+    ef_dir = _effect_dir(name, state)
+    directory_was_missing = not ef_dir.exists()
+    created_directory_identity: os.stat_result | None = None
+    snapshot = effect.model_copy(deep=True)
+    created_files: list[tuple[Path, os.stat_result]] = []
+    try:
+        audio_list = list(effect.audio_list or [])
+        tags = str(payload.get("audioTags") or effect.audio_tags or "")
 
-    audio_list = list(effect.audio_list or [])
-    tags = str(payload.get("audioTags") or effect.audio_tags or "")
-
-    for file_path in paths:
-        try:
-            src = safe_existing_file_path(
-                str(file_path),
-                roots=_local_file_access_roots(state),
-                field="effect audio path",
+        for file_path in paths:
+            try:
+                src = safe_existing_file_path(
+                    resolve_runtime_asset_read_path(
+                        str(file_path),
+                        root=state_project_root(state),
+                    ),
+                    field="effect audio path",
+                )
+            except (OSError, ValueError, FileNotFoundError):
+                continue
+            filename = safe_path_component(src.name, field="effect audio filename")
+            dest, dest_identity = copy_file_exclusive_with_identity(
+                src,
+                ef_dir,
+                filename,
+                field="effect audio filename",
             )
-        except (OSError, ValueError, FileNotFoundError):
-            continue
-        # Copy to managed directory
-        dest = safe_child_path(ef_dir, src.name)
-        # Avoid overwriting: add suffix if file already exists
-        counter = 1
-        while dest.exists():
-            stem = src.stem
-            dest = ef_dir / f"{stem}_{counter}{src.suffix}"
-            counter += 1
-        shutil.copy2(src, dest)
-        dest_str = dest.as_posix()
-        if dest_str not in audio_list:
+            created_files.append((dest, dest_identity))
+            if (
+                directory_was_missing
+                and created_directory_identity is None
+            ):
+                created_directory_identity = ef_dir.lstat()
+            dest_str = project_relative_path(dest, state_project_root(state)) or dest.as_posix()
             audio_list.append(dest_str)
             tags += f"特效 {len(audio_list)}：\n"
 
-    effect.audio_list = audio_list
-    effect.audio_tags = tags
-    state.config_manager.save_effect_config()
+        effect.audio_list = audio_list
+        effect.audio_tags = tags
+        state.config_manager.save_effect_config()
+    except BaseException:
+        _restore_model(effect, snapshot)
+        _unlink_created_files(created_files)
+        if directory_was_missing and created_directory_identity is not None:
+            try:
+                remove_empty_directory_without_links(
+                    ef_dir,
+                    expected_identity=created_directory_identity,
+                )
+            except (OSError, ValueError):
+                pass
+        raise
     return _effect_json_after_reload(state, name)
 
 
+@_serialized_effect_mutation
 def _delete_effect_audio(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
-    name = str(payload.get("name") or "").strip()
+    name = str(payload.get("name") or "")
     _validate_effect_storage_name(name)
     index = int(payload.get("index") or 0)
     effect = _effect_by_name(state, name)
@@ -242,7 +540,12 @@ def _delete_effect_audio(state: BridgeState, payload: dict[str, Any]) -> dict[st
         raise IndexError(f"audio index out of range: {index}")
 
     removed_path = audio_list.pop(index)
-    _unlink_managed_effect_file(name, removed_path)
+    removed_snapshot = _managed_effect_file_snapshot(
+        state,
+        name,
+        str(removed_path),
+    )
+    snapshot = effect.model_copy(deep=True)
 
     # Rebuild tags — preserve all lines to keep 1:1 audio-to-tag mapping
     old_tags = str(effect.audio_tags or "")
@@ -261,30 +564,72 @@ def _delete_effect_audio(state: BridgeState, payload: dict[str, Any]) -> dict[st
 
     effect.audio_list = audio_list
     effect.audio_tags = new_tags
-    state.config_manager.save_effect_config()
+    try:
+        state.config_manager.save_effect_config()
+    except BaseException:
+        _restore_model(effect, snapshot)
+        raise
+    if (
+        removed_snapshot is not None
+        and not _effect_audio_path_in_use(state, removed_path)
+    ):
+        _unlink_managed_effect_file(
+            state,
+            name,
+            removed_path,
+            expected_identity=removed_snapshot[1],
+        )
     return _effect_json_after_reload(state, name)
 
 
+@_serialized_effect_mutation
 def _delete_all_effect_audio(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
-    name = str(payload.get("name") or "").strip()
+    name = str(payload.get("name") or "")
     _validate_effect_storage_name(name)
     effect = _effect_by_name(state, name)
 
-    # Delete all managed audio files
-    for path in (effect.audio_list or []):
-        _unlink_managed_effect_file(name, path)
-
-    effect.audio_list = []
-    effect.audio_tags = ""
-    state.config_manager.save_effect_config()
+    removed_paths = list(effect.audio_list or [])
+    removed_snapshots = {
+        raw_path: file_snapshot
+        for raw_path in removed_paths
+        if (
+            file_snapshot := _managed_effect_file_snapshot(
+                state,
+                name,
+                str(raw_path),
+            )
+        ) is not None
+    }
+    snapshot = effect.model_copy(deep=True)
+    try:
+        effect.audio_list = []
+        effect.audio_tags = ""
+        state.config_manager.save_effect_config()
+    except BaseException:
+        _restore_model(effect, snapshot)
+        raise
+    for path in removed_paths:
+        removed_snapshot = removed_snapshots.get(path)
+        if (
+            removed_snapshot is not None
+            and not _effect_audio_path_in_use(state, path)
+        ):
+            _unlink_managed_effect_file(
+                state,
+                name,
+                path,
+                expected_identity=removed_snapshot[1],
+            )
     return _effect_json_after_reload(state, name)
 
 
+@_serialized_effect_mutation
 def _save_effect_audio_tags(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:
-    name = str(payload.get("name") or "").strip()
+    name = str(payload.get("name") or "")
     _validate_effect_storage_name(name)
     effect = _effect_by_name(state, name)
     new_tags = str(payload.get("audioTags") or "")
+    snapshot = effect.model_copy(deep=True)
     effect.audio_tags = new_tags
     # 检查每个音频是否都有对应提示词
     tag_lines = new_tags.splitlines()
@@ -303,7 +648,11 @@ def _save_effect_audio_tags(state: BridgeState, payload: dict[str, Any]) -> dict
             missing.append(str(i + 1))
     if missing:
         print(f"[Effect] 警告：特效方案 '{name}' 的第 {', '.join(missing)} 个音频未输入提示词，将无法通过关键词触发。")
-    state.config_manager.save_effect_config()
+    try:
+        state.config_manager.save_effect_config()
+    except BaseException:
+        _restore_model(effect, snapshot)
+        raise
     return _effect_json_after_reload(state, name)
 
 
@@ -327,12 +676,21 @@ def _build_effect_usage_guide(state: BridgeState, effect_names: list[str]) -> st
     lines.append('  {"effect": "after:关键词"}      → 对话后播放一次')
     lines.append("")
 
+    paths_changed = False
+    changed_effects: list[tuple[Any, Any]] = []
     for ef_name in effect_names:
         ef = state.config_manager.get_effect_by_name(ef_name)
         if ef is None:
             continue
         tags = (ef.audio_tags or "").splitlines()
-        audio_list = ef.audio_list or []
+        audio_list = [
+            _canonical_effect_audio_value(state, ef_name, str(path or ""))
+            for path in (ef.audio_list or [])
+        ]
+        if audio_list != list(ef.audio_list or []):
+            changed_effects.append((ef, ef.model_copy(deep=True)))
+            ef.audio_list = audio_list
+            paths_changed = True
         all_kw: list[str] = []
         for i, tag_line in enumerate(tags):
             tag_line = tag_line.strip()
@@ -355,6 +713,14 @@ def _build_effect_usage_guide(state: BridgeState, effect_names: list[str]) -> st
             lines.append(f"「{ef_name}」可触发：{', '.join(all_kw)}")
         else:
             lines.append(f"「{ef_name}」已加载但未配置触发词")
+
+    if paths_changed:
+        try:
+            state.config_manager.save_effect_config()
+        except BaseException:
+            for effect, snapshot in changed_effects:
+                _restore_model(effect, snapshot)
+            raise
 
     lines.append("")
     lines.append("注意：仅在适当时机使用特效，过度使用会破坏沉浸感。effect 字段为可选，无需求时省略。")

--- a/frontend_bridge_core/mcp.py
+++ b/frontend_bridge_core/mcp.py
@@ -11,13 +11,31 @@ from application.mcp import (
     _save_and_apply_mcp_config,
     ensure_mcp_config_file,
 )
+from sdk.path_references import state_project_root
+from sdk.process_launch import open_with_default_application
 
 
-def _open_mcp_config_file() -> dict[str, str]:
+def _mcp_config_path(state=None):
+    if state is None:
+        return ensure_mcp_config_file()
+    from config.mcp_config import resolve_mcp_config_path
+
+    return resolve_mcp_config_path(project_root=state_project_root(state))
+
+
+def _open_mcp_config_file(state=None) -> dict[str, str]:
     """Open the MCP configuration through the desktop platform adapter."""
 
-    path = ensure_mcp_config_file()
-    webbrowser.open(path.resolve().as_uri())
+    if state is None:
+        path = ensure_mcp_config_file()
+        webbrowser.open(path.resolve().as_uri())
+    else:
+        path = _mcp_config_path(state)
+        if not path.is_file():
+            from config.mcp_config import default_mcp_config, write_mcp_config
+
+            write_mcp_config(default_mcp_config(), path)
+        open_with_default_application(path)
     return {"path": path.as_posix()}
 
 

--- a/frontend_bridge_core/media.py
+++ b/frontend_bridge_core/media.py
@@ -4,10 +4,16 @@ import base64
 import hashlib
 import mimetypes
 import os
-import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
+
+from sdk.file_transactions import (
+    atomic_binary_writer,
+    open_binary_read_without_links,
+    read_bytes_without_links,
+)
+from sdk.path_contract import managed_child_path, managed_project_storage
 
 from frontend_bridge_core.backgrounds import (
     _delete_all_background_bgm,
@@ -36,54 +42,53 @@ from frontend_bridge_core.characters import (
     _upload_sprite_voice,
 )
 from frontend_bridge_core.memory import _add_character_memory, _delete_character_memory, _list_character_memories
-from sdk.path_utils import safe_child_path, safe_existing_file_path
+from frontend_bridge_core.security import safe_existing_file_path
 
 
 def _media_thumbnail(source: Path, *, project_root: Path, size: int = 160) -> Path:
-    source = safe_existing_file_path(source, roots=[project_root], field="media source")
+    source = safe_existing_file_path(source, field="media source")
     if not source.is_file():
         raise FileNotFoundError(source.as_posix())
 
-    stat = source.stat()
-    target_size = max(32, min(int(size), 512))
-    digest = hashlib.sha256(
-        f"{source.resolve()}\0{stat.st_mtime_ns}\0{stat.st_size}\0{target_size}".encode(
-            "utf-8",
-            errors="surrogatepass",
-        )
-    ).hexdigest()
-    cache_root = project_root / ".cache" / "frontend-media-thumbnails"
-    cache_path = safe_child_path(cache_root, f"{digest}.png")
-    if cache_path.is_file():
-        return cache_path
-
-    from PIL import Image, ImageOps
-
-    cache_root.mkdir(parents=True, exist_ok=True)
-    with Image.open(source) as image:
-        thumbnail = ImageOps.exif_transpose(image)
-        if thumbnail.mode not in {"RGB", "RGBA"}:
-            thumbnail = thumbnail.convert(
-                "RGBA" if "A" in thumbnail.getbands() else "RGB",
+    with open_binary_read_without_links(source) as source_file:
+        metadata = os.fstat(source_file.fileno())
+        target_size = max(32, min(int(size), 512))
+        digest = hashlib.sha256(
+            (
+                f"{source}\0{metadata.st_dev}\0{metadata.st_ino}\0"
+                f"{metadata.st_size}\0{metadata.st_mtime_ns}\0"
+                f"{metadata.st_ctime_ns}\0{target_size}"
+            ).encode(
+                "utf-8",
+                errors="surrogatepass",
             )
-        resampling = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
-        thumbnail.thumbnail((target_size, target_size), resampling)
+        ).hexdigest()
+        cache_root = managed_project_storage(
+            ".cache/frontend-media-thumbnails",
+            root=project_root,
+        )
+        cache_path = managed_child_path(
+            cache_root,
+            f"{digest}.png",
+            field="thumbnail cache filename",
+        )
+        if cache_path.is_file():
+            return cache_path
 
-        with tempfile.NamedTemporaryFile(
-            dir=cache_root,
-            prefix=f"{digest}.",
-            suffix=".tmp",
-            delete=False,
-        ) as handle:
-            tmp_path = Path(handle.name)
-        try:
-            thumbnail.save(tmp_path, format="PNG", optimize=True)
-            tmp_path.replace(cache_path)
-        finally:
-            try:
-                tmp_path.unlink(missing_ok=True)
-            except OSError:
-                pass
+        from PIL import Image, ImageOps
+
+        cache_root.mkdir(parents=True, exist_ok=True)
+        with Image.open(source_file) as image:
+            thumbnail = ImageOps.exif_transpose(image)
+            if thumbnail.mode not in {"RGB", "RGBA"}:
+                thumbnail = thumbnail.convert(
+                    "RGBA" if "A" in thumbnail.getbands() else "RGB",
+                )
+            resampling = getattr(getattr(Image, "Resampling", Image), "LANCZOS")
+            thumbnail.thumbnail((target_size, target_size), resampling)
+
+            with atomic_binary_writer(cache_path) as handle:
+                thumbnail.save(handle, format="PNG", optimize=True)
 
     return cache_path
 
@@ -98,7 +103,7 @@ def _thumbnail_cache_path(thumbnail: Path, project_root: Path) -> str:
 def _media_thumbnail_data_url(source: Path, *, project_root: Path, size: int = 160) -> str:
     thumbnail = _media_thumbnail(source, project_root=project_root, size=size)
     mime_type = mimetypes.guess_type(thumbnail.name)[0] or "image/png"
-    raw = thumbnail.read_bytes()
+    raw = read_bytes_without_links(thumbnail)
     encoded = base64.b64encode(raw).decode("ascii")
     return f"data:{mime_type};base64,{encoded}"
 
@@ -133,7 +138,7 @@ def _media_thumbnail_batch(
                 "path": raw_path,
             }
             if include_data_url:
-                raw = thumbnail.read_bytes()
+                raw = read_bytes_without_links(thumbnail)
                 encoded = base64.b64encode(raw).decode("ascii")
                 payload["dataUrl"] = f"data:{payload['mimeType']};base64,{encoded}"
             return payload

--- a/frontend_bridge_core/media_utils.py
+++ b/frontend_bridge_core/media_utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from frontend_bridge_core.security import portable_path_text
+
 
 def _optional_suffix_check(value: str, suffix: str, label: str) -> tuple[bool, str]:
     if not value:
@@ -17,8 +19,9 @@ def _path_namespace_list(paths: Any) -> list[Any]:
         raise ValueError("paths must be a list")
     out = []
     for item in paths:
-        path = str(item or "").strip()
+        path = str(item or "")
         if path:
+            path = portable_path_text(path, field="path")
             out.append(SimpleNamespace(name=path))
     if not out:
         raise ValueError("at least one path is required")

--- a/frontend_bridge_core/memory.py
+++ b/frontend_bridge_core/memory.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Sequence
 
+from sdk.path_references import state_project_root
+
+
+def _memory_runtime_kwargs(state: Any | None) -> dict[str, Any]:
+    if state is None:
+        return {}
+    return {
+        "root": state_project_root(state),
+        "config_manager": getattr(state, "config_manager", None),
+    }
+
 
 def _check_mem0_before_call() -> dict[str, Any] | None:
     """Return a dependency error if the complete mem0 runtime is unavailable."""
@@ -23,7 +34,11 @@ def _check_mem0_before_call() -> dict[str, Any] | None:
     return runtime_dependency_error_from_module("mem0")
 
 
-def _get_mem0_status(*, start_loading: bool = True) -> dict[str, Any]:
+def _get_mem0_status(
+    state: Any | None = None,
+    *,
+    start_loading: bool = True,
+) -> dict[str, Any]:
     """Return mem0 availability status for frontend polling."""
     dependency_error = _check_mem0_before_call()
     if dependency_error is not None:
@@ -32,7 +47,10 @@ def _get_mem0_status(*, start_loading: bool = True) -> dict[str, Any]:
 
     from application.memory.service import check_mem0_status
 
-    return check_mem0_status(start_loading=start_loading)
+    return check_mem0_status(
+        start_loading=start_loading,
+        **_memory_runtime_kwargs(state),
+    )
 
 
 def _raise_memory_error(result: dict[str, Any]) -> None:
@@ -40,7 +58,11 @@ def _raise_memory_error(result: dict[str, Any]) -> None:
         raise RuntimeError(str(result["error"]))
 
 
-def _list_character_memories(name: str) -> dict[str, Any]:
+def _list_character_memories(
+    name: str,
+    *,
+    state: Any | None = None,
+) -> dict[str, Any]:
     dep_error = _check_mem0_before_call()
     if dep_error is not None:
         return dep_error
@@ -49,12 +71,18 @@ def _list_character_memories(name: str) -> dict[str, Any]:
     from application.memory.service import list_memories
 
     try:
-        return list_memories(name)
+        return list_memories(name, **_memory_runtime_kwargs(state))
     except ToolNotReady as exc:
         return {"status": "loading", "message": exc.message}
 
 
-def _memory_tool_search(query: str, character_name: str, limit: int = 10) -> dict[str, Any]:
+def _memory_tool_search(
+    query: str,
+    character_name: str,
+    limit: int = 10,
+    *,
+    state: Any | None = None,
+) -> dict[str, Any]:
     dep_error = _check_mem0_before_call()
     if dep_error is not None:
         return dep_error
@@ -63,12 +91,22 @@ def _memory_tool_search(query: str, character_name: str, limit: int = 10) -> dic
     from application.memory.service import search_memories
 
     try:
-        return search_memories(query, character_name=character_name, limit=limit)
+        return search_memories(
+            query,
+            character_name=character_name,
+            limit=limit,
+            **_memory_runtime_kwargs(state),
+        )
     except ToolNotReady as exc:
         return {"status": "loading", "message": exc.message}
 
 
-def _memory_tool_remember(content: str, character_name: str) -> dict[str, Any]:
+def _memory_tool_remember(
+    content: str,
+    character_name: str,
+    *,
+    state: Any | None = None,
+) -> dict[str, Any]:
     dep_error = _check_mem0_before_call()
     if dep_error is not None:
         return dep_error
@@ -77,12 +115,20 @@ def _memory_tool_remember(content: str, character_name: str) -> dict[str, Any]:
     from application.memory.service import remember_memory
 
     try:
-        return remember_memory(content, character_name=character_name)
+        return remember_memory(
+            content,
+            character_name=character_name,
+            **_memory_runtime_kwargs(state),
+        )
     except ToolNotReady as exc:
         return {"status": "loading", "message": exc.message}
 
 
-def _memory_tool_forget(memory_id: str) -> dict[str, Any]:
+def _memory_tool_forget(
+    memory_id: str,
+    *,
+    state: Any | None = None,
+) -> dict[str, Any]:
     dep_error = _check_mem0_before_call()
     if dep_error is not None:
         return dep_error
@@ -91,12 +137,17 @@ def _memory_tool_forget(memory_id: str) -> dict[str, Any]:
     from application.memory.service import forget_memory
 
     try:
-        return forget_memory(memory_id)
+        return forget_memory(memory_id, **_memory_runtime_kwargs(state))
     except ToolNotReady as exc:
         return {"status": "loading", "message": exc.message}
 
 
-def _add_character_memory(name: str, content: str) -> dict[str, Any]:
+def _add_character_memory(
+    name: str,
+    content: str,
+    *,
+    state: Any | None = None,
+) -> dict[str, Any]:
     dep_error = _check_mem0_before_call()
     if dep_error is not None:
         return dep_error
@@ -105,14 +156,23 @@ def _add_character_memory(name: str, content: str) -> dict[str, Any]:
     from application.memory.service import remember_and_list
 
     try:
-        result = remember_and_list(content, character_name=name)
+        result = remember_and_list(
+            content,
+            character_name=name,
+            **_memory_runtime_kwargs(state),
+        )
     except ToolNotReady as exc:
         return {"status": "loading", "message": exc.message}
     _raise_memory_error(result)
     return result
 
 
-def _delete_character_memory(name: str, memory_id: str) -> dict[str, Any]:
+def _delete_character_memory(
+    name: str,
+    memory_id: str,
+    *,
+    state: Any | None = None,
+) -> dict[str, Any]:
     dep_error = _check_mem0_before_call()
     if dep_error is not None:
         return dep_error
@@ -121,7 +181,11 @@ def _delete_character_memory(name: str, memory_id: str) -> dict[str, Any]:
     from application.memory.service import forget_and_list
 
     try:
-        result = forget_and_list(memory_id, character_name=name)
+        result = forget_and_list(
+            memory_id,
+            character_name=name,
+            **_memory_runtime_kwargs(state),
+        )
     except ToolNotReady as exc:
         return {"status": "loading", "message": exc.message}
     _raise_memory_error(result)
@@ -179,6 +243,7 @@ def _run_character_memory_import(
         character_name=name,
         source_root=source_root,
         config_manager=state.config_manager,
+        root=state_project_root(state),
         progress_callback=report,
         cancel_callback=raise_if_cancelled,
     )

--- a/frontend_bridge_core/music.py
+++ b/frontend_bridge_core/music.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
+from sdk.path_contract import require_regular_file_without_links
+
+from sdk.path_references import state_project_root
 from application.runtime.state import BridgeState, _jsonify
 from application.runtime.tasks import _append_task_log, _update_task
 
@@ -26,7 +28,12 @@ def _music_cover_search(state: BridgeState, payload: dict[str, Any]) -> dict[str
 
     source = _music_cover_source(payload)
     query = str(payload.get("query") or "").strip()
-    log = search_preview(state.config_manager.config.system_config, source, query)
+    log = search_preview(
+        state.config_manager.config.system_config,
+        source,
+        query,
+        root=state_project_root(state),
+    )
     return {"log": str(log or "")}
 
 
@@ -51,13 +58,19 @@ def _run_music_cover(state: BridgeState, task_id: str, payload: dict[str, Any]) 
         query=query,
         pick_index=pick_index,
         skip_rvc=skip_rvc,
+        root=state_project_root(state),
     )
     log = str(format_pipeline_log(result) or "")
     final_mix = getattr(result, "final_mix", None)
-    audio_path = str(final_mix) if final_mix is not None and Path(final_mix).exists() else ""
+    if final_mix is None:
+        raise FileNotFoundError("Music cover pipeline did not produce a final mix")
+    audio_path = require_regular_file_without_links(
+        final_mix,
+        field="music cover final mix",
+    )
     if log:
         _append_task_log(state, task_id, log)
-    return {"audioPath": audio_path, "log": log}
+    return {"audioPath": str(audio_path), "log": log}
 
 
 def _save_music_cover_config(state: BridgeState, payload: dict[str, Any]) -> dict[str, Any]:

--- a/frontend_bridge_core/path_utils.py
+++ b/frontend_bridge_core/path_utils.py
@@ -1,8 +1,10 @@
-"""Compatibility exports for the canonical :mod:`sdk.path_utils` helpers."""
+"""Compatibility alias for the canonical :mod:`sdk.path_references` module."""
 
 from __future__ import annotations
 
-from sdk.path_utils import resolve_regular_path, strip_windows_verbatim_prefix
+import sys
+
+from sdk import path_references as _implementation
 
 
-__all__ = ["resolve_regular_path", "strip_windows_verbatim_prefix"]
+sys.modules[__name__] = _implementation

--- a/frontend_bridge_core/plugin_publisher.py
+++ b/frontend_bridge_core/plugin_publisher.py
@@ -10,9 +10,18 @@ from application.plugins.publisher import (
     validation_errors,
 )
 
+from .path_utils import state_project_root
 
-def _scan_local_plugin(body: dict[str, Any]) -> dict[str, Any]:
-    return scan_local_plugin(str(body.get("path") or "."))
+
+def _scan_local_plugin(
+    body: dict[str, Any],
+    *,
+    state: Any | None = None,
+) -> dict[str, Any]:
+    return scan_local_plugin(
+        str(body.get("path") or ""),
+        root=state_project_root(state) if state is not None else None,
+    )
 
 
 def _validate_plugin_submission(body: dict[str, Any]) -> dict[str, Any]:

--- a/frontend_bridge_core/plugin_ui.py
+++ b/frontend_bridge_core/plugin_ui.py
@@ -5,12 +5,101 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import quote
 
+from sdk.file_transactions import ensure_portable_name_available
+from sdk.path_contract import (
+    managed_project_directory,
+    project_root as runtime_project_root,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resolve_managed_project_path,
+    resolve_project_output_path,
+    resolve_project_path,
+    resolve_project_read_path,
+    safe_path_component,
+)
+
 from application.plugins.catalog import _plugin_rows
+from sdk.path_references import make_path_reference, path_reference_value
+from .security import portable_path_text, safe_child_path
 
 
-def _plugin_data_root(plugin_id: str) -> Path:
-    cleaned = plugin_id.strip().replace("/", "_") or "unknown"
-    return Path("data/plugins") / cleaned
+def _plugin_identity(value: Any, *, field: str = "plugin id") -> str:
+    return safe_path_component(str(value or ""), field=field)
+
+
+def _identity_matches(value: Any, expected: str, *, field: str) -> bool:
+    try:
+        return _plugin_identity(value, field=field) == expected
+    except ValueError:
+        return False
+
+
+def _plugin_data_root(plugin_id: str, *, project_root: Path | None = None) -> Path:
+    cleaned = safe_path_component(str(plugin_id or ""), field="plugin id")
+    root = require_directory_without_links(
+        runtime_project_root() if project_root is None else project_root,
+        field="plugin project root",
+    )
+    storage = managed_project_directory("data/plugins", cleaned, root=root)
+    ensure_portable_name_available(storage.parent, cleaned)
+    return storage
+
+
+def _plugin_config_file(
+    plugin_root: Path,
+    candidate: Path,
+    *,
+    project_root: Path | None = None,
+) -> Path:
+    """Validate a built-in plugin config leaf before third-party file I/O."""
+
+    project = (
+        runtime_project_root()
+        if project_root is None
+        else resolve_project_path(".", root=project_root)
+    )
+    exact_root = resolve_managed_project_path(plugin_root, root=project)
+    exact_file = resolve_managed_project_path(candidate, root=project)
+    if exact_file.parent != exact_root:
+        raise PermissionError("plugin config file is outside the plugin data root")
+    return exact_file
+
+
+def _stored_plugin_cache_path(
+    value: Any,
+    *,
+    project_root: Path | None = None,
+) -> str:
+    """Serialize an optional plugin cache directory without cwd ownership."""
+
+    raw = str(value or "")
+    if not raw:
+        return ""
+    root = (
+        runtime_project_root()
+        if project_root is None
+        else resolve_project_path(".", root=project_root)
+    )
+    reference = make_path_reference(
+        raw,
+        root,
+        legacy_project_prefixes=(("data", "cache"),),
+        recover_legacy_absolute=False,
+    )
+    stored = path_reference_value(reference)
+    if stored is None:
+        raise ValueError("plugin cache directory could not be classified")
+    # Revalidate the spelling at the output boundary. This rejects linked
+    # parents and ambiguous relative aliases before an optional plugin receives
+    # the persisted value.
+    stored_path = Path(stored).expanduser()
+    if stored_path.is_absolute():
+        require_symlink_free_absolute_path(
+            stored_path,
+            field="plugin cache directory",
+        )
+    resolve_project_output_path(stored, root=root)
+    return stored
 
 
 def _plugin_config_field(
@@ -53,15 +142,29 @@ def _plugin_config_field(
     return field
 
 
-def _builtin_plugin_config_page(plugin_id: str, page_id: str) -> dict[str, Any] | None:
-    root = _plugin_data_root(plugin_id)
+def _builtin_plugin_config_page(
+    plugin_id: str,
+    page_id: str,
+    *,
+    project_root: Path | None = None,
+) -> dict[str, Any] | None:
+    root = _plugin_data_root(plugin_id, project_root=project_root)
     if plugin_id == "com.shinsekai.moondream_vision" and page_id == "moondream_vision":
         from dataclasses import asdict
 
         from plugins.moondream_vision.config_model import default_config_path, load_config
 
-        cfg = load_config(default_config_path(root))
+        config_path = _plugin_config_file(
+            root,
+            default_config_path(root),
+            project_root=project_root,
+        )
+        cfg = load_config(config_path)
         cfg.clamp()
+        cfg.cache_dir = _stored_plugin_cache_path(
+            cfg.cache_dir,
+            project_root=project_root,
+        )
         return {
             "description": (
                 "使用 mss 截屏，通过 Hugging Face Transformers 加载 Moondream2。"
@@ -99,8 +202,9 @@ def _builtin_plugin_config_page(plugin_id: str, page_id: str) -> dict[str, Any] 
                         _plugin_config_field(
                             "cache_dir",
                             "缓存目录",
-                            "text",
+                            "file",
                             default="",
+                            path_kind="directory",
                             placeholder="可选；留空用系统默认 HF 缓存",
                             span="full",
                         ),
@@ -260,7 +364,12 @@ def _builtin_plugin_config_page(plugin_id: str, page_id: str) -> dict[str, Any] 
 
         from plugins.playwright_browser.config_model import default_config_path, load_config
 
-        cfg = load_config(default_config_path(root))
+        config_path = _plugin_config_file(
+            root,
+            default_config_path(root),
+            project_root=project_root,
+        )
+        cfg = load_config(config_path)
         cfg.clamp()
         return {
             "description": (
@@ -303,19 +412,40 @@ def _builtin_plugin_config_page(plugin_id: str, page_id: str) -> dict[str, Any] 
 def _frontend_config_contributions_for(plugin_id: str) -> list[Any]:
     from application.plugins.catalog import frontend_config_contributions_for
 
-    return frontend_config_contributions_for(plugin_id)
+    exact_plugin_id = _plugin_identity(plugin_id)
+    out: list[Any] = []
+    for contribution in frontend_config_contributions_for(exact_plugin_id):
+        if _identity_matches(
+            getattr(contribution, "plugin_id", ""),
+            exact_plugin_id,
+            field="plugin id",
+        ):
+            out.append(contribution)
+    return sorted(out, key=lambda item: float(getattr(item, "order", 100.0) or 100.0))
 
 
 def _frontend_page_contributions_for(plugin_id: str) -> list[Any]:
     from application.plugins.catalog import frontend_page_contributions_for
 
-    return frontend_page_contributions_for(plugin_id)
+    exact_plugin_id = _plugin_identity(plugin_id)
+    out: list[Any] = []
+    for contribution in frontend_page_contributions_for(exact_plugin_id):
+        if _identity_matches(
+            getattr(contribution, "plugin_id", ""),
+            exact_plugin_id,
+            field="plugin id",
+        ):
+            out.append(contribution)
+    return sorted(out, key=lambda item: float(getattr(item, "order", 100.0) or 100.0))
 
 
 def _frontend_chat_ui_contributions() -> list[Any]:
     from application.plugins.catalog import frontend_chat_ui_contributions
 
-    return frontend_chat_ui_contributions()
+    return sorted(
+        frontend_chat_ui_contributions(),
+        key=lambda item: float(getattr(item, "order", 100.0) or 100.0),
+    )
 
 
 def _frontend_chat_ui_action(contribution: Any) -> tuple[str, str, str]:
@@ -410,14 +540,28 @@ def _run_frontend_chat_ui_contribution(plugin_id: str, contribution_id: str) -> 
 
 
 def _frontend_page_contribution(plugin_id: str, page_id: str) -> Any | None:
+    exact_page_id = _plugin_identity(page_id, field="frontend page id")
     for contribution in _frontend_page_contributions_for(plugin_id):
-        if str(getattr(contribution, "page_id", "") or "").strip() == page_id:
+        if _identity_matches(
+            getattr(contribution, "page_id", ""),
+            exact_page_id,
+            field="frontend page id",
+        ):
             return contribution
     return None
 
 
 def _frontend_config_page_payload(contribution: Any) -> dict[str, Any]:
-    page_id = str(getattr(contribution, "page_id", "") or "").strip()
+    page_id = _plugin_identity(
+        getattr(contribution, "page_id", ""),
+        field="frontend page id",
+    )
+    raw_plugin_id = getattr(contribution, "plugin_id", None)
+    plugin_id = (
+        _plugin_identity(raw_plugin_id)
+        if raw_plugin_id is not None
+        else ""
+    )
     title = str(getattr(contribution, "title", "") or "").strip() or page_id
     kind = str(getattr(contribution, "kind", "") or "settings").strip()
     if kind not in {"settings", "tools"}:
@@ -431,7 +575,7 @@ def _frontend_config_page_payload(contribution: Any) -> dict[str, Any]:
         "id": page_id,
         "kind": kind,
         "order": float(getattr(contribution, "order", 100.0) or 100.0),
-        "pluginId": str(getattr(contribution, "plugin_id", "") or ""),
+        "pluginId": plugin_id,
         "pluginVersion": str(getattr(contribution, "plugin_version", "") or ""),
         "restartHint": str(getattr(contribution, "restart_hint", "") or ""),
         "schema": list(getattr(contribution, "schema", []) or []),
@@ -445,7 +589,10 @@ def _frontend_config_page_payload(contribution: Any) -> dict[str, Any]:
                 {
                     "confirm": str(getattr(action, "confirm", "") or ""),
                     "description": str(getattr(action, "description", "") or ""),
-                    "id": str(getattr(action, "id", "") or ""),
+                    "id": _plugin_identity(
+                        getattr(action, "id", ""),
+                        field="frontend action id",
+                    ),
                     "label": str(getattr(action, "label", "") or ""),
                     "order": float(getattr(action, "order", 100.0) or 100.0),
                     "variant": str(getattr(action, "variant", "ghost") or "ghost"),
@@ -458,12 +605,15 @@ def _frontend_config_page_payload(contribution: Any) -> dict[str, Any]:
 
 
 def _frontend_page_payload(contribution: Any) -> dict[str, Any]:
-    page_id = str(getattr(contribution, "page_id", "") or "").strip()
+    page_id = _plugin_identity(
+        getattr(contribution, "page_id", ""),
+        field="frontend page id",
+    )
     title = str(getattr(contribution, "title", "") or "").strip() or page_id
     kind = str(getattr(contribution, "kind", "") or "settings").strip()
     if kind not in {"settings", "tools"}:
         kind = "settings"
-    plugin_id = str(getattr(contribution, "plugin_id", "") or "")
+    plugin_id = _plugin_identity(getattr(contribution, "plugin_id", ""))
     page = {
         "description": str(getattr(contribution, "description", "") or ""),
         "frontendUrl": (
@@ -478,7 +628,11 @@ def _frontend_page_payload(contribution: Any) -> dict[str, Any]:
         "title": title,
     }
     for config_contribution in _frontend_config_contributions_for(plugin_id):
-        if str(getattr(config_contribution, "page_id", "") or "").strip() != page_id:
+        if not _identity_matches(
+            getattr(config_contribution, "page_id", ""),
+            page_id,
+            field="frontend page id",
+        ):
             continue
         config_page = _frontend_config_page_payload(config_contribution)
         if str(config_page.get("kind") or "settings") != kind:
@@ -492,8 +646,15 @@ def _frontend_page_payload(contribution: Any) -> dict[str, Any]:
     return page
 
 
-def _plugin_ui_detail(plugin_id_or_entry: str) -> dict[str, Any]:
-    lookup = plugin_id_or_entry.strip()
+def _plugin_ui_detail(
+    plugin_id_or_entry: str,
+    *,
+    project_root: Path | None = None,
+) -> dict[str, Any]:
+    lookup = portable_path_text(
+        plugin_id_or_entry,
+        field="plugin id or manifest entry",
+    )
     plugin_row = None
     for row in _plugin_rows():
         if row.get("id") == lookup or row.get("entry") == lookup:
@@ -502,7 +663,13 @@ def _plugin_ui_detail(plugin_id_or_entry: str) -> dict[str, Any]:
     if plugin_row is None:
         raise KeyError(f"plugin not found: {lookup}")
 
-    plugin_id = str(plugin_row.get("id") or "").strip()
+    try:
+        plugin_id = _plugin_identity(plugin_row.get("id"))
+    except ValueError:
+        # An offline row can only expose its import entry as an identifier.
+        # It has no live contributions, but remains useful as uninstall/error
+        # metadata and must not be reinterpreted as a local storage name.
+        return {"pages": [], "plugin": plugin_row}
     pages: list[dict[str, Any]] = []
     frontend_page_keys: set[tuple[str, str]] = set()
 
@@ -522,7 +689,13 @@ def _plugin_ui_detail(plugin_id_or_entry: str) -> dict[str, Any]:
     return {"pages": pages, "plugin": plugin_row}
 
 
-def _save_builtin_plugin_config(plugin_id: str, page_id: str, values: dict[str, Any]) -> None:
+def _save_builtin_plugin_config(
+    plugin_id: str,
+    page_id: str,
+    values: dict[str, Any],
+    *,
+    project_root: Path | None = None,
+) -> None:
     def _float_value(key: str, default: float) -> float:
         raw = values.get(key, default)
         if raw is None or raw == "":
@@ -535,7 +708,7 @@ def _save_builtin_plugin_config(plugin_id: str, page_id: str, values: dict[str, 
             return default
         return int(raw)
 
-    root = _plugin_data_root(plugin_id)
+    root = _plugin_data_root(plugin_id, project_root=project_root)
     if plugin_id == "com.shinsekai.moondream_vision" and page_id == "moondream_vision":
         from plugins.moondream_vision.config_model import (
             MoondreamVisionConfig,
@@ -543,11 +716,15 @@ def _save_builtin_plugin_config(plugin_id: str, page_id: str, values: dict[str, 
             save_config,
         )
 
+        cache_dir = _stored_plugin_cache_path(
+            values.get("cache_dir"),
+            project_root=project_root,
+        )
         cfg = MoondreamVisionConfig(
             enabled=bool(values.get("enabled", False)),
             model_id=str(values.get("model_id") or "vikhyatk/moondream2").strip() or "vikhyatk/moondream2",
             revision=str(values.get("revision") or "").strip(),
-            cache_dir=str(values.get("cache_dir") or "").strip(),
+            cache_dir=cache_dir,
             device=str(values.get("device") or "auto").strip().lower(),
             quantization=str(values.get("quantization") or "none").strip().lower(),
             motion_poll_sec=_float_value("motion_poll_sec", MoondreamVisionConfig.motion_poll_sec),
@@ -563,7 +740,12 @@ def _save_builtin_plugin_config(plugin_id: str, page_id: str, values: dict[str, 
             question_foreground=str(values.get("question_foreground") or "").strip(),
             message_prefix=str(values.get("message_prefix") or MoondreamVisionConfig.message_prefix),
         )
-        save_config(default_config_path(root), cfg)
+        config_path = _plugin_config_file(
+            root,
+            default_config_path(root),
+            project_root=project_root,
+        )
+        save_config(config_path, cfg)
         return
 
     if plugin_id == "com.shinsekai.playwright_browser" and page_id == "playwright_browser":
@@ -578,17 +760,38 @@ def _save_builtin_plugin_config(plugin_id: str, page_id: str, values: dict[str, 
             browser_type=str(values.get("browser_type") or "chromium").strip().lower(),
             headless=bool(values.get("headless", True)),
         )
-        save_config(default_config_path(root), cfg)
+        config_path = _plugin_config_file(
+            root,
+            default_config_path(root),
+            project_root=project_root,
+        )
+        save_config(config_path, cfg)
         browser.set_plugin_root(str(root))
         return
 
     raise KeyError(f"plugin page config not supported: {plugin_id}/{page_id}")
 
 
-def _save_plugin_ui_config(plugin_id_or_entry: str, page_id: str, payload: dict[str, Any]) -> dict[str, Any]:
-    detail = _plugin_ui_detail(plugin_id_or_entry)
+def _detail_for_project_root(
+    plugin_id_or_entry: str,
+    project_root: Path | None,
+) -> dict[str, Any]:
+    if project_root is None:
+        return _plugin_ui_detail(plugin_id_or_entry)
+    return _plugin_ui_detail(plugin_id_or_entry, project_root=project_root)
+
+
+def _save_plugin_ui_config(
+    plugin_id_or_entry: str,
+    page_id: str,
+    payload: dict[str, Any],
+    *,
+    project_root: Path | None = None,
+) -> dict[str, Any]:
+    detail = _detail_for_project_root(plugin_id_or_entry, project_root)
     plugin = detail["plugin"]
-    plugin_id = str(plugin.get("id") or "").strip()
+    plugin_id = _plugin_identity(plugin.get("id"))
+    page_id = _plugin_identity(page_id, field="frontend page id")
     page = None
     for candidate in detail["pages"]:
         if str(candidate.get("id") or "") == page_id:
@@ -601,9 +804,13 @@ def _save_plugin_ui_config(plugin_id_or_entry: str, page_id: str, payload: dict[
         raise ValueError("values must be an object")
 
     for contribution in _frontend_config_contributions_for(plugin_id):
-        if str(getattr(contribution, "page_id", "") or "").strip() == page_id:
+        if _identity_matches(
+            getattr(contribution, "page_id", ""),
+            page_id,
+            field="frontend page id",
+        ):
             contribution.save_values(raw_values)
-            updated = _plugin_ui_detail(plugin_id)
+            updated = _detail_for_project_root(plugin_id, project_root)
             updated_page = next(
                 (candidate for candidate in updated["pages"] if candidate.get("id") == page_id),
                 page,
@@ -617,8 +824,13 @@ def _save_plugin_ui_config(plugin_id_or_entry: str, page_id: str, payload: dict[
     if "schema" not in page:
         raise KeyError(f"plugin page config not supported: {plugin_id}/{page_id}")
 
-    _save_builtin_plugin_config(plugin_id, page_id, raw_values)
-    updated = _plugin_ui_detail(plugin_id)
+    _save_builtin_plugin_config(
+        plugin_id,
+        page_id,
+        raw_values,
+        project_root=project_root,
+    )
+    updated = _detail_for_project_root(plugin_id, project_root)
     updated_page = next((candidate for candidate in updated["pages"] if candidate.get("id") == page_id), page)
     return {
         "message": "插件设置已保存。",
@@ -632,24 +844,32 @@ def _run_plugin_ui_action(
     page_id: str,
     action_id: str,
     payload: dict[str, Any],
+    *,
+    project_root: Path | None = None,
 ) -> dict[str, Any]:
     """Find the matching action on a FrontendConfigContribution and invoke its run callback."""
-    detail = _plugin_ui_detail(plugin_id_or_entry)
+    detail = _detail_for_project_root(plugin_id_or_entry, project_root)
     plugin = detail["plugin"]
-    plugin_id = str(plugin.get("id") or "").strip()
+    plugin_id = _plugin_identity(plugin.get("id"))
+    page_id = _plugin_identity(page_id, field="frontend page id")
+    action_id = _plugin_identity(action_id, field="frontend action id")
     raw_values = payload.get("values", payload)
     if not isinstance(raw_values, dict):
         raise ValueError("values must be an object")
 
     for contribution in _frontend_config_contributions_for(plugin_id):
-        if str(getattr(contribution, "page_id", "") or "").strip() != page_id:
+        if not _identity_matches(
+            getattr(contribution, "page_id", ""),
+            page_id,
+            field="frontend page id",
+        ):
             continue
         for action in getattr(contribution, "actions", None) or []:
             if str(getattr(action, "id", "") or "") == action_id:
                 result = action.run(raw_values) or {}
                 if not isinstance(result, Mapping):
                     raise ValueError(f"action {action_id!r} run must return a mapping or None")
-                updated = _plugin_ui_detail(plugin_id)
+                updated = _detail_for_project_root(plugin_id, project_root)
                 updated_page = next(
                     (candidate for candidate in updated["pages"] if candidate.get("id") == page_id),
                     None,
@@ -666,27 +886,48 @@ def _run_plugin_ui_action(
     raise KeyError(f"action not found: {plugin_id}/{page_id}/{action_id}")
 
 
-def _resolve_plugin_frontend_file(plugin_id_or_entry: str, page_id: str, asset_path: str) -> Path:
-    detail = _plugin_ui_detail(plugin_id_or_entry)
+def _resolve_plugin_frontend_file(
+    plugin_id_or_entry: str,
+    page_id: str,
+    asset_path: str,
+    *,
+    project_root: Path | None = None,
+) -> Path:
+    detail = _detail_for_project_root(plugin_id_or_entry, project_root)
     plugin = detail["plugin"]
-    plugin_id = str(plugin.get("id") or "").strip()
+    plugin_id = _plugin_identity(plugin.get("id"))
     contribution = _frontend_page_contribution(plugin_id, page_id)
     if contribution is None:
         raise KeyError(f"plugin frontend page not found: {plugin_id}/{page_id}")
-    entry = Path(str(getattr(contribution, "entry", "") or "")).expanduser()
-    if not entry.is_absolute():
-        entry = (Path.cwd() / entry).resolve()
-    else:
-        entry = entry.resolve()
+    entry_text = portable_path_text(
+        str(getattr(contribution, "entry", "") or ""),
+        field="plugin frontend entry",
+    )
+    entry = resolve_project_read_path(
+        entry_text,
+        root=(
+            runtime_project_root()
+            if project_root is None
+            else project_root
+        ),
+    )
     if not entry.is_file():
         raise FileNotFoundError(entry.as_posix())
-    root = entry.parent.resolve()
-    cleaned_asset = str(asset_path or "").replace("\\", "/").strip("/")
-    target = entry if not cleaned_asset else (root / cleaned_asset).resolve()
-    if root not in target.parents and target != root and target != entry:
-        raise PermissionError("plugin frontend asset is outside frontend root")
+    root = entry.parent
+    raw_asset = str(asset_path or "")
+    if not raw_asset:
+        target = entry
+    else:
+        cleaned_asset = portable_path_text(raw_asset, field="plugin frontend asset")
+        if "\\" in cleaned_asset or cleaned_asset.startswith("/"):
+            raise ValueError("plugin frontend asset must be an exact relative URL path")
+        parts = cleaned_asset.split("/")
+        if any(part in {"", ".", ".."} for part in parts):
+            raise ValueError("plugin frontend asset must be an exact relative URL path")
+        target = safe_child_path(root, cleaned_asset)
     if target.is_dir():
-        target = target / "index.html"
+        relative = target.relative_to(root) / "index.html"
+        target = safe_child_path(root, relative.as_posix())
     if not target.is_file():
         raise FileNotFoundError(target.as_posix())
     return target

--- a/frontend_bridge_core/routes/api.py
+++ b/frontend_bridge_core/routes/api.py
@@ -4,8 +4,7 @@ import hmac
 import ipaddress
 import json
 import mimetypes
-import shutil
-import tempfile
+import os
 import threading
 from http.cookies import SimpleCookie
 from email.parser import BytesParser
@@ -14,9 +13,30 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any, Callable
-from urllib.parse import parse_qs, quote, unquote, urlparse, urlunparse
+from urllib.parse import (
+    parse_qs,
+    parse_qsl,
+    quote,
+    unquote,
+    unquote_to_bytes,
+    urlencode,
+    urlparse,
+    urlunparse,
+)
 
+from sdk.file_transactions import (
+    create_private_temporary_directory,
+    remove_directory_without_links,
+    write_bytes_exclusive,
+)
 from sdk.logging import get_logger, log_context, new_log_id
+from sdk.path_contract import (
+    app_root,
+    relative_path_has_prefix,
+    resolve_runtime_asset_read_path,
+    source_root,
+)
+from sdk.path_references import portable_path_text, state_project_root
 
 from frontend_bridge_core.backgrounds import (
     _delete_all_background_bgm,
@@ -160,14 +180,14 @@ from application.runtime.dependencies import (
     runtime_dependency_error_from_text,
 )
 from frontend_bridge_core.security import (
+    safe_child_path,
     safe_content_disposition,
     safe_header_value,
+    safe_project_path,
 )
 from sdk.path_utils import (
     reject_control_chars,
-    safe_child_path,
     safe_filename,
-    safe_project_path,
 )
 from application.runtime.state import BridgeState, _jsonify, plugin_load_snapshot
 from frontend_bridge_core.static import _frontend_dist_root
@@ -223,6 +243,68 @@ _POLLING_PATHS = {
     "/api/model-assets/status",
     "/api/plugins/status",
 }
+
+
+def _cleanup_upload_directory(
+    path: Path,
+    expected_identity: os.stat_result,
+) -> None:
+    try:
+        remove_directory_without_links(
+            path,
+            expected_identity=expected_identity,
+        )
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+
+
+def _validate_percent_encoding(value: str) -> None:
+    index = 0
+    while index < len(value):
+        if value[index] != "%":
+            index += 1
+            continue
+        if (
+            index + 2 >= len(value)
+            or value[index + 1] not in "0123456789abcdefABCDEF"
+            or value[index + 2] not in "0123456789abcdefABCDEF"
+        ):
+            raise ValueError("URL contains an invalid percent escape")
+        index += 3
+
+
+def _decode_url_component_once(value: str) -> str:
+    """Strictly decode one URL component without replacement characters."""
+
+    _validate_percent_encoding(value)
+    return unquote_to_bytes(value).decode("utf-8", errors="strict")
+
+
+def _parse_query(value: str) -> dict[str, list[str]]:
+    """Decode a query exactly once and reject malformed encoding."""
+
+    _validate_percent_encoding(value)
+    return parse_qs(value, keep_blank_values=True, errors="strict")
+
+
+def _query_value(query: dict[str, list[str]], name: str) -> str:
+    """Return a scalar after the query's single decoding pass."""
+
+    return (query.get(name) or [""])[0]
+
+
+_MULTIPART_UPLOAD_PATHS = frozenset(
+    {
+        "/api/backgrounds/import-upload",
+        "/api/characters/import-upload",
+        "/api/characters/memories/import-preview-upload",
+        "/api/characters/memories/import-upload",
+        "/api/effects/import-upload",
+        "/api/logs/import-upload",
+        "/api/chat/attachments/upload",
+        "/api/chat/themes/upload",
+    }
+)
 
 
 def _safe_export_output_path(name: str, suffix: str) -> tuple[Path, str]:
@@ -353,7 +435,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         if header_token:
             return header_token
         parsed = urlparse(getattr(self, "path", ""))
-        query = parse_qs(parsed.query)
+        query = _parse_query(parsed.query)
         query_token = str(
             (query.get(BRIDGE_AUTH_QUERY) or query.get("token") or [""])[0]
         ).strip()
@@ -399,9 +481,21 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             return detail
         for page in detail.get("pages") or []:
             url = str(page.get("frontendUrl") or "")
-            if url.startswith("/api/") and BRIDGE_AUTH_QUERY not in url:
-                sep = "&" if "?" in url else "?"
-                page["frontendUrl"] = f"{url}{sep}{BRIDGE_AUTH_QUERY}={quote(token, safe='')}"
+            if not url.startswith("/api/"):
+                continue
+            parsed = urlparse(url)
+            query = [
+                (key, value)
+                for key, value in parse_qsl(
+                    parsed.query,
+                    keep_blank_values=True,
+                )
+                if key != BRIDGE_AUTH_QUERY
+            ]
+            query.append((BRIDGE_AUTH_QUERY, token))
+            page["frontendUrl"] = urlunparse(
+                parsed._replace(query=urlencode(query, doseq=True))
+            )
         return detail
 
     def _require_authorized_write(self, path: str) -> None:
@@ -546,35 +640,48 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             raise ValueError("request body must be a JSON object")
         return data
 
-    def _read_upload_files(self) -> tuple[Path, list[Path]]:
+    def _read_upload_files(
+        self,
+    ) -> tuple[Path, os.stat_result, list[Path]]:
         ctype = self.headers.get("Content-Type", "")
         if not ctype.lower().startswith("multipart/form-data"):
             raise ValueError("request must be multipart/form-data")
         length = int(self.headers.get("Content-Length") or "0")
         if length <= 0:
             raise ValueError("request body is empty")
-        temp_dir = Path(tempfile.mkdtemp(prefix="shinsekai-frontend-upload-"))
-        body = self.rfile.read(length)
-        message = BytesParser(policy=default_email_policy).parsebytes(
-            f"Content-Type: {ctype}\r\nMIME-Version: 1.0\r\n\r\n".encode("utf-8") + body
+        temp_dir, temp_dir_identity = create_private_temporary_directory(
+            prefix="shinsekai-frontend-upload-",
         )
-        paths: list[Path] = []
-        for part in message.iter_parts():
-            if part.get_content_disposition() != "form-data":
-                continue
-            if part.get_param("name", header="content-disposition") != "files":
-                continue
-            try:
-                filename = safe_filename(str(part.get_filename() or ""))
-            except ValueError:
-                continue
-            dest = safe_child_path(temp_dir, filename)
-            dest.write_bytes(part.get_payload(decode=True) or b"")
-            paths.append(dest)
-        if not paths:
-            shutil.rmtree(temp_dir, ignore_errors=True)
-            raise ValueError("no files uploaded")
-        return temp_dir, paths
+        try:
+            body = self.rfile.read(length)
+            message = BytesParser(policy=default_email_policy).parsebytes(
+                f"Content-Type: {ctype}\r\nMIME-Version: 1.0\r\n\r\n".encode("utf-8")
+                + body
+            )
+            paths: list[Path] = []
+            for part in message.iter_parts():
+                if part.get_content_disposition() != "form-data":
+                    continue
+                if part.get_param("name", header="content-disposition") != "files":
+                    continue
+                try:
+                    filename = safe_filename(str(part.get_filename() or ""))
+                except ValueError:
+                    continue
+                paths.append(
+                    write_bytes_exclusive(
+                        temp_dir,
+                        filename,
+                        part.get_payload(decode=True) or b"",
+                        field="upload filename",
+                    )
+                )
+            if not paths:
+                raise ValueError("no files uploaded")
+            return temp_dir, temp_dir_identity, paths
+        except BaseException:
+            _cleanup_upload_directory(temp_dir, temp_dir_identity)
+            raise
 
     def do_OPTIONS(self) -> None:  # noqa: N802
         if not self._request_origin_allowed():
@@ -622,7 +729,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif path == "/api/plugins/status":
                 self._send_json(plugin_load_snapshot(self.state))
             elif path.startswith("/api/plugins/") and path.endswith("/ui"):
-                plugin_id = unquote(path[len("/api/plugins/") : -len("/ui")])
+                plugin_id = _decode_url_component_once(path[len("/api/plugins/") : -len("/ui")])
                 self._send_json(self._inject_bridge_token(_plugin_ui_detail(plugin_id)))
             elif path.startswith("/api/plugins/") and "/frontend/" in path:
                 rest = path[len("/api/plugins/") :]
@@ -630,9 +737,9 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 page_part, _, asset_part = frontend_tail.partition("/")
                 self._send_local_file(
                     _resolve_plugin_frontend_file(
-                        unquote(plugin_part),
-                        unquote(page_part),
-                        unquote(asset_part),
+                        _decode_url_component_once(plugin_part),
+                        _decode_url_component_once(page_part),
+                        _decode_url_component_once(asset_part),
                     ),
                     send_body=True,
                 )
@@ -643,7 +750,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif path == "/api/mcp/config":
                 self._send_json(_mcp_config_response())
             elif path.startswith("/api/tasks/"):
-                task_id = unquote(path.rsplit("/", 1)[-1])
+                task_id = _decode_url_component_once(path.rsplit("/", 1)[-1])
                 self._send_json(_get_task(self.state, task_id))
             elif path == "/api/chat/runtime-status":
                 self._send_json(_chat_runtime_status(self.state))
@@ -656,8 +763,8 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif path == "/api/chat/history-file":
                 if not self._request_origin_allowed():
                     raise PermissionError("request origin is not allowed")
-                query = parse_qs(parsed.query)
-                capability = str((query.get("cap") or [""])[0])
+                query = _parse_query(parsed.query)
+                capability = _query_value(query, "cap")
                 self._send_local_file(
                     _chat_history_download_file(self.state, capability),
                     attachment=True,
@@ -669,21 +776,21 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif path == "/api/chat/themes/active":
                 self._send_json(get_active_chat_theme_id(self.state))
             elif path.startswith("/api/chat/themes/"):
-                theme_id = unquote(path[len("/api/chat/themes/"):])
+                theme_id = _decode_url_component_once(path[len("/api/chat/themes/"):])
                 self._send_json(get_chat_theme_manifest(self.state, theme_id))
             elif path == "/api/download":
-                query = parse_qs(parsed.query)
-                target = unquote((query.get("path") or [""])[0])
+                query = _parse_query(parsed.query)
+                target = _query_value(query, "path")
                 self._send_file(target, attachment=True)
             elif path == "/api/media":
                 self._require_authorized_media_read()
-                query = parse_qs(parsed.query)
-                target = unquote((query.get("path") or [""])[0])
+                query = _parse_query(parsed.query)
+                target = _query_value(query, "path")
                 self._send_media_file(target)
             elif path == "/api/media/thumbnail":
-                query = parse_qs(parsed.query)
-                target = unquote((query.get("path") or [""])[0])
-                size = (query.get("size") or ["160"])[0]
+                query = _parse_query(parsed.query)
+                target = _query_value(query, "path")
+                size = _query_value(query, "size") or "160"
                 self._send_media_thumbnail(target, size)
             elif path.startswith("/assets/") or path.startswith("/data/"):
                 self._send_file(path.lstrip("/"))
@@ -705,26 +812,26 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             if path == "/api/chat/history-file":
                 if not self._request_origin_allowed():
                     raise PermissionError("request origin is not allowed")
-                query = parse_qs(parsed.query)
-                capability = str((query.get("cap") or [""])[0])
+                query = _parse_query(parsed.query)
+                capability = _query_value(query, "cap")
                 self._send_local_file(
                     _chat_history_download_file(self.state, capability),
                     attachment=True,
                     send_body=False,
                 )
             elif path == "/api/download":
-                query = parse_qs(parsed.query)
-                target = unquote((query.get("path") or [""])[0])
+                query = _parse_query(parsed.query)
+                target = _query_value(query, "path")
                 self._send_file(target, attachment=True, send_body=False)
             elif path == "/api/media":
                 self._require_authorized_media_read()
-                query = parse_qs(parsed.query)
-                target = unquote((query.get("path") or [""])[0])
+                query = _parse_query(parsed.query)
+                target = _query_value(query, "path")
                 self._send_media_file(target, send_body=False)
             elif path == "/api/media/thumbnail":
-                query = parse_qs(parsed.query)
-                target = unquote((query.get("path") or [""])[0])
-                size = (query.get("size") or ["160"])[0]
+                query = _parse_query(parsed.query)
+                target = _query_value(query, "path")
+                size = _query_value(query, "size") or "160"
                 self._send_media_thumbnail(target, size, send_body=False)
             elif path.startswith("/api/plugins/") and "/frontend/" in path:
                 rest = path[len("/api/plugins/") :]
@@ -732,9 +839,9 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 page_part, _, asset_part = frontend_tail.partition("/")
                 self._send_local_file(
                     _resolve_plugin_frontend_file(
-                        unquote(plugin_part),
-                        unquote(page_part),
-                        unquote(asset_part),
+                        _decode_url_component_once(plugin_part),
+                        _decode_url_component_once(page_part),
+                        _decode_url_component_once(asset_part),
                     ),
                     send_body=False,
                 )
@@ -767,15 +874,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         try:
             path = urlparse(self.path).path
             self._require_authorized_write(path)
-            is_upload = method == "POST" and path in {
-                "/api/characters/import-upload",
-                "/api/characters/memories/import-preview-upload",
-                "/api/characters/memories/import-upload",
-                "/api/backgrounds/import-upload",
-                "/api/logs/import-upload",
-                "/api/chat/themes/upload",
-                "/api/chat/attachments/upload",
-            }
+            is_upload = method == "POST" and path in _MULTIPART_UPLOAD_PATHS
             body = {} if method == "DELETE" or is_upload else self._read_json()
             if method in {"POST", "PUT"} and path == "/api/config/api":
                 self._send_json(_save_api_config(self.state, body))
@@ -823,11 +922,11 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                     )
                 )
             elif method == "POST" and path == "/api/logs/import-upload":
-                temp_dir, paths = self._read_upload_files()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
                 try:
                     self._send_json(_log_snapshot(paths[0], roots=(temp_dir,)))
                 finally:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
             elif method == "POST" and path == "/api/logs/diagnostic-bundle":
                 self._send_json(_diagnostic_bundle(Path.cwd().resolve()))
             elif method == "POST" and path == "/api/music-cover/search":
@@ -869,7 +968,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                             worker=lambda task_id: _download_model_asset(self.state, task_id, spec),
                         )
             elif method == "POST" and path.startswith("/api/tasks/") and path.endswith("/cancel"):
-                task_id = unquote(path[len("/api/tasks/") : -len("/cancel")])
+                task_id = _decode_url_component_once(path[len("/api/tasks/") : -len("/cancel")])
                 self._send_json(_request_task_cancel(self.state, task_id))
             elif method in {"POST", "PUT"} and path == "/api/characters":
                 self._send_json(_save_character(self.state, body))
@@ -878,20 +977,35 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif method == "POST" and path == "/api/characters/translate":
                 self._send_json(_translate_character_fields(self.state, body))
             elif method == "POST" and path == "/api/characters/memories/status":
-                self._send_json(_get_mem0_status())
+                self._send_json(_get_mem0_status(self.state))
             elif method == "POST" and path == "/api/characters/memories/list":
-                self._send_json(_list_character_memories(str(body.get("name") or "")))
+                self._send_json(
+                    _list_character_memories(
+                        str(body.get("name") or ""),
+                        state=self.state,
+                    )
+                )
             elif method == "POST" and path == "/api/characters/memories/add":
-                self._send_json(_add_character_memory(str(body.get("name") or ""), str(body.get("content") or "")))
+                self._send_json(
+                    _add_character_memory(
+                        str(body.get("name") or ""),
+                        str(body.get("content") or ""),
+                        state=self.state,
+                    )
+                )
             elif method == "POST" and path == "/api/characters/memories/delete":
                 self._send_json(
-                    _delete_character_memory(str(body.get("name") or ""), str(body.get("memoryId") or ""))
+                    _delete_character_memory(
+                        str(body.get("name") or ""),
+                        str(body.get("memoryId") or ""),
+                        state=self.state,
+                    )
                 )
             elif method == "POST" and path == "/api/characters/memories/import-preview-upload":
-                temp_dir, paths = self._read_upload_files()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
                 try:
-                    query = parse_qs(urlparse(self.path).query)
-                    name = str((query.get("name") or [""])[0])
+                    query = _parse_query(urlparse(self.path).query)
+                    name = _query_value(query, "name")
                     self._send_json(
                         _preview_character_memory_import(
                             self.state,
@@ -901,11 +1015,11 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                         )
                     )
                 finally:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
             elif method == "POST" and path == "/api/characters/memories/import-upload":
-                temp_dir, paths = self._read_upload_files()
-                query = parse_qs(urlparse(self.path).query)
-                name = str((query.get("name") or [""])[0]).strip()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
+                query = _parse_query(urlparse(self.path).query)
+                name = _query_value(query, "name").strip()
 
                 def run_uploaded_memory_import(task_id: str) -> dict[str, Any]:
                     try:
@@ -917,7 +1031,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                             source_root=temp_dir,
                         )
                     finally:
-                        shutil.rmtree(temp_dir, ignore_errors=True)
+                        _cleanup_upload_directory(temp_dir, temp_dir_identity)
 
                 try:
                     self._enqueue_background_task(
@@ -927,18 +1041,29 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                         worker=run_uploaded_memory_import,
                     )
                 except Exception:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
                     raise
             elif method == "POST" and path == "/api/memory/status":
-                self._send_json(_get_mem0_status(start_loading=bool(body.get("startLoading", True))))
+                self._send_json(
+                    _get_mem0_status(
+                        self.state,
+                        start_loading=bool(body.get("startLoading", True)),
+                    )
+                )
             elif method == "POST" and path == "/api/memory/list":
-                self._send_json(_list_character_memories(str(body.get("name") or body.get("characterName") or "")))
+                self._send_json(
+                    _list_character_memories(
+                        str(body.get("name") or body.get("characterName") or ""),
+                        state=self.state,
+                    )
+                )
             elif method == "POST" and path == "/api/memory/search":
                 self._send_json(
                     _memory_tool_search(
                         str(body.get("query") or ""),
                         str(body.get("characterName") or body.get("character_name") or ""),
                         int(body.get("limit") or 10),
+                        state=self.state,
                     )
                 )
             elif method == "POST" and path == "/api/memory/remember":
@@ -946,10 +1071,16 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                     _memory_tool_remember(
                         str(body.get("content") or ""),
                         str(body.get("characterName") or body.get("character_name") or ""),
+                        state=self.state,
                     )
                 )
             elif method == "POST" and path == "/api/memory/forget":
-                self._send_json(_memory_tool_forget(str(body.get("memoryId") or body.get("memory_id") or "")))
+                self._send_json(
+                    _memory_tool_forget(
+                        str(body.get("memoryId") or body.get("memory_id") or ""),
+                        state=self.state,
+                    )
+                )
             elif method == "POST" and path == "/api/characters/sprite-voice/upload":
                 self._send_json(_upload_sprite_voice(self.state, body))
             elif method == "POST" and path == "/api/characters/sprites/upload":
@@ -979,10 +1110,10 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif method == "POST" and path == "/api/characters/sprite-voice/delete":
                 self._send_json(_delete_sprite_voice(self.state, body))
             elif method == "DELETE" and path.startswith("/api/chat/themes/"):
-                theme_id = unquote(path[len("/api/chat/themes/"):])
+                theme_id = _decode_url_component_once(path[len("/api/chat/themes/"):])
                 self._send_json(delete_chat_theme(self.state, theme_id))
             elif method == "DELETE" and path.startswith("/api/characters/"):
-                name = unquote(path.rsplit("/", 1)[-1])
+                name = _decode_url_component_once(path.rsplit("/", 1)[-1])
                 message, names = self.state.character_manager.delete_character(name)
                 self._send_json({"message": message, "names": names})
             elif method == "POST" and path == "/api/characters/import":
@@ -997,7 +1128,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 self.state.config_manager.reload()
                 self._send_json([item.__dict__ for item in imported])
             elif method == "POST" and path == "/api/characters/import-upload":
-                temp_dir, paths = self._read_upload_files()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
                 try:
                     import tools.file_util as file_util
 
@@ -1007,7 +1138,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                     self.state.config_manager.reload()
                     self._send_json([item.__dict__ for item in imported])
                 finally:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
             elif method == "POST" and path == "/api/characters/export":
                 name = str(body.get("name") or "")
                 character = self.state.config_manager.get_character_by_name(name)
@@ -1054,7 +1185,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif method in {"POST", "PUT"} and path == "/api/backgrounds":
                 self._send_json(_save_background(self.state, body))
             elif method == "DELETE" and path.startswith("/api/backgrounds/"):
-                name = unquote(path.rsplit("/", 1)[-1])
+                name = _decode_url_component_once(path.rsplit("/", 1)[-1])
                 message, names = self.state.background_manager.delete_background(name)
                 if message.startswith("找不到") or message.startswith("请选择") or "失败" in message:
                     raise RuntimeError(message)
@@ -1065,11 +1196,11 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                     raise ValueError("paths must be a list")
                 self._send_json(self._import_background_paths([str(item) for item in paths]))
             elif method == "POST" and path == "/api/backgrounds/import-upload":
-                temp_dir, paths = self._read_upload_files()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
                 try:
                     self._send_json(self._import_background_paths([str(item) for item in paths]))
                 finally:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
             elif method == "POST" and path == "/api/backgrounds/export":
                 name = str(body.get("name") or "")
                 background = self.state.config_manager.get_background_by_name(name)
@@ -1097,7 +1228,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif method in {"POST", "PUT"} and path == "/api/effects":
                 self._send_json(_save_effect(self.state, body))
             elif method == "DELETE" and path.startswith("/api/effects/"):
-                name = unquote(path.rsplit("/", 1)[-1])
+                name = _decode_url_component_once(path.rsplit("/", 1)[-1])
                 self._send_json(_delete_effect(self.state, name))
             elif method == "POST" and path == "/api/effects/import":
                 paths = body.get("paths") or []
@@ -1105,11 +1236,11 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                     raise ValueError("paths must be a list")
                 self._send_json(self._import_effect_paths([str(item) for item in paths]))
             elif method == "POST" and path == "/api/effects/import-upload":
-                temp_dir, paths = self._read_upload_files()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
                 try:
                     self._send_json(self._import_effect_paths([str(item) for item in paths]))
                 finally:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
             elif method == "POST" and path == "/api/effects/export":
                 name = _validate_effect_storage_name(str(body.get("name") or ""))
                 effect = self.state.config_manager.get_effect_by_name(name)
@@ -1231,7 +1362,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                     worker=lambda task_id: _run_app_update(self.state, task_id, body),
                 )
             elif method == "POST" and path.startswith("/api/plugins/") and path.endswith("/enabled"):
-                plugin_id = unquote(path[len("/api/plugins/") : -len("/enabled")])
+                plugin_id = _decode_url_component_once(path[len("/api/plugins/") : -len("/enabled")])
                 self._send_json(_set_plugin_enabled(plugin_id, bool(body.get("enabled"))))
             elif method == "POST" and path.startswith("/api/plugins/") and "/chat-ui/" in path and path.endswith("/run"):
                 rest = path[len("/api/plugins/") :]
@@ -1239,8 +1370,8 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 contribution_part = contribution_tail[: -len("/run")]
                 self._send_json(
                     _run_frontend_chat_ui_contribution(
-                        unquote(plugin_part),
-                        unquote(contribution_part),
+                        _decode_url_component_once(plugin_part),
+                        _decode_url_component_once(contribution_part),
                     )
                 )
             elif method == "POST" and path.startswith("/api/plugins/") and "/ui/" in path and "/actions/" in path:
@@ -1250,9 +1381,9 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 page_part, _, action_tail = ui_tail.partition("/actions/")
                 self._send_json(
                     _run_plugin_ui_action(
-                        unquote(plugin_part),
-                        unquote(page_part),
-                        unquote(action_tail),
+                        _decode_url_component_once(plugin_part),
+                        _decode_url_component_once(page_part),
+                        _decode_url_component_once(action_tail),
                         body,
                     )
                 )
@@ -1262,13 +1393,13 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 page_part = page_tail[: -len("/config")]
                 self._send_json(
                     _save_plugin_ui_config(
-                        unquote(plugin_part),
-                        unquote(page_part),
+                        _decode_url_component_once(plugin_part),
+                        _decode_url_component_once(page_part),
                         body,
                     )
                 )
             elif method == "DELETE" and path.startswith("/api/plugins/"):
-                plugin_id = unquote(path[len("/api/plugins/") :])
+                plugin_id = _decode_url_component_once(path[len("/api/plugins/") :])
                 self._send_json(_uninstall_plugin(plugin_id))
             elif method == "POST" and path == "/api/runtime/install-missing-dependency":
                 module_name = str(body.get("moduleName") or "").strip()
@@ -1300,19 +1431,19 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             elif method == "POST" and path == "/api/chat/themes/save":
                 self._send_json(save_chat_theme(self.state, body))
             elif method == "POST" and path == "/api/chat/themes/upload":
-                temp_dir, paths = self._read_upload_files()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
                 try:
                     if not paths:
                         raise ValueError("未收到主题压缩包")
                     self._send_json(install_theme_from_zip(self.state, paths[0]))
                 finally:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
             elif method == "POST" and path == "/api/chat/attachments/upload":
-                temp_dir, paths = self._read_upload_files()
+                temp_dir, temp_dir_identity, paths = self._read_upload_files()
                 try:
                     self._send_json({"attachments": stage_uploaded_chat_attachments(paths)})
                 finally:
-                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    _cleanup_upload_directory(temp_dir, temp_dir_identity)
             else:
                 self._send_error_json(FileNotFoundError(path), HTTPStatus.NOT_FOUND)
         except Exception as exc:
@@ -1667,40 +1798,26 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         )
 
     def _resolve_project_path(self, raw_path: str) -> Path:
-        raw = str(raw_path or "").strip()
+        raw = portable_path_text(raw_path, field="project path")
         if not raw:
             raise FileNotFoundError(raw_path)
-        if Path(raw).is_absolute():
-            return safe_project_path(raw)
+        return safe_project_path(raw, root=state_project_root(self.state))
 
-        candidates: list[str] = [raw]
-        slash_path = raw.replace("\\", "/")
-        if slash_path != raw:
-            candidates.append(slash_path)
-
-        parts = [part for part in slash_path.split("/") if part and part != "."]
-        if len(parts) >= 5 and parts[0] == "data":
-            family, prefix = parts[1], parts[2]
-            if parts[3] == family and parts[4] == prefix:
-                candidates.append("/".join(parts[:3] + parts[5:]))
-            if family in {"backgrounds", "bgm", "speech", "sprite"}:
-                candidates.append("/".join(parts[:3] + [parts[-1]]))
-
-        first_valid: Path | None = None
-        seen: set[str] = set()
-        for candidate in candidates:
-            if candidate in seen:
-                continue
-            seen.add(candidate)
-            path = safe_project_path(candidate)
-            if first_valid is None:
-                first_valid = path
-            if path.is_file():
-                return path
-        return first_valid if first_valid is not None else safe_project_path(raw)
+    def _resolve_resource_path(self, raw_path: str) -> Path:
+        raw = portable_path_text(raw_path, field="resource path")
+        if not relative_path_has_prefix(
+            raw,
+            (("assets",),),
+            field="resource path",
+        ):
+            raise PermissionError("resource path is outside application assets")
+        return resolve_runtime_asset_read_path(
+            raw,
+            root=state_project_root(self.state),
+        )
 
     def _resolve_media_path(self, raw_path: str) -> Path:
-        raw = str(raw_path or "").strip()
+        raw = portable_path_text(raw_path, field="media path")
         if not raw:
             raise FileNotFoundError(raw_path)
         if is_absolute_local_media_path_text(raw):
@@ -1719,13 +1836,27 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 raw,
                 approved_paths=approved_paths,
             )
+        if relative_path_has_prefix(
+            raw,
+            (("assets",),),
+            field="media path",
+        ):
+            return validate_readable_media_file(
+                self._resolve_resource_path(raw),
+                roots=[source_root(), app_root()],
+            )
         return validate_readable_media_file(
             self._resolve_project_path(raw),
-            roots=[Path.cwd()],
+            roots=[state_project_root(self.state)],
         )
 
     def _resolve_static_path(self, root: Path, request_path: str) -> Path:
-        return safe_child_path(root, request_path)
+        decoded_path = _decode_url_component_once(request_path)
+        if not decoded_path.startswith("/"):
+            raise ValueError(
+                "frontend request path must start with exactly one slash"
+            )
+        return safe_child_path(root, decoded_path[1:])
 
     def _media_thumbnail_batch_response(self, body: dict[str, Any]) -> dict[str, Any]:
         raw_paths = body.get("paths") or []

--- a/frontend_bridge_core/security.py
+++ b/frontend_bridge_core/security.py
@@ -1,43 +1,82 @@
 from __future__ import annotations
 
 import ipaddress
+import os
 import re
+import stat
 from pathlib import Path
 from urllib.parse import quote, urlsplit, urlunsplit
 
-from sdk.path_utils import (
-    reject_control_chars,
-    safe_child_path,
-    safe_existing_dir_path,
-    safe_existing_file_path,
-    safe_existing_path,
-    safe_filename,
-    safe_project_path,
+from sdk.path_contract import (
+    path_is_link_or_reparse_point,
+    project_root,
+    require_symlink_free_absolute_path,
+    resolve_project_read_path,
+    safe_path_component,
+    safe_path_component_with_suffix,
+)
+
+from .path_utils import (
+    is_absolute_path_text,
+    is_windows_drive_relative_path_text,
+    resolved_path_is_within,
+    strip_windows_verbatim_prefix,
 )
 
 
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f\ud800-\udfff]")
 _HOST_RE = re.compile(r"^[A-Za-z0-9.-]+$")
 _SAFE_COMMAND_RE = re.compile(r"^[A-Za-z0-9._+-]+$")
 _SAFE_SEARCH_RE = re.compile(r"^[\w\s.,:;!?()\[\]'\"+&/@#-]{1,200}$", re.UNICODE)
 
 
+def portable_path_text(value: str | os.PathLike[str], *, field: str) -> str:
+    """Validate path text without silently changing the caller's filename."""
+
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _CONTROL_CHARS_RE.search(raw):
+        raise ValueError(
+            f"{field} is required and must not contain surrounding whitespace "
+            "or control characters"
+        )
+    return raw
+
+
+def reject_control_chars(value: str, *, field: str = "value") -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field} is required")
+    if _CONTROL_CHARS_RE.search(text):
+        raise ValueError(f"{field} contains control characters")
+    return text
+
+
 def safe_header_value(value: str) -> str:
-    validated = reject_control_chars(value, field="header")
-    # Keep the standard-library sanitizer shape visible to CodeQL in addition
-    # to the stricter control-character validation above.
-    return validated.replace("\r", "").replace("\n", "")
+    return reject_control_chars(value, field="header")
 
 
 def safe_content_disposition(filename: str) -> str:
-    safe_name = Path(safe_header_value(filename)).name
+    safe_name = Path(reject_control_chars(filename, field="filename")).name
     fallback = re.sub(r"[^A-Za-z0-9._-]+", "_", safe_name).strip("._") or "download"
     encoded = quote(safe_name, safe="")
     return f'attachment; filename="{fallback}"; filename*=UTF-8\'\'{encoded}'
 
 
+def download_url(path: str | os.PathLike[str]) -> str:
+    """Build one bridge download URL without changing the path identity."""
+
+    raw = portable_path_text(path, field="download path")
+    return f"/api/download?path={quote(raw, safe='')}"
+
+
 def _safe_host(host: str) -> str:
-    host = reject_control_chars(host, field="host").lower().rstrip(".")
-    if not _HOST_RE.fullmatch(host):
+    raw = portable_path_text(host, field="host").lower()
+    try:
+        return ipaddress.ip_address(raw).compressed
+    except ValueError:
+        pass
+    host = raw.rstrip(".")
+    if not host or not _HOST_RE.fullmatch(host):
         raise ValueError("URL host is invalid")
     return host
 
@@ -56,12 +95,26 @@ def validated_http_url(
     allow_private_hosts: bool = False,
     field: str = "url",
 ) -> str:
-    url = reject_control_chars(raw_url, field=field)
+    url = str(raw_url or "")
+    if (
+        not url
+        or url != url.strip()
+        or _CONTROL_CHARS_RE.search(url)
+        or "\\" in url
+    ):
+        raise ValueError(
+            f"{field} is required and must not contain surrounding whitespace, "
+            "control characters, or backslashes"
+        )
     parsed = urlsplit(url)
     if parsed.scheme not in {"http", "https"}:
         raise ValueError(f"{field} must use http or https")
     if not parsed.hostname:
         raise ValueError(f"{field} must include a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"{field} must not include credentials")
+    if parsed.fragment:
+        raise ValueError(f"{field} must not include a fragment")
 
     host = _safe_host(parsed.hostname)
     if allowed_hosts is not None and not host_matches(host, allowed_hosts):
@@ -72,18 +125,19 @@ def validated_http_url(
     except ValueError:
         ip = None
     if ip is not None:
-        if ip.is_loopback and not allow_localhost:
-            raise ValueError(f"{field} loopback IP is not allowed")
-        if ip.is_link_local or ip.is_reserved or ip.is_multicast:
+        if ip.is_loopback:
+            if not allow_localhost:
+                raise ValueError(f"{field} loopback IP is not allowed")
+        elif ip.is_link_local or ip.is_reserved or ip.is_multicast:
             raise ValueError(f"{field} special-use IP is not allowed")
-        if ip.is_private and not allow_private_hosts:
+        elif ip.is_private and not allow_private_hosts:
             raise ValueError(f"{field} private IP is not allowed")
     elif host in {"localhost", "localhost.localdomain"} and not allow_localhost:
         raise ValueError(f"{field} localhost is not allowed")
 
-    netloc = host
+    netloc = f"[{host}]" if ":" in host else host
     if parsed.port is not None:
-        netloc = f"{host}:{parsed.port}"
+        netloc = f"{netloc}:{parsed.port}"
     return urlunsplit((parsed.scheme, netloc, parsed.path or "", parsed.query or "", ""))
 
 
@@ -102,14 +156,139 @@ def validated_origin(raw_origin: str, *, allowed_ports: set[int]) -> str:
     return safe_header_value(origin)
 
 
+def _comparison_path(path: Path) -> str:
+    value = str(path)
+    if os.name == "nt":
+        value = strip_windows_verbatim_prefix(value)
+        return os.path.normcase(os.path.normpath(value))
+    return os.path.normpath(value)
+
+
+def _ensure_path_within_base(base: Path, resolved: Path, *, message: str) -> Path:
+    base_value = _comparison_path(base)
+    resolved_value = _comparison_path(resolved)
+    try:
+        common = os.path.commonpath([base_value, resolved_value])
+    except ValueError as exc:
+        raise PermissionError(f"{message} or uses a different drive") from exc
+    if common != base_value:
+        raise PermissionError(message)
+    # Comparison keys must never replace the native I/O path. In particular,
+    # keep a verbatim prefix when the caller supplied or inherited one.
+    return resolved
+
+
+def safe_project_path(raw_path: str | os.PathLike[str], root: Path | None = None) -> Path:
+    from sdk.path_contract import resolve_managed_project_path
+
+    base = project_root() if root is None else root
+    return resolve_managed_project_path(
+        portable_path_text(raw_path, field="path"),
+        root=base,
+    )
+
+
+def safe_child_path(base: Path, raw_path: str | os.PathLike[str]) -> Path:
+    root = require_symlink_free_absolute_path(base, field="base path")
+    raw = portable_path_text(raw_path, field="path")
+    if (
+        is_absolute_path_text(raw)
+        or is_windows_drive_relative_path_text(raw)
+        or "\\" in raw
+    ):
+        raise ValueError("child path must be a portable relative path")
+    parts = raw.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("child path must use exact relative components")
+    for part in parts:
+        safe_path_component(part, field="child path component")
+    candidate = root.joinpath(*parts)
+    if not resolved_path_is_within(candidate, root):
+        raise PermissionError("path is outside base path")
+    return require_symlink_free_absolute_path(candidate, field="child path")
+
+
+def safe_existing_path(
+    raw_path: str | os.PathLike[str],
+    *,
+    field: str = "path",
+    root: Path | None = None,
+) -> Path:
+    raw = portable_path_text(raw_path, field=field)
+    path = resolve_project_read_path(
+        raw,
+        root=project_root() if root is None else root,
+    )
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        raise FileNotFoundError(path) from None
+    return require_symlink_free_absolute_path(path, field=field)
+
+
+def safe_existing_file_path(
+    raw_path: str | os.PathLike[str],
+    *,
+    field: str = "path",
+    root: Path | None = None,
+) -> Path:
+    path = safe_existing_path(raw_path, field=field, root=root)
+    metadata = path.lstat()
+    if path_is_link_or_reparse_point(path) or not stat.S_ISREG(metadata.st_mode):
+        raise FileNotFoundError(path)
+    return path
+
+
+def safe_existing_dir_path(
+    raw_path: str | os.PathLike[str],
+    *,
+    field: str = "path",
+    root: Path | None = None,
+) -> Path:
+    path = safe_existing_path(raw_path, field=field, root=root)
+    metadata = path.lstat()
+    if path_is_link_or_reparse_point(path) or not stat.S_ISDIR(metadata.st_mode):
+        raise NotADirectoryError(path)
+    return path
+
+
+def safe_filename(raw_name: str, *, default_suffix: str = "") -> str:
+    raw = portable_path_text(raw_name, field="filename")
+    if "/" in raw or "\\" in raw:
+        raise ValueError("filename must not contain path separators")
+    name = Path(raw).name
+    if not name or name in {".", ".."}:
+        raise ValueError("filename is invalid")
+    if name != raw:
+        raise ValueError("filename must not contain path separators")
+    if default_suffix:
+        if name.casefold().endswith(default_suffix.casefold()):
+            name = f"{name[:-len(default_suffix)]}{default_suffix}"
+        else:
+            return safe_path_component_with_suffix(
+                name,
+                default_suffix,
+                field="filename",
+            )
+    return safe_path_component(name, field="filename")
+
+
 def safe_executable(raw_executable: str, *, default: str) -> str:
-    raw = str(raw_executable or "").strip() or default
-    raw = reject_control_chars(raw, field="executable")
+    raw = str(raw_executable or "")
+    if not raw:
+        raw = default
+    if raw != raw.strip() or _CONTROL_CHARS_RE.search(raw):
+        raise ValueError(
+            "executable must not contain surrounding whitespace or control characters"
+        )
     if "/" not in raw and "\\" not in raw:
         if not _SAFE_COMMAND_RE.fullmatch(raw):
             raise ValueError("executable name is invalid")
         return raw
-    path = Path(raw).expanduser().resolve(strict=False)
+    path = Path(raw)
+    if not path.is_absolute():
+        raise ValueError("executable path must be absolute")
+    path = resolve_project_read_path(raw, root=project_root())
     if not path.is_file():
         raise FileNotFoundError(path)
     return str(path)

--- a/frontend_bridge_core/template_session.py
+++ b/frontend_bridge_core/template_session.py
@@ -1,0 +1,9 @@
+"""Compatibility alias for template-session persistence."""
+
+from __future__ import annotations
+
+import sys
+
+from application.chat import session_store as _implementation
+
+sys.modules[__name__] = _implementation


### PR DESCRIPTION
## What changed

Applies strict request, media, security, template, plugin, and storage path
handling throughout `frontend_bridge_core/`.

## Why

The frontend bridge accepts external request data and therefore must decode,
authorize, and resolve each path exactly once against an explicit root.

## Impact

Bridge APIs reject malformed encodings and unsafe file references while
preserving valid external media, chat, plugin, and template behavior.

## Root cause

Request parsing and path resolution were distributed across handlers, making
double decoding and mismatched authorization roots possible.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes
`frontend_bridge_core/`.
