### PR TITLE
fix(plugin-system): enforce migration-safe path contracts

### DIFF
--- a/plugin_system/host/service.py
+++ b/plugin_system/host/service.py
@@ -9,15 +9,26 @@ is available (``main`` entry and/or Settings UI). Safe to call multiple times (i
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from queue import Queue
+from threading import RLock
 from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import yaml
 
 from config.config_manager import ConfigManager
 from sdk.messages import UserInputMessage
+from sdk.file_transactions import atomic_write_text, read_text_without_links
+from sdk.path_contract import (
+    managed_project_directory,
+    managed_project_storage,
+    project_root,
+    resolve_managed_project_path,
+    resolve_project_path,
+    resolve_project_read_path,
+)
 from plugin_system.requirements.install import (
     ensure_plugin_site_packages_on_syspath,
     ensure_plugins_namespace_on_syspath,
@@ -42,12 +53,55 @@ logger = logging.getLogger(__name__)
 
 _MANIFEST = Path("data/config/plugins.yaml")
 _loaded: bool = False
+_loaded_project_root: Path | None = None
 _plugin_manager: PluginManager | None = None
 _plugin_tts_handlers: List["MessageHandler"] = []
 _plugin_ui_handlers: List["UIOutputMessageHandler"] = []
 _plugin_dag_yaml_paths: list[str] = []
 _plugin_workflow_contributions: list["WorkflowContribution"] = []
 _plugin_output_contract_patches: list["OutputContractPatch"] = []
+_PLUGIN_MANIFEST_LOCK = RLock()
+
+
+def _exact_manifest_entry(entry: str) -> str:
+    """Validate a plugin import entry without changing its identity."""
+
+    raw = str(entry or "")
+    if not raw:
+        return ""
+    if raw != raw.strip() or any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in raw
+    ):
+        raise ValueError(
+            "plugin manifest entry must not contain surrounding whitespace "
+            "or control characters"
+        )
+    return raw
+
+
+def _plugin_manifest_path(
+    path: Path | None = None,
+    *,
+    root: str | Path | None = None,
+) -> Path:
+    configured = path if path is not None else _MANIFEST
+    active_root = (
+        project_root()
+        if root is None
+        else resolve_project_path(".", root=root)
+    )
+    raw = os.fspath(configured)
+    candidate = Path(raw).expanduser()
+    if candidate.is_absolute():
+        try:
+            candidate.relative_to(active_root)
+        except ValueError:
+            return resolve_project_read_path(raw, root=active_root)
+        return resolve_managed_project_path(raw, root=active_root)
+    return resolve_managed_project_path(raw, root=active_root)
 
 
 @dataclass(frozen=True)
@@ -169,27 +223,51 @@ def ensure_plugins_loaded(
     config: ConfigManager | None = None,
     *,
     runtime_bindings: PluginRuntimeBindings | None = None,
+    root: str | Path | None = None,
 ) -> PluginManager | None:
     """
     Load ``data/config/plugins.yaml`` if present, instantiate plugins, merge adapter
     providers and vision fallbacks, register tools on the global ToolManager, and
     cache message handlers for :mod:`application.chat.handlers.registry`.
     """
-    global _loaded, _plugin_manager, _plugin_tts_handlers, _plugin_ui_handlers
+    global _loaded, _loaded_project_root, _plugin_manager
+    global _plugin_tts_handlers, _plugin_ui_handlers
     global _plugin_dag_yaml_paths
     global _plugin_workflow_contributions, _plugin_output_contract_patches
+    configured_root = root
+    if configured_root is None and config is not None:
+        configured_root = getattr(config, "_project_root", None)
+    active_root = (
+        project_root()
+        if configured_root is None
+        else resolve_project_path(".", root=configured_root)
+    )
     if _loaded:
+        if (
+            _loaded_project_root is not None
+            and _loaded_project_root != active_root
+        ):
+            raise RuntimeError(
+                "plugins are already loaded for a different project root"
+            )
         return _plugin_manager
 
-    ensure_plugins_namespace_on_syspath()
-    ensure_plugin_site_packages_on_syspath()
+    ensure_plugins_namespace_on_syspath(root=active_root)
+    ensure_plugin_site_packages_on_syspath(root=active_root)
 
-    mgr = PluginManager()
-    if _MANIFEST.is_file():
+    manifest = _plugin_manifest_path(root=active_root)
+    mgr = PluginManager(
+        plugin_data_root=managed_project_storage(
+            "data/plugins",
+            root=active_root,
+        ),
+        root=active_root,
+    )
+    if manifest.is_file():
         try:
-            mgr.load_manifest_file(_MANIFEST)
+            mgr.load_manifest_file(manifest)
         except Exception:
-            logger.exception("Failed to load plugin manifest %s", _MANIFEST)
+            logger.exception("Failed to load plugin manifest %s", manifest)
     mgr.instantiate_all()
     cfg = config if config is not None else ConfigManager()
     mgr.load_own_config_all(app_config=cfg)
@@ -256,6 +334,7 @@ def ensure_plugins_loaded(
         _plugin_output_contract_patches = []
 
     _plugin_manager = mgr
+    _loaded_project_root = active_root
     _loaded = True
     return _plugin_manager
 
@@ -352,19 +431,24 @@ def collect_chat_ui_contributions() -> List["ChatUIContribution"]:
     return []
 
 
-def read_plugin_manifest_items(path: Path | None = None) -> list[dict[str, Any]]:
+def read_plugin_manifest_items(
+    path: Path | None = None,
+    *,
+    root: str | Path | None = None,
+) -> list[dict[str, Any]]:
     """
     Return manifest rows as mutable dicts (shallow copy each), preserving list order.
     Only includes dict items with a non-empty string ``entry``.
     """
-    p = path if path is not None else _MANIFEST
-    if not p.is_file():
-        return []
-    try:
-        raw = yaml.safe_load(p.read_text(encoding="utf-8"))
-    except Exception:
-        logger.exception("Failed to parse plugin manifest %s", p)
-        return []
+    with _PLUGIN_MANIFEST_LOCK:
+        p = _plugin_manifest_path(path, root=root)
+        if not p.is_file():
+            return []
+        try:
+            raw = yaml.safe_load(read_text_without_links(p))
+        except Exception:
+            logger.exception("Failed to parse plugin manifest %s", p)
+            return []
     if raw is None:
         return []
     if not isinstance(raw, list):
@@ -374,42 +458,67 @@ def read_plugin_manifest_items(path: Path | None = None) -> list[dict[str, Any]]
         if not isinstance(item, dict):
             continue
         entry = item.get("entry")
-        if not isinstance(entry, str) or not entry.strip():
+        if not isinstance(entry, str):
+            continue
+        try:
+            if not _exact_manifest_entry(entry):
+                continue
+        except ValueError:
+            logger.warning("Ignoring invalid plugin manifest entry %r", entry)
             continue
         out.append(dict(item))
     return out
 
 
-def write_plugin_manifest_items(items: list[dict[str, Any]], path: Path | None = None) -> None:
+def write_plugin_manifest_items(
+    items: list[dict[str, Any]],
+    path: Path | None = None,
+    *,
+    root: str | Path | None = None,
+) -> None:
     """Overwrite manifest with ``items`` (YAML list of mappings)."""
-    p = path if path is not None else _MANIFEST
-    p.parent.mkdir(parents=True, exist_ok=True)
-    text = yaml.safe_dump(
-        items,
-        allow_unicode=True,
-        sort_keys=False,
-        default_flow_style=False,
-    )
-    p.write_text(text, encoding="utf-8")
+    with _PLUGIN_MANIFEST_LOCK:
+        for item in items:
+            entry = item.get("entry") if isinstance(item, dict) else None
+            if not isinstance(entry, str) or not _exact_manifest_entry(entry):
+                raise ValueError("plugin manifest items require an exact entry")
+        p = _plugin_manifest_path(path, root=root)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        text = yaml.safe_dump(
+            items,
+            allow_unicode=True,
+            sort_keys=False,
+            default_flow_style=False,
+        )
+        atomic_write_text(p, text)
 
 
-def set_plugin_manifest_enabled(entry: str, enabled: bool, path: Path | None = None) -> bool:
+def set_plugin_manifest_enabled(
+    entry: str,
+    enabled: bool,
+    path: Path | None = None,
+    *,
+    root: str | Path | None = None,
+) -> bool:
     """
     Set ``enabled`` on the manifest row whose ``entry`` matches (strip-wise).
     Returns True if a row was updated and the file was written.
     """
-    items = read_plugin_manifest_items(path)
-    norm = entry.strip()
-    changed = False
-    for item in items:
-        e = item.get("entry")
-        if isinstance(e, str) and e.strip() == norm:
-            item["enabled"] = bool(enabled)
-            changed = True
-            break
-    if changed:
-        write_plugin_manifest_items(items, path)
-    return changed
+    with _PLUGIN_MANIFEST_LOCK:
+        items = read_plugin_manifest_items(path, root=root)
+        norm = _exact_manifest_entry(entry)
+        if not norm:
+            return False
+        changed = False
+        for item in items:
+            e = item.get("entry")
+            if isinstance(e, str) and e == norm:
+                item["enabled"] = bool(enabled)
+                changed = True
+                break
+        if changed:
+            write_plugin_manifest_items(items, path, root=root)
+        return changed
 
 
 def normalize_manifest_entry(entry: str) -> str:
@@ -417,7 +526,7 @@ def normalize_manifest_entry(entry: str) -> str:
     Registry rows often omit the repo-local package root; downloaded plugins live under
     ``plugins/``, so ensure ``entry`` uses the ``plugins.`` module prefix when absent.
     """
-    norm = entry.strip()
+    norm = _exact_manifest_entry(entry)
     if not norm:
         return norm
     if norm.startswith("plugins."):
@@ -425,37 +534,64 @@ def normalize_manifest_entry(entry: str) -> str:
     return f"plugins.{norm}"
 
 
-def remove_plugin_manifest_entry(entry: str, path: Path | None = None) -> bool:
+def remove_plugin_manifest_entry(
+    entry: str,
+    path: Path | None = None,
+    *,
+    root: str | Path | None = None,
+) -> bool:
     """
     Remove the manifest row whose ``entry`` matches (strip-wise).
     Returns True if a row was removed and the file was written.
     """
-    norm = entry.strip()
-    items = read_plugin_manifest_items(path)
-    kept: list[dict[str, Any]] = []
-    removed = False
-    for item in items:
-        e = item.get("entry")
-        if isinstance(e, str) and e.strip() == norm:
-            removed = True
-            continue
-        kept.append(item)
-    if not removed:
-        return False
-    write_plugin_manifest_items(kept, path)
-    return True
+    with _PLUGIN_MANIFEST_LOCK:
+        norm = _exact_manifest_entry(entry)
+        if not norm:
+            return False
+        items = read_plugin_manifest_items(path, root=root)
+        kept: list[dict[str, Any]] = []
+        removed = False
+        for item in items:
+            e = item.get("entry")
+            if isinstance(e, str) and e == norm:
+                removed = True
+                continue
+            kept.append(item)
+        if not removed:
+            return False
+        write_plugin_manifest_items(kept, path, root=root)
+        return True
 
 
-def infer_plugin_package_directory(entry: str) -> Path | None:
+def infer_plugin_package_directory(
+    entry: str,
+    *,
+    root: str | Path | None = None,
+) -> Path | None:
     """
     Map manifest ``entry`` module path to ``plugins/<top-level-package>/``.
 
     Example: ``plugins.whisper_asr.plugin:WhisperAsrPlugin`` → ``plugins/whisper_asr``.
     """
-    raw = entry.strip()
+    try:
+        return managed_plugin_package_directory(entry, root=root)
+    except (OSError, PermissionError, ValueError):
+        return None
+
+
+def managed_plugin_package_directory(
+    entry: str,
+    *,
+    root: str | Path | None = None,
+) -> Path | None:
+    """Return the strict managed package directory for a manifest entry."""
+
+    raw = _exact_manifest_entry(entry)
     if not raw:
         return None
-    mod = raw.split(":", 1)[0].strip()
+    mod = raw.split(":", 1)[0]
+    if not mod or mod != mod.strip():
+        raise ValueError("plugin module entry is not exact")
     if not mod.startswith("plugins."):
         mod = normalize_manifest_entry(mod)
     if not mod.startswith("plugins."):
@@ -463,10 +599,14 @@ def infer_plugin_package_directory(entry: str) -> Path | None:
     rest = mod[len("plugins.") :]
     if not rest:
         return None
-    top = rest.split(".", 1)[0].strip()
+    top = rest.split(".", 1)[0]
     if not top:
         return None
-    return Path("plugins") / top
+    return managed_project_directory(
+        "plugins",
+        top,
+        root=project_root() if root is None else root,
+    )
 
 
 def append_plugin_manifest_entry_if_missing(
@@ -474,6 +614,7 @@ def append_plugin_manifest_entry_if_missing(
     *,
     enabled: bool = True,
     path: Path | None = None,
+    root: str | Path | None = None,
 ) -> str:
     """
     Append ``- entry: …`` row if not already present (strip-wise match on entry).
@@ -485,11 +626,12 @@ def append_plugin_manifest_entry_if_missing(
     norm = normalize_manifest_entry(entry)
     if not norm:
         return "empty"
-    items = read_plugin_manifest_items(path)
-    for item in items:
-        e = item.get("entry")
-        if isinstance(e, str) and e.strip() == norm:
-            return "exists"
-    items.append({"entry": norm, "enabled": bool(enabled)})
-    write_plugin_manifest_items(items, path)
-    return "added"
+    with _PLUGIN_MANIFEST_LOCK:
+        items = read_plugin_manifest_items(path, root=root)
+        for item in items:
+            e = item.get("entry")
+            if isinstance(e, str) and e == norm:
+                return "exists"
+        items.append({"entry": norm, "enabled": bool(enabled)})
+        write_plugin_manifest_items(items, path, root=root)
+        return "added"

--- a/plugin_system/install/package.py
+++ b/plugin_system/install/package.py
@@ -5,23 +5,51 @@ from __future__ import annotations
 import hashlib
 import os
 import socket
-import shutil
-import tempfile
+import threading
 import uuid
 import zipfile
+from contextlib import contextmanager
+from collections.abc import Iterator
 from http.client import IncompleteRead
-from pathlib import Path, PurePosixPath
+from io import BytesIO
+from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
+from sdk.archive_paths import UnsafeArchiveError, extract_zip_safely
+from sdk.file_transactions import (
+    copy_directory_without_links,
+    create_private_temporary_directory,
+    private_sibling_path,
+    remove_directory_without_links,
+    rename_path_without_overwrite,
+    replace_directory_transactionally,
+)
 from plugin_system.registry.catalog import RegistryPluginRecord
-from plugin_system.registry.download import sanitize_plugins_directory_name
+from plugin_system.registry.download import portable_plugin_target, sanitize_plugins_directory_name
+from sdk.path_contract import (
+    path_is_link_or_reparse_point,
+    project_root,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resolve_project_output_path,
+)
 
 _PACKAGE_USER_AGENT = (
     "EasyAIDesktopAssistant/1.0 (+plugin-package; https://github.com/RachelForster/Shinsekai-Plugin-Registry)"
 )
 _DEFAULT_MAX_BYTES = 16 * 1024 * 1024
+_PACKAGE_INSTALL_LOCK = threading.RLock()
+_UNSPECIFIED_IDENTITY = object()
+
+
+@contextmanager
+def registry_package_install_transaction() -> Iterator[None]:
+    """Serialize publication, dependency validation, and caller rollback."""
+
+    with _PACKAGE_INSTALL_LOCK:
+        yield
 
 
 class PluginPackageError(Exception):
@@ -100,7 +128,21 @@ def _validate_package_url(url: str) -> None:
             f"plugin package host is not allowed: {parsed.hostname}",
             code="package_host_not_allowed",
             user_message="官方包体来源不在允许列表内，已阻止安装。",
+)
+
+
+def _cleanup_private_tree(
+    path: Path,
+    *,
+    expected_identity: os.stat_result,
+) -> None:
+    try:
+        remove_directory_without_links(
+            path,
+            expected_identity=expected_identity,
         )
+    except (FileNotFoundError, OSError, ValueError):
+        pass
 
 
 def _is_transient_network_error(exc: BaseException) -> bool:
@@ -227,77 +269,71 @@ def _verify_package(body: bytes, *, expected_sha256: str, expected_size: int | N
         )
 
 
-def _safe_members(zf: zipfile.ZipFile) -> list[tuple[zipfile.ZipInfo, tuple[str, ...]]]:
-    infos = [info for info in zf.infolist() if info.filename and not info.is_dir()]
-    if not infos:
-        raise PluginPackageNonFallbackError(
-            "plugin package is empty",
-            code="package_bad_zip",
-            user_message="包体校验未通过，已阻止安装。",
-        )
-
-    roots: set[str] = set()
-    parsed: list[tuple[zipfile.ZipInfo, tuple[str, ...]]] = []
-    for info in infos:
-        path = PurePosixPath(info.filename)
-        parts = tuple(part for part in path.parts if part not in {"", "."})
-        if not parts or path.is_absolute() or any(part == ".." for part in parts):
-            raise PluginPackageNonFallbackError(
-                f"unsafe plugin package path: {info.filename}",
-                code="package_unsafe_path",
-                user_message="包体校验未通过，已阻止安装。",
-            )
-        roots.add(parts[0])
-        parsed.append((info, parts))
-
-    strip_root = len(roots) == 1
-    safe: list[tuple[zipfile.ZipInfo, tuple[str, ...]]] = []
-    for info, parts in parsed:
-        rel = parts[1:] if strip_root else parts
-        if rel:
-            safe.append((info, rel))
-    if not safe:
-        raise PluginPackageNonFallbackError(
-            "plugin package has no files after root normalization",
-            code="package_bad_zip",
-            user_message="包体校验未通过，已阻止安装。",
-        )
-    return safe
-
-
-def _extract_safe_zip(body: bytes) -> Path:
-    tmp_root = Path(tempfile.mkdtemp(prefix="shinsekai-plugin-package-"))
-    zip_path = tmp_root / "package.zip"
-    zip_path.write_bytes(body)
+def _extract_safe_zip(body: bytes) -> tuple[Path, os.stat_result, Path]:
+    tmp_root, tmp_root_identity = create_private_temporary_directory(
+        prefix="shinsekai-plugin-package-",
+    )
     try:
-        with zipfile.ZipFile(zip_path) as zf:
-            members = _safe_members(zf)
-            extract_root = (tmp_root / "extract").resolve(strict=False)
-            for info, rel_parts in members:
-                destination = (extract_root / Path(*rel_parts)).resolve(strict=False)
-                if extract_root != destination and extract_root not in destination.parents:
-                    raise PluginPackageNonFallbackError(
-                        f"unsafe plugin package path: {info.filename}",
-                        code="package_unsafe_path",
-                        user_message="包体校验未通过，已阻止安装。",
-                    )
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                with zf.open(info) as src, destination.open("wb") as dst:
-                    shutil.copyfileobj(src, dst)
+        # The package was already downloaded and verified as one in-memory
+        # byte string.  Decode that exact object instead of publishing a
+        # temporary pathname that could be replaced before ZipFile reopens it.
+        with zipfile.ZipFile(BytesIO(body)) as zf:
+            raw_root = tmp_root / "raw"
+            extraction = extract_zip_safely(zf, raw_root)
+        extract_root = tmp_root / "extract"
+        nested_root = raw_root / extraction.top_level if extraction.top_level else None
+        if nested_root is not None and nested_root.is_dir():
+            raw_root_identity = raw_root.lstat()
+            rename_path_without_overwrite(
+                nested_root,
+                extract_root,
+                expected_identity=nested_root.lstat(),
+            )
+            _cleanup_private_tree(
+                raw_root,
+                expected_identity=raw_root_identity,
+            )
+        else:
+            rename_path_without_overwrite(
+                raw_root,
+                extract_root,
+                expected_identity=raw_root.lstat(),
+            )
+    except UnsafeArchiveError as exc:
+        _cleanup_private_tree(
+            tmp_root,
+            expected_identity=tmp_root_identity,
+        )
+        raise PluginPackageNonFallbackError(
+            f"unsafe plugin package path: {exc}",
+            code="package_unsafe_path",
+            user_message="包体校验未通过，已阻止安装。",
+        ) from exc
     except zipfile.BadZipFile as exc:
-        shutil.rmtree(tmp_root, ignore_errors=True)
+        _cleanup_private_tree(
+            tmp_root,
+            expected_identity=tmp_root_identity,
+        )
         raise PluginPackageNonFallbackError(
             "plugin package is not a valid zip",
             code="package_bad_zip",
             user_message="包体校验未通过，已阻止安装。",
         ) from exc
     except Exception:
-        shutil.rmtree(tmp_root, ignore_errors=True)
+        _cleanup_private_tree(
+            tmp_root,
+            expected_identity=tmp_root_identity,
+        )
         raise
-    return tmp_root / "extract"
+    return tmp_root, tmp_root_identity, tmp_root / "extract"
 
 
-def registry_package_target(record: RegistryPluginRecord, *, plugins_parent: Path | None = None) -> Path:
+def registry_package_target(
+    record: RegistryPluginRecord,
+    *,
+    plugins_parent: Path | None = None,
+    root: str | Path | None = None,
+) -> Path:
     folder_name = sanitize_plugins_directory_name(record.name or record.id or record.display_name)
     if not folder_name:
         raise PluginPackageNonFallbackError(
@@ -305,28 +341,124 @@ def registry_package_target(record: RegistryPluginRecord, *, plugins_parent: Pat
             code="package_invalid_name",
             user_message="插件包体缺少安全的安装目录名，请等待维护者修复索引。",
         )
-    parent = Path(plugins_parent) if plugins_parent is not None else Path("plugins")
-    return parent / folder_name
-
-
-def _replace_directory(extracted: Path, target: Path) -> None:
-    target = target.resolve(strict=False)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    backup: Path | None = None
-    if target.exists():
-        backup = target.with_name(f".{target.name}.backup-{uuid.uuid4().hex}")
-        target.rename(backup)
+    active_root = project_root() if root is None else root
+    configured_parent = (
+        plugins_parent
+        if plugins_parent is not None
+        else Path(active_root) / "plugins"
+    )
+    unresolved_parent = Path(configured_parent)
+    if not unresolved_parent.is_absolute():
+        raise ValueError("plugins_parent must be absolute")
+    lexical_parent = require_symlink_free_absolute_path(
+        unresolved_parent,
+        field="plugins directory",
+    )
+    parent = resolve_project_output_path(
+        configured_parent,
+        root=active_root,
+    )
     try:
-        shutil.move(str(extracted), str(target))
-    except Exception:
-        if target.exists():
-            shutil.rmtree(target, ignore_errors=True)
-        if backup is not None and backup.exists():
-            backup.rename(target)
-        raise
-    else:
-        if backup is not None:
-            shutil.rmtree(backup, ignore_errors=True)
+        return portable_plugin_target(parent, folder_name)
+    except FileExistsError as exc:
+        raise PluginPackageNonFallbackError(
+            str(exc),
+            code="package_name_collision",
+            user_message="插件目录名与现有目录在其他系统上会发生冲突，已阻止安装。",
+        ) from exc
+
+
+def _replace_directory(
+    extracted: Path,
+    target: Path,
+    *,
+    overwrite: bool = True,
+    expected_target_identity: os.stat_result | None | object = (
+        _UNSPECIFIED_IDENTITY
+    ),
+    root: str | Path | None = None,
+) -> None:
+    if path_is_link_or_reparse_point(target):
+        raise PluginPackageNonFallbackError(
+            "plugin target must not be a symbolic link",
+            code="package_unsafe_target",
+            user_message="插件安装目录不安全，已阻止覆盖。",
+        )
+    try:
+        target_parent = require_symlink_free_absolute_path(
+            target.parent,
+            field="plugin target parent",
+        )
+        target_parent = resolve_project_output_path(
+            target_parent,
+            root=project_root() if root is None else root,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise PluginPackageNonFallbackError(
+            f"plugin target parent is unsafe: {exc}",
+            code="package_unsafe_target",
+            user_message="插件安装目录不安全，已阻止覆盖。",
+        ) from exc
+    target = target_parent / target.name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target_parent = require_directory_without_links(
+        target.parent,
+        field="plugin target parent",
+    )
+    target = target_parent / target.name
+    if target.exists() and not target.is_dir():
+        raise PluginPackageNonFallbackError(
+            "plugin target is not a directory",
+            code="package_unsafe_target",
+            user_message="插件安装目标不是目录，已阻止覆盖。",
+        )
+    if target.exists() and not overwrite:
+        raise FileExistsError(f"plugin target already exists: {target.name}")
+    try:
+        target_identity = target.lstat()
+    except FileNotFoundError:
+        target_identity = None
+    if expected_target_identity is not _UNSPECIFIED_IDENTITY:
+        if expected_target_identity is None:
+            if target_identity is not None:
+                raise FileExistsError(
+                    f"plugin target appeared before publication: {target.name}"
+                )
+        elif (
+            target_identity is None
+            or not os.path.samestat(expected_target_identity, target_identity)
+        ):
+            raise PermissionError(
+                f"plugin target identity changed before publication: {target}"
+            )
+    staging = private_sibling_path(
+        target,
+        f".install-{uuid.uuid4().hex}",
+        field="plugin installation staging directory",
+    )
+    staging_identity: os.stat_result | None = None
+    try:
+        # ``tempfile`` and the selected project can live on different Windows
+        # volumes.  Build a complete sibling first so publication never
+        # degrades into a partial cross-volume ``shutil.move`` copy.
+        staging = copy_directory_without_links(extracted, staging)
+        staging_identity = staging.lstat()
+        replace_directory_transactionally(
+            staging,
+            target,
+            overwrite=overwrite,
+            expected_staging_identity=staging_identity,
+            expected_destination_identity=target_identity,
+        )
+    finally:
+        if staging_identity is not None:
+            try:
+                remove_directory_without_links(
+                    staging,
+                    expected_identity=staging_identity,
+                )
+            except (OSError, ValueError):
+                pass
 
 
 def install_registry_package_under_plugins(
@@ -335,6 +467,10 @@ def install_registry_package_under_plugins(
     plugins_parent: Path | None = None,
     overwrite: bool = False,
     timeout_sec: float = 180.0,
+    expected_target_identity: os.stat_result | None | object = (
+        _UNSPECIFIED_IDENTITY
+    ),
+    root: str | Path | None = None,
 ) -> Path:
     """Download, verify, and extract an official registry package under ``plugins/``."""
     package_url = (record.package_url or record.download_url or "").strip()
@@ -346,9 +482,18 @@ def install_registry_package_under_plugins(
         )
     _validate_package_url(package_url)
 
-    target = registry_package_target(record, plugins_parent=plugins_parent)
-    if target.is_dir() and not overwrite:
-        return target.resolve(strict=False)
+    target = registry_package_target(
+        record,
+        plugins_parent=plugins_parent,
+        root=root,
+    )
+    with _PACKAGE_INSTALL_LOCK:
+        _assert_expected_plugin_target_identity(
+            target,
+            expected_target_identity,
+        )
+        if target.is_dir() and not overwrite:
+            return _verified_plugin_directory(target)
 
     download_id = str(uuid.uuid4())
     body = _read_url(
@@ -362,10 +507,69 @@ def install_registry_package_under_plugins(
         expected_sha256=(record.package_sha256 or record.sha256 or "").strip(),
         expected_size=record.package_size if record.package_size is not None else record.size,
     )
-    extracted = _extract_safe_zip(body)
-    tmp_root = extracted.parent
+    tmp_root, tmp_root_identity, extracted = _extract_safe_zip(body)
     try:
-        _replace_directory(extracted, target)
+        with _PACKAGE_INSTALL_LOCK:
+            # A peer can finish while this request is downloading.  Recheck
+            # the no-overwrite contract at publication time so a stale
+            # installer cannot replace the peer's complete tree.
+            if path_is_link_or_reparse_point(target):
+                raise PluginPackageNonFallbackError(
+                    "plugin target must not be a symbolic link",
+                    code="package_unsafe_target",
+                    user_message="插件安装目录不安全，已阻止覆盖。",
+                )
+            _assert_expected_plugin_target_identity(
+                target,
+                expected_target_identity,
+            )
+            if target.is_dir() and not overwrite:
+                return _verified_plugin_directory(target)
+            _replace_directory(
+                extracted,
+                target,
+                overwrite=overwrite,
+                expected_target_identity=expected_target_identity,
+                root=root,
+            )
     finally:
-        shutil.rmtree(tmp_root, ignore_errors=True)
-    return target.resolve(strict=False)
+        _cleanup_private_tree(
+            tmp_root,
+            expected_identity=tmp_root_identity,
+        )
+    return _verified_plugin_directory(target)
+
+
+def _assert_expected_plugin_target_identity(
+    target: Path,
+    expected_identity: os.stat_result | None | object,
+) -> None:
+    if expected_identity is _UNSPECIFIED_IDENTITY:
+        return
+    try:
+        current_identity = target.lstat()
+    except FileNotFoundError:
+        current_identity = None
+    if expected_identity is None:
+        if current_identity is not None:
+            raise FileExistsError(
+                f"plugin target appeared during installation: {target.name}"
+            )
+        return
+    if (
+        current_identity is None
+        or not os.path.samestat(expected_identity, current_identity)
+    ):
+        raise PermissionError(
+            f"plugin target identity changed during installation: {target}"
+        )
+
+
+def _verified_plugin_directory(target: Path) -> Path:
+    exact = require_symlink_free_absolute_path(
+        target,
+        field="installed plugin directory",
+    )
+    if not exact.is_dir():
+        raise NotADirectoryError(exact)
+    return exact

--- a/plugin_system/registry/download.py
+++ b/plugin_system/registry/download.py
@@ -5,25 +5,76 @@ from __future__ import annotations
 import json
 import logging
 import os
-import sys
-import tempfile
+import re
+import threading
+import uuid
 import zipfile
 from collections.abc import Callable
+from io import BytesIO
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 from config.mirror_env import mirror_github_url
+from core.archive_paths import extract_zip_safely
+from core.file_transactions import (
+    atomic_write_text,
+    copy_directory_without_links,
+    create_private_temporary_directory,
+    ensure_portable_name_available,
+    private_sibling_path,
+    read_text_without_links,
+    remove_directory_without_links,
+    replace_directory_transactionally,
+)
+from core.paths import (
+    managed_child_path,
+    path_is_link_or_reparse_point,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resolve_project_output_path,
+    truncate_utf8_bytes,
+)
 
 logger = logging.getLogger(__name__)
 _PLUGINS_DIR = Path("plugins")
 _DOWNLOAD_STATE_PATH = Path("data/config/plugin_registry_downloads.json")
+_DOWNLOAD_STATE_LOCK = threading.RLock()
+
+
+def _cleanup_private_tree(
+    path: Path,
+    *,
+    expected_identity: os.stat_result,
+) -> None:
+    try:
+        remove_directory_without_links(
+            path,
+            expected_identity=expected_identity,
+        )
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+
 
 _WIN_RESERVED_DEVICE_NAMES = frozenset(
-    {"CON", "PRN", "AUX", "NUL"}
-    | {f"COM{i}" for i in range(1, 10)}
-    | {f"LPT{i}" for i in range(1, 10)}
+    {"CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$"}
+    | {
+        f"{prefix}{suffix}"
+        for prefix in ("COM", "LPT")
+        for suffix in (*map(str, range(1, 10)), "¹", "²", "³")
+    }
 )
+_REPO_COMPONENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _project_scoped_path(
+    path: Path,
+    *,
+    root: str | Path | None = None,
+) -> Path:
+    if root is None:
+        return resolve_project_output_path(path)
+    return resolve_project_output_path(path, root=root)
 
 
 def sanitize_plugins_directory_name(raw: str, *, max_len: int = 120) -> str:
@@ -38,20 +89,45 @@ def sanitize_plugins_directory_name(raw: str, *, max_len: int = 120) -> str:
     invalid = '<>:"/\\|?*'
     parts: list[str] = []
     for ch in s:
-        if ord(ch) < 32:
+        if (
+            ord(ch) < 32
+            or ord(ch) == 127
+            or 0xD800 <= ord(ch) <= 0xDFFF
+        ):
             parts.append("_")
         elif ch in invalid:
             parts.append("_")
         else:
             parts.append(ch)
     s = "".join(parts).strip(" .")
-    if len(s) > max_len:
-        s = s[:max_len].rstrip(" .")
-    if sys.platform == "win32":
-        stem = s.rstrip(".").upper()
-        if stem in _WIN_RESERVED_DEVICE_NAMES:
-            s = f"{s}_plugin"
-    return s
+    s = truncate_utf8_bytes(s[:max_len].rstrip(" ."), 255).rstrip(" .")
+    # Package directories can be created on one platform and later migrated
+    # to Windows, so enforce Windows device-name portability everywhere.
+    stem, separator, extension = s.partition(".")
+    if stem.upper() in _WIN_RESERVED_DEVICE_NAMES:
+        s = f"{stem}_plugin{separator}{extension}"[:max_len].rstrip(" .")
+    return truncate_utf8_bytes(s, 255).rstrip(" .")
+
+
+def portable_plugin_target(parent: Path, folder_name: str) -> Path:
+    """Resolve a plugin directory without creating cross-platform aliases.
+
+    Linux permits names such as ``Demo`` and ``demo`` (and distinct Unicode
+    normalization forms) side by side, while Windows and common macOS volumes
+    do not.  Reject that ambiguity at installation time so a later project
+    move cannot merge or overwrite two plugin trees.
+    """
+
+    target = managed_child_path(parent, folder_name, field="plugin directory name")
+    if not parent.is_dir():
+        return target
+    try:
+        ensure_portable_name_available(parent, folder_name)
+    except FileExistsError as exc:
+        raise FileExistsError(
+            f"plugin directory name collides on a portable filesystem: {exc}"
+        ) from exc
+    return target
 
 _DL_USER_AGENT = (
     "EasyAIDesktopAssistant/1.0 (+plugin-download; https://github.com/RachelForster/Shinsekai-Plugin-Registry)"
@@ -59,26 +135,53 @@ _DL_USER_AGENT = (
 
 
 def normalize_repo_slug(repo: str) -> str:
-    raw = repo.strip()
-    if not raw:
+    raw = str(repo or "")
+    if (
+        not raw
+        or raw != raw.strip()
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in raw
+        )
+    ):
         return ""
     lowered = raw.lower()
     if lowered.startswith("git@github.com:"):
         raw = raw.split(":", 1)[1]
     elif lowered.startswith(("https://", "http://")):
         parsed = urlsplit(raw)
-        if parsed.hostname != "github.com":
+        try:
+            parsed_port = parsed.port
+        except ValueError:
             return ""
-        raw = parsed.path
+        if (
+            parsed.hostname != "github.com"
+            or parsed.username is not None
+            or parsed_port is not None
+            or bool(parsed.query)
+            or bool(parsed.fragment)
+        ):
+            return ""
+        raw = parsed.path[1:] if parsed.path.startswith("/") else parsed.path
     elif lowered.startswith("github.com/"):
         raw = raw.split("/", 1)[1]
-    raw = raw.split("#", 1)[0].split("?", 1)[0].strip("/")
+    else:
+        if "#" in raw or "?" in raw:
+            return ""
+    if raw.endswith("/"):
+        raw = raw[:-1]
     if raw.endswith(".git"):
         raw = raw[:-4]
-    parts = [p.strip() for p in raw.split("/") if p.strip()]
-    if len(parts) < 2:
+    parts = raw.split("/")
+    if (
+        len(parts) != 2
+        or any(part in {"", ".", ".."} or part != part.strip() for part in parts)
+        or any(not _REPO_COMPONENT_RE.fullmatch(part) for part in parts)
+    ):
         return ""
-    return "/".join(parts[:2]).lower()
+    return "/".join(parts).lower()
 
 
 def normalize_manifest_entry(entry: str) -> str:
@@ -86,9 +189,16 @@ def normalize_manifest_entry(entry: str) -> str:
     Align with :func:`plugin_system.host.normalize_manifest_entry`:
     ensure ``plugins.`` prefix for module paths used under ``plugins/``.
     """
-    norm = entry.strip()
+    norm = str(entry or "")
     if not norm:
         return norm
+    if norm != norm.strip() or any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in norm
+    ):
+        return ""
     if norm.startswith("plugins."):
         return norm
     return f"plugins.{norm}"
@@ -115,14 +225,26 @@ def _normalize_install_metadata(value: object) -> dict[str, object]:
     return {key: item for key, item in value.items() if key in allowed and item not in (None, "")}
 
 
-def _load_download_state_payload() -> tuple[list[str], dict[str, str], dict[str, dict[str, object]]]:
+def _load_download_state_payload(
+    *,
+    root: str | Path | None = None,
+) -> tuple[list[str], dict[str, str], dict[str, dict[str, object]]]:
+    with _DOWNLOAD_STATE_LOCK:
+        return _load_download_state_payload_unlocked(root=root)
+
+
+def _load_download_state_payload_unlocked(
+    *,
+    root: str | Path | None = None,
+) -> tuple[list[str], dict[str, str], dict[str, dict[str, object]]]:
     """Load persisted repos, manifest-entry mapping, and install metadata."""
-    if not _DOWNLOAD_STATE_PATH.is_file():
+    state_path = _project_scoped_path(_DOWNLOAD_STATE_PATH, root=root)
+    if not state_path.is_file():
         return [], {}, {}
     try:
-        raw = json.loads(_DOWNLOAD_STATE_PATH.read_text(encoding="utf-8"))
+        raw = json.loads(read_text_without_links(state_path))
     except (OSError, json.JSONDecodeError):
-        logger.warning("Could not read plugin download state: %s", _DOWNLOAD_STATE_PATH)
+        logger.warning("Could not read plugin download state: %s", state_path)
         return [], {}, {}
     if isinstance(raw, list):
         repos_set = {normalize_repo_slug(str(x)) for x in raw if str(x).strip()}
@@ -143,7 +265,7 @@ def _load_download_state_payload() -> tuple[list[str], dict[str, str], dict[str,
         for k, v in er_raw.items():
             if not isinstance(k, str) or not isinstance(v, str):
                 continue
-            ks, vs = k.strip(), v.strip()
+            ks, vs = k, v
             if not ks or not vs:
                 continue
             nk = normalize_manifest_entry(ks)
@@ -155,16 +277,19 @@ def _load_download_state_payload() -> tuple[list[str], dict[str, str], dict[str,
         for k, v in install_raw.items():
             if not isinstance(k, str):
                 continue
-            nk = normalize_manifest_entry(k.strip())
+            nk = normalize_manifest_entry(k)
             metadata = _normalize_install_metadata(v)
             if nk and metadata:
                 entry_install[nk] = metadata
     return sorted(repos_set), entry_repo, entry_install
 
 
-def _load_download_state() -> tuple[list[str], dict[str, str]]:
+def _load_download_state(
+    *,
+    root: str | Path | None = None,
+) -> tuple[list[str], dict[str, str]]:
     """Load persisted repos (sorted) and manifest-entry -> repo slug mapping."""
-    repos, entry_repo, _entry_install = _load_download_state_payload()
+    repos, entry_repo, _entry_install = _load_download_state_payload(root=root)
     return repos, entry_repo
 
 
@@ -172,28 +297,41 @@ def _write_download_state(
     repos: list[str],
     entry_repo: dict[str, str],
     entry_install: dict[str, dict[str, object]] | None = None,
+    *,
+    root: str | Path | None = None,
 ) -> None:
     if entry_install is None:
-        _repos, _entry_repo, entry_install = _load_download_state_payload()
-    _DOWNLOAD_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _repos, _entry_repo, entry_install = _load_download_state_payload(
+            root=root,
+        )
+    state_path = _project_scoped_path(_DOWNLOAD_STATE_PATH, root=root)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {"repos": repos, "entry_repo": entry_repo, "entry_install": entry_install}
-    _DOWNLOAD_STATE_PATH.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    atomic_write_text(
+        state_path,
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
     )
 
 
-def load_downloaded_repos() -> set[str]:
+def load_downloaded_repos(
+    *,
+    root: str | Path | None = None,
+) -> set[str]:
     """Normalized ``owner/repo`` keys marked as downloaded by this app."""
-    repos, _ = _load_download_state()
+    repos, _ = _load_download_state(root=root)
     return set(repos)
 
 
-def load_plugin_install_metadata(entry: str) -> dict[str, object]:
+def load_plugin_install_metadata(
+    entry: str,
+    *,
+    root: str | Path | None = None,
+) -> dict[str, object]:
     """Return persisted install metadata for a manifest entry."""
-    norm_e = normalize_manifest_entry(entry.strip())
+    norm_e = normalize_manifest_entry(entry)
     if not norm_e:
         return {}
-    _repos, _entry_repo, entry_install = _load_download_state_payload()
+    _repos, _entry_repo, entry_install = _load_download_state_payload(root=root)
     return dict(entry_install.get(norm_e) or {})
 
 
@@ -202,51 +340,106 @@ def mark_repo_downloaded(
     *,
     manifest_entry: str | None = None,
     install_metadata: dict[str, object] | None = None,
+    root: str | Path | None = None,
+) -> None:
+    with _DOWNLOAD_STATE_LOCK:
+        _mark_repo_downloaded_unlocked(
+            repo,
+            manifest_entry=manifest_entry,
+            install_metadata=install_metadata,
+            root=root,
+        )
+
+
+def _mark_repo_downloaded_unlocked(
+    repo: str,
+    *,
+    manifest_entry: str | None = None,
+    install_metadata: dict[str, object] | None = None,
+    root: str | Path | None = None,
 ) -> None:
     slug = normalize_repo_slug(repo)
     if not slug:
         return
-    repos_list, er, entry_install = _load_download_state_payload()
+    repos_list, er, entry_install = _load_download_state_payload(root=root)
     repos_set = set(repos_list)
     repos_set.add(slug)
     er = dict(er)
     entry_install = dict(entry_install)
-    me = (manifest_entry or "").strip()
+    me = manifest_entry or ""
     if me:
         norm_e = normalize_manifest_entry(me)
+        if not norm_e:
+            raise ValueError("manifest entry is not an exact portable value")
         er[norm_e] = slug
         metadata = _normalize_install_metadata(install_metadata or {})
         if metadata:
             entry_install[norm_e] = metadata
         elif install_metadata is not None:
             entry_install.pop(norm_e, None)
-    _write_download_state(sorted(repos_set), er, entry_install)
+    _write_download_state(
+        sorted(repos_set),
+        er,
+        entry_install,
+        root=root,
+    )
 
 
-def unmark_repo_downloaded(repo: str) -> None:
+def unmark_repo_downloaded(
+    repo: str,
+    *,
+    root: str | Path | None = None,
+) -> None:
     """Remove ``owner/repo`` and any manifest entries pointing at it."""
+    with _DOWNLOAD_STATE_LOCK:
+        _unmark_repo_downloaded_unlocked(repo, root=root)
+
+
+def _unmark_repo_downloaded_unlocked(
+    repo: str,
+    *,
+    root: str | Path | None = None,
+) -> None:
     slug = normalize_repo_slug(repo)
     if not slug:
         return
-    repos_list, er, entry_install = _load_download_state_payload()
+    repos_list, er, entry_install = _load_download_state_payload(root=root)
     removed_entries = {k for k, v in er.items() if normalize_repo_slug(v) == slug}
     er = {k: v for k, v in er.items() if k not in removed_entries}
     entry_install = {k: v for k, v in entry_install.items() if k not in removed_entries}
     repos_set = set(repos_list)
     repos_set.discard(slug)
-    _write_download_state(sorted(repos_set), er, entry_install)
+    _write_download_state(
+        sorted(repos_set),
+        er,
+        entry_install,
+        root=root,
+    )
 
 
-def unmark_repo_for_manifest_entry(entry: str) -> bool:
+def unmark_repo_for_manifest_entry(
+    entry: str,
+    *,
+    root: str | Path | None = None,
+) -> bool:
     """
     Drop the download-registry mapping for this manifest ``entry`` and unlist the repo if unused.
 
     Returns True if the state file was updated.
     """
-    norm_e = normalize_manifest_entry(entry.strip())
+    with _DOWNLOAD_STATE_LOCK:
+        return _unmark_repo_for_manifest_entry_unlocked(entry, root=root)
+
+
+def _unmark_repo_for_manifest_entry_unlocked(
+    entry: str,
+    *,
+    root: str | Path | None = None,
+) -> bool:
+    norm_e = normalize_manifest_entry(entry)
     if not norm_e:
         return False
-    repos_list, er, entry_install = _load_download_state_payload()
+    repos_list, er, entry_install = _load_download_state_payload(root=root)
     if norm_e not in er:
         return False
     er = dict(er)
@@ -257,24 +450,20 @@ def unmark_repo_for_manifest_entry(entry: str) -> bool:
     repos_set = set(repos_list)
     if slug not in others:
         repos_set.discard(slug)
-    _write_download_state(sorted(repos_set), er, entry_install)
+    _write_download_state(
+        sorted(repos_set),
+        er,
+        entry_install,
+        root=root,
+    )
     return True
 
 
 def _github_archive_zip_url(repo_slug: str, branch: str) -> str:
-    base = "/".join(p.strip() for p in repo_slug.strip().strip("/").split("/") if p.strip())
+    base = normalize_repo_slug(repo_slug)
+    if not base:
+        raise ValueError("repository must be an exact GitHub owner/name reference")
     return mirror_github_url(f"https://github.com/{base}/archive/refs/heads/{branch}.zip")
-
-
-def _archive_top_prefix(zip_path: Path) -> str:
-    with zipfile.ZipFile(zip_path) as zf:
-        names = [n for n in zf.namelist() if n and not n.endswith("/")]
-        if not names:
-            raise ValueError("empty archive")
-        top = names[0].split("/")[0]
-        if not top:
-            raise ValueError("invalid archive layout")
-        return top
 
 
 def download_github_repo_sources(
@@ -285,6 +474,7 @@ def download_github_repo_sources(
     progress: Callable[[int, int | None], None] | None = None,
     on_phase: Callable[[str], None] | None = None,
     folder_name: str | None = None,
+    root: str | Path | None = None,
 ) -> Path:
     """
     Download ``owner/repo`` default branch (``main`` then ``master``) ZIP and extract under ``plugins/``.
@@ -296,12 +486,28 @@ def download_github_repo_sources(
 
     :returns: Path to the extracted repository root directory inside ``plugins``.
     """
-    slug = "/".join(p.strip() for p in repo.strip().strip("/").split("/") if p.strip())
-    if slug.count("/") < 1:
+    slug = normalize_repo_slug(repo)
+    if not slug:
         raise ValueError(f"invalid repo slug (need owner/name): {repo!r}")
 
-    parent = Path(plugins_parent) if plugins_parent is not None else _PLUGINS_DIR
+    configured_parent = (
+        os.fspath(plugins_parent)
+        if plugins_parent is not None
+        else os.fspath(_project_scoped_path(_PLUGINS_DIR, root=root))
+    )
+    unresolved_parent = Path(configured_parent)
+    if not unresolved_parent.is_absolute():
+        raise ValueError("plugins_parent must be absolute")
+    parent = require_symlink_free_absolute_path(
+        unresolved_parent,
+        field="plugins directory",
+    )
+    parent = resolve_project_output_path(configured_parent, root=root)
     parent.mkdir(parents=True, exist_ok=True)
+    parent = require_directory_without_links(
+        parent,
+        field="plugins directory",
+    )
 
     last_err: BaseException | None = None
     body: bytes | None = None
@@ -336,51 +542,89 @@ def download_github_repo_sources(
     if body is None:
         raise last_err if last_err else URLError("download failed")
 
-    fd, tmp_zip = tempfile.mkstemp(suffix=".zip")
-    os.close(fd)
-    tmp_path = Path(tmp_zip)
+    temp_root, temp_root_identity = create_private_temporary_directory(
+        prefix="shinsekai-github-plugin-",
+    )
     try:
-        tmp_path.write_bytes(body)
-        top = _archive_top_prefix(tmp_path)
-        extracted_path = parent / top
+        extract_root = temp_root / "extract"
+        if on_phase is not None:
+            on_phase("extract")
+        with zipfile.ZipFile(BytesIO(body)) as zf:
+            extraction = extract_zip_safely(
+                zf,
+                extract_root,
+                require_single_root=True,
+            )
+        top = extraction.top_level
+        if not top:
+            raise ValueError("archive has no top-level directory")
+        extracted_path = extract_root / top
         folder_final = (
             sanitize_plugins_directory_name(folder_name.strip())
             if (folder_name and folder_name.strip())
             else ""
         )
-        target_path = parent / folder_final if folder_final else extracted_path
+        # Recheck the caller-owned publication boundary after the network and
+        # extraction delay; a linked managed parent must never redirect the
+        # existence checks or final rename outside the project.
+        parent = require_symlink_free_absolute_path(
+            parent,
+            field="plugins directory",
+        )
+        parent = resolve_project_output_path(parent, root=root)
+        target_path = portable_plugin_target(parent, folder_final or top)
 
-        if folder_final and target_path.is_dir():
-            logger.info("Plugin folder already exists (catalog name): %s", target_path)
-            return target_path.resolve()
+        if target_path.is_dir():
+            target_path = require_symlink_free_absolute_path(
+                target_path,
+                field="installed plugin directory",
+            )
+            if not target_path.is_dir():
+                raise NotADirectoryError(target_path)
+            logger.info("Plugin folder already exists: %s", target_path)
+            return target_path
+        if target_path.exists():
+            raise FileExistsError(f"Plugin target is not a directory: {target_path.name!r}")
 
-        if extracted_path.is_dir():
-            if folder_final and extracted_path.resolve() != target_path.resolve():
-                if target_path.exists():
-                    raise FileExistsError(
-                        f"Cannot rename extracted folder to {target_path.name!r}: target exists"
-                    )
-                extracted_path.rename(target_path)
-                return target_path.resolve()
-            return extracted_path.resolve()
-
-        if on_phase is not None:
-            on_phase("extract")
-        with zipfile.ZipFile(tmp_path) as zf:
-            zf.extractall(parent)
         if not extracted_path.is_dir():
             raise RuntimeError(f"extract finished but folder missing: {extracted_path}")
-
-        if folder_final and extracted_path.resolve() != target_path.resolve():
-            if target_path.exists():
-                raise FileExistsError(
-                    f"Cannot rename extracted folder to {target_path.name!r}: target exists"
-                )
-            extracted_path.rename(target_path)
-            return target_path.resolve()
-        return extracted_path.resolve()
+        staging = private_sibling_path(
+            target_path,
+            f".install-{uuid.uuid4().hex}",
+            field="plugin installation staging directory",
+        )
+        staging_identity: os.stat_result | None = None
+        try:
+            staging = copy_directory_without_links(extracted_path, staging)
+            staging_identity = staging.lstat()
+            replace_directory_transactionally(
+                staging,
+                target_path,
+                overwrite=False,
+                expected_staging_identity=staging_identity,
+                expected_destination_identity=None,
+            )
+        finally:
+            if staging_identity is not None:
+                try:
+                    remove_directory_without_links(
+                        staging,
+                        expected_identity=staging_identity,
+                    )
+                except (OSError, ValueError):
+                    pass
+        target_path = require_symlink_free_absolute_path(
+            target_path,
+            field="installed plugin directory",
+        )
+        if not target_path.is_dir():
+            raise NotADirectoryError(target_path)
+        return target_path
     finally:
-        tmp_path.unlink(missing_ok=True)
+        _cleanup_private_tree(
+            temp_root,
+            expected_identity=temp_root_identity,
+        )
 
 
 def format_download_error(exc: BaseException) -> str:

--- a/plugin_system/requirements/install.py
+++ b/plugin_system/requirements/install.py
@@ -13,6 +13,19 @@ import tempfile
 import time
 from pathlib import Path
 
+from core.paths import (
+    app_root,
+    managed_child_path,
+    managed_project_storage,
+    path_is_link_or_reparse_point,
+    project_root,
+    require_directory_without_links,
+    resolve_executable_file,
+    resolve_project_path,
+    resolve_project_read_path,
+    validate_exact_path_text,
+)
+from core.file_transactions import read_text_without_links, remove_file_without_links
 from core.runtime_env.pip_index import (
     strip_inline_requirement_comment as _strip_inline_requirement_comment,
 )
@@ -37,10 +50,7 @@ def frozen_release_root() -> Path | None:
     """打包运行时返回发行根目录；开发模式返回 ``None``。"""
     if not getattr(sys, "frozen", False):
         return None
-    er = os.environ.get("EASYAI_PROJECT_ROOT")
-    if er:
-        return Path(er).resolve()
-    return Path(sys.executable).resolve().parent.parent
+    return app_root()
 
 
 def pip_python_executable() -> Path:
@@ -53,64 +63,94 @@ def pip_python_executable() -> Path:
     if getattr(sys, "frozen", False):
         root = frozen_release_root()
         if root is not None:
-            runtime = root / "runtime"
-            for name in ("python.exe", "python3.exe"):
-                p = runtime / name
-                if p.is_file():
-                    return p.resolve()
-    return Path(sys.executable).resolve()
+            runtime_candidates = (
+                (
+                    Path("runtime/python.exe"),
+                    Path("runtime/python3.exe"),
+                    Path("runtime/bin/python.exe"),
+                    Path("runtime/bin/python3.exe"),
+                )
+                if os.name == "nt"
+                else (
+                    Path("runtime/bin/python3"),
+                    Path("runtime/bin/python"),
+                    Path("runtime/python3"),
+                    Path("runtime/python"),
+                )
+            )
+            for relative in runtime_candidates:
+                p = root / relative
+                if os.path.lexists(p):
+                    return resolve_executable_file(
+                        p,
+                        field="plugin pip Python executable",
+                    )
+    return resolve_executable_file(
+        Path(sys.executable),
+        field="host Python executable",
+    )
 
 
-def plugin_pip_target_directory() -> Path | None:
+def plugin_pip_target_directory(
+    *,
+    root: str | Path | None = None,
+) -> Path | None:
     """
-    冻结版：pip ``--target`` 的可写目录（与 Tauri bridge / ``main`` 所设发行根一致）。
+    冻结版：pip ``--target`` 的项目数据目录（由统一项目根决定）。
     开发模式返回 ``None``（依赖装入当前环境 site-packages，不使用 ``--target``）。
     """
-    root = frozen_release_root()
-    if root is None:
+    if not getattr(sys, "frozen", False):
         return None
-    return root / "data" / "plugin_site_packages"
+    if root is None:
+        return managed_project_storage("data/plugin_site_packages")
+    return managed_project_storage("data/plugin_site_packages", root=root)
 
 
-def ensure_plugin_site_packages_on_syspath() -> None:
+def ensure_plugin_site_packages_on_syspath(
+    *,
+    root: str | Path | None = None,
+) -> None:
     """若存在冻结版插件依赖目录，则插入 ``sys.path`` 首位（须在加载插件前调用）。"""
-    target = plugin_pip_target_directory()
+    target = (
+        plugin_pip_target_directory()
+        if root is None
+        else plugin_pip_target_directory(root=root)
+    )
     if target is None:
         return
     if not target.is_dir():
         return
-    s = str(target.resolve())
+    target = require_directory_without_links(
+        target,
+        field="plugin site-packages directory",
+    )
+    s = str(target)
     if s not in sys.path:
         sys.path.insert(0, s)
         logger.info("Prepended plugin site-packages to sys.path: %s", s)
 
 
-def ensure_plugins_namespace_on_syspath() -> None:
+def ensure_plugins_namespace_on_syspath(
+    *,
+    root: str | Path | None = None,
+) -> None:
     """
     将「含有 ``plugins/`` 子目录的一层级目录」置于 ``sys.path`` 首位，使 ``import plugins.xxx`` 可解析。
 
     源码运行时常已由入口脚本把项目根加入 ``sys.path``；冻结版仅有 ``_internal`` 等路径时，
-    必须加入发行根（与 ``main`` / ``SettingsUI`` 同层的目录，内含用户可写的 ``plugins/``）。
+    必须加入权威项目数据根（内含用户可写的 ``plugins/``）。
     """
-    if getattr(sys, "frozen", False):
-        root = frozen_release_root()
-        if root is None:
-            return
-        plug = root / "plugins"
-        if not plug.is_dir():
-            logger.debug("Frozen: no plugins directory at %s, skip release root on sys.path", plug)
-            return
-        s = str(root.resolve())
+    active_root = (
+        project_root()
+        if root is None
+        else resolve_project_path(".", root=root)
+    )
+    plugins_root = managed_project_storage("plugins", root=active_root)
+    if plugins_root.is_dir():
+        s = str(active_root)
         if s not in sys.path:
             sys.path.insert(0, s)
-            logger.info("Prepended release root for plugins namespace: %s", s)
-        return
-    cwd = Path.cwd().resolve()
-    if (cwd / "plugins").is_dir():
-        s = str(cwd)
-        if s not in sys.path:
-            sys.path.insert(0, s)
-            logger.info("Prepended cwd for plugins namespace: %s", s)
+            logger.info("Prepended project root for plugins namespace: %s", s)
 
 
 def _requirement_line_project_name(line: str) -> str | None:
@@ -151,10 +191,14 @@ def _pip_base_install_cmd(py: Path, pip_target: Path | None) -> list[str]:
     ]
     if pip_target is not None:
         pip_target.mkdir(parents=True, exist_ok=True)
+        pip_target = require_directory_without_links(
+            pip_target,
+            field="plugin pip target directory",
+        )
         cmd.extend(
             [
                 "--target",
-                str(pip_target.resolve()),
+                str(pip_target),
                 "--no-warn-script-location",
             ]
         )
@@ -190,12 +234,24 @@ def _requirement_line_can_be_pruned(line: str) -> bool:
     return True
 
 
-def _installed_distribution_versions() -> dict[str, str]:
+def _installed_distribution_versions(
+    *,
+    root: str | Path | None = None,
+) -> dict[str, str]:
     paths = list(sys.path)
-    target = plugin_pip_target_directory()
+    target = (
+        plugin_pip_target_directory()
+        if root is None
+        else plugin_pip_target_directory(root=root)
+    )
     if target is not None and target.is_dir():
         # 打包版插件依赖会装进 data/plugin_site_packages，先查这里再看系统路径。
-        target_s = str(target.resolve())
+        target_s = str(
+            require_directory_without_links(
+                target,
+                field="plugin site-packages directory",
+            )
+        )
         paths = [target_s, *[path for path in paths if path != target_s]]
     versions: dict[str, str] = {}
     for distribution in importlib_metadata.distributions(path=paths):
@@ -209,10 +265,16 @@ def _installed_distribution_versions() -> dict[str, str]:
 def _requirement_distribution_version(
     name: str,
     installed_versions: Mapping[str, str] | None = None,
+    *,
+    root: str | Path | None = None,
 ) -> str | None:
     canonical = _canonical_distribution_name(name)
     if installed_versions is None:
-        installed_versions = _installed_distribution_versions()
+        installed_versions = (
+            _installed_distribution_versions()
+            if root is None
+            else _installed_distribution_versions(root=root)
+        )
     return installed_versions.get(canonical)
 
 
@@ -242,12 +304,20 @@ def _requirement_line_is_satisfied(
     return True
 
 
-def _install_lines_after_precheck(lines: list[str]) -> tuple[bool, list[str]]:
+def _install_lines_after_precheck(
+    lines: list[str],
+    *,
+    root: str | Path | None = None,
+) -> tuple[bool, list[str]]:
     # requirements 里出现 -e、--find-links、direct reference 等全局/本地语义时，不做裁剪。
     # 这些行可能影响后续包解析，强行只装“缺失行”反而会破坏作者的安装意图。
     if not all(_requirement_line_can_be_pruned(line) for line in lines):
         return False, lines
-    installed_versions = _installed_distribution_versions()
+    installed_versions = (
+        _installed_distribution_versions()
+        if root is None
+        else _installed_distribution_versions(root=root)
+    )
     install_lines: list[str] = []
     for line in lines:
         stripped = _strip_inline_requirement_comment(line)
@@ -258,17 +328,35 @@ def _install_lines_after_precheck(lines: list[str]) -> tuple[bool, list[str]]:
     return True, install_lines
 
 
-def _write_temp_requirements(prefix: str, lines: list[str]) -> Path:
+def _write_temp_requirements(
+    prefix: str,
+    lines: list[str],
+) -> tuple[Path, os.stat_result]:
     fd, temp_path_str = tempfile.mkstemp(prefix=prefix, suffix=".txt")
-    path = Path(temp_path_str)
+    # ``tempfile`` may return a trusted platform alias such as macOS /var.
+    # Pin the newly created descriptor's canonical identity before passing the
+    # filename to pip or to strict cleanup helpers.
+    path = Path(temp_path_str).resolve(strict=True)
+    identity = os.fstat(fd)
     try:
-        os.close(fd)
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        return path
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            handle.write("\n".join(lines) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if not os.path.samestat(identity, path.lstat()):
+            raise PermissionError("temporary requirements file changed identity")
+        return path, identity
     except BaseException:
+        if fd >= 0:
+            os.close(fd)
         try:
-            path.unlink(missing_ok=True)
-        except OSError:
+            remove_file_without_links(
+                path,
+                missing_ok=True,
+                expected_identity=identity,
+            )
+        except (OSError, ValueError):
             pass
         raise
 
@@ -276,9 +364,14 @@ def _write_temp_requirements(prefix: str, lines: list[str]) -> Path:
 def _finish_install_result(
     result: tuple[str, str],
     pip_target: Path | None,
+    *,
+    root: str | Path | None = None,
 ) -> tuple[str, str]:
     if result[0] == "pip_ok" and pip_target is not None:
-        ensure_plugin_site_packages_on_syspath()
+        if root is None:
+            ensure_plugin_site_packages_on_syspath()
+        else:
+            ensure_plugin_site_packages_on_syspath(root=root)
     return result
 
 
@@ -288,12 +381,13 @@ def install_plugin_requirements_txt(
     requirements_file: str = "requirements.txt",
     timeout_sec: float = 900.0,
     on_output_line: Callable[[str], None] | None = None,
+    root: str | Path | None = None,
 ) -> tuple[str, str]:
     """
     Run ``python -m pip install -r requirements_file`` if it exists under ``plugin_root``.
 
-    冻结版使用 :func:`pip_python_executable`（默认 ``<发行根>/runtime/python.exe``）执行
-    普通依赖使用 ``pip install --target <发行根>/data/plugin_site_packages``；PyTorch
+    冻结版使用 :func:`pip_python_executable`（默认 ``<安装根>/runtime/python.exe``）执行
+    普通依赖使用 ``pip install --target <项目数据根>/data/plugin_site_packages``；PyTorch
     二进制栈是例外，会统一安装进 bundled runtime，避免两套 ``torch`` 同时出现在
     ``sys.path``。宿主须在启动时调用 :func:`ensure_plugin_site_packages_on_syspath`。
 
@@ -315,8 +409,29 @@ def install_plugin_requirements_txt(
     If ``on_output_line`` is set, stdout/stderr lines are forwarded (stripped of trailing newline)
     as pip runs, for UI logs.
     """
-    root = plugin_root.resolve()
-    req = root / requirements_file
+    raw_root = validate_exact_path_text(plugin_root, field="plugin root")
+    unresolved_root = Path(raw_root).expanduser()
+    if (
+        unresolved_root.is_absolute()
+        and path_is_link_or_reparse_point(unresolved_root)
+    ):
+        raise PermissionError("plugin root must not be a symbolic link")
+    active_project_root = (
+        project_root()
+        if root is None
+        else resolve_project_path(".", root=root)
+    )
+    plugin_directory = resolve_project_read_path(
+        raw_root,
+        root=active_project_root,
+    )
+    if not plugin_directory.is_dir():
+        return ("pip_skip_no_requirements", "")
+    req = managed_child_path(
+        plugin_directory,
+        requirements_file,
+        field="requirements filename",
+    )
     if not req.is_file():
         return ("pip_skip_no_requirements", "")
 
@@ -327,7 +442,11 @@ def install_plugin_requirements_txt(
             "pip install may fail (use <release>/runtime/python.exe).",
         )
 
-    pip_target = plugin_pip_target_directory()
+    pip_target = (
+        plugin_pip_target_directory()
+        if root is None
+        else plugin_pip_target_directory(root=active_project_root)
+    )
     base_cmd = _pip_base_install_cmd(py, pip_target)
 
     started = time.monotonic()
@@ -336,7 +455,7 @@ def install_plugin_requirements_txt(
         return max(30.0, timeout_sec - (time.monotonic() - started))
 
     try:
-        lines = req.read_text(encoding="utf-8").splitlines()
+        lines = read_text_without_links(req).splitlines()
     except OSError as exc:
         logger.warning("Could not read %s: %s", req, exc)
         return ("pip_exception", str(exc))
@@ -346,7 +465,14 @@ def install_plugin_requirements_txt(
     torch_lines, source_other_lines = _partition_torch_requirement_lines(lines)
     split_torch = bool(torch_lines) and sys.platform != "darwin"
     precheck_source_lines = source_other_lines if split_torch else lines
-    can_prune, install_lines = _install_lines_after_precheck(precheck_source_lines)
+    can_prune, install_lines = (
+        _install_lines_after_precheck(precheck_source_lines)
+        if root is None
+        else _install_lines_after_precheck(
+            precheck_source_lines,
+            root=active_project_root,
+        )
+    )
     if can_prune and not install_lines and not split_torch:
         logger.info("Plugin pip: all requirements already satisfied, skipping install.")
         return ("pip_ok", "")
@@ -354,13 +480,19 @@ def install_plugin_requirements_txt(
     active_req = req
     active_lines = lines
     precheck_tf: Path | None = None
+    precheck_identity: os.stat_result | None = None
     torch_tf: Path | None = None
+    torch_identity: os.stat_result | None = None
     other_tf: Path | None = None
+    other_identity: os.stat_result | None = None
     try:
         if can_prune:
             # pip 仍然只认识 requirements 文件；在 finally 生效后再写临时文件，
             # 确保写入成功后任何后续异常都会清理掉它。
-            precheck_tf = _write_temp_requirements("easyai_missing_req_", install_lines)
+            precheck_tf, precheck_identity = _write_temp_requirements(
+                "easyai_missing_req_",
+                install_lines,
+            )
             active_req = precheck_tf
             active_lines = install_lines
 
@@ -384,7 +516,7 @@ def install_plugin_requirements_txt(
             )
             managed_torch_lines = list(plan.requirement_lines)
             if managed_torch_lines:
-                torch_tf = _write_temp_requirements(
+                torch_tf, torch_identity = _write_temp_requirements(
                     "easyai_torch_req_",
                     managed_torch_lines,
                 )
@@ -409,7 +541,7 @@ def install_plugin_requirements_txt(
                 cmd_torch.extend(["-r", str(torch_tf)])
                 code1, detail1 = _run_pip_install(
                     _apply_pip_index_and_extra_args(cmd_torch, managed_torch_lines),
-                    cwd=root,
+                    cwd=active_project_root,
                     timeout_sec=remaining_budget(),
                     on_output_line=on_output_line,
                 )
@@ -430,7 +562,7 @@ def install_plugin_requirements_txt(
                             cmd_torch_deps,
                             managed_torch_lines,
                         ),
-                        cwd=root,
+                        cwd=active_project_root,
                         timeout_sec=remaining_budget(),
                         on_output_line=on_output_line,
                     )
@@ -439,9 +571,17 @@ def install_plugin_requirements_txt(
 
             other_lines = install_lines if can_prune else source_other_lines
             if not _has_non_comment_requirement(other_lines):
-                return _finish_install_result(("pip_ok", ""), pip_target)
+                return _finish_install_result(
+                    ("pip_ok", ""),
+                    pip_target,
+                    root=(active_project_root if root is not None else None),
+                )
 
-            other_tf = _write_temp_requirements("easyai_other_req_", other_lines)
+            other_tf, other_identity = _write_temp_requirements(
+                "easyai_other_req_",
+                other_lines,
+            )
+
             # Keep PyTorch-enabled plugins in the bundled runtime environment.
             # pip's ``--target`` resolver ignores distributions already
             # installed in the runtime and would otherwise download a second
@@ -458,7 +598,7 @@ def install_plugin_requirements_txt(
             return _finish_install_result(
                 _run_pip_install(
                     cmd_other,
-                    cwd=root,
+                    cwd=plugin_directory,
                     timeout_sec=remaining_budget(),
                     on_output_line=on_output_line,
                 ),
@@ -472,16 +612,25 @@ def install_plugin_requirements_txt(
         return _finish_install_result(
             _run_pip_install(
                 cmd,
-                cwd=root,
+                cwd=plugin_directory,
                 timeout_sec=timeout_sec,
                 on_output_line=on_output_line,
             ),
             pip_target,
+            root=(active_project_root if root is not None else None),
         )
     finally:
-        for path in (precheck_tf, torch_tf, other_tf):
-            if path is not None:
+        for path, identity in (
+            (precheck_tf, precheck_identity),
+            (torch_tf, torch_identity),
+            (other_tf, other_identity),
+        ):
+            if path is not None and identity is not None:
                 try:
-                    path.unlink(missing_ok=True)
-                except OSError:
+                    remove_file_without_links(
+                        path,
+                        missing_ok=True,
+                        expected_identity=identity,
+                    )
+                except (OSError, ValueError):
                     pass


### PR DESCRIPTION
## What changed

Applies validated package, registry, requirement, and host path handling to
the `plugin_system/` package.

## Why

Plugin archives, manifests, requirements, and host bindings cross a trust
boundary and need explicit roots plus stable filesystem identities.

## Impact

Plugin installation and loading reject unsafe package layouts and ambiguous
paths before mutating the managed plugin environment.

## Root cause

Plugin subsystems previously implemented separate containment and extraction
checks, leaving gaps between validation and use.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `plugin_system/`.
