### PR TITLE
fix(scripts): enforce migration-safe path contracts

### DIFF
--- a/scripts/install.command
+++ b/scripts/install.command
@@ -1,3 +1,30 @@
 #!/bin/bash
-cd "$(dirname "$0")/.."
-exec bash scripts/install.sh
+set -euo pipefail
+
+resolve_script_directory() {
+    local source_path="${BASH_SOURCE[0]}"
+    local link_hops=0
+    while [[ -L "$source_path" ]]; do
+        local source_dir
+        ((link_hops += 1))
+        if ((link_hops > 64)); then
+            echo "Error: launcher path contains too many symbolic-link hops: $source_path" >&2
+            return 1
+        fi
+        source_dir="$(CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd)"
+        source_path="$(/usr/bin/readlink "$source_path")"
+        [[ "$source_path" != /* ]] && source_path="$source_dir/$source_path"
+    done
+    CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd
+}
+
+SCRIPT_DIR="$(resolve_script_directory)"
+PROJECT_ROOT="$(CDPATH= cd -P -- "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+DELEGATED_SCRIPT="$PROJECT_ROOT/scripts/install.sh"
+if [[ -L "$PROJECT_ROOT/scripts" || ! -d "$PROJECT_ROOT/scripts" ||
+      -L "$DELEGATED_SCRIPT" || ! -f "$DELEGATED_SCRIPT" ]]; then
+    echo "Error: delegated installer is missing or unsafe: $DELEGATED_SCRIPT" >&2
+    exit 1
+fi
+exec /bin/bash "$DELEGATED_SCRIPT" "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,41 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
+resolve_script_directory() {
+    local source_path="${BASH_SOURCE[0]}"
+    local source_dir
+    local link_hops=0
+    while [[ -L "$source_path" ]]; do
+        ((link_hops += 1))
+        if ((link_hops > 64)); then
+            echo "Error: launcher path contains too many symbolic-link hops: $source_path" >&2
+            return 1
+        fi
+        source_dir="$(CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd)"
+        source_path="$(/usr/bin/readlink "$source_path")"
+        [[ "$source_path" = /* ]] || source_path="$source_dir/$source_path"
+    done
+    CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd
+}
+
+SCRIPT_DIR="$(resolve_script_directory)"
+PROJECT_ROOT="$(CDPATH= cd -P -- "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PATH_CONTRACT="$PROJECT_ROOT/scripts/shell-path-contract.sh"
+if [[ -L "$PROJECT_ROOT/scripts" || ! -d "$PROJECT_ROOT/scripts" ||
+      -L "$PATH_CONTRACT" || ! -f "$PATH_CONTRACT" ]]; then
+    echo "Error: installer path contract is missing or unsafe: $PATH_CONTRACT" >&2
+    exit 1
+fi
+# shellcheck source=scripts/shell-path-contract.sh
+source "$PATH_CONTRACT"
+
+if ! shinsekai_project_file_is_real "webui_react.py" ||
+   ! shinsekai_project_file_is_real "requirements.txt"; then
+    echo "Error: installer could not identify the Shinsekai project root: $PROJECT_ROOT" >&2
+    exit 1
+fi
 
 echo "========================================"
 echo "  Installing..."
@@ -7,19 +43,42 @@ echo "========================================"
 echo ""
 
 CONDA_ENV_NAME="${SHINSEKAI_CONDA_ENV:-shinsekai}"
+if ! shinsekai_portable_environment_name "$CONDA_ENV_NAME"; then
+    echo "Error: SHINSEKAI_CONDA_ENV must be a portable conda environment name" >&2
+    exit 1
+fi
+
+if [[ -n "${CONDA_EXE:-}" && ( "$CONDA_EXE" != /* || ! -x "$CONDA_EXE" ) ]]; then
+    echo "Error: CONDA_EXE must be an absolute executable path: $CONDA_EXE" >&2
+    exit 1
+fi
+if [[ -n "${CONDA_PREFIX:-}" && "$CONDA_PREFIX" != /* ]]; then
+    echo "Error: CONDA_PREFIX must be an absolute path: $CONDA_PREFIX" >&2
+    exit 1
+fi
+if [[ -n "${HOME:-}" && "$HOME" != /* ]]; then
+    echo "Error: HOME must be an absolute path when set: $HOME" >&2
+    exit 1
+fi
 
 find_conda() {
-    if [ -n "${CONDA_EXE:-}" ] && [ -x "$CONDA_EXE" ]; then
-        printf '%s\n' "$CONDA_EXE"
+    local -a candidates=("/opt/miniconda3/bin/conda" "/opt/anaconda3/bin/conda")
+    local resolved
+    if [[ -n "${HOME:-}" ]]; then
+        candidates=("$HOME/miniconda3/bin/conda" "$HOME/anaconda3/bin/conda" "${candidates[@]}")
+    fi
+    if [ -n "${CONDA_EXE:-}" ] &&
+       resolved="$(shinsekai_resolve_executable "$CONDA_EXE")"; then
+        printf '%s\n' "$resolved"
         return 0
     fi
-    if command -v conda > /dev/null 2>&1; then
-        command -v conda
+    if resolved="$(shinsekai_resolve_executable conda)"; then
+        printf '%s\n' "$resolved"
         return 0
     fi
-    for candidate in "$HOME/miniconda3/bin/conda" "$HOME/anaconda3/bin/conda" "/opt/miniconda3/bin/conda" "/opt/anaconda3/bin/conda"; do
-        if [ -x "$candidate" ]; then
-            printf '%s\n' "$candidate"
+    for candidate in "${candidates[@]}"; do
+        if resolved="$(shinsekai_resolve_executable "$candidate")"; then
+            printf '%s\n' "$resolved"
             return 0
         fi
     done
@@ -27,27 +86,29 @@ find_conda() {
 }
 
 # Check for embedded python, then the project conda env, then system python
-if [ -f "runtime/bin/python3" ]; then
-    PYTHON_CMD=("runtime/bin/python3")
-elif [ -f "runtime/python.exe" ]; then
-    PYTHON_CMD=("runtime/python.exe")
+if EMBEDDED_PYTHON="$(shinsekai_find_embedded_python)"; then
+    PYTHON_CMD=("$EMBEDDED_PYTHON")
 elif [ "${CONDA_DEFAULT_ENV:-}" = "$CONDA_ENV_NAME" ] && [ -n "${CONDA_PREFIX:-}" ] && [ -x "$CONDA_PREFIX/bin/python" ]; then
     echo "Embedded Python not found, using active conda env ${CONDA_ENV_NAME}..."
     PYTHON_CMD=("$CONDA_PREFIX/bin/python")
 elif CONDA_CMD="$(find_conda)"; then
     echo "Embedded Python not found, using conda env ${CONDA_ENV_NAME}..."
-    PYTHON_CMD=("$CONDA_CMD" run -n "$CONDA_ENV_NAME" python)
+    if ! CONDA_PYTHON="$(shinsekai_resolve_conda_python "$CONDA_CMD" "$CONDA_ENV_NAME")"; then
+        echo "Error: conda env ${CONDA_ENV_NAME} does not expose a deterministic Python path"
+        exit 1
+    fi
+    PYTHON_CMD=("$CONDA_CMD" run --cwd / -n "$CONDA_ENV_NAME" "$CONDA_PYTHON")
 else
     echo "Embedded Python not found, falling back to system python3..."
-    if ! command -v python3 &> /dev/null; then
+    if ! SYSTEM_PYTHON="$(shinsekai_resolve_executable python3)"; then
         echo "Error: neither conda env ${CONDA_ENV_NAME} nor python3 was found"
         exit 1
     fi
-    PYTHON_CMD=(python3)
+    PYTHON_CMD=("$SYSTEM_PYTHON")
 fi
 
 # Check if requirements.txt exists
-if [ ! -f "requirements.txt" ]; then
+if ! shinsekai_project_file_is_real "requirements.txt"; then
     echo "Error: requirements.txt not found"
     echo "Please ensure requirements.txt exists in the current directory"
     exit 1
@@ -56,7 +117,7 @@ fi
 echo "Installing dependencies..."
 echo ""
 
-"${PYTHON_CMD[@]}" -m pip install -r requirements.txt
+"${PYTHON_CMD[@]}" -m pip install -r "$PROJECT_ROOT/requirements.txt"
 
 echo ""
 echo "========================================"

--- a/scripts/presubmit.py
+++ b/scripts/presubmit.py
@@ -6,14 +6,25 @@ from __future__ import annotations
 import os
 import re
 import shlex
-import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.file_transactions import (  # noqa: E402
+    read_bytes_without_links,
+    read_text_without_links,
+)
+from core.process_launch import (  # noqa: E402
+    capture_command_executable,
+    capture_launch_directory,
+    run_with_stable_paths,
+)
+
 FRONTEND = ROOT / "frontend"
 ZERO_SHA = "0" * 40
 COMMIT_TYPES = (
@@ -91,8 +102,12 @@ def pre_push(remote_name: str, remote_url: str, hook_input: str) -> int:
     ]
 
     if (FRONTEND / "package.json").exists():
-        pnpm = shutil.which("pnpm")
-        if pnpm is None:
+        try:
+            pnpm = capture_command_executable(
+                "pnpm",
+                field="pnpm executable",
+            ).path
+        except (OSError, PermissionError, RuntimeError, ValueError):
             print("presubmit: pnpm is required for frontend checks but was not found.", file=sys.stderr)
             return 1
         checks.extend(
@@ -143,10 +158,16 @@ def commits_from_pre_push_input(remote_name: str, hook_input: str) -> list[str]:
 
 
 def validate_commit_message_file(message_file: Path) -> int:
+    # Git may pass .git/COMMIT_EDITMSG relative to the worktree even though
+    # this presubmit's file boundary deliberately rejects ambient-cwd paths.
+    # Bind that Git-owned relative spelling to this script's repository root
+    # before handing it to the strict reader.
+    message_path = message_file if message_file.is_absolute() else ROOT / message_file
+    payload = read_bytes_without_links(message_path)
     try:
-        lines = message_file.read_text(encoding="utf-8").splitlines()
+        lines = payload.decode("utf-8").splitlines()
     except UnicodeDecodeError:
-        lines = message_file.read_text().splitlines()
+        lines = payload.decode(errors="replace").splitlines()
 
     title = next((line.strip() for line in lines if line.strip() and not line.startswith("#")), "")
     return validate_title(title)
@@ -217,7 +238,7 @@ def run_check(label: str, command: list[str], cwd: Path) -> int:
     env = os.environ.copy()
     env.setdefault("QT_QPA_PLATFORM", "offscreen")
     env.setdefault("PYTHONIOENCODING", "utf-8")
-    result = subprocess.run(command, cwd=cwd, env=env)
+    result = _run_stable_command(command, cwd=cwd, env=env)
     if result.returncode != 0:
         print(f"presubmit: {label} failed.", file=sys.stderr)
     return result.returncode
@@ -235,14 +256,19 @@ def pytest_cache_dir() -> str:
 
 
 def run_git_lfs_pre_push(remote_name: str, remote_url: str, hook_input: str) -> int:
-    if shutil.which("git-lfs") is None:
+    try:
+        git_lfs = capture_command_executable(
+            "git-lfs",
+            field="git-lfs executable",
+        ).path
+    except (OSError, PermissionError, RuntimeError, ValueError):
         if repository_uses_lfs():
             print("presubmit: git-lfs is required for this repository but was not found.", file=sys.stderr)
             return 1
         return 0
 
-    result = subprocess.run(
-        ["git", "lfs", "pre-push", remote_name, remote_url],
+    result = _run_stable_command(
+        [git_lfs, "pre-push", remote_name, remote_url],
         cwd=ROOT,
         input=hook_input,
         text=True,
@@ -252,20 +278,48 @@ def run_git_lfs_pre_push(remote_name: str, remote_url: str, hook_input: str) -> 
 
 def repository_uses_lfs() -> bool:
     attributes = ROOT / ".gitattributes"
-    if not attributes.exists():
-        return False
     try:
-        return "filter=lfs" in attributes.read_text(encoding="utf-8")
+        return "filter=lfs" in read_text_without_links(attributes)
+    except FileNotFoundError:
+        return False
     except UnicodeDecodeError:
-        return "filter=lfs" in attributes.read_text(errors="ignore")
+        return "filter=lfs" in read_text_without_links(
+            attributes,
+            errors="ignore",
+        )
 
 
 def git(args: list[str], capture_output: bool = False) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
+    return _run_stable_command(
         ["git", *args],
         cwd=ROOT,
         text=True,
         capture_output=capture_output,
+    )
+
+
+def _run_stable_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    **run_kwargs,
+) -> subprocess.CompletedProcess:
+    if not command:
+        raise ValueError("presubmit command is empty")
+    executable = capture_command_executable(
+        command[0],
+        field="presubmit executable",
+    )
+    working_directory = capture_launch_directory(
+        cwd,
+        field="presubmit working directory",
+    )
+    return run_with_stable_paths(
+        [str(executable.path), *command[1:]],
+        cwd=working_directory,
+        executable=executable,
+        run_factory=subprocess.run,
+        **run_kwargs,
     )
 
 

--- a/scripts/release_cherry_pick_command.py
+++ b/scripts/release_cherry_pick_command.py
@@ -5,8 +5,19 @@ import shlex
 import subprocess
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 from urllib.parse import quote
 
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from core.process_launch import (  # noqa: E402
+    capture_command_executable,
+    capture_launch_directory,
+    run_with_stable_paths,
+)
 
 REPO = os.environ["REPO"]
 COMMENT_BODY = os.environ.get("COMMENT_BODY") or ""
@@ -70,11 +81,23 @@ def run(
     check: bool = True,
 ) -> subprocess.CompletedProcess:
     safe_command = validate_subprocess_command(command)
+    executable = capture_command_executable(
+        safe_command[0],
+        field=f"{safe_command[0]} executable",
+    )
+    repository = capture_launch_directory(
+        REPOSITORY_ROOT,
+        field="release command repository",
+    )
+    stable_command = [str(executable.path), *safe_command[1:]]
 
     # nosemgrep justification: argv is validated against a gh/git subcommand
     # allowlist, shell is disabled, and user-controlled values stay literal args.
-    result = subprocess.run(
-        safe_command,
+    result = run_with_stable_paths(
+        stable_command,
+        cwd=repository,
+        executable=executable,
+        run_factory=subprocess.run,
         input=input_text,
         shell=False,
         text=True,

--- a/scripts/resolve-command.ps1
+++ b/scripts/resolve-command.ps1
@@ -1,0 +1,141 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Test-PortableComponent {
+    param([string]$Value)
+
+    if (
+        [string]::IsNullOrWhiteSpace($Value) -or
+        $Value -in @(".", "..") -or
+        $Value.Trim() -cne $Value -or
+        $Value.EndsWith(" ") -or
+        $Value.EndsWith(".") -or
+        [Text.Encoding]::UTF8.GetByteCount($Value) -gt 255
+    ) {
+        return $false
+    }
+    foreach ($character in $Value.ToCharArray()) {
+        $codePoint = [int][char]$character
+        if (
+            $codePoint -le 31 -or
+            $codePoint -eq 127 -or
+            ($codePoint -ge 0xD800 -and $codePoint -le 0xDFFF) -or
+            '<>:"/\|?*'.IndexOf($character) -ge 0
+        ) {
+            return $false
+        }
+    }
+    $stem = $Value.Split(".")[0].ToUpperInvariant()
+    if ($stem -match '\A(CON|PRN|AUX|NUL|CLOCK\$|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³])\z') {
+        return $false
+    }
+    return $true
+}
+
+function Test-ExactAbsolutePath {
+    param([string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value) -or $Value.Trim() -cne $Value) {
+        return $false
+    }
+    if ($Value.ToCharArray() | Where-Object { [char]::IsControl($_) }) {
+        return $false
+    }
+    $driveAbsolute = $Value -match "^[A-Za-z]:[\\/]"
+    $uncAbsolute = $Value -match "^[\\/]{2}[^\\/]+[\\/][^\\/]+"
+    if (-not ($driveAbsolute -or $uncAbsolute)) {
+        return $false
+    }
+    $portable = $Value.Replace("\", "/")
+    if ($portable.StartsWith("//?/") -or $portable.StartsWith("//./") -or $portable.StartsWith("/??/")) {
+        return $false
+    }
+    if ($driveAbsolute) {
+        $tail = $portable.Substring(3)
+        $components = if ($tail.Length -eq 0) {
+            @()
+        }
+        else {
+            @($tail.Split("/"))
+        }
+    }
+    else {
+        $components = @($portable.Substring(2).Split("/"))
+        if ($components.Count -lt 2) {
+            return $false
+        }
+        if ($components.Count -eq 3 -and $components[2].Length -eq 0) {
+            $components = @($components[0], $components[1])
+        }
+    }
+    foreach ($component in $components) {
+        if (-not (Test-PortableComponent $component)) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Test-NoReparseComponents {
+    param([System.IO.FileSystemInfo]$Item)
+
+    $cursor = $Item
+    while ($null -ne $cursor) {
+        if (($cursor.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            return $false
+        }
+        $cursor = $cursor.Parent
+    }
+    return $true
+}
+
+if (-not (Test-PortableComponent $Name)) {
+    exit 1
+}
+
+$extensions = if ([IO.Path]::GetExtension($Name)) {
+    @("")
+}
+else {
+    $configured = if ([string]::IsNullOrWhiteSpace($env:PATHEXT)) {
+        ".COM;.EXE;.BAT;.CMD"
+    }
+    else {
+        $env:PATHEXT
+    }
+    @(
+        $configured.Split(";") |
+            Where-Object { $_ -match "\A\.[A-Za-z0-9]+\z" } |
+            Select-Object -Unique
+    )
+}
+
+foreach ($rawDirectory in $env:PATH.Split(";")) {
+    if (-not (Test-ExactAbsolutePath $rawDirectory)) {
+        continue
+    }
+    foreach ($extension in $extensions) {
+        $candidateName = "$Name$extension"
+        if (-not (Test-PortableComponent $candidateName)) {
+            continue
+        }
+        $candidate = Join-Path -Path $rawDirectory -ChildPath $candidateName
+        if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+            continue
+        }
+        $item = Get-Item -LiteralPath $candidate -Force
+        if (-not (Test-NoReparseComponents $item)) {
+            continue
+        }
+        [Console]::Out.WriteLine($item.FullName)
+        exit 0
+    }
+}
+
+exit 1

--- a/scripts/shell-path-contract.sh
+++ b/scripts/shell-path-contract.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+
+# Shared path boundary for the POSIX launch and install scripts.  The caller
+# must set PROJECT_ROOT to a physical, absolute project directory first.
+
+shinsekai_portable_environment_name() {
+  local value="$1"
+  local stem
+
+  [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ &&
+     "$value" != *. ]] || return 1
+  stem="${value%%.*}"
+  case "$stem" in
+    [Cc][Oo][Nn] | [Pp][Rr][Nn] | [Aa][Uu][Xx] | [Nn][Uu][Ll] | \
+      [Cc][Oo][Mm][1-9] | [Ll][Pp][Tt][1-9])
+      return 1
+      ;;
+  esac
+}
+
+shinsekai_absolute_path_is_exact() {
+  local absolute_path="$1"
+  local cursor=""
+  local component
+  local -a components
+
+  [[ -n "$absolute_path" && "$absolute_path" == /* &&
+     "$absolute_path" != "/" && "$absolute_path" != *\\* &&
+     "$absolute_path" != *$'\n'* && "$absolute_path" != *$'\r'* &&
+     "$absolute_path" != *$'\t'* ]] || return 1
+  IFS="/" read -r -a components <<< "$absolute_path"
+  for component in "${components[@]}"; do
+    [[ -z "$component" && -z "$cursor" ]] && continue
+    [[ -n "$component" && "$component" != "." && "$component" != ".." ]] || return 1
+    cursor="$cursor/$component"
+  done
+}
+
+shinsekai_absolute_path_has_no_links() {
+  local absolute_path="$1"
+  local cursor=""
+  local component
+  local -a components
+
+  shinsekai_absolute_path_is_exact "$absolute_path" || return 1
+  IFS="/" read -r -a components <<< "$absolute_path"
+  for component in "${components[@]}"; do
+    [[ -z "$component" && -z "$cursor" ]] && continue
+    cursor="$cursor/$component"
+    [[ ! -L "$cursor" ]] || return 1
+  done
+}
+
+shinsekai_absolute_file_is_real() {
+  local absolute_path="$1"
+  shinsekai_absolute_path_has_no_links "$absolute_path" &&
+    [[ -f "$absolute_path" ]]
+}
+
+shinsekai_absolute_directory_is_real() {
+  local absolute_path="$1"
+  shinsekai_absolute_path_has_no_links "$absolute_path" &&
+    [[ -d "$absolute_path" ]]
+}
+
+shinsekai_absolute_directory_is_real_or_missing() {
+  local absolute_path="$1"
+  shinsekai_absolute_path_has_no_links "$absolute_path" || return 1
+  if [[ -e "$absolute_path" || -L "$absolute_path" ]]; then
+    [[ -d "$absolute_path" && ! -L "$absolute_path" ]]
+  fi
+}
+
+# Resolve a PATH command once and hand callers the exact absolute spelling.
+# Relative/empty PATH entries and shell functions are cwd- or process-local
+# identities, so launchers must not defer them to a later exec.
+shinsekai_normalize_absolute_link_target() {
+  local raw="$1"
+  local component
+  local result=""
+  local -a components
+  local -a stack=()
+
+  [[ -n "$raw" && "$raw" == /* && "$raw" != *\\* &&
+     "$raw" != *$'\n'* && "$raw" != *$'\r'* &&
+     "$raw" != *$'\t'* ]] || return 1
+  IFS="/" read -r -a components <<< "$raw"
+  for component in "${components[@]}"; do
+    [[ -z "$component" || "$component" == "." ]] && continue
+    if [[ "$component" == ".." ]]; then
+      ((${#stack[@]} > 0)) || return 1
+      stack=("${stack[@]:0:$((${#stack[@]} - 1))}")
+      continue
+    fi
+    stack+=("$component")
+  done
+  ((${#stack[@]} > 0)) || return 1
+  for component in "${stack[@]}"; do
+    result="$result/$component"
+  done
+  shinsekai_absolute_path_is_exact "$result" || return 1
+  printf '%s\n' "$result"
+}
+
+shinsekai_resolve_executable_candidate() {
+  local candidate="$1"
+  local link_target
+  local parent
+  local link_hops=0
+
+  shinsekai_absolute_path_is_exact "$candidate" || return 1
+  while [[ -L "$candidate" ]]; do
+    ((link_hops += 1))
+    ((link_hops <= 64)) || return 1
+    parent="${candidate%/*}"
+    [[ -n "$parent" ]] || parent="/"
+    if [[ "$parent" != "/" ]]; then
+      shinsekai_absolute_directory_is_real "$parent" || return 1
+    fi
+    link_target="$(/usr/bin/readlink "$candidate")" || return 1
+    [[ -n "$link_target" ]] || return 1
+    [[ "$link_target" == /* ]] || link_target="$parent/$link_target"
+    candidate="$(shinsekai_normalize_absolute_link_target "$link_target")" ||
+      return 1
+  done
+  shinsekai_absolute_file_is_real "$candidate" &&
+    [[ -x "$candidate" ]] || return 1
+  printf '%s\n' "$candidate"
+}
+
+shinsekai_resolve_executable() {
+  local requested="$1"
+  local candidate
+  local directory
+  local resolved
+  local -a search_directories
+
+  [[ -n "$requested" && "$requested" != *$'\n'* && "$requested" != *$'\r'* ]] ||
+    return 1
+  if [[ "$requested" == */* ]]; then
+    shinsekai_resolve_executable_candidate "$requested"
+    return
+  else
+    [[ "$requested" != "." && "$requested" != ".." &&
+       "$requested" != *\\* ]] || return 1
+    IFS=":" read -r -a search_directories <<< "${PATH-}"
+    for directory in "${search_directories[@]}"; do
+      shinsekai_absolute_path_is_exact "$directory" || continue
+      candidate="$directory/$requested"
+      if resolved="$(shinsekai_resolve_executable_candidate "$candidate")"; then
+        printf '%s\n' "$resolved"
+        return 0
+      fi
+    done
+  fi
+  return 1
+}
+
+shinsekai_resolve_conda_python() {
+  local conda_executable="$1"
+  local environment_name="$2"
+  local probe_shell
+  local output
+  local line
+  local prefix=""
+
+  probe_shell="$(shinsekai_resolve_executable sh)" || return 1
+  output="$(
+    "$conda_executable" run --cwd / -n "$environment_name" "$probe_shell" -c \
+      'printf "__SHINSEKAI_CONDA_PREFIX__=%s\n" "$CONDA_PREFIX"'
+  )" || return 1
+  while IFS= read -r line; do
+    case "$line" in
+      __SHINSEKAI_CONDA_PREFIX__=*)
+        prefix="${line#__SHINSEKAI_CONDA_PREFIX__=}"
+        ;;
+    esac
+  done <<< "$output"
+  [[ -n "$prefix" && "$prefix" == /* && "$prefix" != *\\* ]] || return 1
+  shinsekai_resolve_executable "$prefix/bin/python"
+}
+
+shinsekai_project_path_has_no_links() {
+  local relative_path="$1"
+  local cursor="$PROJECT_ROOT"
+  local component
+  local -a components
+
+  [[ -n "$relative_path" && "$relative_path" != /* && "$relative_path" != *\\* ]] || return 1
+  IFS="/" read -r -a components <<< "$relative_path"
+  for component in "${components[@]}"; do
+    [[ -n "$component" && "$component" != "." && "$component" != ".." ]] || return 1
+    cursor="$cursor/$component"
+    [[ ! -L "$cursor" ]] || return 1
+  done
+}
+
+shinsekai_project_file_is_real() {
+  local relative_path="$1"
+  shinsekai_project_path_has_no_links "$relative_path" &&
+    [[ -f "$PROJECT_ROOT/$relative_path" ]]
+}
+
+shinsekai_project_directory_is_real() {
+  local relative_path="$1"
+  shinsekai_project_path_has_no_links "$relative_path" &&
+    [[ -d "$PROJECT_ROOT/$relative_path" ]]
+}
+
+shinsekai_project_directory_is_real_or_missing() {
+  local relative_path="$1"
+  local target="$PROJECT_ROOT/$relative_path"
+
+  shinsekai_project_path_has_no_links "$relative_path" || return 1
+  if [[ -e "$target" || -L "$target" ]]; then
+    [[ -d "$target" && ! -L "$target" ]]
+  fi
+}
+
+shinsekai_ensure_project_directory() {
+  local relative_path="$1"
+  local cursor="$PROJECT_ROOT"
+  local component
+  local -a components
+
+  [[ -n "$relative_path" && "$relative_path" != /* && "$relative_path" != *\\* ]] || return 1
+  IFS="/" read -r -a components <<< "$relative_path"
+  for component in "${components[@]}"; do
+    [[ -n "$component" && "$component" != "." && "$component" != ".." ]] || return 1
+    cursor="$cursor/$component"
+    [[ ! -L "$cursor" ]] || return 1
+    if [[ ! -e "$cursor" ]]; then
+      /bin/mkdir "$cursor" || return 1
+    fi
+    [[ -d "$cursor" && ! -L "$cursor" ]] || return 1
+  done
+}
+
+shinsekai_find_embedded_python() {
+  local relative_path
+  for relative_path in \
+    runtime/bin/python3.10 \
+    runtime/bin/python3.11 \
+    runtime/bin/python3.12 \
+    runtime/bin/python3.13 \
+    runtime/bin/python3 \
+    runtime/bin/python \
+    runtime/python.exe
+  do
+    if shinsekai_project_file_is_real "$relative_path" &&
+      [[ -x "$PROJECT_ROOT/$relative_path" ]]; then
+      printf '%s\n' "$PROJECT_ROOT/$relative_path"
+      return 0
+    fi
+  done
+  return 1
+}
+
+shinsekai_ensure_data_directories() {
+  local relative_path
+  for relative_path in \
+    data/config \
+    data/sprite \
+    data/speech \
+    data/models \
+    data/chat_history \
+    data/character_templates
+  do
+    shinsekai_ensure_project_directory "$relative_path" || {
+      echo "Error: refusing unsafe project data directory: $PROJECT_ROOT/$relative_path" >&2
+      return 1
+    }
+  done
+}

--- a/scripts/start.command
+++ b/scripts/start.command
@@ -1,3 +1,30 @@
 #!/bin/bash
-cd "$(dirname "$0")/.."
-exec bash scripts/start.sh "$@"
+set -euo pipefail
+
+resolve_script_directory() {
+    local source_path="${BASH_SOURCE[0]}"
+    local link_hops=0
+    while [[ -L "$source_path" ]]; do
+        local source_dir
+        ((link_hops += 1))
+        if ((link_hops > 64)); then
+            echo "Error: launcher path contains too many symbolic-link hops: $source_path" >&2
+            return 1
+        fi
+        source_dir="$(CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd)"
+        source_path="$(/usr/bin/readlink "$source_path")"
+        [[ "$source_path" != /* ]] && source_path="$source_dir/$source_path"
+    done
+    CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd
+}
+
+SCRIPT_DIR="$(resolve_script_directory)"
+PROJECT_ROOT="$(CDPATH= cd -P -- "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+DELEGATED_SCRIPT="$PROJECT_ROOT/scripts/start.sh"
+if [[ -L "$PROJECT_ROOT/scripts" || ! -d "$PROJECT_ROOT/scripts" ||
+      -L "$DELEGATED_SCRIPT" || ! -f "$DELEGATED_SCRIPT" ]]; then
+    echo "Error: delegated launcher is missing or unsafe: $DELEGATED_SCRIPT" >&2
+    exit 1
+fi
+exec /bin/bash "$DELEGATED_SCRIPT" "$@"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,22 +1,79 @@
 #!/bin/bash
+set -euo pipefail
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-cd "$SCRIPT_DIR/.."
+resolve_script_directory() {
+    local source_path="${BASH_SOURCE[0]}"
+    local source_dir
+    local link_hops=0
+    while [[ -L "$source_path" ]]; do
+        ((link_hops += 1))
+        if ((link_hops > 64)); then
+            echo "Error: launcher path contains too many symbolic-link hops: $source_path" >&2
+            return 1
+        fi
+        source_dir="$(CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd)"
+        source_path="$(/usr/bin/readlink "$source_path")"
+        [[ "$source_path" = /* ]] || source_path="$source_dir/$source_path"
+    done
+    CDPATH= cd -P -- "$(/usr/bin/dirname "$source_path")" && pwd
+}
+
+SCRIPT_DIR="$(resolve_script_directory)"
+PROJECT_ROOT="$(CDPATH= cd -P -- "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PATH_CONTRACT="$PROJECT_ROOT/scripts/shell-path-contract.sh"
+if [[ -L "$PROJECT_ROOT/scripts" || ! -d "$PROJECT_ROOT/scripts" ||
+      -L "$PATH_CONTRACT" || ! -f "$PATH_CONTRACT" ]]; then
+    echo "Error: launcher path contract is missing or unsafe: $PATH_CONTRACT" >&2
+    exit 1
+fi
+# shellcheck source=scripts/shell-path-contract.sh
+source "$PATH_CONTRACT"
+
+if ! shinsekai_project_file_is_real "webui_react.py" ||
+   ! shinsekai_project_file_is_real "requirements.txt"; then
+    echo "Error: launcher could not identify the Shinsekai project root: $PROJECT_ROOT" >&2
+    exit 1
+fi
 
 CONDA_ENV_NAME="${SHINSEKAI_CONDA_ENV:-shinsekai}"
+if ! shinsekai_portable_environment_name "$CONDA_ENV_NAME"; then
+    echo "Error: SHINSEKAI_CONDA_ENV must be a portable conda environment name" >&2
+    exit 1
+fi
+
+if [[ -n "${CONDA_EXE:-}" && ( "$CONDA_EXE" != /* || ! -x "$CONDA_EXE" ) ]]; then
+    echo "Error: CONDA_EXE must be an absolute executable path: $CONDA_EXE" >&2
+    exit 1
+fi
+if [[ -n "${CONDA_PREFIX:-}" && "$CONDA_PREFIX" != /* ]]; then
+    echo "Error: CONDA_PREFIX must be an absolute path: $CONDA_PREFIX" >&2
+    exit 1
+fi
+if [[ -n "${HOME:-}" && "$HOME" != /* ]]; then
+    echo "Error: HOME must be an absolute path when set: $HOME" >&2
+    exit 1
+fi
 
 find_conda() {
-    if [ -n "${CONDA_EXE:-}" ] && [ -x "$CONDA_EXE" ]; then
-        printf '%s\n' "$CONDA_EXE"
+    local -a candidates=("/opt/miniconda3/bin/conda" "/opt/anaconda3/bin/conda")
+    local resolved
+    if [[ -n "${HOME:-}" ]]; then
+        candidates=("$HOME/miniconda3/bin/conda" "$HOME/anaconda3/bin/conda" "${candidates[@]}")
+    fi
+    if [ -n "${CONDA_EXE:-}" ] &&
+       resolved="$(shinsekai_resolve_executable "$CONDA_EXE")"; then
+        printf '%s\n' "$resolved"
         return 0
     fi
-    if command -v conda > /dev/null 2>&1; then
-        command -v conda
+    if resolved="$(shinsekai_resolve_executable conda)"; then
+        printf '%s\n' "$resolved"
         return 0
     fi
-    for candidate in "$HOME/miniconda3/bin/conda" "$HOME/anaconda3/bin/conda" "/opt/miniconda3/bin/conda" "/opt/anaconda3/bin/conda"; do
-        if [ -x "$candidate" ]; then
-            printf '%s\n' "$candidate"
+    for candidate in "${candidates[@]}"; do
+        if resolved="$(shinsekai_resolve_executable "$candidate")"; then
+            printf '%s\n' "$resolved"
             return 0
         fi
     done
@@ -24,23 +81,25 @@ find_conda() {
 }
 
 # Check for embedded python, then the project conda env, then system python
-if [ -f "runtime/bin/python3" ]; then
-    PYTHON_CMD=("runtime/bin/python3")
-elif [ -f "runtime/python.exe" ]; then
-    PYTHON_CMD=("runtime/python.exe")
+if EMBEDDED_PYTHON="$(shinsekai_find_embedded_python)"; then
+    PYTHON_CMD=("$EMBEDDED_PYTHON")
 elif [ "${CONDA_DEFAULT_ENV:-}" = "$CONDA_ENV_NAME" ] && [ -n "${CONDA_PREFIX:-}" ] && [ -x "$CONDA_PREFIX/bin/python" ]; then
     echo "Embedded Python not found, using active conda env ${CONDA_ENV_NAME}..."
     PYTHON_CMD=("$CONDA_PREFIX/bin/python")
 elif CONDA_CMD="$(find_conda)"; then
     echo "Embedded Python not found, using conda env ${CONDA_ENV_NAME}..."
-    PYTHON_CMD=("$CONDA_CMD" run -n "$CONDA_ENV_NAME" python)
+    if ! CONDA_PYTHON="$(shinsekai_resolve_conda_python "$CONDA_CMD" "$CONDA_ENV_NAME")"; then
+        echo "Error: conda env ${CONDA_ENV_NAME} does not expose a deterministic Python path"
+        exit 1
+    fi
+    PYTHON_CMD=("$CONDA_CMD" run --cwd / -n "$CONDA_ENV_NAME" "$CONDA_PYTHON")
 else
     echo "Embedded Python not found, falling back to system python3..."
-    if ! command -v python3 &> /dev/null; then
+    if ! SYSTEM_PYTHON="$(shinsekai_resolve_executable python3)"; then
         echo "Error: neither conda env ${CONDA_ENV_NAME} nor python3 was found"
         exit 1
     fi
-    PYTHON_CMD=(python3)
+    PYTHON_CMD=("$SYSTEM_PYTHON")
 fi
 
-"${PYTHON_CMD[@]}" webui_react.py "$@"
+"${PYTHON_CMD[@]}" "$PROJECT_ROOT/webui_react.py" "$@"


### PR DESCRIPTION
## What changed

Applies portable shell, installer, release, presubmit, and command-resolution
contracts to `scripts/`.

## Why

Automation must resolve repository and executable paths consistently across
shells and platforms, including paths containing spaces or non-ASCII text.

## Impact

Install, startup, release, and presubmit commands avoid ambient-directory and
shell-parsing assumptions.

## Root cause

Script entry points mixed shell expansion with ad hoc path construction,
producing platform-specific resolution behavior.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `scripts/`.
