### PR TITLE
fix(sdk): enforce migration-safe path contracts

### DIFF
--- a/sdk/archive_paths.py
+++ b/sdk/archive_paths.py
@@ -1,0 +1,713 @@
+"""Portable, link-free ZIP extraction for project-managed imports and updates."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from sdk.file_transactions import (
+    capture_directory_identity,
+    file_snapshot_is_stable,
+    inspect_portable_directory_tree_with_metadata,
+    open_binary_read_without_links,
+    open_binary_write_exclusive_without_links,
+    portable_name_key,
+    require_directory_identity,
+)
+from sdk.path_contract import (
+    _metadata_is_link_or_reparse_point,
+    path_is_within,
+    path_is_link_or_reparse_point,
+    require_symlink_free_absolute_path,
+    safe_path_component,
+)
+
+
+class UnsafeArchiveError(ValueError):
+    """Raised before extraction when an archive cannot map to portable paths."""
+
+
+@dataclass(frozen=True)
+class ZipExtraction:
+    top_level: str | None
+    file_count: int
+
+
+@dataclass(frozen=True)
+class _Entry:
+    info: zipfile.ZipInfo
+    relative: Path
+    is_directory: bool
+
+
+@dataclass(frozen=True)
+class _TarEntry:
+    member: tarfile.TarInfo
+    relative: Path
+    is_directory: bool
+
+
+@dataclass(frozen=True)
+class _ZipSource:
+    path: Path
+    archive_name: str
+    identity: os.stat_result
+    parent: Path
+    parent_identity: os.stat_result
+
+
+def _portable_member_parts(raw_name: str) -> tuple[tuple[str, ...], bool]:
+    normalized = str(raw_name or "").replace("\\", "/")
+    if normalized.startswith("/"):
+        raise UnsafeArchiveError(f"unsafe archive path: {raw_name!r}")
+    is_directory = normalized.endswith("/")
+    if is_directory and normalized.endswith("//"):
+        raise UnsafeArchiveError(f"unsafe archive path: {raw_name!r}")
+    member = normalized[:-1] if is_directory else normalized
+    if not member:
+        return (), is_directory
+    if member != member.strip():
+        raise UnsafeArchiveError(f"unsafe archive path: {raw_name!r}")
+    parts = tuple(member.split("/"))
+    if any(part in {"", ".", ".."} for part in parts):
+        raise UnsafeArchiveError(f"unsafe archive path: {raw_name!r}")
+    if parts[0].startswith("~"):
+        raise UnsafeArchiveError(f"unsafe archive home-relative path: {raw_name!r}")
+    for part in parts:
+        try:
+            safe_path_component(part, field="archive path component")
+        except ValueError as exc:
+            raise UnsafeArchiveError(f"non-portable archive path: {raw_name!r}") from exc
+    return parts, is_directory
+
+
+def validate_archive_member_names(names: list[str] | tuple[str, ...]) -> None:
+    """Validate portable member names before delegating to another extractor.
+
+    Some formats (notably 7z) require an external extraction backend.  This
+    preflight still enforces the traversal, case-collision, duplicate, and
+    file/directory invariants used by the manual ZIP/TAR paths.
+    """
+
+    entry_types: dict[tuple[str, ...], str] = {}
+    prefix_spellings: dict[tuple[str, ...], tuple[str, ...]] = {}
+    file_count = 0
+    for raw_name in names:
+        parts, is_directory = _portable_member_parts(raw_name)
+        if not parts:
+            continue
+        folded = tuple(portable_name_key(part) for part in parts)
+        for index in range(1, len(folded) + 1):
+            folded_prefix = folded[:index]
+            spelling = parts[:index]
+            previous_spelling = prefix_spellings.setdefault(folded_prefix, spelling)
+            if previous_spelling != spelling:
+                raise UnsafeArchiveError(
+                    f"archive paths differ only by case: {raw_name!r}"
+                )
+        if folded in entry_types:
+            raise UnsafeArchiveError(f"duplicate portable archive path: {raw_name!r}")
+        for index in range(1, len(folded)):
+            if entry_types.get(folded[:index]) == "file":
+                raise UnsafeArchiveError(f"archive path is nested below a file: {raw_name!r}")
+        if not is_directory and any(
+            len(existing) > len(folded) and existing[: len(folded)] == folded
+            for existing in entry_types
+        ):
+            raise UnsafeArchiveError(f"archive file conflicts with a directory: {raw_name!r}")
+        entry_types[folded] = "directory" if is_directory else "file"
+        if not is_directory:
+            file_count += 1
+    if file_count == 0:
+        raise UnsafeArchiveError("archive contains no regular files")
+
+
+def write_zip_files_without_links(
+    archive: zipfile.ZipFile,
+    members: list[tuple[Path, str]] | tuple[tuple[Path, str], ...],
+) -> int:
+    """Stream exact regular files into a ZIP after validating the member set.
+
+    The complete archive namespace is checked before the first new member is
+    written.  Every source is then opened through the link-free file contract,
+    closing the validation/read race that ``ZipFile.write`` otherwise leaves.
+    """
+
+    normalized: list[tuple[Path, str]] = []
+    for source, raw_name in members:
+        parts, is_directory = _portable_member_parts(raw_name)
+        if not parts or is_directory:
+            raise UnsafeArchiveError(f"archive member must be a regular file: {raw_name!r}")
+        source_path = require_symlink_free_absolute_path(
+            source,
+            field="archive source file",
+        )
+        normalized.append((source_path, "/".join(parts)))
+
+    validate_archive_member_names(tuple([*archive.namelist(), *(name for _, name in normalized)]))
+    pinned: list[_ZipSource] = []
+    for source, archive_name in normalized:
+        source_identity = source.lstat()
+        if (
+            _metadata_is_link_or_reparse_point(source_identity)
+            or not stat.S_ISREG(source_identity.st_mode)
+        ):
+            raise PermissionError(f"archive source must be a regular non-link file: {source}")
+        parent, parent_identity = capture_directory_identity(
+            source.parent,
+            field="archive source parent",
+        )
+        pinned.append(
+            _ZipSource(
+                path=source,
+                archive_name=archive_name,
+                identity=source_identity,
+                parent=parent,
+                parent_identity=parent_identity,
+            )
+        )
+    return _write_pinned_zip_sources(archive, pinned)
+
+
+def write_zip_file_snapshots_without_links(
+    archive: zipfile.ZipFile,
+    members: (
+        list[tuple[Path, str, os.stat_result, os.stat_result]]
+        | tuple[tuple[Path, str, os.stat_result, os.stat_result], ...]
+    ),
+) -> int:
+    """Write previously observed file identities without reopening peers.
+
+    Directory walkers use this variant to carry the exact leaf and parent
+    identities from enumeration into archival.  A same-named file or parent
+    that appears later is therefore never substituted into the ZIP.
+    """
+
+    pinned: list[_ZipSource] = []
+    for source, raw_name, source_identity, parent_identity in members:
+        parts, is_directory = _portable_member_parts(raw_name)
+        if not parts or is_directory:
+            raise UnsafeArchiveError(
+                f"archive member must be a regular file: {raw_name!r}"
+            )
+        source_path = require_symlink_free_absolute_path(
+            source,
+            field="archive source file",
+        )
+        parent, current_parent_identity = capture_directory_identity(
+            source_path.parent,
+            field="archive source parent",
+        )
+        try:
+            current_source_identity = source_path.lstat()
+        except FileNotFoundError:
+            raise PermissionError(
+                f"archive source disappeared before read: {source_path}"
+            ) from None
+        if (
+            not os.path.samestat(parent_identity, current_parent_identity)
+            or _metadata_is_link_or_reparse_point(current_source_identity)
+            or not stat.S_ISREG(current_source_identity.st_mode)
+            or not os.path.samestat(source_identity, current_source_identity)
+        ):
+            raise PermissionError(
+                f"archive source identity changed before read: {source_path}"
+            )
+        pinned.append(
+            _ZipSource(
+                path=source_path,
+                archive_name="/".join(parts),
+                identity=source_identity,
+                parent=parent,
+                parent_identity=parent_identity,
+            )
+        )
+    validate_archive_member_names(
+        tuple(
+            [
+                *archive.namelist(),
+                *(source.archive_name for source in pinned),
+            ]
+        )
+    )
+    return _write_pinned_zip_sources(archive, pinned)
+
+
+def _write_pinned_zip_sources(
+    archive: zipfile.ZipFile,
+    sources: list[_ZipSource],
+    *,
+    expected_root: tuple[Path, os.stat_result] | None = None,
+) -> int:
+    for source in sources:
+        if expected_root is not None:
+            require_directory_identity(
+                expected_root[0],
+                expected_root[1],
+                field="archive source root",
+            )
+        with tempfile.SpooledTemporaryFile(
+            max_size=8 * 1024 * 1024,
+            mode="w+b",
+        ) as staged:
+            with open_binary_read_without_links(
+                source.path,
+                expected_identity=source.identity,
+                expected_parent_identity=source.parent_identity,
+            ) as input_file:
+                metadata = os.fstat(input_file.fileno())
+                shutil.copyfileobj(
+                    input_file,
+                    staged,
+                    length=1024 * 1024,
+                )
+                final_metadata = os.fstat(input_file.fileno())
+            if not file_snapshot_is_stable(metadata, final_metadata):
+                raise PermissionError(
+                    "archive source changed while it was being read: "
+                    f"{source.path}"
+                )
+            staged.seek(0)
+            try:
+                date_time = time.localtime(metadata.st_mtime)[:6]
+            except (OSError, OverflowError, ValueError):
+                date_time = (1980, 1, 1, 0, 0, 0)
+            if date_time[0] < 1980:
+                date_time = (1980, 1, 1, 0, 0, 0)
+            elif date_time[0] > 2107:
+                date_time = (2107, 12, 31, 23, 59, 58)
+            info = zipfile.ZipInfo(source.archive_name, date_time=date_time)
+            info.external_attr = (metadata.st_mode & 0xFFFF) << 16
+            info.compress_type = archive.compression
+            with archive.open(info, "w", force_zip64=True) as output:
+                shutil.copyfileobj(staged, output, length=1024 * 1024)
+        require_directory_identity(
+            source.parent,
+            source.parent_identity,
+            field="archive source parent",
+        )
+        try:
+            current_identity = source.path.lstat()
+        except FileNotFoundError:
+            raise PermissionError(
+                f"archive source disappeared during read: {source.path}"
+            ) from None
+        if (
+            _metadata_is_link_or_reparse_point(current_identity)
+            or not os.path.samestat(source.identity, current_identity)
+        ):
+            raise PermissionError(
+                f"archive source identity changed during read: {source.path}"
+            )
+        if expected_root is not None:
+            require_directory_identity(
+                expected_root[0],
+                expected_root[1],
+                field="archive source root",
+            )
+    return len(sources)
+
+
+def write_directory_to_zip_without_links(
+    archive: zipfile.ZipFile,
+    source_root: str | Path,
+) -> int:
+    """Archive a complete portable directory tree without following aliases."""
+
+    root = require_symlink_free_absolute_path(
+        source_root,
+        field="archive source directory",
+    )
+    root_identity, directories, files = inspect_portable_directory_tree_with_metadata(
+        root
+    )
+    directory_identities = dict(directories)
+    directory_identities[Path()] = root_identity
+    pinned = [
+        _ZipSource(
+            path=root / relative,
+            archive_name=relative.as_posix(),
+            identity=identity,
+            parent=root / relative.parent,
+            parent_identity=directory_identities[relative.parent],
+        )
+        for relative, identity in files
+    ]
+    validate_archive_member_names(
+        tuple([*archive.namelist(), *(source.archive_name for source in pinned)])
+    )
+    return _write_pinned_zip_sources(
+        archive,
+        pinned,
+        expected_root=(root, root_identity),
+    )
+
+
+def _validated_entries(
+    zf: zipfile.ZipFile,
+    *,
+    require_single_root: bool,
+    strip_single_root: bool,
+) -> tuple[list[_Entry], str | None]:
+    parsed: list[tuple[zipfile.ZipInfo, tuple[str, ...], bool]] = []
+    roots: set[str] = set()
+    for info in zf.infolist():
+        parts, directory_by_name = _portable_member_parts(info.filename)
+        if not parts:
+            continue
+        unix_mode = info.external_attr >> 16
+        file_type = stat.S_IFMT(unix_mode)
+        if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+            raise UnsafeArchiveError(f"archive contains a link or special file: {info.filename!r}")
+        if directory_by_name and file_type == stat.S_IFREG:
+            raise UnsafeArchiveError(
+                f"archive regular file has a directory-shaped name: {info.filename!r}"
+            )
+        is_directory = directory_by_name or file_type == stat.S_IFDIR
+        roots.add(parts[0])
+        parsed.append((info, parts, is_directory))
+
+    files = [entry for entry in parsed if not entry[2]]
+    if not files:
+        raise UnsafeArchiveError("archive contains no regular files")
+    folded_roots = {portable_name_key(root) for root in roots}
+    if len(roots) != len(folded_roots):
+        raise UnsafeArchiveError("archive top-level paths differ only by case")
+    if (require_single_root or strip_single_root) and len(folded_roots) != 1:
+        raise UnsafeArchiveError("archive must contain exactly one top-level directory")
+
+    top_level = parsed[0][1][0] if len(folded_roots) == 1 else None
+    if (require_single_root or strip_single_root) and any(len(parts) < 2 for _, parts, _ in files):
+        raise UnsafeArchiveError("archive files must be nested below one top-level directory")
+
+    entries: list[_Entry] = []
+    entry_types: dict[tuple[str, ...], str] = {}
+    prefix_spellings: dict[tuple[str, ...], tuple[str, ...]] = {}
+    for info, original_parts, is_directory in parsed:
+        parts = original_parts[1:] if strip_single_root else original_parts
+        if not parts:
+            continue
+        folded = tuple(portable_name_key(part) for part in parts)
+        for index in range(1, len(folded) + 1):
+            folded_prefix = folded[:index]
+            spelling = parts[:index]
+            previous_spelling = prefix_spellings.setdefault(folded_prefix, spelling)
+            if previous_spelling != spelling:
+                raise UnsafeArchiveError(
+                    f"archive paths differ only by case: {info.filename!r}"
+                )
+        if folded in entry_types:
+            raise UnsafeArchiveError(f"duplicate portable archive path: {info.filename!r}")
+        for index in range(1, len(folded)):
+            if entry_types.get(folded[:index]) == "file":
+                raise UnsafeArchiveError(f"archive path is nested below a file: {info.filename!r}")
+        if not is_directory and any(
+            len(existing) > len(folded) and existing[: len(folded)] == folded
+            for existing in entry_types
+        ):
+            raise UnsafeArchiveError(f"archive file conflicts with a directory: {info.filename!r}")
+        entry_types[folded] = "directory" if is_directory else "file"
+        entries.append(_Entry(info=info, relative=Path(*parts), is_directory=is_directory))
+    return entries, top_level
+
+
+def extract_zip_safely(
+    zf: zipfile.ZipFile,
+    target_dir: str | Path,
+    *,
+    require_single_root: bool = False,
+    strip_single_root: bool = False,
+) -> ZipExtraction:
+    """Validate every member first, then extract regular files without links."""
+
+    entries, top_level = _validated_entries(
+        zf,
+        require_single_root=require_single_root,
+        strip_single_root=strip_single_root,
+    )
+    target_dir = require_symlink_free_absolute_path(
+        target_dir,
+        field="archive extraction target",
+    )
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir = require_symlink_free_absolute_path(
+        target_dir,
+        field="archive extraction target",
+    )
+    target_dir, root_identity = capture_directory_identity(
+        target_dir,
+        field="archive extraction target",
+    )
+    root = target_dir.resolve(strict=True)
+    _preflight_destinations(
+        target_dir,
+        root,
+        entries,
+        expected_root_identity=root_identity,
+    )
+    file_count = 0
+    for entry in entries:
+        _require_extraction_root_identity(target_dir, root_identity)
+        destination = target_dir / entry.relative
+        if path_is_link_or_reparse_point(destination):
+            raise UnsafeArchiveError(f"archive target is a symbolic link: {entry.relative.as_posix()!r}")
+        resolved = destination.resolve(strict=False)
+        if not path_is_within(resolved, root):
+            raise UnsafeArchiveError(f"archive member escapes extraction root: {entry.info.filename!r}")
+        if entry.is_directory:
+            destination.mkdir(parents=True, exist_ok=True)
+            require_symlink_free_absolute_path(
+                destination,
+                field="archive directory destination",
+            )
+            _require_extraction_root_identity(target_dir, root_identity)
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        require_symlink_free_absolute_path(
+            destination,
+            field="archive file destination",
+            include_leaf=False,
+        )
+        _require_extraction_root_identity(target_dir, root_identity)
+        destination_parent, destination_parent_identity = capture_directory_identity(
+            destination.parent,
+            field="archive file destination parent",
+        )
+        with (
+            zf.open(entry.info, "r") as source,
+            open_binary_write_exclusive_without_links(
+                destination,
+                expected_parent_identity=destination_parent_identity,
+            ) as output,
+        ):
+            output_identity = os.fstat(output.fileno())
+            shutil.copyfileobj(source, output)
+        _require_extraction_root_identity(target_dir, root_identity)
+        require_directory_identity(
+            destination_parent,
+            destination_parent_identity,
+            field="archive file destination parent",
+        )
+        _require_extracted_file_identity(
+            destination,
+            output_identity,
+            entry.relative,
+        )
+        file_count += 1
+    _require_extraction_root_identity(target_dir, root_identity)
+    return ZipExtraction(top_level=top_level, file_count=file_count)
+
+
+def _require_extraction_root_identity(
+    target_dir: Path,
+    expected_identity: os.stat_result,
+) -> None:
+    try:
+        require_directory_identity(
+            target_dir,
+            expected_identity,
+            field="archive extraction target",
+        )
+    except (OSError, ValueError) as exc:
+        raise UnsafeArchiveError(
+            "archive extraction target changed identity during extraction"
+        ) from exc
+
+
+def _require_extracted_file_identity(
+    destination: Path,
+    expected_identity: os.stat_result,
+    relative: Path,
+) -> None:
+    try:
+        current_identity = destination.lstat()
+    except OSError as exc:
+        raise UnsafeArchiveError(
+            f"archive output disappeared: {relative.as_posix()!r}"
+        ) from exc
+    if (
+        _metadata_is_link_or_reparse_point(current_identity)
+        or not stat.S_ISREG(current_identity.st_mode)
+        or not os.path.samestat(expected_identity, current_identity)
+    ):
+        raise UnsafeArchiveError(
+            f"archive output changed identity: {relative.as_posix()!r}"
+        )
+
+
+def _preflight_destinations(
+    target_dir: Path,
+    root: Path,
+    entries: list[_Entry] | list[_TarEntry],
+    *,
+    expected_root_identity: os.stat_result,
+) -> None:
+    """Reject link and existing-path conflicts before the first file is written."""
+
+    for entry in entries:
+        _require_extraction_root_identity(target_dir, expected_root_identity)
+        destination = target_dir / entry.relative
+        cursor = target_dir
+        for index, part in enumerate(entry.relative.parts):
+            cursor = cursor / part
+            try:
+                metadata = cursor.lstat()
+            except FileNotFoundError:
+                metadata = None
+            except OSError as exc:
+                raise UnsafeArchiveError(
+                    f"archive target cannot be inspected: {entry.relative.as_posix()!r}"
+                ) from exc
+            if metadata is not None and _metadata_is_link_or_reparse_point(metadata):
+                raise UnsafeArchiveError(
+                    "archive target contains a symbolic link or reparse point: "
+                    f"{entry.relative.as_posix()!r}"
+                )
+            if (
+                index < len(entry.relative.parts) - 1
+                and metadata is not None
+                and not stat.S_ISDIR(metadata.st_mode)
+            ):
+                raise UnsafeArchiveError(
+                    "archive target parent conflicts with an existing non-directory: "
+                    f"{entry.relative.as_posix()!r}"
+                )
+        if not path_is_within(destination.resolve(strict=False), root):
+            raise UnsafeArchiveError(
+                f"archive member escapes extraction root: {entry.relative.as_posix()!r}"
+            )
+        if entry.is_directory:
+            if destination.exists() and not destination.is_dir():
+                raise UnsafeArchiveError(
+                    f"archive directory conflicts with an existing file: {entry.relative.as_posix()!r}"
+                )
+        elif destination.exists():
+                raise UnsafeArchiveError(
+                    f"archive file already exists: {entry.relative.as_posix()!r}"
+                )
+    _require_extraction_root_identity(target_dir, expected_root_identity)
+
+
+def extract_tar_safely(tf: tarfile.TarFile, target_dir: str | Path) -> ZipExtraction:
+    """Validate a TAR completely and extract only ordinary files/directories."""
+
+    target_dir = require_symlink_free_absolute_path(
+        target_dir,
+        field="archive extraction target",
+    )
+    parsed: list[_TarEntry] = []
+    roots: set[str] = set()
+    entry_types: dict[tuple[str, ...], str] = {}
+    prefix_spellings: dict[tuple[str, ...], tuple[str, ...]] = {}
+    for member in tf.getmembers():
+        parts, directory_by_name = _portable_member_parts(member.name)
+        if not parts:
+            continue
+        if member.isfile() and directory_by_name:
+            raise UnsafeArchiveError(
+                f"archive regular file has a directory-shaped name: {member.name!r}"
+            )
+        is_directory = member.isdir()
+        if not is_directory and not member.isfile():
+            raise UnsafeArchiveError(f"archive contains a link or special file: {member.name!r}")
+        folded = tuple(portable_name_key(part) for part in parts)
+        for index in range(1, len(folded) + 1):
+            folded_prefix = folded[:index]
+            spelling = parts[:index]
+            previous_spelling = prefix_spellings.setdefault(folded_prefix, spelling)
+            if previous_spelling != spelling:
+                raise UnsafeArchiveError(f"archive paths differ only by case: {member.name!r}")
+        if folded in entry_types:
+            raise UnsafeArchiveError(f"duplicate portable archive path: {member.name!r}")
+        for index in range(1, len(folded)):
+            if entry_types.get(folded[:index]) == "file":
+                raise UnsafeArchiveError(f"archive path is nested below a file: {member.name!r}")
+        if not is_directory and any(
+            len(existing) > len(folded) and existing[: len(folded)] == folded
+            for existing in entry_types
+        ):
+            raise UnsafeArchiveError(f"archive file conflicts with a directory: {member.name!r}")
+        entry_types[folded] = "directory" if is_directory else "file"
+        roots.add(parts[0])
+        parsed.append(_TarEntry(member=member, relative=Path(*parts), is_directory=is_directory))
+
+    files = [entry for entry in parsed if not entry.is_directory]
+    if not files:
+        raise UnsafeArchiveError("archive contains no regular files")
+    folded_roots = {portable_name_key(root) for root in roots}
+    if len(roots) != len(folded_roots):
+        raise UnsafeArchiveError("archive top-level paths differ only by case")
+    top_level = parsed[0].relative.parts[0] if len(folded_roots) == 1 else None
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir = require_symlink_free_absolute_path(
+        target_dir,
+        field="archive extraction target",
+    )
+    target_dir, root_identity = capture_directory_identity(
+        target_dir,
+        field="archive extraction target",
+    )
+    root = target_dir.resolve(strict=True)
+    _preflight_destinations(
+        target_dir,
+        root,
+        parsed,
+        expected_root_identity=root_identity,
+    )
+    for entry in parsed:
+        _require_extraction_root_identity(target_dir, root_identity)
+        destination = target_dir / entry.relative
+        if path_is_link_or_reparse_point(destination) or not path_is_within(
+            destination.resolve(strict=False),
+            root,
+        ):
+            raise UnsafeArchiveError(f"archive member escapes extraction root: {entry.member.name!r}")
+        if entry.is_directory:
+            destination.mkdir(parents=True, exist_ok=True)
+            require_symlink_free_absolute_path(
+                destination,
+                field="archive directory destination",
+            )
+            _require_extraction_root_identity(target_dir, root_identity)
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        require_symlink_free_absolute_path(
+            destination,
+            field="archive file destination",
+            include_leaf=False,
+        )
+        _require_extraction_root_identity(target_dir, root_identity)
+        destination_parent, destination_parent_identity = capture_directory_identity(
+            destination.parent,
+            field="archive file destination parent",
+        )
+        source = tf.extractfile(entry.member)
+        if source is None:
+            raise UnsafeArchiveError(f"archive file cannot be read: {entry.member.name!r}")
+        with source, open_binary_write_exclusive_without_links(
+            destination,
+            expected_parent_identity=destination_parent_identity,
+        ) as output:
+            output_identity = os.fstat(output.fileno())
+            shutil.copyfileobj(source, output)
+        _require_extraction_root_identity(target_dir, root_identity)
+        require_directory_identity(
+            destination_parent,
+            destination_parent_identity,
+            field="archive file destination parent",
+        )
+        _require_extracted_file_identity(
+            destination,
+            output_identity,
+            entry.relative,
+        )
+    _require_extraction_root_identity(target_dir, root_identity)
+    return ZipExtraction(top_level=top_level, file_count=len(files))

--- a/sdk/chat_ui_theme.py
+++ b/sdk/chat_ui_theme.py
@@ -17,11 +17,34 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
+
+from sdk.archive_paths import (
+    UnsafeArchiveError,
+    extract_zip_safely,
+    write_directory_to_zip_without_links,
+)
+from sdk.file_transactions import (
+    atomic_binary_writer,
+    file_snapshot_is_stable,
+    inspect_portable_directory_tree,
+    open_binary_read_without_links,
+    read_text_snapshot_without_links,
+)
+from sdk.path_contract import (
+    path_is_within,
+    project_root,
+    require_symlink_free_absolute_path,
+    resolve_managed_project_path,
+    resolve_project_output_path,
+    safe_path_component,
+    validate_exact_path_text,
+)
 
 #: manifest schema 版本，与前端 ``CHAT_THEME_SCHEMA`` 一致。
 CHAT_THEME_SCHEMA = 1
@@ -180,21 +203,46 @@ class ThemeValidationResult:
 # --------------------------------------------------------------------------- #
 
 def slugify_theme_id(value: str) -> str:
-    """把任意字符串规整成合法主题 id。"""
+    """把任意字符串规整成可移植的合法主题目录 id。"""
     slug = re.sub(r"[^a-z0-9_-]+", "-", str(value or "").strip().lower()).strip("-")
-    return slug[:64] or "theme"
+    slug = slug[:64] or "theme"
+    try:
+        safe_path_component(slug, field="theme id")
+    except ValueError:
+        # Windows device aliases (for example CON and LPT1) satisfy the theme
+        # id grammar but cannot be directory names.  Keep slugification
+        # deterministic while moving the identifier out of that namespace.
+        slug = f"theme-{slug}"[:64]
+    return slug
 
 
 def _is_safe_asset_ref(value: str) -> bool:
     """资源引用必须是沙箱内相对路径。"""
-    if not value or not isinstance(value, str):
+    if (
+        not value
+        or not isinstance(value, str)
+        or value != value.strip()
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in value
+        )
+    ):
         return False
     if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", value):  # 含 scheme（http:/file:/data: 等）
         return False
     if value.startswith("/") or value.startswith("\\"):
         return False
-    parts = Path(value.replace("\\", "/")).parts
-    return ".." not in parts
+    parts = value.replace("\\", "/").split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return False
+    try:
+        for part in parts:
+            safe_path_component(part, field="theme asset path component")
+    except ValueError:
+        return False
+    return True
 
 
 def _is_safe_css_value(value: str) -> bool:
@@ -387,9 +435,11 @@ def validate_manifest(data: Any) -> ThemeValidationResult:
     if schema != CHAT_THEME_SCHEMA:
         errors.append(f"schema 必须为 {CHAT_THEME_SCHEMA}，实际 {schema!r}")
 
-    theme_id = str(data.get("id") or "").strip()
+    theme_id = str(data.get("id") or "")
     if not theme_id:
         errors.append("缺少 id")
+    elif theme_id != theme_id.strip():
+        errors.append("id 首尾不能包含空白字符")
     elif not _ID_RE.match(theme_id):
         errors.append("id 仅允许小写字母/数字/-/_，且需以字母数字开头")
 
@@ -602,20 +652,42 @@ def validate_manifest(data: Any) -> ThemeValidationResult:
     return ThemeValidationResult(ok=not errors, errors=errors, warnings=warnings, normalized=normalized)
 
 
-def validate_theme_dir(theme_dir: Path) -> ThemeValidationResult:
+def validate_theme_dir(theme_dir: str | Path) -> ThemeValidationResult:
     """读取并校验一个主题目录（含 theme.json + 引用资源是否存在）。"""
-    manifest_path = Path(theme_dir) / MANIFEST_NAME
-    if not manifest_path.is_file():
+    raw_theme_dir = validate_exact_path_text(theme_dir, field="theme directory")
+    unresolved_theme_dir = Path(raw_theme_dir).expanduser()
+    if unresolved_theme_dir.is_absolute():
+        try:
+            require_symlink_free_absolute_path(
+                unresolved_theme_dir,
+                field="theme directory",
+            )
+        except (OSError, ValueError) as exc:
+            return ThemeValidationResult(ok=False, errors=[f"主题目录扫描失败: {exc}"])
+    theme_dir = resolve_project_output_path(raw_theme_dir, root=project_root())
+    try:
+        _, files = inspect_portable_directory_tree(theme_dir)
+    except (OSError, ValueError) as exc:
+        return ThemeValidationResult(
+            ok=False,
+            errors=[f"主题目录包含符号链接或非法路径，扫描失败: {exc}"],
+        )
+    file_names = {path.as_posix() for path in files}
+    manifest_path = theme_dir / MANIFEST_NAME
+    if MANIFEST_NAME not in file_names:
         return ThemeValidationResult(ok=False, errors=[f"缺少 {MANIFEST_NAME}"])
     try:
-        data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        manifest_text, _manifest_identity = read_text_snapshot_without_links(
+            manifest_path,
+        )
+        data = json.loads(manifest_text)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         return ThemeValidationResult(ok=False, errors=[f"{MANIFEST_NAME} 解析失败: {exc}"])
 
     result = validate_manifest(data)
     # 校验引用资源是否真实存在于目录内
     for ref in _iter_asset_refs(result.normalized):
-        if not (Path(theme_dir) / ref).is_file():
+        if ref not in file_names:
             result.warnings.append(f"引用的资源不存在: {ref}")
     return result
 
@@ -649,43 +721,87 @@ def _iter_background_image_refs(value: Any):
 # 打包 / 安全解压
 # --------------------------------------------------------------------------- #
 
-def pack_theme(theme_dir: Path, output_zip: Path) -> Path:
+def pack_theme(theme_dir: str | Path, output_zip: str | Path) -> Path:
     """把一个主题目录打成 .zip（校验通过才打包）。"""
-    theme_dir = Path(theme_dir)
+    raw_theme_dir = validate_exact_path_text(theme_dir, field="theme directory")
     result = validate_theme_dir(theme_dir)
     if not result.ok:
         raise ValueError("主题校验失败:\n" + "\n".join(result.errors))
-    output_zip = Path(output_zip)
-    output_zip.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(output_zip, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for file in theme_dir.rglob("*"):
-            if file.is_file():
-                zf.write(file, file.relative_to(theme_dir).as_posix())
+    theme_dir = resolve_project_output_path(raw_theme_dir, root=project_root())
+    raw_output_zip = validate_exact_path_text(output_zip, field="theme package output")
+    unresolved_output_zip = Path(raw_output_zip).expanduser()
+    if unresolved_output_zip.is_absolute():
+        require_symlink_free_absolute_path(
+            unresolved_output_zip,
+            field="theme package output",
+        )
+    output_zip = resolve_project_output_path(raw_output_zip, root=project_root())
+    if output_zip == theme_dir or path_is_within(output_zip, theme_dir):
+        raise ValueError("主题包输出不能位于待打包主题目录内部")
+    with atomic_binary_writer(output_zip) as output_file:
+        with zipfile.ZipFile(output_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            write_directory_to_zip_without_links(zf, theme_dir)
     return output_zip
 
 
-def safe_extract(zip_path: Path, dest_dir: Path) -> Path:
+def safe_extract(zip_path: str | Path, dest_dir: str | Path) -> Path:
     """zip-slip 安全解压到 ``dest_dir``，返回解压根目录。"""
-    dest_dir = Path(dest_dir)
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    dest_root = dest_dir.resolve()
-    with zipfile.ZipFile(zip_path) as zf:
-        for member in zf.namelist():
-            target = (dest_dir / member).resolve()
-            if not str(target).startswith(str(dest_root)):
-                raise ValueError(f"非法压缩包条目（路径穿越）: {member}")
-        zf.extractall(dest_dir)
+    raw_zip_path = validate_exact_path_text(zip_path, field="theme package path")
+    unresolved_zip_path = Path(raw_zip_path).expanduser()
+    if unresolved_zip_path.is_absolute():
+        zip_path = require_symlink_free_absolute_path(
+            unresolved_zip_path,
+            field="theme package path",
+        )
+    else:
+        zip_path = resolve_managed_project_path(
+            raw_zip_path,
+            root=project_root(),
+        )
+    if not zip_path.is_file():
+        raise FileNotFoundError(zip_path)
+    raw_dest_dir = validate_exact_path_text(
+        dest_dir,
+        field="theme extraction directory",
+    )
+    unresolved_dest_dir = Path(raw_dest_dir).expanduser()
+    if unresolved_dest_dir.is_absolute():
+        require_symlink_free_absolute_path(
+            unresolved_dest_dir,
+            field="theme extraction directory",
+        )
+    dest_dir = resolve_project_output_path(raw_dest_dir, root=project_root())
+    try:
+        with open_binary_read_without_links(zip_path) as source:
+            initial_metadata = os.fstat(source.fileno())
+            with zipfile.ZipFile(source) as zf:
+                extract_zip_safely(zf, dest_dir)
+            final_metadata = os.fstat(source.fileno())
+        if not file_snapshot_is_stable(initial_metadata, final_metadata):
+            raise PermissionError(
+                f"theme package changed while it was extracted: {zip_path}"
+            )
+    except UnsafeArchiveError as exc:
+        raise ValueError(f"非法压缩包条目（路径穿越或非便携路径）: {exc}") from exc
     return dest_dir
 
 
 def locate_manifest_root(extracted: Path) -> Optional[Path]:
     """在解压结果里定位 theme.json 所在目录（支持 zip 根或单层子目录）。"""
     extracted = Path(extracted)
-    if (extracted / MANIFEST_NAME).is_file():
+    try:
+        directories, files = inspect_portable_directory_tree(extracted)
+    except (OSError, PermissionError, ValueError):
+        return None
+    file_set = set(files)
+    if Path(MANIFEST_NAME) in file_set:
         return extracted
-    subdirs = [c for c in extracted.iterdir() if c.is_dir()]
-    if len(subdirs) == 1 and (subdirs[0] / MANIFEST_NAME).is_file():
-        return subdirs[0]
+    subdirs = [path for path in directories if len(path.parts) == 1]
+    if (
+        len(subdirs) == 1
+        and subdirs[0] / MANIFEST_NAME in file_set
+    ):
+        return extracted / subdirs[0]
     return None
 
 
@@ -706,7 +822,7 @@ def _main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     if args.cmd == "validate":
-        result = validate_theme_dir(Path(args.dir))
+        result = validate_theme_dir(args.dir)
         for e in result.errors:
             print(f"[error] {e}")
         for w in result.warnings:
@@ -714,7 +830,7 @@ def _main(argv: Optional[List[str]] = None) -> int:
         print("OK" if result.ok else "FAILED")
         return 0 if result.ok else 1
     if args.cmd == "pack":
-        out = pack_theme(Path(args.dir), Path(args.output))
+        out = pack_theme(args.dir, args.output)
         print(f"packed -> {out}")
         return 0
     return 2

--- a/sdk/cli/__main__.py
+++ b/sdk/cli/__main__.py
@@ -7,20 +7,44 @@ import json
 import sys
 from pathlib import Path
 
+from sdk.file_transactions import atomic_write_text
+from sdk.path_contract import (
+    project_root,
+    resolve_managed_project_path,
+    resolve_project_output_path,
+    resolve_project_read_path,
+    safe_path_component,
+    validate_exact_path_text,
+)
+
 from sdk.cli.registry_ops import (
     dump_registry_json,
+    exact_registry_entry,
     load_registry_json,
     merge_registry_entry,
+    normalize_repo_slug,
     run_git_commit,
 )
 from sdk.cli.scaffold import package_to_class_suffix, validate_package_name, write_plugin_project
 
 
+def _resolve_create_root(value: str) -> Path:
+    raw = validate_exact_path_text(
+        value,
+        field="plugin scaffold root",
+        allow_dot_root=True,
+    )
+    if raw == ".":
+        return project_root()
+    return resolve_project_output_path(raw, root=project_root())
+
+
 def _cmd_create(ns: argparse.Namespace) -> int:
     package = validate_package_name(ns.package)
-    plugin_id = (ns.plugin_id or "").strip() or f"com.example.{package}"
+    plugin_id = ns.plugin_id or f"com.example.{package}"
+    safe_path_component(plugin_id, field="plugin id")
     display_name = (ns.display_name or "").strip() or package.replace("_", " ").title()
-    root = Path(ns.root).resolve()
+    root = _resolve_create_root(ns.root)
     dest = write_plugin_project(
         root=root,
         package=package,
@@ -38,12 +62,13 @@ def _cmd_create(ns: argparse.Namespace) -> int:
 
 
 def _cmd_registry_snippet(ns: argparse.Namespace) -> int:
+    repo = normalize_repo_slug(ns.repo)
     row = {
         "name": ns.name.strip(),
         "author": ns.author.strip(),
-        "repo": ns.repo.strip().strip("/"),
+        "repo": repo,
         "description": ns.description.strip(),
-        "entry": ns.entry.strip(),
+        "entry": exact_registry_entry(ns.entry),
     }
     text = json.dumps(row, ensure_ascii=False, indent=2)
     print(text)
@@ -56,8 +81,14 @@ def _cmd_registry_snippet(ns: argparse.Namespace) -> int:
 
 
 def _cmd_registry_append(ns: argparse.Namespace) -> int:
-    registry_root = Path(ns.registry).resolve()
-    json_path = Path(ns.file).resolve() if ns.file else registry_root / "plugins.json"
+    registry_root = resolve_project_read_path(ns.registry, root=project_root())
+    if not registry_root.is_dir():
+        print(f"Missing {registry_root}", file=sys.stderr)
+        return 2
+    json_path = resolve_managed_project_path(
+        "plugins.json" if ns.file is None else ns.file,
+        root=registry_root,
+    )
     if not json_path.is_file():
         print(f"Missing {json_path}", file=sys.stderr)
         return 2
@@ -79,12 +110,16 @@ def _cmd_registry_append(ns: argparse.Namespace) -> int:
         print("\n(dry-run: plugins.json not modified)", file=sys.stderr)
         return 0
 
-    json_path.write_text(body, encoding="utf-8")
+    atomic_write_text(json_path, body)
     print(f"Wrote {json_path}")
 
     if ns.commit:
         msg = ns.message.strip() or f"registry: add {ns.name.strip()}"
-        run_git_commit(registry_root, msg)
+        run_git_commit(
+            registry_root,
+            msg,
+            file_path=json_path.relative_to(registry_root).as_posix(),
+        )
         print(f"Committed in {registry_root}: {msg!r}")
         print("Push your branch and open a PR against Shinsekai-Plugin-Registry.", file=sys.stderr)
     else:
@@ -111,9 +146,8 @@ def main(argv: list[str] | None = None) -> int:
     p_c.add_argument("package", help="Snake_case package name, e.g. my_screen_tool")
     p_c.add_argument(
         "--root",
-        type=Path,
-        default=Path("."),
-        help="Assistant repo root (default: current directory)",
+        default=".",
+        help="Assistant repo root (default: active Shinsekai project root)",
     )
     p_c.add_argument("--plugin-id", dest="plugin_id", default="", help="Stable id, default com.example.<package>")
     p_c.add_argument("--display-name", dest="display_name", default="", help="Settings nav label / human title")
@@ -146,12 +180,10 @@ def main(argv: list[str] | None = None) -> int:
     p_a.add_argument(
         "--registry",
         required=True,
-        type=Path,
         help="Path to local git clone of Shinsekai-Plugin-Registry",
     )
     p_a.add_argument(
         "--file",
-        type=Path,
         default=None,
         help="Alternate plugins.json path (default: <registry>/plugins.json)",
     )

--- a/sdk/cli/registry_ops.py
+++ b/sdk/cli/registry_ops.py
@@ -8,13 +8,60 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from sdk.file_transactions import read_text_without_links
+from sdk.process_launch import (
+    capture_command_executable,
+    capture_launch_directory,
+    run_with_stable_paths,
+)
+from sdk.path_contract import (
+    require_directory_without_links,
+    resolve_managed_project_path,
+)
+
+
+def exact_registry_entry(entry: str) -> str:
+    raw = str(entry or "")
+    if not raw or raw != raw.strip() or any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in raw
+    ):
+        raise ValueError(
+            "registry entry is required and must not contain surrounding whitespace "
+            "or control characters"
+        )
+    return raw
+
+
 def normalize_repo_slug(repo: str) -> str:
-    parts = [p.strip() for p in repo.strip().strip("/").split("/") if p.strip()]
-    return "/".join(parts).lower()
+    raw = str(repo or "")
+    if (
+        not raw
+        or raw != raw.strip()
+        or raw.startswith("/")
+        or raw.endswith("/")
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in raw
+        )
+    ):
+        raise ValueError("repo must be an exact owner/name slug")
+    parts = raw.split("/")
+    if (
+        len(parts) != 2
+        or any(part in {"", ".", ".."} or part != part.strip() for part in parts)
+        or any(not re.fullmatch(r"[A-Za-z0-9._-]+", part) for part in parts)
+    ):
+        raise ValueError("repo must be an exact owner/name slug")
+    return raw
 
 
 def load_registry_json(path: Path) -> list[dict[str, Any]]:
-    text = path.read_text(encoding="utf-8")
+    text = read_text_without_links(path)
 
     def _relax_trailing_commas(s: str) -> str:
         return re.sub(r",(\s*[}\]])", r"\1", s.strip())
@@ -51,15 +98,12 @@ def merge_registry_entry(
     replace: bool,
 ) -> list[dict[str, Any]]:
     slug = normalize_repo_slug(repo)
-    if not slug or slug.count("/") < 1:
-        raise ValueError("repo must look like owner/name")
-
     new_row = {
         "name": name.strip(),
         "author": author.strip(),
-        "repo": repo.strip().strip("/"),
+        "repo": slug,
         "description": description.strip(),
-        "entry": entry.strip(),
+        "entry": exact_registry_entry(entry),
     }
 
     out: list[dict[str, Any]] = []
@@ -68,7 +112,7 @@ def merge_registry_entry(
         if not isinstance(row, dict):
             continue
         r = row.get("repo", "")
-        if isinstance(r, str) and normalize_repo_slug(r) == slug:
+        if isinstance(r, str) and normalize_repo_slug(r).casefold() == slug.casefold():
             if replace:
                 if not replaced_or_skipped:
                     out.append(dict(new_row))
@@ -87,14 +131,43 @@ def merge_registry_entry(
     return out
 
 
-def run_git_commit(registry_root: Path, message: str) -> None:
-    subprocess.run(
-        ["git", "add", "plugins.json"],
-        cwd=registry_root,
+def run_git_commit(
+    registry_root: Path,
+    message: str,
+    *,
+    file_path: str = "plugins.json",
+) -> None:
+    registry_root = require_directory_without_links(
+        registry_root,
+        field="registry clone root",
+    )
+    raw_file_path = str(file_path)
+    if Path(raw_file_path).is_absolute():
+        raise ValueError("registry file path must be relative to the registry clone")
+    managed_file = resolve_managed_project_path(
+        raw_file_path,
+        root=registry_root,
+    )
+    relative_file = managed_file.relative_to(registry_root).as_posix()
+    root_snapshot = capture_launch_directory(
+        registry_root,
+        field="registry clone root",
+    )
+    git_snapshot = capture_command_executable(
+        "git",
+        field="git executable",
+    )
+    run_with_stable_paths(
+        [git_snapshot.path, "add", "--", relative_file],
+        cwd=root_snapshot,
+        executable=git_snapshot,
+        run_factory=subprocess.run,
         check=True,
     )
-    subprocess.run(
-        ["git", "commit", "-m", message],
-        cwd=registry_root,
+    run_with_stable_paths(
+        [git_snapshot.path, "commit", "-m", message],
+        cwd=root_snapshot,
+        executable=git_snapshot,
+        run_factory=subprocess.run,
         check=True,
     )

--- a/sdk/cli/scaffold.py
+++ b/sdk/cli/scaffold.py
@@ -5,16 +5,23 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from sdk.file_transactions import atomic_write_text
+from sdk.path_contract import (
+    managed_child_path,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+)
+
 _PACKAGE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 def validate_package_name(name: str) -> str:
-    if not _PACKAGE_RE.fullmatch(name.strip()):
+    if name != name.strip() or not _PACKAGE_RE.fullmatch(name):
         raise ValueError(
             "package must be snake_case: ^[a-z][a-z0-9_]*$ "
             "(example: my_screen_tool)"
         )
-    return name.strip()
+    return name
 
 
 def package_to_class_suffix(package: str) -> str:
@@ -29,8 +36,21 @@ def write_plugin_project(
     display_name: str,
     include_settings_ui: bool,
 ) -> Path:
-    plugins_dir = root / "plugins"
-    dest = plugins_dir / package
+    package = validate_package_name(package)
+    safe_root = require_symlink_free_absolute_path(
+        root,
+        field="plugin scaffold root",
+    )
+    plugins_dir = managed_child_path(
+        safe_root,
+        "plugins",
+        field="plugin scaffold directory",
+    )
+    dest = managed_child_path(
+        plugins_dir,
+        package,
+        field="plugin package name",
+    )
     if dest.exists():
         raise FileNotFoundError(f"already exists: {dest}")
 
@@ -39,11 +59,19 @@ def write_plugin_project(
     entry = f"plugins.{package}.plugin:{class_name}"
 
     plugins_dir.mkdir(parents=True, exist_ok=True)
+    plugins_dir = require_directory_without_links(
+        plugins_dir,
+        field="plugin scaffold directory",
+    )
     dest.mkdir(parents=False)
+    dest = require_directory_without_links(
+        dest,
+        field="plugin package directory",
+    )
 
-    (dest / "__init__.py").write_text(
+    atomic_write_text(
+        managed_child_path(dest, "__init__.py", field="plugin scaffold filename"),
         f'"""Plugin package ``{package}`` (Easy AI Desktop Assistant)."""\n',
-        encoding="utf-8",
     )
 
     if include_settings_ui:
@@ -62,7 +90,10 @@ def write_plugin_project(
             priority=100,
         )
 
-    (dest / "plugin.py").write_text(plugin_body, encoding="utf-8")
+    atomic_write_text(
+        managed_child_path(dest, "plugin.py", field="plugin scaffold filename"),
+        plugin_body,
+    )
 
     readme = _README.format(
         package=package,
@@ -71,7 +102,10 @@ def write_plugin_project(
         plugin_id=plugin_id,
         display_name=display_name,
     )
-    (dest / "README.md").write_text(readme, encoding="utf-8")
+    atomic_write_text(
+        managed_child_path(dest, "README.md", field="plugin scaffold filename"),
+        readme,
+    )
 
     return dest
 

--- a/sdk/file_transactions.py
+++ b/sdk/file_transactions.py
@@ -1,0 +1,2676 @@
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import threading
+import unicodedata
+import uuid
+from contextlib import contextmanager
+from functools import wraps
+from pathlib import Path
+from typing import BinaryIO, Iterator, TextIO
+
+from .path_contract import (
+    _metadata_is_link_or_reparse_point,
+    managed_child_path,
+    path_is_link_or_reparse_point,
+    portable_path_component_prefix,
+    require_symlink_free_absolute_path,
+    safe_path_component,
+    safe_path_component_with_suffix,
+)
+
+
+_EXCLUSIVE_FILE_PUBLICATION_LOCK = threading.Lock()
+_DIRECTORY_PUBLICATION_LOCK = threading.RLock()
+_UNSPECIFIED_IDENTITY = object()
+_TEMPFILE_RANDOM_TOKEN_RESERVE = 16
+
+
+def private_sibling_path(
+    path: str | os.PathLike[str],
+    suffix: str,
+    *,
+    field: str = "private sibling path",
+) -> Path:
+    """Return a portable private sibling while preserving an exact suffix."""
+
+    target = Path(path)
+    name = safe_path_component_with_suffix(
+        f".{target.name}",
+        suffix,
+        field=field,
+    )
+    return target.with_name(name)
+
+
+def _serialized_path_mutation(function):
+    @wraps(function)
+    def wrapped(*args, **kwargs):
+        with _DIRECTORY_PUBLICATION_LOCK:
+            return function(*args, **kwargs)
+
+    return wrapped
+
+
+def _exact_path(
+    value: str | os.PathLike[str],
+    *,
+    field: str,
+    allow_filesystem_root: bool = False,
+) -> Path:
+    return require_symlink_free_absolute_path(
+        value,
+        field=field,
+        allow_filesystem_root=allow_filesystem_root,
+    )
+
+
+def portable_name_key(value: str) -> str:
+    """Return the collision key used by common case-insensitive filesystems."""
+
+    return unicodedata.normalize("NFC", str(value)).casefold()
+
+
+def create_private_temporary_directory(
+    *,
+    prefix: str,
+    directory: str | os.PathLike[str] | None = None,
+) -> tuple[Path, os.stat_result]:
+    """Create a private temporary directory and return its pinned identity.
+
+    ``tempfile.TemporaryDirectory`` later removes whatever occupies its name.
+    Long-running encoders, extractors, and network tasks must instead remember
+    the directory created at entry so cleanup cannot delete a replacement that
+    appeared after a rename or a peer race.
+    """
+
+    if (
+        not prefix
+        or prefix != prefix.strip()
+        or "\x00" in prefix
+        or "/" in prefix
+        or "\\" in prefix
+    ):
+        raise ValueError("temporary directory prefix must be one exact path component")
+    prefix = portable_path_component_prefix(
+        prefix,
+        reserved_suffix_bytes=_TEMPFILE_RANDOM_TOKEN_RESERVE,
+        field="temporary directory prefix",
+    )
+
+    parent: Path | None = None
+    if directory is not None:
+        parent = _exact_path(directory, field="temporary directory parent")
+        if path_is_link_or_reparse_point(parent) or not parent.is_dir():
+            raise NotADirectoryError(parent)
+
+    raw_path = Path(tempfile.mkdtemp(prefix=prefix, dir=parent))
+    raw_identity = raw_path.lstat()
+    path = raw_path.resolve(strict=True)
+    path = _exact_path(path, field="private temporary directory")
+    identity = path.lstat()
+    if (
+        _metadata_is_link_or_reparse_point(identity)
+        or not stat.S_ISDIR(identity.st_mode)
+        or not os.path.samestat(raw_identity, identity)
+    ):
+        raise PermissionError("private temporary directory changed identity during creation")
+    return path, identity
+
+
+@contextmanager
+def private_temporary_directory(
+    *,
+    prefix: str,
+    directory: str | os.PathLike[str] | None = None,
+) -> Iterator[Path]:
+    """Yield an owned temporary directory and clean only that exact identity."""
+
+    path, identity = create_private_temporary_directory(
+        prefix=prefix,
+        directory=directory,
+    )
+    try:
+        yield path
+    finally:
+        try:
+            remove_directory_without_links(path, expected_identity=identity)
+        except (OSError, ValueError):
+            # The directory may have been atomically published or replaced.
+            # In either case the expected identity prevents deleting a peer.
+            pass
+
+
+def _native_rename_without_overwrite(
+    source: Path,
+    destination: Path,
+    *,
+    expected_source_identity: os.stat_result,
+    expected_source_parent_identity: os.stat_result,
+    expected_destination_parent_identity: os.stat_result,
+) -> None:
+    """Invoke the host's atomic no-replace rename primitive.
+
+    POSIX calls are directory-descriptor relative. Full-path ``renameat2``
+    with ``AT_FDCWD`` would re-resolve a parent that changed after validation
+    and could move a peer's same-named object from the replacement directory.
+    """
+
+    if os.name == "nt":
+        # Windows MoveFile semantics, which back ``os.rename``, fail when the
+        # destination already exists.
+        if (
+            not os.path.samestat(
+                expected_source_parent_identity,
+                source.parent.lstat(),
+            )
+            or not os.path.samestat(
+                expected_destination_parent_identity,
+                destination.parent.lstat(),
+            )
+            or not os.path.samestat(expected_source_identity, source.lstat())
+        ):
+            raise PermissionError("rename path identity changed before publication")
+        if os.path.lexists(destination):
+            raise FileExistsError(destination)
+        os.rename(source, destination)
+        return
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    directory_flags = os.O_RDONLY
+    directory_flags |= getattr(os, "O_DIRECTORY", 0)
+    directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+    directory_flags |= getattr(os, "O_CLOEXEC", 0)
+    source_parent_descriptor = os.open(source.parent, directory_flags)
+    destination_parent_descriptor = -1
+    try:
+        destination_parent_descriptor = os.open(
+            destination.parent,
+            directory_flags,
+        )
+        if not os.path.samestat(
+            expected_source_parent_identity,
+            os.fstat(source_parent_descriptor),
+        ):
+            raise PermissionError("rename source parent identity changed")
+        if not os.path.samestat(
+            expected_destination_parent_identity,
+            os.fstat(destination_parent_descriptor),
+        ):
+            raise PermissionError("rename destination parent identity changed")
+        current_source_identity = os.stat(
+            source.name,
+            dir_fd=source_parent_descriptor,
+            follow_symlinks=False,
+        )
+        if not os.path.samestat(
+            expected_source_identity,
+            current_source_identity,
+        ):
+            raise PermissionError("rename source identity changed")
+        try:
+            os.stat(
+                destination.name,
+                dir_fd=destination_parent_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(destination)
+
+        source_bytes = os.fsencode(source.name)
+        destination_bytes = os.fsencode(destination.name)
+        if sys.platform.startswith("linux"):
+            renameat2 = getattr(libc, "renameat2", None)
+            if renameat2 is None:
+                raise OSError(
+                    errno.ENOTSUP,
+                    "atomic no-replace rename is unavailable on this Linux runtime",
+                    destination,
+                )
+            renameat2.argtypes = [
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            renameat2.restype = ctypes.c_int
+            result = renameat2(
+                source_parent_descriptor,
+                source_bytes,
+                destination_parent_descriptor,
+                destination_bytes,
+                1,  # RENAME_NOREPLACE
+            )
+        elif sys.platform == "darwin":
+            renameatx_np = getattr(libc, "renameatx_np", None)
+            if renameatx_np is None:
+                raise OSError(
+                    errno.ENOTSUP,
+                    "atomic descriptor-relative no-replace rename is unavailable "
+                    "on this macOS runtime",
+                    destination,
+                )
+            renameatx_np.argtypes = [
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            renameatx_np.restype = ctypes.c_int
+            result = renameatx_np(
+                source_parent_descriptor,
+                source_bytes,
+                destination_parent_descriptor,
+                destination_bytes,
+                0x00000004,  # RENAME_EXCL
+            )
+        else:
+            raise OSError(
+                errno.ENOTSUP,
+                "atomic no-replace rename is unavailable on this platform",
+                destination,
+            )
+
+        if result != 0:
+            error_number = ctypes.get_errno()
+            raise OSError(
+                error_number,
+                os.strerror(error_number),
+                destination,
+            )
+        published_identity = os.stat(
+            destination.name,
+            dir_fd=destination_parent_descriptor,
+            follow_symlinks=False,
+        )
+        if not os.path.samestat(expected_source_identity, published_identity):
+            raise PermissionError(
+                "rename destination does not contain the source identity"
+            )
+    finally:
+        if destination_parent_descriptor >= 0:
+            os.close(destination_parent_descriptor)
+        os.close(source_parent_descriptor)
+
+
+@_serialized_path_mutation
+def rename_path_without_overwrite(
+    source: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+    expected_source_parent_identity: os.stat_result | None = None,
+    expected_destination_parent_identity: os.stat_result | None = None,
+) -> Path:
+    """Atomically move one exact path while preserving every occupied target.
+
+    A preceding ``exists`` check cannot make POSIX ``rename`` safe: another
+    process can create a file or an empty directory between the check and the
+    rename, and POSIX then replaces it.  Use the host no-replace primitive and
+    verify that the published identity is the exact source captured before the
+    operation.
+    """
+
+    source_path = require_symlink_free_absolute_path(
+        source,
+        field="rename source",
+        include_leaf=False,
+    )
+    target = require_symlink_free_absolute_path(
+        destination,
+        field="rename destination",
+        include_leaf=False,
+    )
+    if source_path == target:
+        raise ValueError("rename source and destination must differ")
+    source_parent = require_symlink_free_absolute_path(
+        source_path.parent,
+        field="rename source parent",
+    )
+    target_parent = require_symlink_free_absolute_path(
+        target.parent,
+        field="rename destination parent",
+    )
+    if not source_parent.is_dir():
+        raise NotADirectoryError(source_parent)
+    if not target_parent.is_dir():
+        raise NotADirectoryError(target_parent)
+    source_parent_metadata = source_parent.lstat()
+    target_parent_metadata = target_parent.lstat()
+    if (
+        expected_source_parent_identity is not None
+        and not os.path.samestat(
+            expected_source_parent_identity,
+            source_parent_metadata,
+        )
+    ):
+        raise PermissionError(
+            f"rename source parent identity changed: {source_parent}"
+        )
+    if (
+        expected_destination_parent_identity is not None
+        and not os.path.samestat(
+            expected_destination_parent_identity,
+            target_parent_metadata,
+        )
+    ):
+        raise PermissionError(
+            f"rename destination parent identity changed: {target_parent}"
+        )
+
+    try:
+        source_metadata = source_path.lstat()
+    except FileNotFoundError:
+        raise FileNotFoundError(source_path) from None
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, source_metadata)
+    ):
+        raise PermissionError(f"rename source identity changed: {source_path}")
+    if os.path.lexists(target):
+        raise FileExistsError(target)
+    ensure_portable_name_available(
+        target_parent,
+        target.name,
+        expected_directory_identity=target_parent_metadata,
+    )
+
+    _native_rename_without_overwrite(
+        source_path,
+        target,
+        expected_source_identity=source_metadata,
+        expected_source_parent_identity=source_parent_metadata,
+        expected_destination_parent_identity=target_parent_metadata,
+    )
+    if (
+        not os.path.samestat(source_parent_metadata, source_parent.lstat())
+        or not os.path.samestat(target_parent_metadata, target_parent.lstat())
+    ):
+        raise PermissionError("rename parent identity changed during publication")
+    try:
+        published_metadata = target.lstat()
+    except FileNotFoundError:
+        raise PermissionError(f"renamed path disappeared: {target}") from None
+    if not os.path.samestat(source_metadata, published_metadata):
+        raise PermissionError(
+            f"rename destination does not contain the source identity: {target}"
+        )
+    return target
+
+
+@contextmanager
+def open_binary_read_without_links(
+    path: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+    expected_parent_identity: os.stat_result | None = None,
+) -> Iterator[BinaryIO]:
+    """Open one exact regular file without following path aliases.
+
+    Validation is repeated after opening and the opened descriptor is compared
+    with the current leaf metadata.  This keeps callers from validating one
+    project file and then reading a replacement symlink, junction, or different
+    file through the same spelling.
+    """
+
+    source = _exact_path(path, field="source file")
+    parent, parent_identity = _directory_identity(
+        source.parent,
+        field="source file parent",
+    )
+    if source.parent != parent:
+        raise PermissionError("source file parent changed identity")
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(f"source file parent identity changed: {parent}")
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    parent_descriptor = -1
+    try:
+        if os.open in os.supports_dir_fd:
+            directory_flags = os.O_RDONLY
+            directory_flags |= getattr(os, "O_DIRECTORY", 0)
+            directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+            directory_flags |= getattr(os, "O_CLOEXEC", 0)
+            parent_descriptor = os.open(parent, directory_flags)
+            if not os.path.samestat(
+                parent_identity,
+                os.fstat(parent_descriptor),
+            ):
+                raise PermissionError(
+                    f"source file parent identity changed: {parent}"
+                )
+            descriptor = os.open(
+                source.name,
+                flags,
+                dir_fd=parent_descriptor,
+            )
+        else:
+            _require_directory_identity(
+                parent,
+                parent_identity,
+                field="source file parent",
+            )
+            descriptor = os.open(source, flags)
+    except FileNotFoundError:
+        if parent_descriptor >= 0:
+            os.close(parent_descriptor)
+            parent_descriptor = -1
+        raise FileNotFoundError(source) from None
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+            descriptor = -1
+        if parent_descriptor >= 0:
+            os.close(parent_descriptor)
+            parent_descriptor = -1
+        raise
+    try:
+        opened_metadata = os.fstat(descriptor)
+        source = _exact_path(source, field="source file")
+        current_metadata = source.lstat()
+        if (
+            not stat.S_ISREG(opened_metadata.st_mode)
+            or _metadata_is_link_or_reparse_point(current_metadata)
+            or not os.path.samestat(opened_metadata, current_metadata)
+            or (
+                expected_identity is not None
+                and not file_snapshot_is_stable(
+                    expected_identity,
+                    opened_metadata,
+                )
+            )
+        ):
+            raise PermissionError(f"source file identity changed: {source}")
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="source file parent",
+        )
+        handle = os.fdopen(descriptor, "rb")
+        descriptor = -1
+        with handle:
+            yield handle
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if parent_descriptor >= 0:
+            os.close(parent_descriptor)
+
+
+def read_text_without_links(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+    errors: str = "strict",
+    expected_identity: os.stat_result | None = None,
+    expected_parent_identity: os.stat_result | None = None,
+) -> str:
+    """Read one stable text-file snapshot through the link-free contract."""
+
+    payload, _metadata = read_bytes_snapshot_without_links(
+        path,
+        expected_identity=expected_identity,
+        expected_parent_identity=expected_parent_identity,
+    )
+    return payload.decode(encoding, errors=errors)
+
+
+def read_bytes_without_links(
+    path: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+    expected_parent_identity: os.stat_result | None = None,
+) -> bytes:
+    """Read one stable byte snapshot through the exact link-free contract."""
+
+    payload, _metadata = read_bytes_snapshot_without_links(
+        path,
+        expected_identity=expected_identity,
+        expected_parent_identity=expected_parent_identity,
+    )
+    return payload
+
+
+def file_snapshot_is_stable(
+    before: os.stat_result,
+    after: os.stat_result,
+) -> bool:
+    """Return whether a descriptor still exposes the same immutable snapshot."""
+
+    return (
+        os.path.samestat(before, after)
+        and before.st_mode == after.st_mode
+        and before.st_size == after.st_size
+        and before.st_mtime_ns == after.st_mtime_ns
+        and before.st_ctime_ns == after.st_ctime_ns
+    )
+
+
+def read_bytes_snapshot_without_links(
+    path: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+    expected_parent_identity: os.stat_result | None = None,
+) -> tuple[bytes, os.stat_result]:
+    """Read bytes and metadata from one stable, identity-bound file snapshot.
+
+    Holding a descriptor prevents a pathname replacement from retargeting the
+    read, but it does not prevent another writer from mutating the same inode
+    in place.  Configuration, template, manifest, and metadata readers need
+    both guarantees, so reject a snapshot whose size or write/change time
+    moves while it is being consumed.
+    """
+
+    source_path = _exact_path(path, field="source file")
+    with open_binary_read_without_links(
+        source_path,
+        expected_identity=expected_identity,
+        expected_parent_identity=expected_parent_identity,
+    ) as source:
+        before = os.fstat(source.fileno())
+        payload = source.read()
+        after = os.fstat(source.fileno())
+    if not file_snapshot_is_stable(before, after):
+        raise PermissionError(
+            f"source file changed while it was being read: {source_path}"
+        )
+    return payload, before
+
+
+def read_text_snapshot_without_links(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+    errors: str = "strict",
+    expected_identity: os.stat_result | None = None,
+    expected_parent_identity: os.stat_result | None = None,
+) -> tuple[str, os.stat_result]:
+    """Read text and metadata from one stable, identity-bound file snapshot."""
+
+    payload, metadata = read_bytes_snapshot_without_links(
+        path,
+        expected_identity=expected_identity,
+        expected_parent_identity=expected_parent_identity,
+    )
+    return payload.decode(encoding, errors=errors), metadata
+
+
+def ensure_portable_name_available(
+    directory: Path,
+    requested_name: str,
+    *,
+    expected_directory_identity: os.stat_result | None = None,
+) -> None:
+    """Reject a different existing spelling that aliases on common filesystems."""
+
+    parent = _exact_path(directory, field="managed directory")
+    try:
+        parent, parent_identity, entries = (
+            snapshot_directory_entries_without_links(
+                parent,
+                field="managed directory",
+            )
+        )
+    except NotADirectoryError:
+        if not parent.exists():
+            return
+        raise
+    if (
+        expected_directory_identity is not None
+        and not os.path.samestat(
+            expected_directory_identity,
+            parent_identity,
+        )
+    ):
+        raise PermissionError(f"managed directory identity changed: {parent}")
+    requested_key = portable_name_key(requested_name)
+    for child, _metadata in entries:
+        if portable_name_key(child.name) == requested_key and child.name != requested_name:
+            raise FileExistsError(
+                f"portable filename collision: {requested_name!r} conflicts with {child.name!r}"
+            )
+    _require_directory_identity(
+        parent,
+        parent_identity,
+        field="managed directory",
+    )
+
+
+def _existing_regular_file_identity(target: Path) -> os.stat_result | None:
+    """Capture one destination identity, distinguishing absence from replacement."""
+
+    try:
+        metadata = target.lstat()
+    except FileNotFoundError:
+        return None
+    if _metadata_is_link_or_reparse_point(metadata):
+        raise PermissionError(f"refusing to replace symbolic link: {target}")
+    if not stat.S_ISREG(metadata.st_mode):
+        raise IsADirectoryError(target)
+    return metadata
+
+
+def _directory_identity(
+    path: str | os.PathLike[str],
+    *,
+    field: str,
+    allow_filesystem_root: bool = False,
+) -> tuple[Path, os.stat_result]:
+    directory = _exact_path(
+        path,
+        field=field,
+        allow_filesystem_root=allow_filesystem_root,
+    )
+    try:
+        metadata = directory.lstat()
+    except FileNotFoundError:
+        raise NotADirectoryError(directory) from None
+    if (
+        _metadata_is_link_or_reparse_point(metadata)
+        or not stat.S_ISDIR(metadata.st_mode)
+    ):
+        raise NotADirectoryError(directory)
+    return directory, metadata
+
+
+def _require_directory_identity(
+    path: str | os.PathLike[str],
+    expected_identity: os.stat_result,
+    *,
+    field: str,
+    allow_filesystem_root: bool = False,
+) -> Path:
+    directory, current_identity = _directory_identity(
+        path,
+        field=field,
+        allow_filesystem_root=allow_filesystem_root,
+    )
+    if not os.path.samestat(expected_identity, current_identity):
+        raise PermissionError(f"{field} identity changed: {directory}")
+    return directory
+
+
+def capture_directory_identity(
+    path: str | os.PathLike[str],
+    *,
+    field: str = "directory",
+) -> tuple[Path, os.stat_result]:
+    """Return one link-free directory together with its filesystem identity.
+
+    Path-only APIs used by external tools cannot retain a directory descriptor.
+    Their callers can capture the directory once, perform the long operation,
+    then pass the identity into the publication primitive and revalidate it
+    before accepting any output.
+    """
+
+    return _directory_identity(path, field=field)
+
+
+def snapshot_directory_entries_without_links(
+    path: str | os.PathLike[str],
+    *,
+    field: str = "directory",
+    allow_filesystem_root: bool = False,
+) -> tuple[Path, os.stat_result, list[tuple[Path, os.stat_result]]]:
+    """Return one directory's entries from a single identity-checked scan.
+
+    Entry metadata is collected without following links.  The public
+    directory name is checked before and after ``scandir`` so callers never
+    combine names from an old directory with files reached through a
+    replacement directory bearing the same pathname.
+    """
+
+    directory, directory_identity = _directory_identity(
+        path,
+        field=field,
+        allow_filesystem_root=allow_filesystem_root,
+    )
+    descriptor = -1
+    try:
+        if (
+            os.scandir in os.supports_fd
+            and os.stat in os.supports_dir_fd
+        ):
+            directory_flags = os.O_RDONLY
+            directory_flags |= getattr(os, "O_DIRECTORY", 0)
+            directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+            directory_flags |= getattr(os, "O_CLOEXEC", 0)
+            descriptor = os.open(directory, directory_flags)
+            opened_identity = os.fstat(descriptor)
+            if not os.path.samestat(
+                directory_identity,
+                opened_identity,
+            ):
+                raise PermissionError(
+                    f"{field} identity changed: {directory}"
+                )
+            try:
+                with os.scandir(descriptor) as scanner:
+                    entries = [
+                        (
+                            directory / entry.name,
+                            os.stat(
+                                entry.name,
+                                dir_fd=descriptor,
+                                follow_symlinks=False,
+                            ),
+                        )
+                        for entry in scanner
+                    ]
+            except FileNotFoundError as exc:
+                raise PermissionError(
+                    f"{field} identity changed or contents changed during scan: "
+                    f"{directory}"
+                ) from exc
+            final_opened_identity = os.fstat(descriptor)
+            if not file_snapshot_is_stable(
+                opened_identity,
+                final_opened_identity,
+            ):
+                raise PermissionError(
+                    f"{field} identity changed or contents changed during scan: "
+                    f"{directory}"
+                )
+        else:
+            try:
+                with os.scandir(directory) as scanner:
+                    entries = [
+                        (
+                            directory / entry.name,
+                            entry.stat(follow_symlinks=False),
+                        )
+                        for entry in scanner
+                    ]
+            except FileNotFoundError as exc:
+                raise PermissionError(
+                    f"{field} identity changed or contents changed during scan: "
+                    f"{directory}"
+                ) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    _directory, final_identity = _directory_identity(
+        directory,
+        field=field,
+        allow_filesystem_root=allow_filesystem_root,
+    )
+    if not file_snapshot_is_stable(
+        directory_identity,
+        final_identity,
+    ):
+        raise PermissionError(f"{field} identity changed: {directory}")
+    return directory, directory_identity, entries
+
+
+def require_directory_identity(
+    path: str | os.PathLike[str],
+    expected_identity: os.stat_result,
+    *,
+    field: str = "directory",
+    allow_filesystem_root: bool = False,
+) -> Path:
+    """Require that a public path still names the captured directory."""
+
+    return _require_directory_identity(
+        path,
+        expected_identity,
+        field=field,
+        allow_filesystem_root=allow_filesystem_root,
+    )
+
+
+def atomic_write_text(
+    path: str | os.PathLike[str],
+    text: str,
+    *,
+    encoding: str = "utf-8",
+    expected_parent_identity: os.stat_result | None = None,
+) -> None:
+    """Publish a complete text file while preserving the previous file on failure."""
+
+    target = _exact_path(path, field="atomic write target")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target = _exact_path(target, field="atomic write target")
+    parent, parent_identity = _directory_identity(
+        target.parent,
+        field="atomic write parent",
+    )
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(f"atomic write parent identity changed: {parent}")
+    target_identity = _existing_regular_file_identity(target)
+
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding=encoding,
+        dir=parent,
+        prefix=portable_path_component_prefix(
+            f".{target.name}.",
+            reserved_suffix_bytes=_TEMPFILE_RANDOM_TOKEN_RESERVE + len(".tmp"),
+            field="atomic write temporary prefix",
+        ),
+        suffix=".tmp",
+        delete=False,
+    )
+    staging = Path(handle.name)
+    staging_identity = os.fstat(handle.fileno())
+    try:
+        with handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        target = _exact_path(target, field="atomic write target")
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="atomic write parent",
+        )
+        if path_is_link_or_reparse_point(target):
+            raise PermissionError(f"refusing to replace symbolic link: {target}")
+        replace_file_transactionally(
+            staging,
+            target,
+            expected_staging_identity=staging_identity,
+            expected_destination_identity=target_identity,
+            expected_parent_identity=parent_identity,
+        )
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="atomic write parent",
+        )
+    finally:
+        remove_file_without_links(
+            staging,
+            missing_ok=True,
+            expected_identity=staging_identity,
+        )
+
+
+@contextmanager
+def atomic_binary_writer(
+    path: str | os.PathLike[str],
+    *,
+    expected_parent_identity: os.stat_result | None = None,
+) -> Iterator[BinaryIO]:
+    """Yield a private binary staging file and atomically publish it on success."""
+
+    target = _exact_path(path, field="atomic write target")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target = _exact_path(target, field="atomic write target")
+    parent, parent_identity = _directory_identity(
+        target.parent,
+        field="atomic write parent",
+    )
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(f"atomic write parent identity changed: {parent}")
+    target_identity = _existing_regular_file_identity(target)
+
+    handle = tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=parent,
+        prefix=portable_path_component_prefix(
+            f".{target.name}.",
+            reserved_suffix_bytes=_TEMPFILE_RANDOM_TOKEN_RESERVE + len(".tmp"),
+            field="atomic write temporary prefix",
+        ),
+        suffix=".tmp",
+        delete=False,
+    )
+    staging = Path(handle.name)
+    staging_identity = os.fstat(handle.fileno())
+    try:
+        with handle:
+            yield handle
+            handle.flush()
+            os.fsync(handle.fileno())
+        target = _exact_path(target, field="atomic write target")
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="atomic write parent",
+        )
+        if path_is_link_or_reparse_point(target):
+            raise PermissionError(f"refusing to replace symbolic link: {target}")
+        replace_file_transactionally(
+            staging,
+            target,
+            expected_staging_identity=staging_identity,
+            expected_destination_identity=target_identity,
+            expected_parent_identity=parent_identity,
+        )
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="atomic write parent",
+        )
+    finally:
+        remove_file_without_links(
+            staging,
+            missing_ok=True,
+            expected_identity=staging_identity,
+        )
+
+
+def atomic_write_bytes(path: str | os.PathLike[str], content: bytes) -> None:
+    """Publish a complete binary file while preserving the prior file on failure."""
+
+    with atomic_binary_writer(path) as handle:
+        handle.write(content)
+
+
+@_serialized_path_mutation
+def replace_file_transactionally(
+    staging: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    *,
+    expected_staging_identity: os.stat_result | None = None,
+    expected_destination_identity: os.stat_result | None | object = (
+        _UNSPECIFIED_IDENTITY
+    ),
+    expected_parent_identity: os.stat_result | None = None,
+) -> Path:
+    """Atomically publish one complete sibling file.
+
+    External encoders and archive writers often require a filesystem path
+    instead of an already-open handle.  They can write to a private sibling
+    and hand it here only after validation; the old destination remains intact
+    until publication.  Both paths are pinned by filesystem identity, and the
+    destination is moved aside with no-replace semantics before the staging
+    identity is published.  A peer-created destination is therefore preserved
+    instead of being silently overwritten by POSIX ``replace`` semantics.
+    """
+
+    staging_path = _exact_path(staging, field="staging file")
+    target = _exact_path(destination, field="destination file")
+    if staging_path == target:
+        raise ValueError("staging and destination files must differ")
+    if staging_path.parent != target.parent:
+        raise ValueError("staging and destination files must share a parent")
+    parent, parent_identity = _directory_identity(
+        staging_path.parent,
+        field="file publication parent",
+    )
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(f"file publication parent identity changed: {parent}")
+    if path_is_link_or_reparse_point(staging_path):
+        raise PermissionError(f"staging file must not be a symbolic link: {staging_path}")
+    try:
+        staging_metadata = staging_path.lstat()
+    except FileNotFoundError:
+        raise FileNotFoundError(staging_path) from None
+    if not stat.S_ISREG(staging_metadata.st_mode):
+        raise PermissionError(f"staging file must be a regular file: {staging_path}")
+    if (
+        expected_staging_identity is not None
+        and not os.path.samestat(expected_staging_identity, staging_metadata)
+    ):
+        raise PermissionError(f"staging file identity changed: {staging_path}")
+
+    target_metadata = _existing_regular_file_identity(target)
+    if expected_destination_identity is not _UNSPECIFIED_IDENTITY:
+        if expected_destination_identity is None:
+            if target_metadata is not None:
+                raise FileExistsError(
+                    f"destination file appeared before publication: {target}"
+                )
+        elif (
+            target_metadata is None
+            or not os.path.samestat(expected_destination_identity, target_metadata)
+        ):
+            raise PermissionError(f"destination file identity changed: {target}")
+    ensure_portable_name_available(target.parent, target.name)
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(staging_path, flags)
+    try:
+        opened_metadata = os.fstat(descriptor)
+        current_metadata = staging_path.lstat()
+        if (
+            not stat.S_ISREG(opened_metadata.st_mode)
+            or path_is_link_or_reparse_point(staging_path)
+            or not os.path.samestat(opened_metadata, current_metadata)
+        ):
+            raise PermissionError(f"staging file identity changed: {staging_path}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+    staging_path = _exact_path(staging_path, field="staging file")
+    target = _exact_path(target, field="destination file")
+    _require_directory_identity(
+        parent,
+        parent_identity,
+        field="file publication parent",
+    )
+    if staging_path.parent != target.parent:
+        raise ValueError("publication paths changed parent")
+    if path_is_link_or_reparse_point(staging_path) or not staging_path.is_file():
+        raise PermissionError(f"staging file changed before publication: {staging_path}")
+    current_staging_metadata = staging_path.lstat()
+    if not os.path.samestat(opened_metadata, current_staging_metadata):
+        raise PermissionError(f"staging file identity changed: {staging_path}")
+
+    current_target_metadata = _existing_regular_file_identity(target)
+    if target_metadata is None:
+        if current_target_metadata is not None:
+            raise FileExistsError(
+                f"destination file appeared during publication: {target}"
+            )
+    elif (
+        current_target_metadata is None
+        or not os.path.samestat(target_metadata, current_target_metadata)
+    ):
+        raise PermissionError(f"destination file identity changed: {target}")
+
+    backup: Path | None = None
+    if target_metadata is not None:
+        raw_backup = private_sibling_path(
+            target,
+            f".backup-{uuid.uuid4().hex}",
+            field="file publication backup",
+        )
+        rename_path_without_overwrite(
+            target,
+            raw_backup,
+            expected_identity=target_metadata,
+        )
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="file publication parent",
+        )
+        try:
+            backup = _exact_path(raw_backup, field="file publication backup")
+            backup_metadata = backup.lstat()
+            if (
+                _metadata_is_link_or_reparse_point(backup_metadata)
+                or not stat.S_ISREG(backup_metadata.st_mode)
+                or not os.path.samestat(target_metadata, backup_metadata)
+            ):
+                raise PermissionError(
+                    f"destination file identity changed: {target}"
+                )
+        except BaseException:
+            if not os.path.lexists(target) and os.path.lexists(raw_backup):
+                try:
+                    rename_path_without_overwrite(
+                        raw_backup,
+                        target,
+                        expected_identity=target_metadata,
+                    )
+                except OSError:
+                    pass
+            raise
+
+    try:
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="file publication parent",
+        )
+        rename_path_without_overwrite(
+            staging_path,
+            target,
+            expected_identity=staging_metadata,
+        )
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="file publication parent",
+        )
+        published_metadata = target.lstat()
+        if not os.path.samestat(staging_metadata, published_metadata):
+            raise PermissionError(
+                f"staging file identity changed during publication: {staging_path}"
+            )
+    except BaseException:
+        if backup is not None and not os.path.lexists(target):
+            rename_path_without_overwrite(
+                backup,
+                target,
+                expected_identity=target_metadata,
+            )
+            backup = None
+        raise
+
+    if backup is not None:
+        remove_file_without_links(
+            backup,
+            expected_identity=target_metadata,
+        )
+    _require_directory_identity(
+        parent,
+        parent_identity,
+        field="file publication parent",
+    )
+    return target
+
+
+def copy_file_transactionally(
+    source: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    *,
+    expected_source_identity: os.stat_result | None = None,
+    expected_source_parent_identity: os.stat_result | None = None,
+    expected_destination_parent_identity: os.stat_result | None = None,
+) -> Path:
+    """Copy one regular file and atomically publish the complete result.
+
+    The source is held through one validated descriptor, while the destination
+    is written to a private sibling first.  This prevents application updates
+    and other overwrite flows from exposing a partially copied file or
+    following a path component that was replaced by a link.
+    """
+
+    source_path = _exact_path(source, field="source file")
+    target = _exact_path(destination, field="destination file")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target = _exact_path(target, field="destination file")
+    parent, parent_identity = _directory_identity(
+        target.parent,
+        field="copy destination parent",
+    )
+    if (
+        expected_destination_parent_identity is not None
+        and not os.path.samestat(
+            expected_destination_parent_identity,
+            parent_identity,
+        )
+    ):
+        raise PermissionError(
+            f"copy destination parent identity changed: {parent}"
+        )
+    target_identity = _existing_regular_file_identity(target)
+
+    handle = tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=parent,
+        prefix=portable_path_component_prefix(
+            f".{target.name}.",
+            reserved_suffix_bytes=_TEMPFILE_RANDOM_TOKEN_RESERVE + len(".copy"),
+            field="copy temporary prefix",
+        ),
+        suffix=".copy",
+        delete=False,
+    )
+    staging = Path(handle.name)
+    staging_identity = os.fstat(handle.fileno())
+    try:
+        with open_binary_read_without_links(
+            source_path,
+            expected_identity=expected_source_identity,
+            expected_parent_identity=expected_source_parent_identity,
+        ) as input_file:
+            source_metadata = os.fstat(input_file.fileno())
+            with handle:
+                shutil.copyfileobj(input_file, handle)
+                if hasattr(os, "fchmod"):
+                    os.fchmod(
+                        handle.fileno(),
+                        stat.S_IMODE(source_metadata.st_mode),
+                    )
+                if os.utime in os.supports_fd:
+                    try:
+                        os.utime(
+                            handle.fileno(),
+                            ns=(
+                                source_metadata.st_atime_ns,
+                                source_metadata.st_mtime_ns,
+                            ),
+                        )
+                    except (NotImplementedError, OSError):
+                        pass
+                handle.flush()
+                os.fsync(handle.fileno())
+            final_source_metadata = os.fstat(input_file.fileno())
+            if not file_snapshot_is_stable(
+                source_metadata,
+                final_source_metadata,
+            ):
+                raise PermissionError(
+                    f"source file changed while it was being copied: {source_path}"
+                )
+        return replace_file_transactionally(
+            staging,
+            target,
+            expected_staging_identity=staging_identity,
+            expected_destination_identity=target_identity,
+            expected_parent_identity=parent_identity,
+        )
+    finally:
+        if not handle.closed:
+            handle.close()
+        remove_file_without_links(
+            staging,
+            missing_ok=True,
+            expected_identity=staging_identity,
+            expected_parent_identity=parent_identity,
+        )
+
+
+def remove_file_without_links(
+    path: str | os.PathLike[str],
+    *,
+    missing_ok: bool = False,
+    expected_identity: os.stat_result | None = None,
+    expected_parent_identity: os.stat_result | None = None,
+) -> None:
+    """Remove one exact regular file without deleting a replacement identity.
+
+    The file is opened without following its leaf, compared with the current
+    path, then renamed to a private sibling.  The renamed object must still be
+    the same file before it is unlinked.  If another process replaced the path
+    during the operation, that replacement is restored or preserved instead of
+    being silently deleted.
+    """
+
+    target = _exact_path(path, field="file removal target")
+    parent, parent_identity = _directory_identity(
+        target.parent,
+        field="file removal parent",
+    )
+    if target.parent != parent:
+        raise PermissionError("file removal parent changed identity")
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(f"file removal parent identity changed: {parent}")
+
+    with _DIRECTORY_PUBLICATION_LOCK:
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="file removal parent",
+        )
+        if (
+            expected_parent_identity is not None
+            and not os.path.samestat(expected_parent_identity, parent_identity)
+        ):
+            raise PermissionError(f"file removal parent identity changed: {parent}")
+        target = _exact_path(target, field="file removal target")
+        try:
+            current_metadata = target.lstat()
+        except FileNotFoundError:
+            if missing_ok:
+                return
+            raise FileNotFoundError(target) from None
+        if (
+            _metadata_is_link_or_reparse_point(current_metadata)
+            or not stat.S_ISREG(current_metadata.st_mode)
+        ):
+            raise PermissionError(
+                f"file removal target must be a regular non-link file: {target}"
+            )
+        if (
+            expected_identity is not None
+            and not os.path.samestat(expected_identity, current_metadata)
+        ):
+            raise PermissionError(f"file removal target identity changed: {target}")
+
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(target, flags)
+        try:
+            opened_metadata = os.fstat(descriptor)
+            current_metadata = target.lstat()
+            if (
+                not stat.S_ISREG(opened_metadata.st_mode)
+                or _metadata_is_link_or_reparse_point(current_metadata)
+                or not os.path.samestat(opened_metadata, current_metadata)
+                or (
+                    expected_identity is not None
+                    and not os.path.samestat(expected_identity, opened_metadata)
+                )
+            ):
+                raise PermissionError(f"file removal target identity changed: {target}")
+        finally:
+            os.close(descriptor)
+
+        trash = private_sibling_path(
+            target,
+            f".delete-{uuid.uuid4().hex}",
+            field="file removal staging path",
+        )
+        trash = _exact_path(trash, field="file removal staging path")
+        if os.path.lexists(trash):
+            raise FileExistsError(trash)
+
+        rename_path_without_overwrite(
+            target,
+            trash,
+            expected_identity=opened_metadata,
+        )
+        try:
+            exact_trash = _exact_path(trash, field="file removal staging path")
+            trash_metadata = exact_trash.lstat()
+            if (
+                _metadata_is_link_or_reparse_point(trash_metadata)
+                or not stat.S_ISREG(trash_metadata.st_mode)
+                or not os.path.samestat(opened_metadata, trash_metadata)
+            ):
+                raise PermissionError(
+                    f"file removal target changed before deletion: {target}"
+                )
+            exact_trash.unlink()
+        except BaseException:
+            if os.path.lexists(trash) and not os.path.lexists(target):
+                try:
+                    rename_path_without_overwrite(
+                        trash,
+                        target,
+                        expected_identity=opened_metadata,
+                    )
+                except OSError:
+                    pass
+            raise
+
+
+def remove_link_without_following(
+    path: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    """Remove one exact symlink/junction without following or deleting a replacement."""
+
+    target = require_symlink_free_absolute_path(
+        path,
+        field="link removal target",
+        include_leaf=False,
+    )
+    parent = _exact_path(target.parent, field="link removal parent")
+    if target.parent != parent:
+        raise PermissionError("link removal parent changed identity")
+
+    with _DIRECTORY_PUBLICATION_LOCK:
+        target = require_symlink_free_absolute_path(
+            target,
+            field="link removal target",
+            include_leaf=False,
+        )
+        try:
+            target_metadata = target.lstat()
+        except FileNotFoundError:
+            raise FileNotFoundError(target) from None
+        if not _metadata_is_link_or_reparse_point(target_metadata):
+            raise PermissionError(f"link removal target is not a link: {target}")
+        if (
+            expected_identity is not None
+            and not os.path.samestat(expected_identity, target_metadata)
+        ):
+            raise PermissionError(f"link removal target identity changed: {target}")
+
+        trash = private_sibling_path(
+            target,
+            f".delete-{uuid.uuid4().hex}",
+            field="link removal staging path",
+        )
+        trash = require_symlink_free_absolute_path(
+            trash,
+            field="link removal staging path",
+            include_leaf=False,
+        )
+        if os.path.lexists(trash):
+            raise FileExistsError(trash)
+
+        rename_path_without_overwrite(
+            target,
+            trash,
+            expected_identity=target_metadata,
+        )
+        try:
+            trash = require_symlink_free_absolute_path(
+                trash,
+                field="link removal staging path",
+                include_leaf=False,
+            )
+            trash_metadata = trash.lstat()
+            if (
+                not _metadata_is_link_or_reparse_point(trash_metadata)
+                or not os.path.samestat(target_metadata, trash_metadata)
+            ):
+                raise PermissionError(
+                    f"link removal target changed before deletion: {target}"
+                )
+            if stat.S_ISDIR(trash_metadata.st_mode):
+                trash.rmdir()
+            else:
+                trash.unlink()
+        except BaseException:
+            if os.path.lexists(trash) and not os.path.lexists(target):
+                try:
+                    rename_path_without_overwrite(
+                        trash,
+                        target,
+                        expected_identity=target_metadata,
+                    )
+                except OSError:
+                    pass
+            raise
+
+
+def remove_empty_directory_without_links(
+    path: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    """Remove one exact empty directory without deleting a replacement identity."""
+
+    target = _exact_path(path, field="empty directory removal target")
+    parent = _exact_path(target.parent, field="empty directory removal parent")
+    if target.parent != parent:
+        raise PermissionError("empty directory removal parent changed identity")
+
+    with _DIRECTORY_PUBLICATION_LOCK:
+        target = _exact_path(target, field="empty directory removal target")
+        try:
+            target_metadata = target.lstat()
+        except FileNotFoundError:
+            raise FileNotFoundError(target) from None
+        if (
+            _metadata_is_link_or_reparse_point(target_metadata)
+            or not stat.S_ISDIR(target_metadata.st_mode)
+        ):
+            raise NotADirectoryError(target)
+        if (
+            expected_identity is not None
+            and not os.path.samestat(expected_identity, target_metadata)
+        ):
+            raise PermissionError(
+                f"empty directory removal target identity changed: {target}"
+            )
+
+        trash = private_sibling_path(
+            target,
+            f".delete-{uuid.uuid4().hex}",
+            field="empty directory removal staging path",
+        )
+        trash = _exact_path(trash, field="empty directory removal staging path")
+        if os.path.lexists(trash):
+            raise FileExistsError(trash)
+
+        rename_path_without_overwrite(
+            target,
+            trash,
+            expected_identity=target_metadata,
+        )
+        try:
+            trash = _exact_path(trash, field="empty directory removal staging path")
+            trash_metadata = trash.lstat()
+            if (
+                _metadata_is_link_or_reparse_point(trash_metadata)
+                or not stat.S_ISDIR(trash_metadata.st_mode)
+                or not os.path.samestat(target_metadata, trash_metadata)
+            ):
+                raise PermissionError(
+                    f"empty directory removal target changed before deletion: {target}"
+                )
+            trash.rmdir()
+        except BaseException:
+            if os.path.lexists(trash) and not os.path.lexists(target):
+                try:
+                    rename_path_without_overwrite(
+                        trash,
+                        target,
+                        expected_identity=target_metadata,
+                    )
+                except OSError:
+                    pass
+            raise
+
+
+def open_text_append_without_links(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+    buffering: int = 1,
+    expected_parent_identity: os.stat_result | None = None,
+) -> TextIO:
+    """Open an append target relative to one identity-bound parent directory.
+
+    Validating a link-free pathname and then calling ``open(path)`` still
+    leaves a parent-replacement window.  Prefer descriptor-relative creation
+    where the host supports it, compare the opened leaf with the public name,
+    and recheck the parent before returning a writable handle.
+    """
+
+    target = _exact_path(path, field="append target")
+    if expected_parent_identity is None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    parent, parent_identity = _directory_identity(
+        target.parent,
+        field="append target parent",
+    )
+    if target.parent != parent:
+        raise PermissionError("append target parent changed identity")
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(f"append target parent identity changed: {parent}")
+
+    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    parent_descriptor = -1
+    created = False
+    try:
+        if os.open in os.supports_dir_fd:
+            directory_flags = os.O_RDONLY
+            directory_flags |= getattr(os, "O_DIRECTORY", 0)
+            directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+            directory_flags |= getattr(os, "O_CLOEXEC", 0)
+            parent_descriptor = os.open(parent, directory_flags)
+            if not os.path.samestat(
+                parent_identity,
+                os.fstat(parent_descriptor),
+            ):
+                raise PermissionError(
+                    f"append target parent identity changed: {parent}"
+                )
+            try:
+                os.stat(
+                    target.name,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                created = True
+            descriptor = os.open(
+                target.name,
+                flags,
+                0o600,
+                dir_fd=parent_descriptor,
+            )
+        else:
+            _require_directory_identity(
+                parent,
+                parent_identity,
+                field="append target parent",
+            )
+            created = not os.path.lexists(target)
+            descriptor = os.open(target, flags, 0o600)
+
+        opened_metadata = os.fstat(descriptor)
+        target = _exact_path(target, field="append target")
+        current_metadata = target.lstat()
+        if (
+            not stat.S_ISREG(opened_metadata.st_mode)
+            or _metadata_is_link_or_reparse_point(current_metadata)
+            or not os.path.samestat(opened_metadata, current_metadata)
+        ):
+            raise PermissionError(f"append target must be a regular non-link file: {target}")
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="append target parent",
+        )
+        handle = os.fdopen(
+            descriptor,
+            "a",
+            encoding=encoding,
+            buffering=buffering,
+        )
+        descriptor = -1
+        return handle
+    except BaseException:
+        if created and descriptor >= 0:
+            try:
+                opened_identity = os.fstat(descriptor)
+                if parent_descriptor >= 0:
+                    current_identity = os.stat(
+                        target.name,
+                        dir_fd=parent_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if os.path.samestat(opened_identity, current_identity):
+                        os.unlink(target.name, dir_fd=parent_descriptor)
+                else:
+                    current_identity = target.lstat()
+                    if os.path.samestat(opened_identity, current_identity):
+                        target.unlink()
+            except OSError:
+                pass
+        raise
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if parent_descriptor >= 0:
+            os.close(parent_descriptor)
+
+
+def open_binary_write_exclusive_without_links(
+    path: str | os.PathLike[str],
+    *,
+    expected_parent_identity: os.stat_result | None = None,
+) -> BinaryIO:
+    """Create one exact regular file exclusively and verify its opened identity.
+
+    On hosts with descriptor-relative filesystem calls, creation is bound to
+    the already-validated parent directory.  This prevents a same-named
+    replacement directory from receiving the new file between validation and
+    ``open``.  The optional expected identity extends that binding across a
+    caller's longer transaction.
+    """
+
+    target = _exact_path(path, field="exclusive write target")
+    parent, parent_identity = _directory_identity(
+        target.parent,
+        field="exclusive write parent",
+    )
+    if target.parent != parent:
+        raise PermissionError("exclusive write parent changed identity")
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(f"exclusive write parent identity changed: {parent}")
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    parent_descriptor = -1
+    try:
+        if os.open in os.supports_dir_fd:
+            directory_flags = os.O_RDONLY
+            directory_flags |= getattr(os, "O_DIRECTORY", 0)
+            directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+            directory_flags |= getattr(os, "O_CLOEXEC", 0)
+            parent_descriptor = os.open(parent, directory_flags)
+            if not os.path.samestat(
+                parent_identity,
+                os.fstat(parent_descriptor),
+            ):
+                raise PermissionError(
+                    f"exclusive write parent identity changed: {parent}"
+                )
+            descriptor = os.open(
+                target.name,
+                flags,
+                0o600,
+                dir_fd=parent_descriptor,
+            )
+        else:
+            _require_directory_identity(
+                parent,
+                parent_identity,
+                field="exclusive write parent",
+            )
+            descriptor = os.open(target, flags, 0o600)
+
+        opened_metadata = os.fstat(descriptor)
+        target = _exact_path(target, field="exclusive write target")
+        current_metadata = target.lstat()
+        if (
+            not stat.S_ISREG(opened_metadata.st_mode)
+            or _metadata_is_link_or_reparse_point(current_metadata)
+            or not os.path.samestat(opened_metadata, current_metadata)
+        ):
+            raise PermissionError(
+                f"exclusive write target identity changed: {target}"
+            )
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="exclusive write parent",
+        )
+        handle = os.fdopen(descriptor, "wb")
+        descriptor = -1
+        return handle
+    except BaseException:
+        if descriptor >= 0 and parent_descriptor >= 0:
+            try:
+                created_identity = os.fstat(descriptor)
+                current_identity = os.stat(
+                    target.name,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                if os.path.samestat(created_identity, current_identity):
+                    os.unlink(target.name, dir_fd=parent_descriptor)
+            except OSError:
+                pass
+        raise
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if parent_descriptor >= 0:
+            os.close(parent_descriptor)
+
+
+def _open_portable_destination(
+    directory: str | os.PathLike[str],
+    requested_name: str,
+    *,
+    field: str,
+) -> tuple[Path, BinaryIO, Path, os.stat_result]:
+    """Reserve a unique portable filename and return its exclusive handle."""
+
+    raw_name = safe_path_component(requested_name, field=field)
+    destination_dir = _exact_path(directory, field=f"{field} directory")
+    if path_is_link_or_reparse_point(destination_dir):
+        raise PermissionError(f"{field} directory must not be a symbolic link")
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination_dir, destination_dir_identity = _directory_identity(
+        destination_dir,
+        field=f"{field} directory",
+    )
+
+    source_name = Path(raw_name)
+    suffix = source_name.suffix
+    stem = source_name.name[: -len(suffix)] if suffix else source_name.name
+
+    # Exclusive creation protects exact-name publication across processes.  The
+    # process lock also closes the directory-listing race for case/Unicode aliases
+    # on case-sensitive filesystems, where two distinct spellings could otherwise
+    # both be created before either caller observes the other one.
+    with _EXCLUSIVE_FILE_PUBLICATION_LOCK:
+        (
+            _destination_dir,
+            listed_directory_identity,
+            entries,
+        ) = snapshot_directory_entries_without_links(
+            destination_dir,
+            field=f"{field} directory",
+        )
+        if not os.path.samestat(
+            destination_dir_identity,
+            listed_directory_identity,
+        ):
+            raise PermissionError(
+                f"{field} directory identity changed: {destination_dir}"
+            )
+        existing_keys = {
+            portable_name_key(child.name)
+            for child, _metadata in entries
+        }
+        counter = 0
+        while True:
+            candidate_name = (
+                raw_name
+                if counter == 0
+                else safe_path_component_with_suffix(
+                    stem,
+                    f"_{counter}{suffix}",
+                    field=field,
+                )
+            )
+            if portable_name_key(candidate_name) in existing_keys:
+                counter += 1
+                continue
+            destination = managed_child_path(destination_dir, candidate_name, field=field)
+            try:
+                return (
+                    destination,
+                    open_binary_write_exclusive_without_links(
+                        destination,
+                        expected_parent_identity=destination_dir_identity,
+                    ),
+                    destination_dir,
+                    destination_dir_identity,
+                )
+            except FileExistsError:
+                existing_keys.add(portable_name_key(candidate_name))
+                counter += 1
+
+
+def write_bytes_exclusive(
+    directory: str | os.PathLike[str],
+    requested_name: str,
+    content: bytes,
+    *,
+    field: str = "filename",
+) -> Path:
+    """Publish bytes under a unique portable filename without overwriting."""
+
+    destination, output, destination_dir, destination_dir_identity = (
+        _open_portable_destination(
+            directory,
+            requested_name,
+            field=field,
+        )
+    )
+    destination_identity = os.fstat(output.fileno())
+    try:
+        with output:
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        _require_directory_identity(
+            destination_dir,
+            destination_dir_identity,
+            field=f"{field} directory",
+        )
+        current_identity = destination.lstat()
+        if not os.path.samestat(destination_identity, current_identity):
+            raise PermissionError(
+                f"published file identity changed: {destination}"
+            )
+    except BaseException:
+        remove_file_without_links(
+            destination,
+            missing_ok=True,
+            expected_identity=destination_identity,
+        )
+        raise
+    return destination
+
+
+def copy_file_exclusive(
+    source: str | os.PathLike[str],
+    directory: str | os.PathLike[str],
+    requested_name: str,
+    *,
+    field: str = "filename",
+    expected_source_identity: os.stat_result | None = None,
+) -> Path:
+    """Copy one file and return its exclusively published path."""
+
+    destination, _identity = copy_file_exclusive_with_identity(
+        source,
+        directory,
+        requested_name,
+        field=field,
+        expected_source_identity=expected_source_identity,
+    )
+    return destination
+
+
+def copy_file_exclusive_with_identity(
+    source: str | os.PathLike[str],
+    directory: str | os.PathLike[str],
+    requested_name: str,
+    *,
+    field: str = "filename",
+    expected_source_identity: os.stat_result | None = None,
+) -> tuple[Path, os.stat_result]:
+    """Copy one file under a unique portable name without overwriting anything.
+
+    The destination is opened with exclusive creation.  This makes an upload
+    safe even when another request creates the same name between validation and
+    the copy itself.  Returning the descriptor-captured identity lets a later
+    rollback remove only this exact file, never a replacement at the same name.
+    """
+
+    source_path = _exact_path(source, field="source file")
+    if path_is_link_or_reparse_point(source_path):
+        raise PermissionError(f"source file must not be a symbolic link: {source_path}")
+
+    destination, output, destination_dir, destination_dir_identity = (
+        _open_portable_destination(
+            directory,
+            requested_name,
+            field=field,
+        )
+    )
+    destination_identity = os.fstat(output.fileno())
+    try:
+        with output:
+            with open_binary_read_without_links(
+                source_path,
+                expected_identity=expected_source_identity,
+            ) as input_file:
+                source_metadata = os.fstat(input_file.fileno())
+                shutil.copyfileobj(input_file, output)
+                final_source_metadata = os.fstat(input_file.fileno())
+                if not file_snapshot_is_stable(
+                    source_metadata,
+                    final_source_metadata,
+                ):
+                    raise PermissionError(
+                        f"source file changed while it was being copied: {source_path}"
+                    )
+                output.flush()
+                os.fsync(output.fileno())
+        _require_directory_identity(
+            destination_dir,
+            destination_dir_identity,
+            field=f"{field} directory",
+        )
+        current_identity = destination.lstat()
+        if not os.path.samestat(destination_identity, current_identity):
+            raise PermissionError(
+                f"published file identity changed: {destination}"
+            )
+    except BaseException:
+        remove_file_without_links(
+            destination,
+            missing_ok=True,
+            expected_identity=destination_identity,
+        )
+        raise
+    return destination, destination_identity
+
+
+def _inspect_portable_directory_tree_with_metadata(
+    source_root: Path,
+) -> tuple[
+    os.stat_result,
+    list[tuple[Path, os.stat_result]],
+    list[tuple[Path, os.stat_result]],
+]:
+    """Return a portable tree inventory pinned to every observed identity."""
+
+    source_root = _exact_path(source_root, field="source tree root")
+    root_metadata = source_root.lstat()
+    if (
+        _metadata_is_link_or_reparse_point(root_metadata)
+        or not stat.S_ISDIR(root_metadata.st_mode)
+    ):
+        raise PermissionError(
+            f"source directory must be a real directory: {source_root}"
+        )
+
+    directories: list[tuple[Path, os.stat_result]] = []
+    files: list[tuple[Path, os.stat_result]] = []
+
+    def inspect(
+        relative: Path,
+        expected_directory_identity: os.stat_result,
+    ) -> None:
+        directory = _exact_path(
+            source_root / relative,
+            field="source tree directory",
+        )
+        (
+            directory,
+            directory_metadata,
+            scanned_entries,
+        ) = snapshot_directory_entries_without_links(
+            directory,
+            field="source tree directory",
+        )
+        if not os.path.samestat(
+            expected_directory_identity,
+            directory_metadata,
+        ):
+            raise PermissionError(
+                f"source tree directory identity changed: {directory}"
+            )
+        entries = sorted(
+            scanned_entries,
+            key=lambda entry: (
+                portable_name_key(entry[0].name),
+                entry[0].name,
+            ),
+        )
+        spellings: dict[str, str] = {}
+        for entry_path, metadata in entries:
+            name = safe_path_component(
+                entry_path.name,
+                field="directory entry name",
+            )
+            key = portable_name_key(name)
+            previous = spellings.setdefault(key, name)
+            if previous != name:
+                raise FileExistsError(
+                    f"portable filename collision: {name!r} conflicts with {previous!r}"
+                )
+            child_relative = relative / name
+            if _metadata_is_link_or_reparse_point(metadata):
+                raise PermissionError(
+                    "source tree contains a symbolic link or reparse point: "
+                    f"{entry_path}"
+                )
+            if stat.S_ISDIR(metadata.st_mode):
+                directories.append((child_relative, metadata))
+                inspect(child_relative, metadata)
+            elif stat.S_ISREG(metadata.st_mode):
+                files.append((child_relative, metadata))
+            else:
+                raise PermissionError(
+                    f"source tree contains a special file: {entry_path}"
+                )
+
+    inspect(Path(), root_metadata)
+    final_root_metadata = source_root.lstat()
+    if not os.path.samestat(root_metadata, final_root_metadata):
+        raise PermissionError(
+            f"source tree root identity changed: {source_root}"
+        )
+    return root_metadata, directories, files
+
+
+def inspect_portable_directory_tree(source_root: Path) -> tuple[list[Path], list[Path]]:
+    """Return a link-free portable tree inventory relative to ``source_root``."""
+
+    _root_metadata, directories, files = (
+        _inspect_portable_directory_tree_with_metadata(source_root)
+    )
+    return (
+        [relative for relative, _metadata in directories],
+        [relative for relative, _metadata in files],
+    )
+
+
+def inspect_portable_directory_tree_with_metadata(
+    source_root: Path,
+) -> tuple[
+    os.stat_result,
+    list[tuple[Path, os.stat_result]],
+    list[tuple[Path, os.stat_result]],
+]:
+    """Return a portable tree inventory with every observed identity pinned."""
+
+    return _inspect_portable_directory_tree_with_metadata(source_root)
+
+
+def _metadata_snapshot(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _tree_inventory_snapshot(
+    root_metadata: os.stat_result,
+    directories: list[tuple[Path, os.stat_result]],
+    files: list[tuple[Path, os.stat_result]],
+) -> tuple[
+    tuple[int, int, int, int, int, int],
+    tuple[tuple[str, tuple[int, int, int, int, int, int]], ...],
+    tuple[tuple[str, tuple[int, int, int, int, int, int]], ...],
+]:
+    return (
+        _metadata_snapshot(root_metadata),
+        tuple(
+            (relative.as_posix(), _metadata_snapshot(metadata))
+            for relative, metadata in directories
+        ),
+        tuple(
+            (relative.as_posix(), _metadata_snapshot(metadata))
+            for relative, metadata in files
+        ),
+    )
+
+
+def _assert_directory_chain_identities(
+    root: Path,
+    relative: Path,
+    identities: dict[Path, os.stat_result],
+    *,
+    field: str,
+) -> None:
+    cursor = Path()
+    for component in relative.parts:
+        cursor /= component
+        expected = identities[cursor]
+        current_path = _exact_path(root / cursor, field=field)
+        current = current_path.lstat()
+        if (
+            _metadata_is_link_or_reparse_point(current)
+            or not stat.S_ISDIR(current.st_mode)
+            or not os.path.samestat(expected, current)
+        ):
+            raise PermissionError(
+                f"{field} identity changed: {current_path}"
+            )
+
+
+def copy_directory_without_links(
+    source: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    *,
+    expected_source_identity: os.stat_result | None = None,
+) -> Path:
+    """Copy a portable directory tree without following symbolic links.
+
+    Exporting a project directory with ``shutil.copytree`` follows links by
+    default.  A stale or malicious asset link could therefore pull unrelated
+    host files into a shareable package.  Preflight the complete tree first,
+    reject non-portable/colliding names and special files, then copy regular
+    files using ``O_NOFOLLOW`` where the host provides it.
+    """
+
+    source_root = _exact_path(source, field="source directory")
+    target_root = _exact_path(destination, field="destination directory")
+    if os.path.lexists(target_root):
+        raise FileExistsError(target_root)
+    source_identity, directories, files = (
+        _inspect_portable_directory_tree_with_metadata(source_root)
+    )
+    if (
+        expected_source_identity is not None
+        and not os.path.samestat(expected_source_identity, source_identity)
+    ):
+        raise PermissionError(
+            f"source directory identity changed: {source_root}"
+        )
+    source_snapshot = _tree_inventory_snapshot(
+        source_identity,
+        directories,
+        files,
+    )
+    source_directory_identities = {
+        Path(): source_identity,
+        **dict(directories),
+    }
+    target_root.parent.mkdir(parents=True, exist_ok=True)
+    target_root = _exact_path(target_root, field="destination directory")
+    target_root.mkdir()
+    target_root = _exact_path(target_root, field="destination directory")
+    target_identity = target_root.lstat()
+    target_directory_identities = {Path(): target_identity}
+    target_file_snapshots: dict[
+        Path,
+        tuple[int, int, int, int, int, int],
+    ] = {}
+    try:
+        for relative, source_directory_identity in directories:
+            _assert_directory_chain_identities(
+                source_root,
+                relative,
+                source_directory_identities,
+                field="source tree directory",
+            )
+            _assert_directory_chain_identities(
+                target_root,
+                relative.parent,
+                target_directory_identities,
+                field="destination tree directory",
+            )
+            target_directory = target_root / relative
+            target_directory.mkdir()
+            target_directory_identity = target_directory.lstat()
+            if (
+                _metadata_is_link_or_reparse_point(target_directory_identity)
+                or not stat.S_ISDIR(target_directory_identity.st_mode)
+            ):
+                raise PermissionError(
+                    f"destination tree directory changed: {target_directory}"
+                )
+            target_directory_identities[relative] = target_directory_identity
+            current_source_identity = (source_root / relative).lstat()
+            if not os.path.samestat(
+                source_directory_identity,
+                current_source_identity,
+            ):
+                raise PermissionError(
+                    f"source tree directory identity changed: {source_root / relative}"
+                )
+        for relative, source_file_identity in files:
+            _assert_directory_chain_identities(
+                source_root,
+                relative.parent,
+                source_directory_identities,
+                field="source tree directory",
+            )
+            _assert_directory_chain_identities(
+                target_root,
+                relative.parent,
+                target_directory_identities,
+                field="destination tree directory",
+            )
+            source_file = _exact_path(
+                source_root / relative,
+                field="source tree file",
+            )
+            with open_binary_read_without_links(source_file) as input_file:
+                opened_source_identity = os.fstat(input_file.fileno())
+                if not os.path.samestat(
+                    source_file_identity,
+                    opened_source_identity,
+                ):
+                    raise PermissionError(
+                        f"source tree file identity changed: {source_file}"
+                    )
+                with open_binary_write_exclusive_without_links(
+                    target_root / relative
+                ) as output_file:
+                    opened_target_identity = os.fstat(output_file.fileno())
+                    shutil.copyfileobj(input_file, output_file)
+                copied_target = target_root / relative
+                copied_target_identity = copied_target.lstat()
+                if not os.path.samestat(
+                    opened_target_identity,
+                    copied_target_identity,
+                ):
+                    raise PermissionError(
+                        f"destination tree file identity changed: {copied_target}"
+                    )
+                target_file_snapshots[relative] = _metadata_snapshot(
+                    copied_target_identity
+                )
+                final_source_metadata = os.fstat(input_file.fileno())
+                if _metadata_snapshot(
+                    source_file_identity
+                ) != _metadata_snapshot(final_source_metadata):
+                    raise PermissionError(
+                        f"source tree file changed while copying: {source_file}"
+                    )
+
+        final_source_inventory = _inspect_portable_directory_tree_with_metadata(
+            source_root
+        )
+        if source_snapshot != _tree_inventory_snapshot(*final_source_inventory):
+            raise PermissionError(
+                f"source directory changed while copying: {source_root}"
+            )
+        (
+            final_target_identity,
+            final_target_directories,
+            final_target_files,
+        ) = _inspect_portable_directory_tree_with_metadata(target_root)
+        if not os.path.samestat(target_identity, final_target_identity):
+            raise PermissionError(
+                f"destination directory identity changed: {target_root}"
+            )
+        if {
+            relative for relative, _metadata in final_target_directories
+        } != set(target_directory_identities).difference({Path()}):
+            raise PermissionError(
+                f"destination directory tree changed while copying: {target_root}"
+            )
+        for relative, metadata in final_target_directories:
+            if not os.path.samestat(
+                target_directory_identities[relative],
+                metadata,
+            ):
+                raise PermissionError(
+                    f"destination tree directory identity changed: {target_root / relative}"
+                )
+        if {
+            relative for relative, _metadata in final_target_files
+        } != set(target_file_snapshots):
+            raise PermissionError(
+                f"destination file tree changed while copying: {target_root}"
+            )
+        for relative, metadata in final_target_files:
+            if target_file_snapshots[relative] != _metadata_snapshot(metadata):
+                raise PermissionError(
+                    f"destination tree file changed while copying: {target_root / relative}"
+                )
+    except BaseException:
+        try:
+            remove_directory_without_links(
+                target_root,
+                expected_identity=target_identity,
+            )
+        except (OSError, ValueError):
+            pass
+        raise
+    return target_root
+
+
+def remove_directory_without_links(
+    path: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    """Remove one exact directory without following a renamed path alias.
+
+    Managed callers commonly validate a directory, persist related state, and
+    only then delete its tree. Revalidate the complete component chain at the
+    destructive boundary and first move the directory to a private sibling.
+    That prevents a concurrent replacement at the original name from becoming
+    the object passed to ``shutil.rmtree``.
+    """
+
+    target = _exact_path(path, field="directory removal target")
+    parent = _exact_path(target.parent, field="directory removal parent")
+    if target.parent != parent:
+        raise PermissionError("directory removal parent changed identity")
+
+    with _DIRECTORY_PUBLICATION_LOCK:
+        target = _exact_path(target, field="directory removal target")
+        try:
+            target_metadata = target.lstat()
+        except FileNotFoundError:
+            raise NotADirectoryError(target) from None
+        if (
+            _metadata_is_link_or_reparse_point(target_metadata)
+            or not stat.S_ISDIR(target_metadata.st_mode)
+        ):
+            raise NotADirectoryError(target)
+        if (
+            expected_identity is not None
+            and not os.path.samestat(expected_identity, target_metadata)
+        ):
+            raise PermissionError(
+                f"directory removal target identity changed: {target}"
+            )
+        trash = private_sibling_path(
+            target,
+            f".delete-{uuid.uuid4().hex}",
+            field="directory removal staging path",
+        )
+        trash = _exact_path(trash, field="directory removal staging path")
+        if os.path.lexists(trash):
+            raise FileExistsError(trash)
+
+        rename_path_without_overwrite(
+            target,
+            trash,
+            expected_identity=target_metadata,
+        )
+        try:
+            trash = _exact_path(trash, field="directory removal staging path")
+            trash_metadata = trash.lstat()
+            if (
+                _metadata_is_link_or_reparse_point(trash_metadata)
+                or not stat.S_ISDIR(trash_metadata.st_mode)
+                or not os.path.samestat(target_metadata, trash_metadata)
+            ):
+                raise PermissionError(
+                    f"directory removal target changed before deletion: {target}"
+                )
+            shutil.rmtree(trash)
+        except BaseException:
+            if not os.path.lexists(target) and os.path.lexists(trash):
+                try:
+                    restored = _exact_path(
+                        trash,
+                        field="directory removal rollback path",
+                    )
+                    if (
+                        not path_is_link_or_reparse_point(restored)
+                        and restored.is_dir()
+                    ):
+                        rename_path_without_overwrite(
+                            restored,
+                            target,
+                            expected_identity=target_metadata,
+                        )
+                except (OSError, PermissionError, ValueError):
+                    pass
+            raise
+
+
+@_serialized_path_mutation
+def clear_directory_without_links(
+    path: str | os.PathLike[str],
+    *,
+    expected_identity: os.stat_result | None = None,
+) -> None:
+    """Remove owned children while preserving the directory's exact identity.
+
+    Extraction fallbacks sometimes need an empty output directory but must not
+    delete and recreate the root: doing so invalidates the identity held by the
+    outer cancellation/rollback path. Each child is removed through the same
+    no-link, identity-checked primitives used by public destructive operations.
+    """
+
+    root = _exact_path(path, field="directory clearing target")
+    root_metadata = root.lstat()
+    if (
+        _metadata_is_link_or_reparse_point(root_metadata)
+        or not stat.S_ISDIR(root_metadata.st_mode)
+    ):
+        raise NotADirectoryError(root)
+    if (
+        expected_identity is not None
+        and not os.path.samestat(expected_identity, root_metadata)
+    ):
+        raise PermissionError(f"directory clearing target identity changed: {root}")
+
+    _root, listed_root_metadata, entries = (
+        snapshot_directory_entries_without_links(
+            root,
+            field="directory clearing target",
+        )
+    )
+    if not os.path.samestat(root_metadata, listed_root_metadata):
+        raise PermissionError(
+            f"directory clearing target identity changed: {root}"
+        )
+    for child, child_metadata in entries:
+        current_root = root.lstat()
+        if not os.path.samestat(root_metadata, current_root):
+            raise PermissionError(f"directory clearing target identity changed: {root}")
+        if _metadata_is_link_or_reparse_point(child_metadata):
+            remove_link_without_following(
+                child,
+                expected_identity=child_metadata,
+            )
+        elif stat.S_ISDIR(child_metadata.st_mode):
+            remove_directory_without_links(
+                child,
+                expected_identity=child_metadata,
+            )
+        elif stat.S_ISREG(child_metadata.st_mode):
+            remove_file_without_links(
+                child,
+                expected_identity=child_metadata,
+            )
+        else:
+            raise PermissionError(
+                f"directory contains a non-regular entry that cannot be cleared: {child}"
+            )
+
+    final_metadata = root.lstat()
+    if not os.path.samestat(root_metadata, final_metadata):
+        raise PermissionError(f"directory clearing target identity changed: {root}")
+    _root, final_snapshot_identity, remaining_entries = (
+        snapshot_directory_entries_without_links(
+            root,
+            field="directory clearing target",
+        )
+    )
+    if (
+        not os.path.samestat(root_metadata, final_snapshot_identity)
+        or remaining_entries
+    ):
+        raise OSError(f"directory changed while being cleared: {root}")
+
+
+@_serialized_path_mutation
+def replace_directory_transactionally(
+    staging: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    *,
+    overwrite: bool = True,
+    expected_staging_identity: os.stat_result | None = None,
+    expected_destination_identity: os.stat_result | None | object = (
+        _UNSPECIFIED_IDENTITY
+    ),
+    expected_parent_identity: os.stat_result | None = None,
+) -> Path:
+    """Atomically publish a complete sibling directory and restore on failure.
+
+    The caller must first materialize ``staging`` beside ``destination``.  This
+    makes the final rename atomic even when the original download or extraction
+    lived on another volume.
+    """
+
+    staging_root = _exact_path(staging, field="staging directory")
+    target_root = _exact_path(destination, field="destination directory")
+    if staging_root == target_root:
+        raise ValueError("staging and destination directories must differ")
+    if staging_root.parent != target_root.parent:
+        raise ValueError("staging and destination directories must share a parent")
+    parent, parent_identity = _directory_identity(
+        staging_root.parent,
+        field="directory publication parent",
+    )
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(expected_parent_identity, parent_identity)
+    ):
+        raise PermissionError(
+            f"directory publication parent identity changed: {parent}"
+        )
+    if path_is_link_or_reparse_point(staging_root) or not staging_root.is_dir():
+        raise NotADirectoryError(staging_root)
+    staging_identity = staging_root.lstat()
+    if (
+        expected_staging_identity is not None
+        and not os.path.samestat(expected_staging_identity, staging_identity)
+    ):
+        raise PermissionError(
+            f"staging directory identity changed: {staging_root}"
+        )
+    inspect_portable_directory_tree(staging_root)
+
+    _require_directory_identity(
+        parent,
+        parent_identity,
+        field="directory publication parent",
+    )
+
+    with _DIRECTORY_PUBLICATION_LOCK:
+        staging_root = _exact_path(staging_root, field="staging directory")
+        target_root = _exact_path(target_root, field="destination directory")
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="directory publication parent",
+        )
+        if staging_root.parent != target_root.parent:
+            raise ValueError("publication paths changed parent")
+        if path_is_link_or_reparse_point(staging_root) or not staging_root.is_dir():
+            raise NotADirectoryError(staging_root)
+        if not os.path.samestat(staging_identity, staging_root.lstat()):
+            raise PermissionError(
+                f"staging directory identity changed: {staging_root}"
+            )
+        ensure_portable_name_available(parent, target_root.name)
+
+        target_exists = os.path.lexists(target_root)
+        target_identity: os.stat_result | None = None
+        if target_exists:
+            target_identity = target_root.lstat()
+            if (
+                _metadata_is_link_or_reparse_point(target_identity)
+                or not stat.S_ISDIR(target_identity.st_mode)
+            ):
+                raise NotADirectoryError(target_root)
+        if expected_destination_identity is not _UNSPECIFIED_IDENTITY:
+            if expected_destination_identity is None:
+                if target_identity is not None:
+                    raise FileExistsError(
+                        f"destination directory appeared before publication: {target_root}"
+                    )
+            elif (
+                target_identity is None
+                or not os.path.samestat(
+                    expected_destination_identity,
+                    target_identity,
+                )
+            ):
+                raise PermissionError(
+                    f"destination directory identity changed: {target_root}"
+                )
+        if target_exists and not overwrite:
+            raise FileExistsError(target_root)
+
+        backup: Path | None = None
+        if target_exists:
+            raw_backup = private_sibling_path(
+                target_root,
+                f".backup-{uuid.uuid4().hex}",
+                field="directory publication backup",
+            )
+            rename_path_without_overwrite(
+                target_root,
+                raw_backup,
+                expected_identity=target_identity,
+            )
+            _require_directory_identity(
+                parent,
+                parent_identity,
+                field="directory publication parent",
+            )
+            try:
+                backup = _exact_path(
+                    raw_backup,
+                    field="directory publication backup",
+                )
+                backup_metadata = backup.lstat()
+                if (
+                    _metadata_is_link_or_reparse_point(backup_metadata)
+                    or not stat.S_ISDIR(backup_metadata.st_mode)
+                    or target_identity is None
+                    or not os.path.samestat(target_identity, backup_metadata)
+                ):
+                    raise PermissionError(
+                        f"destination directory identity changed: {target_root}"
+                    )
+            except BaseException:
+                if not os.path.lexists(target_root) and os.path.lexists(raw_backup):
+                    try:
+                        rename_path_without_overwrite(
+                            raw_backup,
+                            target_root,
+                            expected_identity=target_identity,
+                        )
+                    except OSError:
+                        pass
+                raise
+
+        try:
+            _require_directory_identity(
+                parent,
+                parent_identity,
+                field="directory publication parent",
+            )
+            rename_path_without_overwrite(
+                staging_root,
+                target_root,
+                expected_identity=staging_identity,
+            )
+            _require_directory_identity(
+                parent,
+                parent_identity,
+                field="directory publication parent",
+            )
+            published_metadata = target_root.lstat()
+            if not os.path.samestat(staging_identity, published_metadata):
+                raise PermissionError(
+                    f"staging directory identity changed during publication: {staging_root}"
+                )
+        except BaseException:
+            if backup is not None and not os.path.lexists(target_root):
+                rename_path_without_overwrite(
+                    backup,
+                    target_root,
+                    expected_identity=target_identity,
+                )
+                backup = None
+            raise
+
+        if backup is not None:
+            backup = _exact_path(backup, field="directory publication backup")
+            if (
+                not backup.is_dir()
+                or target_identity is None
+                or not os.path.samestat(target_identity, backup.lstat())
+            ):
+                raise NotADirectoryError(backup)
+            remove_directory_without_links(
+                backup,
+                expected_identity=target_identity,
+            )
+        _require_directory_identity(
+            parent,
+            parent_identity,
+            field="directory publication parent",
+        )
+        return target_root

--- a/sdk/graph.py
+++ b/sdk/graph.py
@@ -7,13 +7,22 @@ unless a subclass chooses to own execution.
 
 from __future__ import annotations
 
+import errno
 import importlib
 import inspect
+import os
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from sdk.file_transactions import atomic_write_text, read_text_without_links
+from sdk.path_contract import (
+    project_root,
+    resolve_project_output_path,
+    resolve_project_read_path,
+)
 
 try:
     from typing import Self
@@ -329,8 +338,9 @@ class DagBuilder:
         import yaml
 
         out = yaml.dump(self.to_dict(), allow_unicode=True, sort_keys=False)
-        if path:
-            Path(path).write_text(out, encoding="utf-8")
+        if path is not None:
+            target = resolve_project_output_path(path, root=project_root())
+            atomic_write_text(target, out)
         return out
 
     def load_dict(self, data: dict) -> None:
@@ -364,9 +374,36 @@ class DagBuilder:
 
         text = path_or_text
         if "\n" not in path_or_text and "\r" not in path_or_text:
-            p = Path(path_or_text)
-            if p.is_file():
-                text = p.read_text(encoding="utf-8")
+            path_like = (
+                "/" in path_or_text
+                or "\\" in path_or_text
+                or path_or_text.startswith("~")
+                or path_or_text.lower().endswith((".yaml", ".yml"))
+            )
+            try:
+                p = resolve_project_read_path(path_or_text, root=project_root())
+            except (OSError, PermissionError, ValueError):
+                # Inline one-line YAML often contains punctuation that is not
+                # legal in a portable filename.  Preserve that form, but fail
+                # closed for anything that clearly declares path identity.
+                try:
+                    inline_value = yaml.safe_load(path_or_text)
+                except yaml.YAMLError:
+                    inline_value = None
+                if path_like and not isinstance(inline_value, dict):
+                    raise
+            else:
+                if p.is_file():
+                    # Resolve before the existence probe.  Probing ``Path``
+                    # directly would interpret a relative workflow against
+                    # launcher cwd instead of the authoritative project root.
+                    text = read_text_without_links(p)
+                elif path_like:
+                    raise FileNotFoundError(
+                        errno.ENOENT,
+                        "Workflow YAML file does not exist",
+                        os.fspath(p),
+                    )
         data = yaml.safe_load(text)
         if not isinstance(data, dict):
             raise ValueError("YAML must be a dict with 'nodes' and 'edges'")

--- a/sdk/logging/configure.py
+++ b/sdk/logging/configure.py
@@ -9,12 +9,34 @@ import logging.handlers
 import os
 import queue
 import re
+import stat
 import sys
 import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
+from sdk.file_transactions import (
+    open_text_append_without_links,
+    read_text_without_links,
+    remove_file_without_links,
+    require_directory_identity,
+    rename_path_without_overwrite,
+    snapshot_directory_entries_without_links,
+)
+from sdk.path_contract import (
+    managed_child_path,
+    managed_project_storage,
+    path_is_link_or_reparse_point,
+    project_root as configured_project_root,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resolve_project_output_path,
+    resolve_project_path,
+    safe_path_component,
+    truncate_utf8_bytes,
+)
 from sdk.logging.context import get_log_context, new_log_id
 from sdk.logging.environment import runtime_environment
 from sdk.logging.formatters import ConsoleFormatter, JsonLineFormatter
@@ -52,34 +74,101 @@ class _PreservingQueueHandler(logging.handlers.QueueHandler):
         return copy.copy(record)
 
 
+class _PathSafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """Rotate only exact regular files under the shared path contract."""
+
+    def _open(self):
+        return open_text_append_without_links(
+            self.baseFilename,
+            encoding=self.encoding or "utf-8",
+        )
+
+    @staticmethod
+    def _regular_file_identity(path: str) -> os.stat_result:
+        candidate = Path(path)
+        metadata = candidate.lstat()
+        if path_is_link_or_reparse_point(candidate) or not stat.S_ISREG(
+            metadata.st_mode
+        ):
+            raise PermissionError(f"log rotation source is not a regular file: {candidate}")
+        return metadata
+
+    def doRollover(self) -> None:  # noqa: N802 - stdlib API name
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        if self.backupCount > 0:
+            for index in range(self.backupCount - 1, 0, -1):
+                source = self.rotation_filename(f"{self.baseFilename}.{index}")
+                destination = self.rotation_filename(
+                    f"{self.baseFilename}.{index + 1}"
+                )
+                if not os.path.lexists(source):
+                    continue
+                source_identity = self._regular_file_identity(source)
+                if os.path.lexists(destination):
+                    destination_identity = self._regular_file_identity(
+                        destination
+                    )
+                    remove_file_without_links(
+                        destination,
+                        expected_identity=destination_identity,
+                    )
+                rename_path_without_overwrite(
+                    source,
+                    destination,
+                    expected_identity=source_identity,
+                )
+
+            destination = self.rotation_filename(f"{self.baseFilename}.1")
+            if os.path.lexists(self.baseFilename):
+                source_identity = self._regular_file_identity(self.baseFilename)
+                if os.path.lexists(destination):
+                    destination_identity = self._regular_file_identity(
+                        destination
+                    )
+                    remove_file_without_links(
+                        destination,
+                        expected_identity=destination_identity,
+                    )
+                rename_path_without_overwrite(
+                    self.baseFilename,
+                    destination,
+                    expected_identity=source_identity,
+                )
+
+        if not self.delay:
+            self.stream = self._open()
+
+
 def _safe_name(value: str) -> str:
-    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip()).strip("-")
-    return safe or "app"
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip()).strip(" .-")
+    safe = truncate_utf8_bytes(safe or "app", 255)
+    try:
+        return safe_path_component(safe, field="logging application name")
+    except ValueError:
+        # The sanitizer's alphabet has already removed separators and control
+        # characters and the byte limit is already enforced, so the remaining
+        # failure is a Windows device alias.
+        return safe_path_component(
+            truncate_utf8_bytes(f"app-{safe}", 255),
+            field="logging application name",
+        )
 
 
 def _read_version(project_root: Path) -> str:
-    candidates = [project_root / "VERSION"]
-    frozen_root = getattr(sys, "_MEIPASS", None)
-    if frozen_root:
-        candidates.append(Path(frozen_root) / "VERSION")
-    executable_root = Path(sys.executable).resolve(strict=False).parent
-    candidates.append(executable_root / "VERSION")
-    seen: set[Path] = set()
-    for candidate in candidates:
-        try:
-            path = candidate.resolve(strict=False)
-        except OSError:
-            path = candidate
-        if path in seen:
-            continue
-        seen.add(path)
-        try:
-            value = path.read_text(encoding="utf-8").strip()
-        except OSError:
-            continue
-        if value:
-            return value
-    return "unknown"
+    del project_root  # Version metadata belongs to the immutable distribution.
+    try:
+        from sdk.path_contract import resource_path
+
+        candidate = resource_path("VERSION")
+    except Exception:
+        return "unknown"
+    try:
+        return read_text_without_links(candidate).strip() or "unknown"
+    except (OSError, PermissionError, ValueError):
+        return "unknown"
 
 
 def _parse_level(value: str | int | None) -> int:
@@ -95,14 +184,42 @@ def _cleanup_old_logs(log_dir: Path, retention_days: int) -> None:
         return
     cutoff = time.time() - retention_days * 86400
     try:
-        entries = list(log_dir.glob("*.jsonl*"))
+        log_dir, log_dir_identity, directory_entries = (
+            snapshot_directory_entries_without_links(
+                log_dir,
+                field="log directory",
+            )
+        )
+        entries = [
+            (path, metadata)
+            for path, metadata in directory_entries
+            if path.match("*.jsonl*")
+        ]
+        require_directory_identity(
+            log_dir,
+            log_dir_identity,
+            field="log directory",
+        )
     except OSError:
         return
-    for path in entries:
+    for path, metadata in entries:
         try:
-            if path.is_file() and path.stat().st_mtime < cutoff:
-                path.unlink()
-        except OSError:
+            require_directory_identity(
+                log_dir,
+                log_dir_identity,
+                field="log directory",
+            )
+            if (
+                not path_is_link_or_reparse_point(path)
+                and stat.S_ISREG(metadata.st_mode)
+                and metadata.st_mtime < cutoff
+            ):
+                remove_file_without_links(
+                    path,
+                    expected_identity=metadata,
+                    expected_parent_identity=log_dir_identity,
+                )
+        except (OSError, ValueError):
             continue
 
 
@@ -154,7 +271,11 @@ def configure_logging(
     """
     global _listener, _queue_handler, _atexit_registered
 
-    root_path = Path(project_root or os.environ.get("EASYAI_PROJECT_ROOT") or Path.cwd()).resolve()
+    root_path = (
+        resolve_project_path(".", root=project_root)
+        if project_root is not None
+        else configured_project_root()
+    )
     version = _read_version(root_path)
     safe_app_name = _safe_name(app_name)
     resolved_level = _parse_level(level)
@@ -174,12 +295,35 @@ def configure_logging(
 
         if file:
             try:
-                base_dir = Path(log_dir).resolve() if log_dir else root_path / "logs" / safe_app_name
+                if log_dir is not None:
+                    configured_log_dir = Path(log_dir).expanduser()
+                    if configured_log_dir.is_absolute():
+                        require_symlink_free_absolute_path(
+                            configured_log_dir,
+                            field="log directory",
+                        )
+                    base_dir = resolve_project_output_path(
+                        log_dir,
+                        root=root_path,
+                    )
+                else:
+                    base_dir = managed_project_storage(
+                        Path("logs") / safe_app_name,
+                        root=root_path,
+                    )
                 base_dir.mkdir(parents=True, exist_ok=True)
+                base_dir = require_directory_without_links(
+                    base_dir,
+                    field="log directory",
+                )
                 _cleanup_old_logs(base_dir, retention_days)
                 stamp = time.strftime("%Y%m%d-%H%M%S")
-                output_path = base_dir / f"{stamp}-{os.getpid()}.jsonl"
-                file_handler = logging.handlers.RotatingFileHandler(
+                output_path = managed_child_path(
+                    base_dir,
+                    f"{stamp}-{os.getpid()}-{uuid.uuid4().hex}.jsonl",
+                    field="log filename",
+                )
+                file_handler = _PathSafeRotatingFileHandler(
                     output_path,
                     maxBytes=max_bytes,
                     backupCount=backup_count,

--- a/sdk/manager.py
+++ b/sdk/manager.py
@@ -6,11 +6,29 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from collections.abc import Callable, Iterable, Iterator, MutableMapping, Sequence
 from pathlib import Path
 from typing import Any, Type
 
 import yaml
+
+from sdk.file_transactions import (
+    ensure_portable_name_available,
+    portable_name_key,
+    read_text_without_links,
+)
+from sdk.path_contract import (
+    managed_child_path,
+    project_root,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    resolve_managed_project_path,
+    resolve_project_output_path,
+    resolve_project_path,
+    resolve_project_read_path,
+    safe_path_component,
+)
 
 from sdk.handlers import MessageHandler, UIOutputMessageHandler
 from sdk.adapters import (
@@ -68,10 +86,43 @@ class PluginManager:
         *,
         plugin_data_root: Path | None = None,
         discovery: PluginDiscoveryRegistry | None = None,
+        root: str | Path | None = None,
     ) -> None:
-        self._plugin_data_root = (
-            Path(plugin_data_root) if plugin_data_root is not None else Path("data/plugins")
+        authoritative_root = (
+            project_root()
+            if root is None
+            else resolve_project_path(".", root=root)
         )
+        configured_value = (
+            os.fspath(plugin_data_root)
+            if plugin_data_root is not None
+            else os.fspath(authoritative_root / "data" / "plugins")
+        )
+        configured_root = Path(configured_value).expanduser()
+        explicitly_absolute = configured_root.is_absolute()
+        project_owned = not explicitly_absolute
+        if explicitly_absolute:
+            try:
+                configured_root.relative_to(authoritative_root)
+                project_owned = True
+            except ValueError:
+                project_owned = False
+        if project_owned:
+            resolved_root = resolve_managed_project_path(
+                configured_value,
+                root=authoritative_root,
+            )
+        else:
+            require_symlink_free_absolute_path(
+                configured_root,
+                field="plugin data root",
+            )
+            resolved_root = resolve_project_output_path(
+                configured_value,
+                root=authoritative_root,
+            )
+        self._project_root = authoritative_root
+        self._plugin_data_root = resolved_root
         self._discovery = discovery if discovery is not None else PluginDiscoveryRegistry()
         self._hook_dispatcher = PluginHookDispatcher()
         self._capabilities: PluginCapabilityRegistry | None = None
@@ -110,13 +161,14 @@ class PluginManager:
         self._discovery.register_descriptors(descriptors)
 
     def load_manifest_file(self, path: Path) -> None:
-        text = path.read_text(encoding="utf-8")
-        if path.suffix.lower() in {".yaml", ".yml"}:
+        source = resolve_project_read_path(path, root=self._project_root)
+        text = read_text_without_links(source)
+        if source.suffix.lower() in {".yaml", ".yml"}:
             raw = yaml.safe_load(text) or []
         else:
             raw = json.loads(text)
         if not isinstance(raw, list):
-            raise ValueError(f"Plugin manifest must be a list: {path}")
+            raise ValueError(f"Plugin manifest must be a list: {source}")
         descs: list[PluginDescriptor] = []
         for item in raw:
             if not isinstance(item, dict):
@@ -124,6 +176,13 @@ class PluginManager:
             entry = item.get("entry")
             if not entry or not isinstance(entry, str):
                 raise ValueError(f"Manifest item missing string 'entry': {item!r}")
+            if entry != entry.strip() or any(
+                ord(character) < 32
+                or ord(character) == 127
+                or 0xD800 <= ord(character) <= 0xDFFF
+                for character in entry
+            ):
+                raise ValueError(f"Manifest item entry is not exact: {item!r}")
             enabled = bool(item.get("enabled", True))
             extra = {
                 k: v
@@ -131,7 +190,7 @@ class PluginManager:
                 if k not in ("entry", "enabled")
             }
             descs.append(
-                PluginDescriptor(entry=entry.strip(), enabled=enabled, extra=extra)
+                PluginDescriptor(entry=entry, enabled=enabled, extra=extra)
             )
         self.load_from_descriptors(descs)
 
@@ -163,16 +222,43 @@ class PluginManager:
         if self._initialized and app_config is None:
             return
         self._plugin_data_root.mkdir(parents=True, exist_ok=True)
+        self._plugin_data_root = require_directory_without_links(
+            self._plugin_data_root,
+            field="plugin data root",
+        )
         self._hook_dispatcher.clear()
         self._capabilities = PluginCapabilityRegistry(
             hook_dispatcher=self._hook_dispatcher,
         )
-        host = PluginHostContext.from_config_manager(app_config)
+        host = PluginHostContext.from_config_manager(
+            app_config,
+            project_data_dir=self._plugin_data_root.parent,
+        )
 
+        claimed_storage: set[str] = set()
         for plugin in self._instances:
-            root = self._plugin_data_root / plugin.plugin_id.replace("/", "_")
-            root.mkdir(parents=True, exist_ok=True)
             try:
+                storage_name = safe_path_component(
+                    str(plugin.plugin_id),
+                    field="plugin id",
+                )
+                storage_key = portable_name_key(storage_name)
+                if storage_key in claimed_storage:
+                    raise FileExistsError(
+                        f"plugin id collides with another loaded plugin: {plugin.plugin_id}"
+                    )
+                ensure_portable_name_available(self._plugin_data_root, storage_name)
+                root = managed_child_path(
+                    self._plugin_data_root,
+                    storage_name,
+                    field="plugin id",
+                )
+                root.mkdir(exist_ok=True)
+                root = require_directory_without_links(
+                    root,
+                    field="plugin data directory",
+                )
+                claimed_storage.add(storage_key)
                 assert self._capabilities is not None
                 self._capabilities.set_settings_ui_plugin_context(
                     plugin.plugin_id, plugin.plugin_version

--- a/sdk/path_contract.py
+++ b/sdk/path_contract.py
@@ -1,0 +1,1463 @@
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import stat
+import sys
+from pathlib import Path
+from urllib.parse import SplitResult, unquote_to_bytes, urlsplit
+
+
+_WINDOWS_ABSOLUTE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_DRIVE_RELATIVE_RE = re.compile(r"^[A-Za-z]:[^\\/]")
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$"}
+    | {
+        f"{prefix}{suffix}"
+        for prefix in ("COM", "LPT")
+        for suffix in (*map(str, range(1, 10)), "¹", "²", "³")
+    }
+)
+_PATH_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f\ud800-\udfff]")
+_ENCODED_PATH_SEPARATOR_RE = re.compile(r"%(?:2f|5c)", re.IGNORECASE)
+_INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_MAX_PORTABLE_COMPONENT_UTF8_BYTES = 255
+
+
+def truncate_utf8_bytes(value: str, max_bytes: int) -> str:
+    """Truncate text at a Unicode boundary without exceeding ``max_bytes``."""
+
+    if max_bytes < 0:
+        raise ValueError("maximum UTF-8 byte length must not be negative")
+    raw = str(value)
+    try:
+        encoded = raw.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError("value contains invalid Unicode") from exc
+    if len(encoded) <= max_bytes:
+        return raw
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _split_unambiguous_media_url(raw: str, *, field: str) -> SplitResult:
+    """Parse one direct media URL whose authority has one browser identity."""
+
+    if "\\" in raw:
+        raise ValueError(f"{field} contains an ambiguous path separator")
+    try:
+        parsed = urlsplit(raw)
+        # ``urlsplit`` defers invalid/non-numeric and out-of-range port
+        # validation until this property is read, while the browser URL parser
+        # rejects such values immediately.
+        parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{field} is malformed") from exc
+    if "%" in parsed.netloc or any(character.isspace() for character in parsed.netloc):
+        # A browser can decode an escaped HTTP hostname to a different textual
+        # identity (for example an encoded loopback address).  Unicode may be
+        # supplied directly; only authority encodings and whitespace are
+        # ambiguous here.
+        raise ValueError(f"{field} contains an ambiguous authority")
+    return parsed
+
+
+def _validate_windows_namespace_text(raw: str, *, field: str) -> None:
+    r"""Allow only filesystem-shaped Windows verbatim paths.
+
+    ``\\.\`` addresses devices, while verbatim namespaces such as
+    ``\\?\GLOBALROOT`` do not name an ordinary drive/UNC file.  Treating
+    either as a normal path can change ownership and containment semantics.
+    """
+
+    portable = raw.replace("\\", "/")
+    if portable.startswith("//./") or portable.startswith("/??/"):
+        raise ValueError(f"{field} uses a Windows device namespace")
+    if not portable.startswith("//?/"):
+        return
+    tail = portable[len("//?/") :]
+    if re.match(r"^[A-Za-z]:/", tail):
+        return
+    if tail.upper().startswith("UNC/"):
+        unc_parts = tail[len("UNC/") :].split("/")
+        if len(unc_parts) >= 2 and unc_parts[0] and unc_parts[1]:
+            return
+    raise ValueError(f"{field} uses an unsupported Windows verbatim namespace")
+
+
+def _resolve(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _configured_environment_path(name: str) -> str | None:
+    """Return an explicitly configured path without normalizing its identity.
+
+    Presence is authoritative.  In particular, an empty current variable must
+    not silently fall through to a legacy variable or a different default
+    root: that would recreate the split-root behavior this module prevents.
+    """
+
+    return os.environ[name] if name in os.environ else None
+
+
+def user_home_directory() -> Path:
+    """Return one exact, absolute user-home identity.
+
+    ``Path.home()`` accepts platform environment variables directly.  Validate
+    the resulting text before callers append cache, download, or configuration
+    paths so an invalid ``HOME``/``USERPROFILE`` cannot create a second path
+    interpretation in Python while the desktop shell rejects it.
+    """
+
+    try:
+        home = Path.home()
+    except (KeyError, RuntimeError) as exc:
+        raise ValueError("user home directory is unavailable") from exc
+    return _explicit_absolute_root(home, field="user home directory")
+
+
+def path_is_within(candidate: Path, root: Path) -> bool:
+    """Return whether a host path is contained by the requested boundary."""
+
+    try:
+        candidate.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def safe_path_component(value: str, *, field: str = "path component") -> str:
+    """Validate a portable single directory or file-name component."""
+
+    raw = str(value or "")
+    if (
+        not raw
+        or raw != raw.strip()
+        or raw in {".", ".."}
+        or _PATH_CONTROL_RE.search(raw)
+        or any(character in '<>:"/\\|?*' for character in raw)
+        or raw.endswith((" ", "."))
+        or len(raw.encode("utf-8")) > _MAX_PORTABLE_COMPONENT_UTF8_BYTES
+    ):
+        raise ValueError(f"{field} is not a portable path component")
+    if raw.split(".", 1)[0].upper() in _WINDOWS_RESERVED_NAMES:
+        raise ValueError(f"{field} is a reserved Windows device name")
+    return raw
+
+
+def safe_path_component_with_suffix(
+    base: str,
+    suffix: str,
+    *,
+    field: str = "path component",
+) -> str:
+    """Fit a derived component while preserving its semantic suffix.
+
+    Callers commonly validate a source name and then append a collision
+    counter, digest, extension, or timestamp. Reserve the suffix bytes first
+    so that the final on-disk component—not only its input—satisfies the
+    portable 255-byte limit.
+    """
+
+    suffix_text = str(suffix)
+    try:
+        suffix_size = len(suffix_text.encode("utf-8"))
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{field} contains invalid Unicode") from exc
+    available = _MAX_PORTABLE_COMPONENT_UTF8_BYTES - suffix_size
+    if available <= 0:
+        raise ValueError(f"{field} suffix is too long")
+    fitted_base = truncate_utf8_bytes(str(base), available)
+    if not fitted_base:
+        raise ValueError(f"{field} base is too long for its suffix")
+    return safe_path_component(f"{fitted_base}{suffix_text}", field=field)
+
+
+def portable_path_component_prefix(
+    value: str,
+    *,
+    reserved_suffix_bytes: int,
+    field: str = "path component prefix",
+) -> str:
+    """Fit a temporary-name prefix while reserving bytes added by its creator.
+
+    ``tempfile`` accepts a prefix and then appends a private random token (and
+    sometimes a caller-provided suffix). Validate the eventual component with
+    an ASCII placeholder, then return only the fitted prefix.
+    """
+
+    if reserved_suffix_bytes <= 0:
+        raise ValueError("reserved suffix bytes must be positive")
+    placeholder = "x" * reserved_suffix_bytes
+    candidate = safe_path_component_with_suffix(
+        str(value),
+        placeholder,
+        field=field,
+    )
+    return candidate[:-reserved_suffix_bytes]
+
+
+def _exact_relative_parts(raw: str, *, field: str) -> tuple[str, ...]:
+    """Parse a portable relative path before ``Path`` can erase aliases."""
+
+    portable = raw.replace("\\", "/")
+    parts = tuple(portable.split("/"))
+    if ".." in parts:
+        raise PermissionError(f"{field} escapes its project boundary")
+    if not parts or any(part in {"", "."} for part in parts):
+        raise ValueError(f"{field} must use exact relative components")
+    if parts[0].startswith("~"):
+        raise ValueError(f"{field} must not use a user-home alias")
+    for component in parts:
+        safe_path_component(component, field=f"{field} component")
+    return parts
+
+
+def canonical_relative_path_with_prefix(
+    value: str | os.PathLike[str],
+    prefixes: tuple[tuple[str, ...], ...],
+    *,
+    field: str = "path",
+) -> str | None:
+    """Return an exact relative path with a matched prefix's canonical spelling.
+
+    Prefix matching is intentionally case-insensitive so persisted Windows
+    paths remain recognizable after migration.  Returning the caller's
+    original prefix spelling would then make the same reference fail on a
+    case-sensitive filesystem, so every matched component is replaced with
+    the configured canonical spelling while the unclassified tail is kept
+    byte-for-byte.
+    """
+
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            f"{field} is empty or contains surrounding whitespace or control characters"
+        )
+    if (
+        _WINDOWS_ABSOLUTE_RE.match(raw)
+        or _WINDOWS_DRIVE_RELATIVE_RE.match(raw)
+        or raw.startswith(("\\\\", "//"))
+        or Path(raw).is_absolute()
+    ):
+        raise ValueError(f"{field} must be relative")
+    parts = _exact_relative_parts(raw, field=field)
+    folded = tuple(part.casefold() for part in parts)
+    for prefix_value in prefixes:
+        prefix = tuple(str(part) for part in prefix_value)
+        if not prefix:
+            continue
+        for component in prefix:
+            safe_path_component(component, field=f"{field} prefix component")
+        if folded[: len(prefix)] == tuple(part.casefold() for part in prefix):
+            return "/".join((*prefix, *parts[len(prefix) :]))
+    return None
+
+
+def relative_path_has_prefix(
+    value: str | os.PathLike[str],
+    prefixes: tuple[tuple[str, ...], ...],
+    *,
+    field: str = "path",
+) -> bool:
+    """Classify an exact portable relative path without normalizing aliases."""
+
+    return (
+        canonical_relative_path_with_prefix(
+            value,
+            prefixes,
+            field=field,
+        )
+        is not None
+    )
+
+
+def _validate_exact_absolute_text(
+    raw: str,
+    *,
+    field: str,
+    allow_non_native: bool = False,
+) -> None:
+    """Reject aliases and non-portable components before native resolution."""
+
+    _validate_windows_namespace_text(raw, field=field)
+    if os.name != "nt" and Path(raw).is_absolute() and "\\" in raw:
+        # POSIX permits a literal backslash in a filename, while persisted
+        # project paths and the Windows launcher interpret it as a separator.
+        # Accepting it here would give the Python and Node/Tauri layers two
+        # different identities for the same path text.
+        raise ValueError(f"{field} contains a non-portable path component")
+    portable = raw.replace("\\", "/")
+    if portable.startswith("//?/"):
+        namespace_tail = portable[len("//?/") :]
+        if re.match(r"^[A-Za-z]:/", namespace_tail):
+            portable = namespace_tail
+        elif namespace_tail.upper().startswith("UNC/"):
+            portable = f"//{namespace_tail[len('UNC/') :]}"
+
+    if re.match(r"^[A-Za-z]:/", portable):
+        components = portable[3:].split("/") if portable[3:] else []
+    elif portable.startswith("//"):
+        if os.name != "nt" and not allow_non_native:
+            raise ValueError(f"{field} uses non-native UNC syntax")
+        unc_parts = portable[2:].split("/")
+        if len(unc_parts) < 2 or not unc_parts[0] or not unc_parts[1]:
+            raise ValueError(f"{field} uses invalid UNC syntax")
+        if len(unc_parts) == 3 and unc_parts[2] == "":
+            unc_parts = unc_parts[:2]
+        components = unc_parts
+    elif portable.startswith("/"):
+        components = portable[1:].split("/") if portable[1:] else []
+    else:
+        return
+    if any(part in {"", ".", ".."} for part in components):
+        raise ValueError(f"{field} must not contain lexical path aliases")
+    for component in components:
+        safe_path_component(component, field=f"{field} component")
+
+
+def _expand_exact_path(raw: str, *, field: str) -> tuple[Path, bool]:
+    """Expand a path while retaining enough raw text to reject aliases."""
+
+    _validate_windows_namespace_text(raw, field=field)
+    portable = raw.replace("\\", "/")
+    first_component, _, home_tail = portable.partition("/")
+    if first_component.startswith("~") and first_component != "~":
+        raise ValueError(f"{field} must use only the current user-home alias")
+    try:
+        unexpanded = Path(raw)
+        candidate = unexpanded.expanduser()
+    except (KeyError, RuntimeError) as exc:
+        raise ValueError(f"{field} contains an unknown user-home prefix") from exc
+    if (
+        _WINDOWS_ABSOLUTE_RE.match(raw) or raw.startswith(("\\\\", "//"))
+    ) and not candidate.is_absolute():
+        raise ValueError(
+            f"{field} uses non-native absolute syntax that is not native to this platform"
+        )
+
+    home_alias = first_component.startswith("~")
+    if home_alias:
+        if home_tail and any(part in {"", ".", ".."} for part in home_tail.split("/")):
+            raise ValueError(f"{field} must not contain lexical path aliases")
+        if not candidate.is_absolute():
+            raise ValueError(f"{field} contains an unknown user-home prefix")
+        _validate_exact_absolute_text(os.fspath(candidate), field=field)
+        return candidate, True
+
+    if unexpanded.is_absolute():
+        _validate_exact_absolute_text(raw, field=field)
+    return candidate, candidate.is_absolute()
+
+
+def validate_exact_path_text(
+    value: str | os.PathLike[str],
+    *,
+    field: str = "path",
+    allow_dot_root: bool = False,
+    allow_non_native_absolute: bool = False,
+) -> str:
+    """Validate path identity before :class:`Path` can normalize it.
+
+    This helper is for boundaries that must inspect or preserve the caller's
+    lexical path (for example persisted cross-platform references).  Normal
+    project I/O should use :func:`resolve_project_path` or one of the managed
+    resolvers directly.
+    """
+
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            f"{field} is empty or contains surrounding whitespace or control characters"
+        )
+    _validate_windows_namespace_text(raw, field=field)
+    if _WINDOWS_DRIVE_RELATIVE_RE.match(raw):
+        raise ValueError(f"{field} uses ambiguous Windows drive-relative syntax")
+    if raw == ".":
+        if allow_dot_root:
+            return raw
+        raise ValueError(f"{field} must use exact path components")
+
+    native_candidate = Path(raw)
+    absolute_text = (
+        native_candidate.is_absolute()
+        or bool(_WINDOWS_ABSOLUTE_RE.match(raw))
+        or raw.startswith(("\\\\", "//"))
+    )
+    if absolute_text:
+        _validate_exact_absolute_text(
+            raw,
+            field=field,
+            allow_non_native=allow_non_native_absolute,
+        )
+        if not allow_non_native_absolute:
+            _expand_exact_path(raw, field=field)
+        return raw
+
+    if raw.replace("\\", "/").split("/", 1)[0].startswith("~"):
+        _expand_exact_path(raw, field=field)
+        return raw
+
+    _exact_relative_parts(raw, field=field)
+    return raw
+
+
+def _metadata_is_link_or_reparse_point(metadata: os.stat_result) -> bool:
+    """Recognize POSIX links and Windows junction/reparse-point aliases."""
+
+    if stat.S_ISLNK(metadata.st_mode):
+        return True
+    attributes = getattr(metadata, "st_file_attributes", 0)
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x00000400)
+    return bool(attributes & reparse_point)
+
+
+def path_is_link_or_reparse_point(value: str | os.PathLike[str]) -> bool:
+    """Return whether one existing leaf is a symlink, junction, or reparse point."""
+
+    path = Path(value)
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise PermissionError(f"path metadata cannot be inspected: {path}") from exc
+    return _metadata_is_link_or_reparse_point(metadata)
+
+
+def require_symlink_free_absolute_path(
+    value: str | os.PathLike[str],
+    *,
+    field: str = "path",
+    include_leaf: bool = True,
+    allow_filesystem_root: bool = False,
+) -> Path:
+    """Return one exact absolute path after rejecting every existing link component."""
+
+    raw = validate_exact_path_text(value, field=field)
+    try:
+        candidate = Path(raw).expanduser()
+    except (KeyError, RuntimeError) as exc:
+        raise ValueError(f"{field} contains an unknown user-home prefix") from exc
+    if not candidate.is_absolute():
+        raise ValueError(f"{field} must be an absolute path")
+    if candidate == Path(candidate.anchor) and not allow_filesystem_root:
+        raise PermissionError(f"{field} must not be a filesystem root")
+
+    parts = candidate.parts
+    cursor = Path(candidate.anchor)
+    for index, component in enumerate(parts[1:], start=1):
+        cursor = cursor / component
+        if not include_leaf and index == len(parts) - 1:
+            break
+        try:
+            metadata = cursor.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise PermissionError(f"{field} component cannot be inspected: {cursor}") from exc
+        if _metadata_is_link_or_reparse_point(metadata):
+            raise PermissionError(
+                f"{field} contains a symbolic link component or reparse point: {cursor}"
+            )
+    return candidate
+
+
+def require_regular_file_without_links(
+    value: str | os.PathLike[str],
+    *,
+    field: str = "file",
+) -> Path:
+    """Return one exact regular file after rejecting every path alias.
+
+    This is the execution/open-by-path counterpart to the descriptor-based
+    helpers in :mod:`core.file_transactions`.  Process launchers cannot hand
+    an already-open descriptor to every supported platform, so they must at
+    least derive both readiness and the final command from this same strict
+    path identity.
+    """
+
+    candidate = require_symlink_free_absolute_path(value, field=field)
+    try:
+        metadata = candidate.lstat()
+    except FileNotFoundError:
+        raise FileNotFoundError(candidate) from None
+    if (
+        _metadata_is_link_or_reparse_point(metadata)
+        or not stat.S_ISREG(metadata.st_mode)
+    ):
+        raise FileNotFoundError(candidate)
+    return candidate
+
+
+def require_directory_without_links(
+    value: str | os.PathLike[str],
+    *,
+    field: str = "directory",
+    allow_filesystem_root: bool = False,
+) -> Path:
+    """Return one exact existing directory after rejecting every path alias."""
+
+    candidate = require_symlink_free_absolute_path(
+        value,
+        field=field,
+        allow_filesystem_root=allow_filesystem_root,
+    )
+    try:
+        metadata = candidate.lstat()
+    except FileNotFoundError:
+        raise NotADirectoryError(candidate) from None
+    if (
+        _metadata_is_link_or_reparse_point(metadata)
+        or not stat.S_ISDIR(metadata.st_mode)
+    ):
+        raise NotADirectoryError(candidate)
+    return candidate
+
+
+def resolve_executable_file(
+    value: str | os.PathLike[str],
+    *,
+    field: str = "executable",
+) -> Path:
+    """Resolve one executable leaf alias to a stable regular-file identity.
+
+    POSIX virtual environments commonly expose ``bin/python`` as a symbolic
+    link, so rejecting every executable leaf link would break legitimate local
+    runtimes.  The containing path must still be link-free; only the final
+    executable component may be an alias.  Launchers receive the resolved
+    regular file rather than the alias spelling, keeping discovery and process
+    execution on the same identity.
+    """
+
+    candidate = require_symlink_free_absolute_path(
+        value,
+        field=field,
+        include_leaf=False,
+    )
+    try:
+        resolved = candidate.resolve(strict=True)
+    except FileNotFoundError:
+        raise FileNotFoundError(candidate) from None
+    resolved = require_regular_file_without_links(resolved, field=field)
+    if not os.access(resolved, os.X_OK):
+        raise PermissionError(f"{field} is not executable: {resolved}")
+    return resolved
+
+
+def _explicit_absolute_root(value: str | Path, *, field: str) -> Path:
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(f"{field} is empty or contains non-portable characters")
+    first_component = raw.replace("\\", "/").split("/", 1)[0]
+    if first_component.startswith("~"):
+        raise ValueError(f"{field} must be an exact absolute path, not a user-home alias")
+    try:
+        candidate = Path(raw).expanduser()
+    except (KeyError, RuntimeError) as exc:
+        raise ValueError(f"{field} contains an unknown user-home prefix") from exc
+    if not candidate.is_absolute():
+        raise ValueError(f"{field} must be an absolute path")
+    _validate_exact_absolute_text(raw, field=field)
+    if candidate == Path(candidate.anchor):
+        raise ValueError(f"{field} must not be a filesystem root")
+    # Root values are ownership boundaries, not ordinary aliases.  Inspect
+    # the spelling supplied by the caller before ``resolve()`` can erase a
+    # symlink or Windows reparse-point component.  Missing leaf directories
+    # remain valid here because project-root activation may create them later.
+    require_symlink_free_absolute_path(candidate, field=field)
+    resolved = _resolve(candidate)
+    if resolved == Path(resolved.anchor):
+        raise ValueError(f"{field} must not be a filesystem root")
+    _validate_exact_absolute_text(os.fspath(resolved), field=f"resolved {field}")
+    return resolved
+
+
+def resolve_project_path(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+) -> Path:
+    """Resolve a native path under the project-root contract.
+
+    Relative references are project-owned and therefore must remain inside the
+    authoritative root after normalization and symlink resolution.  An
+    explicitly absolute reference retains its external-path meaning.
+    """
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            "path is empty or contains surrounding whitespace or control characters"
+        )
+    if _WINDOWS_DRIVE_RELATIVE_RE.match(raw):
+        raise ValueError("Windows drive-relative paths are ambiguous")
+    candidate, explicitly_absolute = _expand_exact_path(raw, field="path")
+    if not explicitly_absolute:
+        if raw == ".":
+            candidate = project
+        else:
+            try:
+                parts = _exact_relative_parts(raw, field="path")
+            except PermissionError as exc:
+                raise PermissionError("relative path escapes project root") from exc
+            candidate = project.joinpath(*parts)
+    resolved = candidate.resolve(strict=False)
+    if not explicitly_absolute and not path_is_within(resolved, project):
+        raise PermissionError("relative path escapes project root")
+    return resolved
+
+
+def resolve_runtime_asset_path(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+    resource_prefixes: tuple[tuple[str, ...], ...] = (("assets",),),
+) -> Path:
+    """Resolve an exact persisted runtime asset reference.
+
+    Known relative resource prefixes belong to the immutable application
+    roots, other relative references belong to the authoritative writable
+    project root, and explicit native absolute paths retain their external
+    read semantics.  A shared classifier keeps desktop and React/Tauri media
+    consumers from interpreting the same stored value against different roots.
+    """
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    raw = validate_exact_path_text(value, field="runtime asset path")
+    candidate = Path(raw).expanduser()
+    explicitly_absolute = (
+        candidate.is_absolute()
+        or bool(_WINDOWS_ABSOLUTE_RE.match(raw))
+        or raw.startswith(("\\\\", "//"))
+        or raw.replace("\\", "/").split("/", 1)[0].startswith("~")
+    )
+    canonical_resource = (
+        canonical_relative_path_with_prefix(
+            raw,
+            resource_prefixes,
+            field="runtime asset path",
+        )
+        if not explicitly_absolute
+        else None
+    )
+    if canonical_resource is not None:
+        return resource_path(canonical_resource)
+    if not explicitly_absolute:
+        return resolve_managed_project_path(raw, root=project)
+    try:
+        candidate.relative_to(project)
+    except ValueError:
+        return resolve_project_path(raw, root=project)
+    return resolve_managed_project_path(raw, root=project)
+
+
+def resolve_runtime_asset_read_path(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+    resource_prefixes: tuple[tuple[str, ...], ...] = (("assets",),),
+) -> Path:
+    """Resolve a runtime input while preserving and checking its exact identity.
+
+    This is the strict counterpart to :func:`resolve_runtime_asset_path`.
+    Runtime asset references still use the same application-resource,
+    project-data, and explicit-external classification, but no caller-supplied
+    component may be a symbolic link or Windows reparse point.  In particular,
+    the path is never canonicalized before link inspection, so an alias cannot
+    be laundered into an apparently safe target before a no-follow reader sees
+    it.
+
+    General model/cache consumers may intentionally rely on symlinked files
+    and should continue using :func:`resolve_runtime_asset_path`.  Import,
+    conversion, archive, and workflow boundaries should use this function.
+    """
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    raw = validate_exact_path_text(value, field="runtime asset input path")
+    candidate, explicitly_absolute = _expand_exact_path(
+        raw,
+        field="runtime asset input path",
+    )
+
+    canonical_resource = (
+        canonical_relative_path_with_prefix(
+            raw,
+            resource_prefixes,
+            field="runtime asset input path",
+        )
+        if not explicitly_absolute
+        else None
+    )
+    if canonical_resource is not None:
+        parts = _exact_relative_parts(
+            canonical_resource,
+            field="runtime asset input path",
+        )
+        resource_roots: list[Path] = []
+        for candidate_root in (source_root(), app_root()):
+            if candidate_root not in resource_roots:
+                resource_roots.append(candidate_root)
+        for resource_root in resource_roots:
+            exact_resource = require_symlink_free_absolute_path(
+                resource_root.joinpath(*parts),
+                field="runtime asset input path",
+            )
+            if exact_resource.exists():
+                return exact_resource
+        return require_symlink_free_absolute_path(
+            resource_roots[0].joinpath(*parts),
+            field="runtime asset input path",
+        )
+
+    if not explicitly_absolute:
+        return resolve_managed_project_path(raw, root=project)
+    try:
+        candidate.relative_to(project)
+    except ValueError:
+        return require_symlink_free_absolute_path(
+            candidate,
+            field="runtime asset input path",
+        )
+    return resolve_managed_project_path(raw, root=project)
+
+
+def validate_runtime_media_reference(
+    value: str | os.PathLike[str] | None,
+    *,
+    allow_empty: bool = True,
+) -> str:
+    """Validate a local-media reference before URL encoding or ``Path`` use."""
+
+    raw = "" if value is None else os.fspath(value)
+    if not raw:
+        if allow_empty:
+            return ""
+        raise ValueError("media path is empty")
+    if raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError("media path contains non-portable characters")
+    lowered = raw.lower()
+    if lowered.startswith(("http://", "https://")):
+        parsed = _split_unambiguous_media_url(raw, field="media URL")
+        if (
+            parsed.scheme.lower() not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError("media URL must be an absolute HTTP(S) URL without credentials")
+        return raw
+    if lowered.startswith("asset:"):
+        parsed = _split_unambiguous_media_url(raw, field="asset media URL")
+        if (
+            parsed.scheme.lower() != "asset"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError("asset media URL must be absolute and omit credentials")
+        return raw
+    if lowered.startswith("blob:"):
+        if not raw[len("blob:") :]:
+            raise ValueError("blob media URL is empty")
+        return raw
+    if lowered.startswith("data:"):
+        if "," not in raw[len("data:") :]:
+            raise ValueError("data media URL is malformed")
+        return raw
+    if raw.startswith("/assets/"):
+        path_end = min(
+            (index for index in (raw.find("?"), raw.find("#")) if index >= 0),
+            default=len(raw),
+        )
+        encoded_path = raw[:path_end]
+        if (
+            _ENCODED_PATH_SEPARATOR_RE.search(encoded_path)
+            or _INVALID_PERCENT_ESCAPE_RE.search(encoded_path)
+        ):
+            raise ValueError("application media URL contains ambiguous encoding")
+        try:
+            decoded_path = unquote_to_bytes(encoded_path).decode(
+                "utf-8",
+                errors="strict",
+            )
+        except UnicodeDecodeError as exc:
+            raise ValueError("application media URL contains invalid UTF-8") from exc
+        if not decoded_path.startswith("/assets/") or "\\" in decoded_path:
+            raise ValueError("application media URL is outside application assets")
+        try:
+            validate_exact_path_text(
+                decoded_path[1:],
+                field="application media path",
+            )
+        except PermissionError as exc:
+            raise ValueError(
+                "application media URL escapes application assets"
+            ) from exc
+        return raw
+    validate_exact_path_text(raw, field="media path")
+    return raw
+
+
+def runtime_media_reference_is_direct(value: str) -> bool:
+    """Return whether a validated media reference is already browser-addressable."""
+
+    raw = validate_runtime_media_reference(value)
+    lowered = raw.lower()
+    return (
+        lowered.startswith(("http://", "https://", "blob:", "data:", "asset:"))
+        or raw.startswith("/assets/")
+    )
+
+
+def managed_child_path(base: Path, component: str, *, field: str = "path component") -> Path:
+    """Resolve one portable child while refusing symlink or traversal escapes."""
+
+    resolved_base = require_symlink_free_absolute_path(
+        base,
+        field=f"{field} base",
+    )
+    name = safe_path_component(component, field=field)
+    unresolved = resolved_base / name
+    target = require_symlink_free_absolute_path(
+        unresolved,
+        field=field,
+    )
+    if target == resolved_base or not path_is_within(target, resolved_base):
+        raise PermissionError(f"{field} is outside managed storage")
+    return target
+
+
+def resolve_managed_project_path(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+) -> Path:
+    """Resolve a project-owned path without following any symbolic-link component."""
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            "managed path is empty or contains surrounding whitespace or control characters"
+        )
+    if _WINDOWS_DRIVE_RELATIVE_RE.match(raw):
+        raise ValueError("Windows drive-relative managed paths are ambiguous")
+    native_candidate, explicitly_absolute = _expand_exact_path(
+        raw,
+        field="managed path",
+    )
+    candidate = native_candidate
+    if not explicitly_absolute:
+        try:
+            parts = _exact_relative_parts(raw, field="managed path")
+        except PermissionError as exc:
+            raise PermissionError("managed path escapes project root") from exc
+        candidate = project.joinpath(*parts)
+    try:
+        relative = candidate.relative_to(project)
+    except ValueError as exc:
+        raise PermissionError(
+            "managed path is outside project root (escapes project root)"
+        ) from exc
+    if not relative.parts or any(part in {".", ".."} for part in relative.parts):
+        raise PermissionError(
+            "managed path is outside project root (escapes project root)"
+        )
+
+    cursor = project
+    for component in relative.parts:
+        safe_path_component(component, field="managed path component")
+        cursor = cursor / component
+        try:
+            metadata = cursor.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise PermissionError(
+                f"managed path component cannot be inspected: {cursor}"
+            ) from exc
+        if _metadata_is_link_or_reparse_point(metadata):
+            raise PermissionError(
+                "managed path contains symbolic links or reparse points and escapes project root "
+                f"boundary: {cursor}"
+            )
+    resolved = candidate.resolve(strict=False)
+    if resolved == project or not path_is_within(resolved, project):
+        raise PermissionError(
+            "managed path is outside project root (escapes project root)"
+        )
+    return resolved
+
+
+def resolve_project_read_path(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+    allow_filesystem_root: bool = False,
+) -> Path:
+    """Resolve one project-relative or explicit external input without links.
+
+    Relative inputs are project-owned and use the managed-path contract.
+    Explicit absolute inputs retain their external location, but every
+    existing component is inspected before callers open the file or traverse
+    the directory.  Unlike :func:`resolve_project_path`, this function never
+    calls ``resolve()`` on the caller's leaf and therefore cannot erase the
+    evidence that the supplied path was a symlink or junction.
+    """
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    try:
+        raw = validate_exact_path_text(value, field="project input path")
+    except PermissionError as exc:
+        raise PermissionError("project input path escapes project root") from exc
+    candidate, explicitly_absolute = _expand_exact_path(
+        raw,
+        field="project input path",
+    )
+    if explicitly_absolute:
+        return require_symlink_free_absolute_path(
+            candidate,
+            field="project input path",
+            allow_filesystem_root=allow_filesystem_root,
+        )
+    return resolve_managed_project_path(raw, root=project)
+
+
+def resolve_project_output_path(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+) -> Path:
+    """Resolve a writable path under the project ownership contract.
+
+    Relative paths and absolute paths that point back into the active project
+    are project-managed and may not traverse symbolic links.  Only an explicit
+    absolute path outside the project retains external-output semantics.
+    """
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            "output path is empty or contains surrounding whitespace or control characters"
+        )
+    try:
+        candidate = Path(raw).expanduser()
+    except (KeyError, RuntimeError) as exc:
+        raise ValueError("output path contains an unknown user-home prefix") from exc
+
+    # Every relative output is project-owned by definition.  Validate its
+    # unresolved components first so a linked project directory is reported
+    # (and rejected) as such instead of being flattened into a generic escape
+    # after ``Path.resolve()`` follows the link.
+    if not candidate.is_absolute():
+        return resolve_managed_project_path(value, root=project)
+
+    resolved = resolve_project_path(value, root=project)
+    try:
+        candidate.relative_to(project)
+        lexically_inside_project = True
+    except ValueError:
+        lexically_inside_project = False
+    if lexically_inside_project or path_is_within(resolved, project):
+        return resolve_managed_project_path(value, root=project)
+    return resolved
+
+
+def _managed_storage_root(project: Path, relative_root: str | os.PathLike[str]) -> tuple[Path, Path]:
+    """Resolve a fixed managed root without following storage-directory links."""
+
+    raw = os.fspath(relative_root)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            "managed storage path is empty or contains surrounding whitespace or control characters"
+        )
+    raw = raw.replace("\\", "/")
+    storage_relative = Path(raw)
+    if storage_relative.is_absolute():
+        _validate_exact_absolute_text(raw, field="managed storage path")
+        try:
+            storage_relative = storage_relative.relative_to(project)
+        except ValueError as exc:
+            raise PermissionError("managed storage is outside project root") from exc
+    else:
+        storage_relative = Path(
+            *_exact_relative_parts(raw, field="managed storage path")
+        )
+    storage = resolve_managed_project_path(storage_relative, root=project)
+    return storage_relative, storage
+
+
+def managed_project_storage(
+    relative_root: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+) -> Path:
+    """Return a symlink-free project-managed storage directory path."""
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    return _managed_storage_root(project, relative_root)[1]
+
+
+def managed_project_directory(
+    relative_root: str | os.PathLike[str],
+    component: str,
+    *,
+    root: str | Path | None = None,
+) -> Path:
+    """Return a strict child of a fixed project-managed storage directory."""
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    _, storage = _managed_storage_root(project, relative_root)
+    return managed_child_path(storage, component)
+
+
+def managed_project_file(
+    value: str | os.PathLike[str],
+    relative_root: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+) -> Path | None:
+    """Resolve a persisted asset only when it belongs to known managed storage.
+
+    Absolute paths saved by an older installation are rebased only when they
+    contain the exact managed suffix (for example ``data/sprite``).  The
+    returned target is always inside the current project and symbolic links
+    are rejected, so callers can safely use it for deletion.
+    """
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    storage_relative, storage = _managed_storage_root(project, relative_root)
+
+    raw = os.fspath(value)
+    if (
+        not raw
+        or raw != raw.strip()
+        or _PATH_CONTROL_RE.search(raw)
+        or _WINDOWS_DRIVE_RELATIVE_RE.match(raw)
+    ):
+        return None
+    normalized = raw.replace("\\", "/")
+    candidate = Path(normalized).expanduser()
+    absolute_text = (
+        candidate.is_absolute()
+        or bool(_WINDOWS_ABSOLUTE_RE.match(normalized))
+        or normalized.startswith("//")
+    )
+
+    try:
+        validate_exact_path_text(
+            raw,
+            field="managed asset path",
+            allow_non_native_absolute=True,
+        )
+    except (PermissionError, ValueError):
+        return None
+
+    unresolved: Path | None = None
+    if candidate.is_absolute():
+        unresolved = candidate
+    elif not absolute_text:
+        unresolved = project / candidate
+
+    if unresolved is not None:
+        try:
+            relative_to_project = unresolved.relative_to(project)
+            project_owned = not any(
+                part in {".", ".."} for part in relative_to_project.parts
+            )
+        except ValueError:
+            project_owned = False
+        resolved = None
+        if project_owned:
+            try:
+                # Destructive callers need every component below the storage
+                # root checked too. Resolving first would flatten an alias
+                # such as ``data/sprite/A -> data/sprite/B`` and could delete
+                # B's file while removing A's config entry.
+                resolved = resolve_managed_project_path(unresolved, root=project)
+            except (OSError, RuntimeError, ValueError):
+                resolved = None
+        if resolved is not None and path_is_within(resolved, storage):
+            return resolved
+
+    # An existing absolute path outside managed storage is an external asset,
+    # even if its parent names happen to contain a legacy suffix such as
+    # ``data/sprite`` or it resolves through an alias back into the project.
+    # Legacy rebasing is only safe after the old target has disappeared;
+    # destructive callers must never redirect a live external reference onto
+    # a same-named current-project file.
+    if unresolved is not None and os.path.lexists(unresolved):
+        return None
+
+    if not absolute_text:
+        return None
+
+    raw_parts = [part for part in normalized.split("/") if part not in {"", "."}]
+    prefix_parts = [part for part in storage_relative.as_posix().split("/") if part]
+    folded = [part.casefold() for part in raw_parts]
+    folded_prefix = [part.casefold() for part in prefix_parts]
+    for index in range(len(raw_parts) - len(prefix_parts), -1, -1):
+        if folded[index : index + len(prefix_parts)] != folded_prefix:
+            continue
+        mapped = project.joinpath(*raw_parts[index:])
+        try:
+            resolved = resolve_managed_project_path(mapped, root=project)
+        except (OSError, RuntimeError, ValueError):
+            return None
+        return resolved if path_is_within(resolved, storage) else None
+    return None
+
+
+def portable_project_path(
+    value: str | os.PathLike[str],
+    *,
+    root: str | Path | None = None,
+) -> str:
+    """Serialize a current-project path with portable forward slashes."""
+
+    project = (
+        _explicit_absolute_root(root, field="project root")
+        if root is not None
+        else project_root()
+    )
+    raw = validate_exact_path_text(value, field="path")
+    candidate = Path(raw).expanduser()
+
+    if not candidate.is_absolute():
+        managed = resolve_managed_project_path(raw, root=project)
+        return managed.relative_to(project).as_posix()
+
+    try:
+        candidate.relative_to(project)
+    except ValueError:
+        # Keep an explicitly external alias absolute. Resolving it first could
+        # turn an external symlink into a project-owned scalar reference and
+        # silently change ownership when the value is loaded again.
+        return Path(os.path.abspath(candidate)).as_posix()
+
+    managed = resolve_managed_project_path(raw, root=project)
+    return managed.relative_to(project).as_posix()
+
+
+def prepare_and_activate_project_root(
+    value: str | Path,
+    *,
+    field: str = "project root",
+) -> Path:
+    """Create, validate, and activate one identity-bound writable root.
+
+    The legacy startup sequence validated a path and later passed its text to
+    ``chdir``.  A rename between those operations could make the process cwd,
+    environment root, and validated data directory refer to different
+    objects.  Keep creation, the write probe, and cwd activation on one
+    captured root/data identity instead.
+    """
+
+    from .file_transactions import (
+        capture_directory_identity,
+        open_binary_write_exclusive_without_links,
+        remove_file_without_links,
+        require_directory_identity,
+    )
+
+    try:
+        unresolved_root = Path(os.fspath(value)).expanduser()
+    except (KeyError, RuntimeError) as exc:
+        raise ValueError(f"{field} contains an unknown user-home prefix") from exc
+    require_symlink_free_absolute_path(unresolved_root, field=field)
+    root = _explicit_absolute_root(value, field=field)
+    root.mkdir(parents=True, exist_ok=True)
+    data_root = root / "data"
+    data_root.mkdir(parents=True, exist_ok=True)
+    require_symlink_free_absolute_path(
+        data_root,
+        field=f"{field} data directory",
+    )
+    root, root_identity = capture_directory_identity(root, field=field)
+    data_root, data_root_identity = capture_directory_identity(
+        data_root,
+        field=f"{field} data directory",
+    )
+    if not path_is_within(data_root, root):
+        raise PermissionError(f"{field} data directory escapes its root")
+
+    probe = data_root / (
+        f".shinsekai-write-test-{os.getpid()}-{secrets.token_hex(8)}"
+    )
+    probe_identity: os.stat_result | None = None
+    probe_errors: list[str] = []
+    try:
+        with open_binary_write_exclusive_without_links(
+            probe,
+            expected_parent_identity=data_root_identity,
+        ) as probe_file:
+            probe_identity = os.fstat(probe_file.fileno())
+            probe_file.write(b"ok")
+            probe_file.flush()
+            os.fsync(probe_file.fileno())
+    except OSError as exc:
+        probe_errors.append(f"write: {exc}")
+    finally:
+        if probe_identity is not None:
+            try:
+                remove_file_without_links(
+                    probe,
+                    expected_identity=probe_identity,
+                    expected_parent_identity=data_root_identity,
+                    missing_ok=True,
+                )
+            except (OSError, ValueError) as exc:
+                probe_errors.append(f"cleanup: {exc}")
+    try:
+        require_directory_identity(root, root_identity, field=field)
+        require_directory_identity(
+            data_root,
+            data_root_identity,
+            field=f"{field} data directory",
+        )
+    except (OSError, ValueError) as exc:
+        probe_errors.append(f"identity: {exc}")
+    if probe_errors:
+        raise PermissionError(
+            f"{field} is not safely writable: {root}: {'; '.join(probe_errors)}"
+        )
+
+    _change_working_directory_to_identity(
+        root,
+        root_identity,
+        field=field,
+    )
+    require_directory_identity(root, root_identity, field=field)
+    require_directory_identity(
+        data_root,
+        data_root_identity,
+        field=f"{field} data directory",
+    )
+    return root
+
+
+def _change_working_directory_to_identity(
+    root: Path,
+    expected_identity: os.stat_result,
+    *,
+    field: str,
+) -> None:
+    """Change cwd to the captured directory, restoring the old cwd on error."""
+
+    from .file_transactions import require_directory_identity
+
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    can_use_directory_fd = hasattr(os, "fchdir") and hasattr(os, "O_DIRECTORY")
+    previous_fd: int | None = None
+    target_fd: int | None = None
+    previous_path: Path | None = None
+    changed = False
+    try:
+        if can_use_directory_fd:
+            previous_fd = os.open(".", directory_flags)
+            target_fd = os.open(root, directory_flags)
+            target_identity = os.fstat(target_fd)
+            if (
+                not stat.S_ISDIR(target_identity.st_mode)
+                or not os.path.samestat(expected_identity, target_identity)
+            ):
+                raise PermissionError(f"{field} identity changed before activation")
+            require_directory_identity(root, expected_identity, field=field)
+            os.fchdir(target_fd)
+        else:
+            previous_path = Path.cwd()
+            require_directory_identity(root, expected_identity, field=field)
+            os.chdir(root)
+        changed = True
+        cwd_identity = os.stat(".")
+        if (
+            not stat.S_ISDIR(cwd_identity.st_mode)
+            or not os.path.samestat(expected_identity, cwd_identity)
+        ):
+            raise PermissionError(f"{field} cwd identity changed during activation")
+        require_directory_identity(root, expected_identity, field=field)
+    except BaseException:
+        if changed:
+            try:
+                if previous_fd is not None:
+                    os.fchdir(previous_fd)
+                elif previous_path is not None:
+                    os.chdir(previous_path)
+            except OSError:
+                pass
+        raise
+    finally:
+        if target_fd is not None:
+            os.close(target_fd)
+        if previous_fd is not None:
+            os.close(previous_fd)
+
+
+def activate_project_root(default_root: str | Path) -> Path:
+    """Select and activate one authoritative project root for this process.
+
+    Legacy Python entry points used to import configuration modules before
+    agreeing on a working directory.  That made reads and writes diverge when
+    an executable was started from a shortcut, a different shell directory,
+    or with only one of the project-root environment variables set.
+
+    Explicit environment roots must be absolute: resolving a relative value
+    against an arbitrary launcher cwd would recreate the ambiguity this helper
+    is intended to remove.  The selected value is written back to both the
+    current and legacy environment names before callers import data modules.
+    """
+
+    configured_value = ""
+    configured_source = ""
+    for name in ("SHINSEKAI_PROJECT_ROOT", "EASYAI_PROJECT_ROOT"):
+        raw = _configured_environment_path(name)
+        if raw is not None:
+            configured_value = raw
+            configured_source = name
+            break
+
+    candidate: Path | None = None
+    try:
+        if not configured_source and getattr(sys, "frozen", False):
+            raise ValueError(
+                "frozen runtimes require an explicit SHINSEKAI_PROJECT_ROOT"
+            )
+        selected = configured_value if configured_source else default_root
+        candidate = Path(selected)
+        source = configured_source or "default project root"
+        root = prepare_and_activate_project_root(selected, field=source)
+    except (OSError, RuntimeError, ValueError) as exc:
+        source = configured_source or "default project root"
+        display_candidate = candidate if candidate is not None else configured_value or default_root
+        raise RuntimeError(
+            f"{source} cannot be activated: {display_candidate!s}: {exc}"
+        ) from exc
+
+    resolved = str(root)
+    os.environ["SHINSEKAI_PROJECT_ROOT"] = resolved
+    os.environ["EASYAI_PROJECT_ROOT"] = resolved
+    return root
+
+
+def source_root() -> Path:
+    raw = _configured_environment_path("SHINSEKAI_SOURCE_ROOT")
+    if raw is not None:
+        path = _explicit_absolute_root(raw, field="SHINSEKAI_SOURCE_ROOT")
+        if not path.is_dir():
+            raise NotADirectoryError(f"configured source root is not a directory: {path}")
+        return path
+    return _explicit_absolute_root(
+        _resolve(Path(__file__).parent.parent),
+        field="source root",
+    )
+
+
+def project_root() -> Path:
+    """Return the authoritative writable root, independent of process cwd.
+
+    Standard entry points always publish an explicit project-root environment
+    value.  The stable app/source fallback is retained for direct library and
+    developer-tool use, but an arbitrary launcher working directory is never
+    promoted to application data ownership.
+    """
+
+    raw = _configured_environment_path("SHINSEKAI_PROJECT_ROOT")
+    if raw is None:
+        raw = _configured_environment_path("EASYAI_PROJECT_ROOT")
+    if raw is not None:
+        return _explicit_absolute_root(raw, field="configured project root")
+    if getattr(sys, "frozen", False):
+        raise RuntimeError(
+            "frozen runtime requires an explicit SHINSEKAI_PROJECT_ROOT"
+        )
+    return app_root()
+
+
+def app_root() -> Path:
+    raw = _configured_environment_path("SHINSEKAI_APP_ROOT")
+    if raw is not None:
+        path = _explicit_absolute_root(raw, field="configured app root")
+        if not path.is_dir():
+            raise NotADirectoryError(f"configured app root is not a directory: {path}")
+        return path
+    if getattr(sys, "frozen", False):
+        return _explicit_absolute_root(
+            _resolve(Path(sys.executable).parent.parent),
+            field="frozen app root",
+        )
+    return source_root()
+
+
+def resource_path(path: str | Path) -> Path:
+    """Resolve immutable application resources, never writable project data."""
+
+    raw = os.fspath(path)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            "resource path is empty or contains surrounding whitespace or control characters"
+        )
+    if _WINDOWS_DRIVE_RELATIVE_RE.match(raw):
+        raise ValueError("Windows drive-relative resource paths are ambiguous")
+    candidate, explicitly_absolute = _expand_exact_path(raw, field="resource path")
+    if explicitly_absolute:
+        return _resolve(candidate)
+    try:
+        parts = _exact_relative_parts(raw, field="resource path")
+    except PermissionError as exc:
+        raise PermissionError("relative resource path escapes application roots") from exc
+    candidate = Path(*parts)
+
+    for root in (source_root(), app_root()):
+        resolved = _resolve(root / candidate)
+        if not path_is_within(resolved, root):
+            raise PermissionError("relative resource path escapes application roots")
+        if resolved.exists():
+            return resolved
+    fallback_root = source_root()
+    resolved = _resolve(fallback_root / candidate)
+    if not path_is_within(resolved, fallback_root):
+        raise PermissionError("relative resource path escapes application roots")
+    return resolved

--- a/sdk/path_references.py
+++ b/sdk/path_references.py
@@ -1,0 +1,569 @@
+"""Lightweight, dependency-free path helpers.
+
+Kept import-light on purpose so any module can reuse these without pulling
+in the rest of the frontend bridge.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
+_PATH_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f\ud800-\udfff]")
+
+
+def portable_path_text(
+    value: str | os.PathLike[str],
+    *,
+    field: str,
+) -> str:
+    """Validate path text without silently changing its identity."""
+
+    raw = os.fspath(value)
+    if not raw or raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError(
+            f"{field} is required and must not contain surrounding whitespace "
+            "or control characters"
+        )
+    return raw
+
+
+def strip_windows_verbatim_prefix(value: str) -> str:
+    r"""Drop Windows extended-length path prefixes (``\\?\`` / ``//?/``, incl. UNC).
+
+    ``Path.resolve()`` can hand back such a prefixed path for long paths on
+    Windows; stripping it yields the plain form callers and external tools
+    (e.g. the file browser, the TTS engine) expect.
+    """
+    upper_value = value.upper()
+    if upper_value.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + value[len("\\\\?\\UNC\\") :]
+    if value.startswith("\\\\?\\"):
+        tail = value[len("\\\\?\\") :]
+        return tail if _WINDOWS_DRIVE_RE.match(tail) else value
+    if upper_value.startswith("//?/UNC/"):
+        return "//" + value[len("//?/UNC/") :]
+    if value.startswith("//?/"):
+        tail = value[len("//?/") :]
+        return tail if _WINDOWS_DRIVE_RE.match(tail) else value
+    return value
+
+
+def display_path(value: str | os.PathLike[str]) -> str:
+    """Return a stable, user-facing path without Windows verbatim prefixes."""
+
+    text = strip_windows_verbatim_prefix(os.fspath(value))
+    if os.name == "nt" or _WINDOWS_DRIVE_RE.match(text) or text.startswith(("\\\\", "//")):
+        return text.replace("\\", "/")
+    return text
+
+
+def is_absolute_path_text(value: str | os.PathLike[str]) -> bool:
+    """Recognize native paths plus Windows drive/UNC paths on every host.
+
+    Recognizing Windows syntax on non-Windows hosts makes persisted path
+    migration testable and prevents a moved Windows session from being
+    mistaken for a project-relative path when inspected elsewhere.
+    """
+
+    text = strip_windows_verbatim_prefix(os.fspath(value))
+    return (
+        Path(text).is_absolute()
+        or bool(_WINDOWS_DRIVE_RE.match(text))
+        or text.startswith(("\\\\", "//"))
+    )
+
+
+def is_windows_drive_relative_path_text(value: str | os.PathLike[str]) -> bool:
+    """Return whether a value uses ambiguous Windows ``C:relative`` syntax."""
+
+    text = strip_windows_verbatim_prefix(os.fspath(value))
+    return bool(_WINDOWS_DRIVE_PREFIX_RE.match(text)) and not bool(
+        _WINDOWS_DRIVE_RE.match(text)
+    )
+
+
+def common_path_is_within(
+    root: str | os.PathLike[str],
+    candidate: str | os.PathLike[str],
+    *,
+    path_module: Any = os.path,
+) -> bool:
+    """Return whether *candidate* is inside *root*, including *root* itself.
+
+    ``os.path.commonpath`` raises ``ValueError`` for paths on different
+    Windows drives.  Containment is a predicate, so a different drive is a
+    normal ``False`` result rather than an exception leaking into API calls.
+    ``path_module`` is injectable so Windows semantics can be tested on POSIX.
+    """
+
+    try:
+        root_text = strip_windows_verbatim_prefix(os.fspath(root))
+        candidate_text = strip_windows_verbatim_prefix(os.fspath(candidate))
+        normalized_root = path_module.normcase(path_module.normpath(root_text))
+        normalized_candidate = path_module.normcase(
+            path_module.normpath(candidate_text)
+        )
+        common = path_module.normcase(
+            path_module.normpath(path_module.commonpath([normalized_root, normalized_candidate]))
+        )
+    except (AttributeError, OSError, TypeError, ValueError):
+        return False
+    return common == normalized_root
+
+
+def relative_path_if_within(
+    root: str | os.PathLike[str],
+    candidate: str | os.PathLike[str],
+    *,
+    path_module: Any = os.path,
+) -> str | None:
+    """Return a portable relative path when *candidate* is contained by *root*."""
+
+    if not common_path_is_within(root, candidate, path_module=path_module):
+        return None
+    try:
+        relative = path_module.relpath(
+            strip_windows_verbatim_prefix(os.fspath(candidate)),
+            strip_windows_verbatim_prefix(os.fspath(root)),
+        )
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+    return str(relative).replace("\\", "/")
+
+
+def resolved_path_is_within(candidate: Path, root: Path) -> bool:
+    """Containment check for already resolved host paths."""
+
+    return common_path_is_within(root, candidate)
+
+
+def state_project_root(state: Any) -> Path:
+    """Resolve the bridge's authoritative writable project root.
+
+    Request handling must not infer this boundary from the process working
+    directory: launchers and tests can change cwd independently of the
+    project-root contract.
+    """
+
+    missing = object()
+    state_root = getattr(state, "project_root_dir", missing)
+    candidates: list[tuple[str, Any]] = []
+    if state_root is not missing:
+        candidates.append(("state.project_root_dir", state_root))
+    if "SHINSEKAI_PROJECT_ROOT" in os.environ:
+        candidates.append(
+            ("SHINSEKAI_PROJECT_ROOT", os.environ["SHINSEKAI_PROJECT_ROOT"])
+        )
+    elif "EASYAI_PROJECT_ROOT" in os.environ:
+        candidates.append(("EASYAI_PROJECT_ROOT", os.environ["EASYAI_PROJECT_ROOT"]))
+    for source, candidate in candidates:
+        raw = str(candidate) if candidate is not None else ""
+        try:
+            if raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+                raise ValueError("project root contains non-portable characters")
+            from sdk.path_contract import resolve_project_path
+
+            return resolve_project_path(".", root=raw)
+        except (OSError, RuntimeError, ValueError) as exc:
+            # An explicitly supplied root is authoritative.  Falling through
+            # to another environment variable or cwd would silently read and
+            # write a second project, which is worse than a controlled error.
+            raise ValueError(f"invalid project root from {source}") from exc
+    try:
+        from sdk.path_contract import project_root
+
+        return project_root()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RuntimeError("stable project root is unavailable and no project root was configured") from exc
+
+
+def resolve_from_root(value: str | os.PathLike[str], root: Path) -> Path:
+    """Resolve a native path while keeping relative values inside *root*.
+
+    Absolute paths are explicit external references.  Relative paths are
+    project references and may not escape through ``..`` or a symbolic link.
+    """
+
+    from sdk.path_contract import resolve_project_path
+
+    return resolve_project_path(value, root=root)
+
+
+def project_relative_path(value: str | os.PathLike[str] | Path, root: Path) -> str | None:
+    """Return a portable POSIX project-relative value, or ``None`` if external."""
+
+    try:
+        base = resolve_from_root(".", root)
+        candidate = resolve_from_root(value, base)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return relative_path_if_within(base, candidate)
+
+
+def normalize_project_relative_path(value: str | os.PathLike[str]) -> str | None:
+    """Validate and portably encode an exact project-relative path.
+
+    Separator conversion is needed so Windows references remain portable.
+    Lexical aliases are rejected instead of collapsed: resolving ``a/../b``
+    or ``a//b`` as ``b``/``a/b`` would make the stored identity disagree with
+    the path selected by the caller (and can differ around symbolic links).
+    """
+
+    original = os.fspath(value)
+    if original != original.strip():
+        return None
+    raw = strip_windows_verbatim_prefix(original).replace("\\", "/")
+    if (
+        not raw
+        or _PATH_CONTROL_RE.search(raw)
+        or is_absolute_path_text(raw)
+        or is_windows_drive_relative_path_text(raw)
+    ):
+        return None
+    parts = raw.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    first_component = parts[0]
+    if first_component.startswith("~"):
+        return None
+    try:
+        from sdk.path_contract import safe_path_component
+
+        for part in parts:
+            safe_path_component(part, field="project-relative path component")
+    except ValueError:
+        return None
+    return "/".join(parts)
+
+
+def legacy_project_relative_path(
+    value: str | os.PathLike[str],
+    prefixes: Iterable[Iterable[str]],
+) -> str | None:
+    """Recover a managed suffix from an absolute path saved before a root move.
+
+    Only explicitly supplied managed prefixes are recognized.  This avoids
+    treating arbitrary external files as project data merely because one of
+    their parent directories happens to be named ``data``.
+    """
+
+    original = display_path(value)
+    if original != original.strip() or _PATH_CONTROL_RE.search(original):
+        return None
+    try:
+        from sdk.path_contract import validate_exact_path_text
+
+        validate_exact_path_text(
+            original,
+            field="legacy project path",
+            allow_non_native_absolute=True,
+        )
+    except (PermissionError, ValueError):
+        return None
+    raw = original.replace("\\", "/")
+    parts = [part for part in raw.split("/") if part not in {"", "."}]
+    folded = [part.casefold() for part in parts]
+    for prefix_value in prefixes:
+        prefix = [
+            str(part).strip("/\\")
+            for part in prefix_value
+            if str(part).strip("/\\")
+        ]
+        if not prefix:
+            continue
+        folded_prefix = [part.casefold() for part in prefix]
+        for index in range(len(parts) - len(prefix), -1, -1):
+            if folded[index : index + len(prefix)] != folded_prefix:
+                continue
+            return normalize_project_relative_path(
+                "/".join((*prefix, *parts[index + len(prefix) :]))
+            )
+    return None
+
+
+def _relative_path_with_known_prefix(
+    value: str,
+    prefixes: Iterable[Iterable[str]],
+) -> str | None:
+    """Return *value* with a matched prefix's configured canonical spelling."""
+
+    relative = normalize_project_relative_path(value)
+    if relative is None:
+        return None
+    parts = relative.split("/")
+    folded = [part.casefold() for part in parts]
+    for prefix_value in prefixes:
+        prefix = [
+            str(part).strip("/\\")
+            for part in prefix_value
+            if str(part).strip("/\\")
+        ]
+        if not prefix:
+            continue
+        folded_prefix = [part.casefold() for part in prefix]
+        if folded[: len(prefix)] == folded_prefix:
+            return "/".join((*prefix, *parts[len(prefix) :]))
+    return None
+
+
+def _current_resource_relative_path(
+    candidate: Path,
+    prefixes: Iterable[Iterable[str]],
+) -> str | None:
+    """Encode a path under a live application root as a resource reference."""
+
+    try:
+        from sdk.path_contract import (
+            app_root,
+            require_symlink_free_absolute_path,
+            resource_path,
+            source_root,
+        )
+    except ImportError:
+        return None
+
+    roots: list[Path] = []
+    for root_getter in (source_root, app_root):
+        try:
+            root = root_getter()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if root not in roots:
+            roots.append(root)
+
+    for root in roots:
+        try:
+            require_symlink_free_absolute_path(
+                candidate,
+                field="application resource reference",
+            )
+        except (OSError, PermissionError, RuntimeError, ValueError):
+            return None
+        try:
+            lexical_relative = candidate.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        relative = _relative_path_with_known_prefix(lexical_relative, prefixes)
+        if relative is None:
+            continue
+        # Relative resource resolution checks the resolved target remains
+        # inside an application root, so an in-tree symbolic link cannot turn
+        # an immutable reference into an arbitrary external path.
+        resolved_resource = resource_path(relative).resolve(strict=False)
+        try:
+            resolved_candidate = candidate.resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if resolved_resource == resolved_candidate:
+            return relative
+    return None
+
+
+def make_path_reference(
+    value: str | os.PathLike[str],
+    project_root: Path,
+    *,
+    legacy_project_prefixes: Iterable[Iterable[str]] = (),
+    resource_prefixes: Iterable[Iterable[str]] = (),
+    recover_legacy_absolute: bool = True,
+) -> dict[str, str] | None:
+    """Encode a persisted path as resource, project-relative, or external.
+
+    Project-owned references survive installation/data-root moves.  External
+    references remain absolute and retain their distinct semantics. Immutable
+    application resources keep a separate scope so writable project files can
+    never shadow them after the source/data roots diverge.
+    """
+
+    raw = os.fspath(value)
+    if not raw:
+        return None
+    if raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        raise ValueError("path contains surrounding whitespace or control characters")
+    from sdk.path_contract import resolve_project_path, validate_exact_path_text
+
+    root = resolve_project_path(".", root=project_root)
+
+    raw = strip_windows_verbatim_prefix(raw)
+    try:
+        validate_exact_path_text(
+            raw,
+            field="path",
+            allow_non_native_absolute=True,
+        )
+    except PermissionError as exc:
+        raise ValueError("project path must not escape the project root") from exc
+
+    first_component = raw.replace("\\", "/").split("/", 1)[0]
+    if first_component.startswith("~"):
+        try:
+            expanded = Path(raw).expanduser()
+        except (KeyError, RuntimeError) as exc:
+            raise ValueError("path contains an unknown user-home prefix") from exc
+        if not expanded.is_absolute():
+            raise ValueError("user-home path could not be expanded absolutely")
+        raw = os.fspath(expanded)
+
+    if not is_absolute_path_text(raw):
+        relative = normalize_project_relative_path(raw)
+        if relative is None:
+            raise ValueError("project path must not escape the project root")
+        resource_relative = _relative_path_with_known_prefix(
+            relative,
+            resource_prefixes,
+        )
+        if resource_relative is not None:
+            return {"scope": "resource", "path": resource_relative}
+        project_relative = _relative_path_with_known_prefix(
+            relative,
+            legacy_project_prefixes,
+        )
+        return {
+            "scope": "project",
+            "path": project_relative or relative,
+        }
+
+    native_path = Path(raw).expanduser()
+    if native_path.is_absolute():
+        resource_relative = _current_resource_relative_path(
+            native_path,
+            resource_prefixes,
+        )
+        if resource_relative is not None:
+            return {"scope": "resource", "path": resource_relative}
+        try:
+            lexical_relative = native_path.relative_to(root)
+        except ValueError:
+            lexical_relative = None
+        if lexical_relative is not None:
+            # Ownership comes from the path the caller supplied, not from a
+            # resolved target. Otherwise an internal alias escaping the
+            # project is mislabeled external, while an external alias pointing
+            # back into it is mislabeled managed.
+            from sdk.path_contract import resolve_managed_project_path
+
+            managed = resolve_managed_project_path(raw, root=root)
+            managed_relative = managed.relative_to(root).as_posix()
+            canonical_managed_relative = _relative_path_with_known_prefix(
+                managed_relative,
+                legacy_project_prefixes,
+            )
+            return {
+                "scope": "project",
+                "path": canonical_managed_relative or managed_relative,
+            }
+
+    if recover_legacy_absolute:
+        legacy_resource_relative = legacy_project_relative_path(
+            raw,
+            resource_prefixes,
+        )
+        if legacy_resource_relative is not None:
+            source_exists = False
+            if native_path.is_absolute():
+                try:
+                    source_exists = native_path.exists()
+                except OSError:
+                    source_exists = False
+            if not source_exists:
+                return {"scope": "resource", "path": legacy_resource_relative}
+
+        legacy_relative = legacy_project_relative_path(
+            raw,
+            legacy_project_prefixes,
+        )
+        if legacy_relative is not None:
+            source_exists = False
+            if native_path.is_absolute():
+                try:
+                    source_exists = native_path.exists()
+                except OSError:
+                    source_exists = False
+            if not source_exists:
+                return {"scope": "project", "path": legacy_relative}
+
+    return {"scope": "external", "path": display_path(raw)}
+
+
+def path_reference_value(
+    reference: Any,
+    *,
+    project_prefixes: Iterable[Iterable[str]] = (),
+    resource_prefixes: Iterable[Iterable[str]] = (),
+) -> str | None:
+    """Validate a stored path reference and return its scalar compatibility value.
+
+    Older reference objects can retain Windows-only case variants even after
+    their scalar compatibility field has been migrated.  Optional known
+    prefixes let persistence owners repair that spelling while reading the
+    reference, without guessing the case of user-controlled tail components.
+    """
+
+    if not isinstance(reference, dict):
+        return None
+    scope = str(reference.get("scope") or "").strip().lower()
+    raw = str(reference.get("path") or "")
+    if raw != raw.strip() or _PATH_CONTROL_RE.search(raw):
+        return None
+    if scope == "project":
+        relative = normalize_project_relative_path(raw)
+        if relative is None:
+            return None
+        return (
+            _relative_path_with_known_prefix(relative, project_prefixes)
+            or relative
+        )
+    if scope == "resource":
+        relative = normalize_project_relative_path(raw)
+        if relative is None:
+            return None
+        return (
+            _relative_path_with_known_prefix(relative, resource_prefixes)
+            or relative
+        )
+    if scope == "external" and is_absolute_path_text(raw):
+        displayed = display_path(raw)
+        try:
+            from sdk.path_contract import validate_exact_path_text
+
+            validate_exact_path_text(
+                displayed,
+                field="external path",
+                allow_non_native_absolute=True,
+            )
+        except (PermissionError, ValueError):
+            return None
+        return displayed
+    return None
+
+
+def resolve_regular_path(
+    value: str | os.PathLike[str],
+    *,
+    strict: bool = False,
+) -> Path:
+    r"""Resolve a path, preferring regular Win32 spelling only when safe.
+
+    Rust's ``Path::canonicalize`` may return a verbatim path. Short existing
+    paths are converted back only when both spellings identify the same object.
+    Long paths retain ``\\?\`` for explicit ``MAX_PATH`` compatibility.
+    """
+
+    resolved = Path(os.fspath(value)).expanduser().resolve(strict=strict)
+    if os.name == "nt":
+        resolved_text = str(resolved)
+        regular_text = strip_windows_verbatim_prefix(resolved_text)
+        if regular_text != resolved_text and len(regular_text) < 248:
+            regular = Path(regular_text)
+            try:
+                if resolved.exists() and regular.exists() and os.path.samefile(resolved, regular):
+                    return regular.resolve(strict=strict)
+            except OSError:
+                pass
+    return resolved

--- a/sdk/plugin_host_context.py
+++ b/sdk/plugin_host_context.py
@@ -10,8 +10,16 @@ saving YAML, and accessing every manager.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any
+
+from sdk.path_contract import (
+    project_root,
+    resolve_managed_project_path,
+    resolve_project_output_path,
+    validate_exact_path_text,
+)
 
 
 @dataclass(frozen=True)
@@ -34,7 +42,28 @@ class PluginHostContext:
     huggingface_cache_dir: Path
 
     @classmethod
-    def from_config_manager(cls, cm: Any | None) -> PluginHostContext:
+    def from_config_manager(
+        cls,
+        cm: Any | None,
+        *,
+        project_data_dir: str | os.PathLike[str] | None = None,
+    ) -> PluginHostContext:
+        configured_value = os.fspath(
+            project_root() / "data"
+            if project_data_dir is None
+            else project_data_dir
+        )
+        validate_exact_path_text(
+            configured_value,
+            field="project_data_dir",
+        )
+        configured_data_dir = Path(configured_value)
+        if not configured_data_dir.is_absolute():
+            raise ValueError("project_data_dir must be absolute")
+        data_dir = resolve_managed_project_path(
+            configured_value,
+            root=configured_data_dir.parent,
+        )
         if cm is None:
             return cls(
                 ui_language="zh_CN",
@@ -44,16 +73,23 @@ class PluginHostContext:
                 selected_llm_provider="",
                 tts_provider="",
                 live_room_id="",
-                project_data_dir=Path("data"),
-                huggingface_cache_dir=(Path.cwd() / "data/cache/huggingface").resolve(strict=False),
+                project_data_dir=data_dir,
+                huggingface_cache_dir=resolve_managed_project_path(
+                    data_dir / "cache" / "huggingface",
+                    root=data_dir.parent,
+                ),
             )
         cfg = cm.config
         sys = cfg.system_config
         api = cfg.api_config
-        raw_hf_cache = str(getattr(sys, "huggingface_cache_dir", "") or "./data/cache/huggingface")
-        hf_cache = Path(raw_hf_cache).expanduser()
-        if not hf_cache.is_absolute():
-            hf_cache = Path.cwd() / hf_cache
+        raw_hf_cache = str(
+            getattr(sys, "huggingface_cache_dir", "")
+            or "data/cache/huggingface"
+        )
+        hf_cache = resolve_project_output_path(
+            raw_hf_cache,
+            root=data_dir.parent,
+        )
         return cls(
             ui_language=str(sys.ui_language),
             voice_language=str(sys.voice_language),
@@ -62,8 +98,8 @@ class PluginHostContext:
             selected_llm_provider=str(api.llm_provider),
             tts_provider=str(api.tts_provider),
             live_room_id=str(sys.live_room_id),
-            project_data_dir=Path("data"),
-            huggingface_cache_dir=hf_cache.resolve(strict=False),
+            project_data_dir=data_dir,
+            huggingface_cache_dir=hf_cache,
         )
 
 

--- a/sdk/process_launch.py
+++ b/sdk/process_launch.py
@@ -1,0 +1,507 @@
+"""Identity-bound paths for subprocess launch boundaries.
+
+External runtimes only accept path strings.  Capture every selected file and
+directory before composing the command, then validate the same objects
+immediately before and after process creation.  If a public pathname is
+replaced during ``Popen``, terminate the child instead of letting discovery
+and execution silently refer to different filesystem objects.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from sdk.file_transactions import (
+    capture_directory_identity,
+    file_snapshot_is_stable,
+    open_binary_read_without_links,
+    require_directory_identity,
+)
+from sdk.path_contract import (
+    path_is_link_or_reparse_point,
+    require_regular_file_without_links,
+    resolve_executable_file,
+    safe_path_component,
+    validate_exact_path_text,
+)
+
+_PYTHON_LOCATION_ENVIRONMENT_NAMES = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "PYTHONUSERBASE",
+    "PYTHONPYCACHEPREFIX",
+    "PYTHONEXECUTABLE",
+    "__PYVENV_LAUNCHER__",
+)
+
+
+@dataclass(frozen=True)
+class LaunchDirectorySnapshot:
+    path: Path
+    identity: os.stat_result
+    field: str
+
+
+@dataclass(frozen=True)
+class LaunchFileSnapshot:
+    path: Path
+    identity: os.stat_result
+    parent: LaunchDirectorySnapshot
+    field: str
+
+
+def isolated_python_environment(
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a child environment that cannot inherit another Python tree."""
+
+    environment = dict(os.environ if source is None else source)
+    for name in _PYTHON_LOCATION_ENVIRONMENT_NAMES:
+        environment.pop(name, None)
+    environment["PYTHONNOUSERSITE"] = "1"
+    return environment
+
+
+def capture_launch_directory(
+    value: str | os.PathLike[str],
+    *,
+    field: str,
+) -> LaunchDirectorySnapshot:
+    path, identity = capture_directory_identity(value, field=field)
+    return LaunchDirectorySnapshot(path=path, identity=identity, field=field)
+
+
+def capture_launch_file(
+    value: str | os.PathLike[str],
+    *,
+    field: str,
+    executable: bool = False,
+) -> LaunchFileSnapshot:
+    path = (
+        resolve_executable_file(value, field=field)
+        if executable
+        else require_regular_file_without_links(value, field=field)
+    )
+    parent = capture_launch_directory(
+        path.parent,
+        field=f"{field} parent",
+    )
+    with open_binary_read_without_links(
+        path,
+        expected_parent_identity=parent.identity,
+    ) as handle:
+        before = os.fstat(handle.fileno())
+        after = os.fstat(handle.fileno())
+    if not file_snapshot_is_stable(before, after):
+        raise PermissionError(f"{field} changed while its identity was captured: {path}")
+    require_launch_directory(parent)
+    return LaunchFileSnapshot(
+        path=path,
+        identity=after,
+        parent=parent,
+        field=field,
+    )
+
+
+def capture_command_executable(
+    value: str | os.PathLike[str],
+    *,
+    field: str,
+    search_path: str | None = None,
+    path_extensions: str | None = None,
+) -> LaunchFileSnapshot:
+    raw = os.fspath(value)
+    if (
+        not raw
+        or raw != raw.strip()
+        or any(ord(character) < 32 or ord(character) == 127 for character in raw)
+    ):
+        raise ValueError(f"{field} is empty or contains non-portable characters")
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return capture_launch_file(
+            candidate,
+            field=field,
+            executable=True,
+        )
+    elif "/" in raw or "\\" in raw:
+        raise ValueError(f"{field} path must be absolute")
+    safe_path_component(raw, field=field)
+
+    configured_path = os.environ.get("PATH") if search_path is None else search_path
+    if configured_path is None:
+        raise FileNotFoundError(f"{field} cannot be resolved because PATH is absent")
+    last_error: BaseException | None = None
+    for directory_value in configured_path.split(os.pathsep):
+        if not directory_value:
+            continue
+        try:
+            validate_exact_path_text(
+                directory_value,
+                field=f"{field} PATH directory",
+            )
+            directory = Path(directory_value)
+        except (OSError, PermissionError, RuntimeError, ValueError) as exc:
+            last_error = exc
+            continue
+        if not directory.is_absolute():
+            continue
+        for name in _executable_candidate_names(raw, path_extensions):
+            try:
+                return capture_launch_file(
+                    directory / name,
+                    field=field,
+                    executable=True,
+                )
+            except (OSError, PermissionError, RuntimeError, ValueError) as exc:
+                last_error = exc
+    detail = f": {last_error}" if last_error is not None else ""
+    raise FileNotFoundError(
+        f"{field} was not found in deterministic absolute PATH entries: {raw}{detail}"
+    )
+
+
+def _executable_candidate_names(
+    command: str,
+    path_extensions: str | None,
+) -> tuple[str, ...]:
+    if os.name != "nt" or Path(command).suffix:
+        return (command,)
+    return _portable_windows_executable_candidate_names(
+        command,
+        path_extensions,
+    )
+
+
+def _portable_windows_executable_candidate_names(
+    command: str,
+    path_extensions: str | None,
+) -> tuple[str, ...]:
+    """Append only PATHEXT suffixes whose final component stays portable."""
+
+    configured = (
+        os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+        if path_extensions is None
+        else path_extensions
+    )
+    extensions = [
+        extension
+        for extension in configured.split(";")
+        if _portable_windows_path_extension(extension)
+    ]
+    candidates: list[str] = []
+    for extension in extensions:
+        candidate = f"{command}{extension}"
+        try:
+            safe_path_component(
+                candidate,
+                field="Windows executable candidate",
+            )
+        except ValueError:
+            continue
+        candidates.append(candidate)
+    return tuple(candidates)
+
+
+def _portable_windows_path_extension(value: str) -> bool:
+    return (
+        len(value) > 1
+        and value.startswith(".")
+        and all(
+            character.isascii() and character.isalnum()
+            for character in value[1:]
+        )
+    )
+
+
+def require_launch_directory(snapshot: LaunchDirectorySnapshot) -> None:
+    require_directory_identity(
+        snapshot.path,
+        snapshot.identity,
+        field=snapshot.field,
+    )
+
+
+def require_launch_file(snapshot: LaunchFileSnapshot) -> None:
+    require_launch_directory(snapshot.parent)
+    with open_binary_read_without_links(
+        snapshot.path,
+        expected_identity=snapshot.identity,
+        expected_parent_identity=snapshot.parent.identity,
+    ) as handle:
+        before = os.fstat(handle.fileno())
+        after = os.fstat(handle.fileno())
+    if not file_snapshot_is_stable(before, after):
+        raise PermissionError(
+            f"{snapshot.field} changed while its identity was checked: {snapshot.path}"
+        )
+    require_launch_directory(snapshot.parent)
+
+
+def require_launch_snapshots(
+    *,
+    directories: Iterable[LaunchDirectorySnapshot] = (),
+    files: Iterable[LaunchFileSnapshot] = (),
+) -> None:
+    for directory in directories:
+        require_launch_directory(directory)
+    for file in files:
+        require_launch_file(file)
+
+
+def terminate_invalid_launch(process: Any) -> None:
+    try:
+        process.terminate()
+        process.wait(timeout=2)
+    except Exception:
+        try:
+            process.kill()
+        except Exception:
+            pass
+
+
+def popen_with_stable_paths(
+    argv: Sequence[str | os.PathLike[str]],
+    *,
+    cwd: LaunchDirectorySnapshot,
+    executable: LaunchFileSnapshot,
+    required_directories: Sequence[LaunchDirectorySnapshot] = (),
+    required_files: Sequence[LaunchFileSnapshot] = (),
+    env: Mapping[str, str] | None = None,
+    popen_factory: Callable[..., Any] = subprocess.Popen,
+    **popen_kwargs: Any,
+) -> Any:
+    if not argv:
+        raise ValueError("process command is empty")
+    command = [os.fspath(item) for item in argv]
+    if os.path.normcase(os.path.normpath(command[0])) != os.path.normcase(
+        os.path.normpath(os.fspath(executable.path))
+    ):
+        raise ValueError("process executable does not match its captured path")
+    directories = (cwd, *required_directories)
+    files = (executable, *required_files)
+    require_launch_snapshots(directories=directories, files=files)
+    launch_kwargs = {
+        **popen_kwargs,
+        "cwd": os.fspath(cwd.path),
+    }
+    if env is not None:
+        launch_kwargs["env"] = dict(env)
+    process = popen_factory(command, **launch_kwargs)
+    try:
+        require_launch_snapshots(directories=directories, files=files)
+    except BaseException:
+        terminate_invalid_launch(process)
+        raise
+    return process
+
+
+def run_with_stable_paths(
+    argv: Sequence[str | os.PathLike[str]],
+    *,
+    cwd: LaunchDirectorySnapshot,
+    executable: LaunchFileSnapshot,
+    required_directories: Sequence[LaunchDirectorySnapshot] = (),
+    required_files: Sequence[LaunchFileSnapshot] = (),
+    env: Mapping[str, str] | None = None,
+    run_factory: Callable[..., Any] = subprocess.run,
+    **run_kwargs: Any,
+) -> Any:
+    if not argv:
+        raise ValueError("process command is empty")
+    command = [os.fspath(item) for item in argv]
+    if os.path.normcase(os.path.normpath(command[0])) != os.path.normcase(
+        os.path.normpath(os.fspath(executable.path))
+    ):
+        raise ValueError("process executable does not match its captured path")
+    directories = (cwd, *required_directories)
+    files = (executable, *required_files)
+    require_launch_snapshots(directories=directories, files=files)
+    launch_kwargs = {
+        **run_kwargs,
+        "cwd": os.fspath(cwd.path),
+    }
+    if env is not None:
+        launch_kwargs["env"] = dict(env)
+    result = run_factory(command, **launch_kwargs)
+    require_launch_snapshots(directories=directories, files=files)
+    return result
+
+
+def run_shell_with_stable_paths(
+    command: str,
+    *,
+    cwd: LaunchDirectorySnapshot,
+    required_directories: Sequence[LaunchDirectorySnapshot] = (),
+    required_files: Sequence[LaunchFileSnapshot] = (),
+    env: Mapping[str, str] | None = None,
+    run_factory: Callable[..., Any] = subprocess.run,
+    **run_kwargs: Any,
+) -> Any:
+    shell = capture_command_executable(
+        os.environ.get("COMSPEC", "cmd.exe") if os.name == "nt" else "sh",
+        field="command shell executable",
+    )
+    directories = (cwd, *required_directories)
+    files = (shell, *required_files)
+    require_launch_snapshots(directories=directories, files=files)
+    launch_kwargs = {
+        **run_kwargs,
+        "cwd": os.fspath(cwd.path),
+        "executable": os.fspath(shell.path),
+        "shell": True,
+    }
+    if env is not None:
+        launch_kwargs["env"] = dict(env)
+    result = run_factory(command, **launch_kwargs)
+    require_launch_snapshots(directories=directories, files=files)
+    return result
+
+
+def open_with_default_application(
+    value: str | os.PathLike[str],
+    *,
+    wait: bool = False,
+    check: bool = False,
+    system_name: str | None = None,
+    popen_factory: Callable[..., Any] = subprocess.Popen,
+    run_factory: Callable[..., Any] = subprocess.run,
+    startfile_factory: Callable[[str], Any] | None = None,
+) -> Any:
+    path = Path(value)
+    if path_is_link_or_reparse_point(path):
+        raise PermissionError(
+            f"default application target must not be a symbolic link: {path}"
+        )
+    try:
+        file_snapshot = capture_launch_file(
+            path,
+            field="default application target",
+        )
+    except (FileNotFoundError, IsADirectoryError):
+        file_snapshot = None
+        directory_snapshot = capture_launch_directory(
+            path,
+            field="default application target",
+        )
+        cwd = directory_snapshot
+    else:
+        directory_snapshot = None
+        cwd = file_snapshot.parent
+
+    selected_system = (system_name or platform.system()).lower()
+    if selected_system == "windows":
+        startfile = startfile_factory or getattr(os, "startfile", None)
+        if startfile is None:
+            raise NotImplementedError("the platform does not provide os.startfile")
+        result = startfile(os.fspath(path))
+        require_launch_snapshots(
+            directories=(
+                (directory_snapshot,) if directory_snapshot is not None else ()
+            ),
+            files=((file_snapshot,) if file_snapshot is not None else ()),
+        )
+        return result
+
+    command_name = "open" if selected_system == "darwin" else "xdg-open"
+    if selected_system not in {"darwin", "linux"}:
+        raise NotImplementedError(
+            f"default application launch is unsupported on {selected_system}"
+        )
+    opener = capture_command_executable(
+        command_name,
+        field="default application launcher",
+    )
+    required_directories = (
+        (directory_snapshot,) if directory_snapshot is not None else ()
+    )
+    required_files = (file_snapshot,) if file_snapshot is not None else ()
+    command = [opener.path, path]
+    if wait:
+        return run_with_stable_paths(
+            command,
+            cwd=cwd,
+            executable=opener,
+            required_directories=required_directories,
+            required_files=required_files,
+            run_factory=run_factory,
+            check=check,
+        )
+    return popen_with_stable_paths(
+        command,
+        cwd=cwd,
+        executable=opener,
+        required_directories=required_directories,
+        required_files=required_files,
+        popen_factory=popen_factory,
+    )
+
+
+def open_url_with_default_application(
+    value: str,
+    *,
+    system_name: str | None = None,
+    popen_factory: Callable[..., Any] = subprocess.Popen,
+    startfile_factory: Callable[[str], Any] | None = None,
+) -> Any:
+    url = str(value)
+    if (
+        not url
+        or url != url.strip()
+        or any(ord(character) < 32 or ord(character) == 127 for character in url)
+    ):
+        raise ValueError("browser URL is empty or contains non-portable characters")
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("browser URL must be an absolute HTTP(S) URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("browser URL must not contain embedded credentials")
+
+    selected_system = (system_name or platform.system()).lower()
+    if selected_system == "windows":
+        startfile = startfile_factory or getattr(os, "startfile", None)
+        if startfile is None:
+            raise NotImplementedError("the platform does not provide os.startfile")
+        return startfile(url)
+
+    command_name = "open" if selected_system == "darwin" else "xdg-open"
+    if selected_system not in {"darwin", "linux"}:
+        raise NotImplementedError(
+            f"default URL launch is unsupported on {selected_system}"
+        )
+    opener = capture_command_executable(
+        command_name,
+        field="default URL launcher",
+    )
+    return popen_with_stable_paths(
+        [opener.path, url],
+        cwd=opener.parent,
+        executable=opener,
+        popen_factory=popen_factory,
+    )
+
+
+__all__ = [
+    "LaunchDirectorySnapshot",
+    "LaunchFileSnapshot",
+    "capture_launch_directory",
+    "capture_launch_file",
+    "capture_command_executable",
+    "isolated_python_environment",
+    "popen_with_stable_paths",
+    "open_with_default_application",
+    "open_url_with_default_application",
+    "require_launch_directory",
+    "require_launch_file",
+    "require_launch_snapshots",
+    "run_shell_with_stable_paths",
+    "run_with_stable_paths",
+    "terminate_invalid_launch",
+]

--- a/sdk/register.py
+++ b/sdk/register.py
@@ -8,8 +8,10 @@ import importlib
 import logging
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, replace
-from pathlib import Path
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Type
+
+from sdk.path_contract import safe_path_component, validate_exact_path_text
 
 from sdk.handlers import MessageHandler, UIOutputMessageHandler
 from sdk.adapters import (
@@ -54,6 +56,43 @@ from sdk.types import (
 
 logger = logging.getLogger(__name__)
 
+
+def _portable_required_text(value: str, *, field: str) -> str:
+    raw = str(value or "")
+    if (
+        not raw
+        or raw != raw.strip()
+        or any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in raw
+        )
+    ):
+        raise ValueError(
+            f"{field} is required and must not contain non-portable characters"
+        )
+    return raw
+
+
+def _workflow_path_text(value: str) -> str:
+    exact = _portable_required_text(value, field="Workflow YAML path")
+    return validate_exact_path_text(exact, field="Workflow YAML path")
+
+
+def _frontend_entry_path_text(value: str) -> str:
+    exact = _portable_required_text(value, field="frontend entry path")
+    return validate_exact_path_text(exact, field="frontend entry path")
+
+
+def _validate_contribution_identity(value: str, *, field: str) -> str:
+    return safe_path_component(str(value or ""), field=field)
+
+
+def _validate_optional_plugin_id(value: str | None) -> None:
+    if value is not None:
+        _validate_contribution_identity(value, field="plugin id")
+
 @dataclass(frozen=True)
 class _ClassEntry:
     cls: Type[PluginBase]
@@ -81,10 +120,8 @@ class PluginDiscoveryRegistry:
         self._class_entries.append(_ClassEntry(cls=cls, enabled=enabled))
 
     def register_entry(self, entry: str, *, enabled: bool = True) -> None:
-        cleaned = entry.strip()
-        if not cleaned:
-            raise ValueError("Plugin entry cannot be empty")
-        self._import_entries.append(_ImportEntry(entry=cleaned, enabled=enabled))
+        exact = _portable_required_text(entry, field="Plugin entry")
+        self._import_entries.append(_ImportEntry(entry=exact, enabled=enabled))
 
     def register_descriptors(self, descriptors: Iterable[PluginDescriptor]) -> None:
         for d in descriptors:
@@ -226,6 +263,7 @@ class PluginCapabilityRegistry:
 
     def set_settings_ui_plugin_context(self, plugin_id: str, plugin_version: str) -> None:
         """Host-only: while a plugin's ``initialize`` runs, attach id/version to settings contributions."""
+        _validate_contribution_identity(plugin_id, field="plugin id")
         self._settings_ui_plugin_ctx = (plugin_id, plugin_version)
 
     def clear_settings_ui_plugin_context(self) -> None:
@@ -264,6 +302,8 @@ class PluginCapabilityRegistry:
                 plugin_id=contribution.plugin_id or pid,
                 plugin_version=contribution.plugin_version or ver,
             )
+        _validate_contribution_identity(contribution.page_id, field="settings page id")
+        _validate_optional_plugin_id(contribution.plugin_id)
         self._settings_contributions.append(contribution)
 
     def register_tools_tab(self, contribution: ToolsTabContribution) -> None:
@@ -281,6 +321,8 @@ class PluginCapabilityRegistry:
                 plugin_id=contribution.plugin_id or pid,
                 plugin_version=contribution.plugin_version or ver,
             )
+        _validate_contribution_identity(contribution.tab_id, field="tools tab id")
+        _validate_optional_plugin_id(contribution.plugin_id)
         self._tools_tab_contributions.append(contribution)
 
     def register_frontend_config_page(self, contribution: FrontendConfigContribution) -> None:
@@ -292,6 +334,10 @@ class PluginCapabilityRegistry:
                 plugin_id=contribution.plugin_id or pid,
                 plugin_version=contribution.plugin_version or ver,
             )
+        _validate_contribution_identity(contribution.page_id, field="frontend page id")
+        _validate_optional_plugin_id(contribution.plugin_id)
+        for action in contribution.actions:
+            _validate_contribution_identity(action.id, field="frontend action id")
         self._frontend_config_contributions.append(contribution)
 
     def register_frontend_page(self, contribution: FrontendPageContribution) -> None:
@@ -303,6 +349,9 @@ class PluginCapabilityRegistry:
                 plugin_id=contribution.plugin_id or pid,
                 plugin_version=contribution.plugin_version or ver,
             )
+        _validate_contribution_identity(contribution.page_id, field="frontend page id")
+        _validate_optional_plugin_id(contribution.plugin_id)
+        _frontend_entry_path_text(contribution.entry)
         self._frontend_page_contributions.append(contribution)
 
     def register_frontend_chat_ui(self, contribution: FrontendChatUIContribution) -> None:
@@ -359,6 +408,8 @@ class PluginCapabilityRegistry:
                 plugin_id=contribution.plugin_id or pid,
                 plugin_version=contribution.plugin_version or ver,
             )
+        _validate_contribution_identity(contribution.widget_id, field="chat widget id")
+        _validate_optional_plugin_id(contribution.plugin_id)
         self._chat_ui_contributions.append(contribution)
 
     def register_dag_yaml(self, path: str) -> None:
@@ -368,13 +419,12 @@ class PluginCapabilityRegistry:
             Kept for compatibility. Prefer :meth:`register_workflow` when the
             workflow also owns an LLM output contract/schema.
         """
-        cleaned = str(path).strip()
-        if not cleaned:
-            raise ValueError("Workflow YAML path cannot be empty")
+        cleaned = _workflow_path_text(path)
+        portable_name = PurePosixPath(cleaned.replace("\\", "/")).stem
         self.register_workflow(
             WorkflowContribution(
                 id=cleaned,
-                name=Path(cleaned).stem or cleaned,
+                name=portable_name or cleaned,
                 yaml_path=cleaned,
             )
         )
@@ -383,8 +433,7 @@ class PluginCapabilityRegistry:
         """Register a selectable workflow and optional output contract/schema."""
         if not contribution.id.strip():
             raise ValueError("WorkflowContribution.id cannot be empty")
-        if not contribution.yaml_path.strip():
-            raise ValueError("WorkflowContribution.yaml_path cannot be empty")
+        _workflow_path_text(contribution.yaml_path)
         self._workflow_contributions.append(contribution)
 
     def register_output_contract_patch(self, patch: OutputContractPatch) -> None:

--- a/sdk/types.py
+++ b/sdk/types.py
@@ -155,9 +155,9 @@ class FrontendPageContribution:
     A plugin-owned frontend page served as static files and embedded by iframe.
 
     ``entry`` points at the page's ``index.html``. Relative paths are resolved
-    from the current working directory; plugins may pass an absolute path based
-    on ``Path(__file__).parent``. Assets are served only from the entry file's
-    containing directory.
+    from the host's authoritative project root; plugins may pass an explicit
+    absolute path based on ``Path(__file__).parent``. Assets are served only
+    from the entry file's containing directory.
     """
 
     page_id: str


### PR DESCRIPTION
## What changed

Introduces shared path-contract, path-reference, archive, file-transaction,
and process-launch APIs under `sdk/`.

## Why

Extensions and host services need one public contract for resolving roots,
validating references, and launching processes safely.

## Impact

SDK consumers can reuse the same exact-path and filesystem-identity guarantees
as the application rather than maintaining local helpers.

## Root cause

Path safety primitives were fragmented across internal modules and were not
available through a stable SDK boundary.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `sdk/`.
