### PR TITLE
test(path-contract): cover migration-safe path contracts

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,15 +25,20 @@ except Exception:
 # Make project root importable (tests run from repo root)
 _THIS_FILE = Path(__file__).resolve()
 _PROJECT_ROOT = _THIS_FILE.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 
 def _configure_test_temp_dir() -> None:
-    temp_root_override = os.environ.get("SHINSEKAI_PYTEST_TEMP_ROOT")
-    temp_root = (
-        Path(temp_root_override)
-        if temp_root_override
-        else Path(tempfile.gettempdir()) / "shinsekai-pytest-runtime"
-    )
+    if "SHINSEKAI_PYTEST_TEMP_ROOT" in os.environ:
+        from core.paths import resolve_project_path
+
+        temp_root = resolve_project_path(
+            ".",
+            root=os.environ["SHINSEKAI_PYTEST_TEMP_ROOT"],
+        )
+    else:
+        temp_root = Path(tempfile.gettempdir()) / "shinsekai-pytest-runtime"
     temp_root.mkdir(parents=True, exist_ok=True)
     temp_path = str(temp_root)
     os.environ.setdefault("TMPDIR", temp_path)
@@ -50,9 +55,6 @@ from queue import Queue
 from unittest.mock import MagicMock
 
 import pytest
-
-if str(_PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PROJECT_ROOT))
 
 from sdk.messages import UserInputMessage, LLMDialogMessage, TTSOutputMessage
 

--- a/test/unit/adapters/test_asr_adapter.py
+++ b/test/unit/adapters/test_asr_adapter.py
@@ -9,6 +9,8 @@ from ai.asr.asr_adapter import (
     ui_lang_to_asr_lang,
     system_config_to_asr_lang,
     normalize_asr_provider_storage_key,
+    _resolve_vosk_model_path,
+    _resolve_whisper_model_reference,
     _whisper_triplet_from_sys,
 )
 from sdk.adapters.asr import ASRAdapter
@@ -39,6 +41,70 @@ def test_vosk_start_raises_when_model_failed_to_load() -> None:
 
     with pytest.raises(RuntimeError, match="Vosk model is unavailable"):
         adapter.start()
+
+
+def test_relative_vosk_model_uses_project_root_after_cwd_changes(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+
+    assert _resolve_vosk_model_path("data/models/vosk") == (
+        project / "data/models/vosk"
+    ).as_posix()
+
+
+def test_vosk_model_path_rejects_outer_whitespace(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _resolve_vosk_model_path(" data/models/vosk")
+
+
+def test_vosk_model_path_rejects_project_symlink_escape(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    try:
+        (project / "models").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        _resolve_vosk_model_path("models/vosk")
+
+
+def test_builtin_vosk_model_uses_application_resource_not_project_shadow(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    source_model = source / "assets/system/models/vosk-model"
+    project_model = project / "assets/system/models/vosk-model"
+    source_model.mkdir(parents=True)
+    project_model.mkdir(parents=True)
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    assert _resolve_vosk_model_path("assets/system/models/vosk-model") == (
+        source_model.as_posix()
+    )
+
+
+def test_vosk_model_path_rejects_legacy_dot_alias_after_config_migration(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
+    with pytest.raises(ValueError, match="exact relative components"):
+        _resolve_vosk_model_path("./assets/system/models/vosk-model")
 
 
 class TestMockASRAdapter:
@@ -162,3 +228,47 @@ class TestWhisperTriplet:
         assert sz == "large-v3"
         assert dev == "cuda"
         assert ct == "float16"
+
+    def test_local_model_uses_project_root_after_cwd_changes(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        unrelated = tmp_path / "unrelated"
+        project.mkdir()
+        unrelated.mkdir()
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+        monkeypatch.chdir(unrelated)
+
+        assert _resolve_whisper_model_reference("data/models/whisper") == (
+            project / "data/models/whisper"
+        ).as_posix()
+
+    def test_huggingface_model_id_is_not_reinterpreted_as_a_local_path(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
+        assert (
+            _resolve_whisper_model_reference("Systran/faster-whisper-small")
+            == "Systran/faster-whisper-small"
+        )
+
+    def test_local_model_rejects_linked_project_parent(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        external = tmp_path / "external"
+        project.mkdir()
+        external.mkdir()
+        try:
+            (project / "data").symlink_to(external, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("directory symlinks are unavailable")
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+        with pytest.raises(PermissionError, match="symbolic link"):
+            _resolve_whisper_model_reference("data/models/whisper")
+
+    def test_model_reference_does_not_silently_trim(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
+        with pytest.raises(ValueError, match="surrounding whitespace"):
+            _resolve_whisper_model_reference(" small")

--- a/test/unit/adapters/test_t2i_project_paths.py
+++ b/test/unit/adapters/test_t2i_project_paths.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import base64
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from ai.t2i.t2i_adapter import ComfyUIT2IAdapter, StableDiffusionAdapter, _output_path
+
+
+class _Response:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, list[str]]:
+        return {"images": [base64.b64encode(b"png").decode("ascii")]}
+
+
+def test_default_t2i_output_uses_project_root_after_cwd_changes(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setattr("ai.t2i.t2i_adapter.requests.post", lambda *_args, **_kwargs: _Response())
+
+    output = StableDiffusionAdapter().generate_image("landscape")
+
+    assert output == (project / "data/generated/temp_t2i_sd.png").as_posix()
+    assert (project / "data/generated/temp_t2i_sd.png").read_bytes() == b"png"
+    assert not (unrelated / "temp_t2i_sd.png").exists()
+
+
+def test_relative_t2i_output_is_anchored_to_project_root(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setattr("ai.t2i.t2i_adapter.requests.post", lambda *_args, **_kwargs: _Response())
+
+    output = StableDiffusionAdapter().generate_image("landscape", "output/image.png")
+
+    assert output == (project / "output/image.png").as_posix()
+    assert (project / "output/image.png").is_file()
+    assert not (unrelated / "output").exists()
+
+
+def test_explicit_empty_t2i_output_does_not_select_the_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
+    with pytest.raises(ValueError, match="path is empty"):
+        _output_path("", "data/generated/default.png")
+
+    assert not (tmp_path / "data/generated/default.png").exists()
+
+
+def test_relative_comfyui_inputs_use_project_root_after_cwd_changes(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    workflow = project / "data/workflows/default.json"
+    work_dir = project / "tools/ComfyUI"
+    workflow.parent.mkdir(parents=True)
+    work_dir.mkdir(parents=True)
+    unrelated.mkdir()
+    workflow.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_start_server_process", lambda self: None)
+
+    adapter = ComfyUIT2IAdapter(
+        work_path="tools/ComfyUI",
+        workflow_path="data/workflows/default.json",
+    )
+
+    assert adapter.work_path == work_dir.as_posix()
+    assert adapter.workflow_path == workflow.as_posix()
+    assert adapter.workflow_template == {}
+
+
+def test_builtin_comfyui_workflow_uses_application_resource_not_project_shadow(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    source_workflow = source / "assets/system/workflow/comfy.json"
+    project_workflow = project / "assets/system/workflow/comfy.json"
+    source_workflow.parent.mkdir(parents=True)
+    project_workflow.parent.mkdir(parents=True)
+    source_workflow.write_text('{"owner": "resource"}', encoding="utf-8")
+    project_workflow.write_text('{"owner": "project"}', encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_start_server_process", lambda self: None)
+
+    adapter = ComfyUIT2IAdapter(
+        workflow_path="assets/system/workflow/comfy.json",
+    )
+
+    assert adapter.workflow_path == source_workflow.as_posix()
+    assert adapter.workflow_template == {"owner": "resource"}
+
+
+@pytest.mark.parametrize("linked_field", ("workflow_path", "work_path"))
+def test_comfyui_rejects_linked_local_inputs_before_startup(
+    tmp_path,
+    monkeypatch,
+    linked_field,
+):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    workflow = project / "data/workflows/default.json"
+    work_dir = project / "tools/ComfyUI"
+    workflow.parent.mkdir(parents=True)
+    work_dir.parent.mkdir(parents=True)
+    external.mkdir()
+    workflow.write_text("{}", encoding="utf-8")
+    work_dir.mkdir()
+    if linked_field == "workflow_path":
+        linked_target = external / "workflow.json"
+        linked_target.write_text("{}", encoding="utf-8")
+        alias = project / "data/workflows/linked.json"
+        kwargs = {
+            "workflow_path": "data/workflows/linked.json",
+            "work_path": "tools/ComfyUI",
+        }
+    else:
+        linked_target = external / "ComfyUI"
+        linked_target.mkdir()
+        alias = project / "tools/LinkedComfyUI"
+        kwargs = {
+            "workflow_path": "data/workflows/default.json",
+            "work_path": "tools/LinkedComfyUI",
+        }
+    try:
+        alias.symlink_to(
+            linked_target,
+            target_is_directory=linked_target.is_dir(),
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_start_server_process", lambda self: None)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        ComfyUIT2IAdapter(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("workflow_path", " data/workflows/default.json"),
+        ("work_path", "tools/ComfyUI "),
+    ],
+)
+def test_comfyui_rejects_paths_with_ambiguous_outer_whitespace(
+    tmp_path,
+    monkeypatch,
+    field,
+    value,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    workflow = project / "data/workflows/default.json"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_start_server_process", lambda self: None)
+    kwargs = {
+        "workflow_path": "data/workflows/default.json",
+        "work_path": "",
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        ComfyUIT2IAdapter(**kwargs)
+
+
+def test_comfyui_workflow_switch_is_resolved_and_transactional(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    first = project / "data/workflows/first.json"
+    second = project / "data/workflows/second.json"
+    first.parent.mkdir(parents=True)
+    first.write_text('{"workflow": 1}', encoding="utf-8")
+    second.write_text("not-json", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_start_server_process", lambda self: None)
+    adapter = ComfyUIT2IAdapter(workflow_path="data/workflows/first.json")
+
+    adapter.switch_model({"workflow_path": "data/workflows/second.json"})
+
+    assert adapter.workflow_path == first.as_posix()
+    assert adapter.workflow_template == {"workflow": 1}
+
+
+def test_comfyui_clone_startup_uses_native_python_and_explicit_working_directory(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    workflow = project / "data/workflows/default.json"
+    work_dir = project / "tools/ComfyUI"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    work_dir.mkdir(parents=True)
+    main_script = work_dir / "main.py"
+    main_script.write_text("", encoding="utf-8")
+    calls = []
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setenv("PYTHONHOME", "/stale/python")
+    monkeypatch.setenv("PYTHONPATH", "/stale/project")
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_is_server_ready", lambda self: False)
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_wait_for_server_ready", lambda self: True)
+    monkeypatch.setattr(
+        "ai.t2i.t2i_adapter.subprocess.Popen",
+        lambda command, **kwargs: calls.append((command, kwargs)),
+    )
+
+    ComfyUIT2IAdapter(
+        work_path="tools/ComfyUI",
+        workflow_path="data/workflows/default.json",
+    )
+
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command == [Path(sys.executable).resolve().as_posix(), main_script.as_posix()]
+    assert kwargs["cwd"] == work_dir.as_posix()
+    assert kwargs["env"]["PYTHONNOUSERSITE"] == "1"
+    assert "PYTHONHOME" not in kwargs["env"]
+    assert "PYTHONPATH" not in kwargs["env"]
+
+
+def test_comfyui_startup_rejects_linked_script_at_launch_boundary(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    workflow = project / "data/workflows/default.json"
+    work_dir = project / "tools/ComfyUI"
+    external_script = tmp_path / "external-main.py"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    work_dir.mkdir(parents=True)
+    external_script.write_text("", encoding="utf-8")
+    try:
+        (work_dir / "main.py").symlink_to(external_script)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_is_server_ready", lambda self: False)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        ComfyUIT2IAdapter(
+            work_path="tools/ComfyUI",
+            workflow_path="data/workflows/default.json",
+        )
+
+
+def test_comfyui_startup_resolves_standard_venv_python_leaf_alias(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    workflow = project / "data/workflows/default.json"
+    work_dir = project / "tools/ComfyUI"
+    python_target = tmp_path / "python"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    (work_dir / ".venv/bin").mkdir(parents=True)
+    main_script = work_dir / "main.py"
+    main_script.write_text("", encoding="utf-8")
+    python_target.write_text("", encoding="utf-8")
+    python_target.chmod(python_target.stat().st_mode | stat.S_IXUSR)
+    try:
+        (work_dir / ".venv/bin/python").symlink_to(python_target)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+    calls = []
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_is_server_ready", lambda self: False)
+    monkeypatch.setattr(ComfyUIT2IAdapter, "_wait_for_server_ready", lambda self: True)
+    monkeypatch.setattr(
+        "ai.t2i.t2i_adapter.subprocess.Popen",
+        lambda command, **kwargs: calls.append((command, kwargs)),
+    )
+
+    ComfyUIT2IAdapter(
+        work_path="tools/ComfyUI",
+        workflow_path="data/workflows/default.json",
+    )
+
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command == [python_target.as_posix(), main_script.as_posix()]
+    assert kwargs["cwd"] == work_dir.as_posix()
+    assert kwargs["env"]["PYTHONNOUSERSITE"] == "1"

--- a/test/unit/ai/memory/test_imports.py
+++ b/test/unit/ai/memory/test_imports.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from ai.memory import imports as memory_imports
 from ai.memory.imports import execute_memory_import, preview_memory_import
 from test.mocks import MockLLMAdapter
 
@@ -150,6 +151,35 @@ def test_preview_accepts_relative_file_inside_server_managed_source_root(tmp_pat
     assert preview["files"][0]["name"] == "history.txt"
 
 
+def test_preview_rejects_ambiguous_whitespace_in_source_path(tmp_path):
+    source = tmp_path / "history.txt"
+    source.write_text("User: likes tea", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="文件路径不允许"):
+        preview_memory_import(
+            [f" {source.name}"],
+            character_name="Mika",
+            source_root=tmp_path,
+        )
+
+
+def test_preview_rejects_symbolic_link_source_even_when_target_is_inside_root(tmp_path):
+    source = tmp_path / "history.txt"
+    alias = tmp_path / "history-alias.txt"
+    source.write_text("User: likes tea", encoding="utf-8")
+    try:
+        alias.symlink_to(source)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    with pytest.raises(ValueError, match="文件路径不允许"):
+        preview_memory_import(
+            [alias],
+            character_name="Mika",
+            source_root=tmp_path,
+        )
+
+
 def test_preview_accepts_active_branch_export(tmp_path):
     path = tmp_path / "branches.json"
     path.write_text(
@@ -170,3 +200,33 @@ def test_preview_accepts_active_branch_export(tmp_path):
 
     assert preview["dialogueLineCount"] == 2
     assert preview["files"][0]["dialogueCharacters"] == len("你: branch\nMika: selected")
+
+
+def test_preview_rejects_source_changed_after_size_validation(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "history.txt"
+    source.write_text("User: approved", encoding="utf-8")
+    real_normalize = memory_imports._normalized_paths
+
+    def normalize_then_change(*args, **kwargs):
+        normalized = real_normalize(*args, **kwargs)
+        source.write_text(
+            "User: replacement-is-longer",
+            encoding="utf-8",
+        )
+        return normalized
+
+    monkeypatch.setattr(
+        memory_imports,
+        "_normalized_paths",
+        normalize_then_change,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        preview_memory_import(
+            [source],
+            character_name="Mika",
+            source_root=tmp_path,
+        )

--- a/test/unit/ai/memory/test_operations.py
+++ b/test/unit/ai/memory/test_operations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import urllib.error
+from pathlib import Path
 
 from ai.memory import operations
 
@@ -115,6 +116,35 @@ def test_memory_list_uses_top_k_with_new_mem0_versions(monkeypatch):
 
     assert memory.requested_top_k == 200
     assert result["count"] == 200
+
+
+def test_local_memory_operation_passes_explicit_project_context(
+    tmp_path,
+    monkeypatch,
+):
+    selected = tmp_path / "selected"
+    selected.mkdir()
+    config_manager = object()
+    captured = {}
+
+    def fake_ensure_mem0(**kwargs):
+        captured.update(kwargs)
+        return _FakeMemory()
+
+    monkeypatch.delenv("SHINSEKAI_MEMORY_SERVICE_URL", raising=False)
+    monkeypatch.setattr(operations, "ensure_mem0", fake_ensure_mem0)
+
+    result = operations.memory_list(
+        "Alice",
+        root=selected,
+        config_manager=config_manager,
+    )
+
+    assert result["count"] == 3
+    assert captured == {
+        "root": Path(selected),
+        "config_manager": config_manager,
+    }
 
 
 def test_local_memory_operations_are_serialized(monkeypatch):

--- a/test/unit/ai/memory/test_queue.py
+++ b/test/unit/ai/memory/test_queue.py
@@ -86,10 +86,10 @@ def test_memory_write_queue_reports_persistence_failure_and_keeps_items(tmp_path
     queue = MemoryWriteQueue(path=tmp_path / "queue.json", remember_func=remember)
     queue.enqueue("persist me", character_name="Alice")
 
-    def fail_replace(_src, _dst):
+    def fail_write(_path, _data):
         raise OSError("disk full")
 
-    monkeypatch.setattr(memory_queue_module.os, "replace", fail_replace)
+    monkeypatch.setattr(memory_queue_module, "atomic_write_text", fail_write)
 
     with pytest.raises(QueuePersistenceError):
         queue.flush()
@@ -97,3 +97,54 @@ def test_memory_write_queue_reports_persistence_failure_and_keeps_items(tmp_path
     assert saved == [("Alice", "persist me")]
     assert len(queue) == 1
     assert queue.pending()[0]["memory"] == "persist me"
+
+
+def test_default_memory_queue_path_uses_project_root_after_cwd_changes(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    queue = MemoryWriteQueue(remember_func=lambda *_args: {"ok": True})
+
+    queue.enqueue("persist in selected project")
+
+    assert queue.path == project / "data/memory/pending_queue.json"
+    assert queue.path.is_file()
+    assert not (unrelated / "data").exists()
+
+
+def test_default_memory_queue_rejects_intermediate_symlink_escape(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    try:
+        (project / "data" / "memory").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        MemoryWriteQueue()
+
+    assert list(external.iterdir()) == []
+
+
+def test_external_memory_queue_rejects_linked_parent(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    project.mkdir()
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        MemoryWriteQueue(path=alias / "pending.json")
+
+    assert list(external.iterdir()) == []

--- a/test/unit/ai/memory/test_service_config.py
+++ b/test/unit/ai/memory/test_service_config.py
@@ -27,6 +27,7 @@ def _isolate_embedding_cache_roots(monkeypatch, tmp_path: Path) -> None:
     """Keep cache-detection tests independent from developer machine state."""
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
     monkeypatch.setenv("HF_HOME", str(tmp_path / "empty-hf-home"))
     monkeypatch.delenv("HF_HUB_CACHE", raising=False)
     monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
@@ -98,6 +99,7 @@ def _write_complete_embedding_snapshot(
 
 def test_mem0_uses_local_multilingual_embedding(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
     monkeypatch.setattr(memory_config, "ConfigManager", _FakeConfigManager)
 
     config = memory_config.build_mem0_config()
@@ -385,5 +387,100 @@ def test_embedding_model_cache_detection_ignores_onnx_only_cache(monkeypatch, tm
     refs.mkdir()
     (refs / "main").write_text(snapshot.name, encoding="utf-8")
     monkeypatch.setenv("HF_HUB_CACHE", str(hub_cache))
+
+    assert memory_config.is_embedding_model_cached() is False
+
+
+def test_mem0_storage_uses_project_root_after_cwd_changes(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setattr(memory_config, "ConfigManager", _FakeConfigManager)
+
+    config = memory_config.build_mem0_config()
+
+    assert config["vector_store"]["config"]["path"] == (
+        project / "data/memory/qdrant"
+    ).as_posix()
+    assert config["history_db_path"] == (project / "data/memory/mem0_history.db").as_posix()
+    assert not (unrelated / "data").exists()
+
+
+def test_mem0_storage_prefers_explicit_root_over_ambient_root(
+    monkeypatch,
+    tmp_path,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+
+    config = memory_config.build_mem0_config(
+        root=selected,
+        config_manager=_FakeConfigManager(),
+    )
+
+    assert config["vector_store"]["config"]["path"] == (
+        selected / "data/memory/qdrant"
+    ).as_posix()
+    assert config["history_db_path"] == (
+        selected / "data/memory/mem0_history.db"
+    ).as_posix()
+    assert not (ambient / "data/memory").exists()
+
+
+def test_embedding_cache_detection_does_not_follow_project_hub_symlink(
+    monkeypatch,
+    tmp_path,
+):
+    project = tmp_path / "project"
+    hf_home = project / "data/cache/huggingface"
+    external_hub = tmp_path / "external-hub"
+    snapshot = (
+        external_hub
+        / "models--sentence-transformers--paraphrase-multilingual-MiniLM-L12-v2"
+        / "snapshots"
+        / "abc123"
+    )
+    hf_home.mkdir(parents=True)
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}", encoding="utf-8")
+    (snapshot / "model.safetensors").write_bytes(b"model")
+    try:
+        (hf_home / "hub").symlink_to(external_hub, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(project))
+    monkeypatch.setenv("HF_HOME", "data/cache/huggingface")
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+
+    assert memory_config.is_embedding_model_cached() is False
+
+
+def test_embedding_cache_detection_ignores_stale_non_active_cache(
+    monkeypatch,
+    tmp_path,
+):
+    project = tmp_path / "project"
+    active_cache = tmp_path / "active-cache"
+    stale_cache = project / "data/cache/huggingface/hub"
+    snapshot = (
+        stale_cache
+        / "models--sentence-transformers--paraphrase-multilingual-MiniLM-L12-v2"
+        / "snapshots"
+        / "abc123"
+    )
+    project.mkdir()
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}", encoding="utf-8")
+    (snapshot / "model.safetensors").write_bytes(b"model")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(project))
+    monkeypatch.setenv("HF_HUB_CACHE", str(active_cache))
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
 
     assert memory_config.is_embedding_model_cached() is False

--- a/test/unit/ai/vision/test_chat_vision_service.py
+++ b/test/unit/ai/vision/test_chat_vision_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
+import pytest
+
 from ai.vision.message_content import normalize_anthropic_user_content, normalize_openai_messages
 from ai.vision.service import ChatVisionService
 from core.media.chat_attachments import resolve_chat_attachments
@@ -44,7 +46,7 @@ def test_chat_vision_service_prefers_native_image_blocks(tmp_path: Path):
     assert isinstance(prepared.content, list)
     assert prepared.content[0] == {"type": "text", "text": "What is here?\n\nImage attachments: moon.png"}
     assert prepared.content[1]["type"] == "local_image"
-    assert prepared.content[1]["path"] == str(image.path)
+    assert prepared.content[1]["path"] == (image.reference or str(image.path))
     assert prepared.content[1]["data"] == base64.b64encode(b"image-bytes").decode("ascii")
 
 
@@ -196,3 +198,37 @@ def test_file_attachments_are_read_locally_and_passed_to_the_llm(tmp_path: Path)
     assert reads == [str(document.resolve())]
     assert "facts from local file_read" in prepared.content
     assert "BEGIN ATTACHED FILE: facts.txt" in prepared.content
+
+
+def test_default_file_attachment_reader_rejects_content_changed_after_validation(
+    tmp_path: Path,
+):
+    document = tmp_path / "facts.txt"
+    document.write_text("approved", encoding="utf-8")
+    attachment = resolve_chat_attachments(
+        [{"kind": "file", "path": str(document)}]
+    )[0]
+    document.write_text("replacement-is-longer", encoding="utf-8")
+
+    prepared = ChatVisionService().prepare(
+        "Read it",
+        [attachment],
+        adapter=_NativeAdapter(),
+    )
+
+    assert "Unable to read file" in prepared.content
+    assert "replacement-is-longer" not in prepared.content
+
+
+def test_native_image_reader_rejects_content_changed_after_validation(
+    tmp_path: Path,
+):
+    image = _image_attachment(tmp_path)
+    image.path.write_bytes(b"replacement-image-is-longer")
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        ChatVisionService().prepare(
+            "Inspect",
+            [image],
+            adapter=_NativeAdapter(),
+        )

--- a/test/unit/ai/vision/test_fallback_preference.py
+++ b/test/unit/ai/vision/test_fallback_preference.py
@@ -34,7 +34,12 @@ def _image(tmp_path: Path) -> ResolvedChatAttachment:
     path = tmp_path / "apple.png"
     path.write_bytes(b"apple-bytes")
     return ResolvedChatAttachment(
-        kind="image", mime_type="image/png", name="apple.png", path=path, size=path.stat().st_size
+        identity=path.stat(),
+        kind="image",
+        mime_type="image/png",
+        name="apple.png",
+        path=path,
+        size=path.stat().st_size,
     )
 
 

--- a/test/unit/ai/vision/test_vision_manager.py
+++ b/test/unit/ai/vision/test_vision_manager.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from ai.vision import VisionAdapter, VisionManager
-from ai.vision.moondream_adapter import MoondreamPluginUnavailable, MoondreamVisionAdapter
+from ai.vision.moondream_adapter import (
+    MOONDREAM_PLUGIN_ID,
+    MoondreamPluginUnavailable,
+    MoondreamVisionAdapter,
+    _bind_plugin_config_paths,
+    _moondream_config_path,
+)
 
 
 class FakeVisionAdapter(VisionAdapter):
@@ -21,7 +29,118 @@ def test_vision_manager_dispatches_to_registered_adapter(monkeypatch):
 
 
 def test_moondream_adapter_requires_the_optional_plugin(monkeypatch):
-    monkeypatch.setattr("ai.vision.moondream_adapter.installed_moondream_directory", lambda: None)
+    monkeypatch.setattr(
+        "ai.vision.moondream_adapter.installed_moondream_directory",
+        lambda **_kwargs: None,
+    )
 
     with pytest.raises(MoondreamPluginUnavailable, match="Moondream"):
         MoondreamVisionAdapter()
+
+
+def test_moondream_cache_path_uses_project_root_after_cwd_changes(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    config = SimpleNamespace(cache_dir="data/cache/moondream")
+
+    _bind_plugin_config_paths(config)
+
+    assert config.cache_dir == (project / "data/cache/moondream").as_posix()
+
+
+def test_moondream_cache_path_prefers_explicit_root_over_ambient_root(
+    tmp_path,
+    monkeypatch,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+    config = SimpleNamespace(cache_dir="data/cache/moondream")
+
+    _bind_plugin_config_paths(config, root=selected)
+
+    assert config.cache_dir == (
+        selected / "data/cache/moondream"
+    ).as_posix()
+
+
+def test_moondream_cache_path_rejects_outer_whitespace(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _bind_plugin_config_paths(SimpleNamespace(cache_dir=" data/cache/moondream"))
+
+
+def test_moondream_config_fallback_uses_project_data_not_plugin_source(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    def _not_bound():
+        raise RuntimeError("plugin root not set")
+
+    path = _moondream_config_path(
+        SimpleNamespace(default_config_path=lambda root: root / "config.json"),
+        SimpleNamespace(plugin_config_path=_not_bound),
+    )
+
+    assert path == (
+        project / "data" / "plugins" / MOONDREAM_PLUGIN_ID / "config.json"
+    )
+
+
+def test_moondream_config_fallback_prefers_explicit_root(
+    tmp_path,
+    monkeypatch,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+
+    def not_bound():
+        raise RuntimeError("plugin root not set")
+
+    path = _moondream_config_path(
+        SimpleNamespace(default_config_path=lambda root: root / "config.json"),
+        SimpleNamespace(plugin_config_path=not_bound),
+        root=selected,
+    )
+
+    assert path == (
+        selected
+        / "data/plugins"
+        / MOONDREAM_PLUGIN_ID
+        / "config.json"
+    )
+
+
+def test_moondream_config_rejects_linked_leaf(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    plugin_root = project / "data" / "plugins" / MOONDREAM_PLUGIN_ID
+    external = tmp_path / "external.json"
+    plugin_root.mkdir(parents=True)
+    external.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    try:
+        (plugin_root / "config.json").symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        _moondream_config_path(
+            SimpleNamespace(default_config_path=lambda root: root / "config.json"),
+            SimpleNamespace(
+                plugin_config_path=lambda: plugin_root / "config.json",
+            ),
+        )

--- a/test/unit/application/test_chat_templates.py
+++ b/test/unit/application/test_chat_templates.py
@@ -148,8 +148,12 @@ def test_save_template_session_persists_only_resolved_characters_and_their_defau
     services_package = ModuleType("ui.settings_ui.services")
     services_package.__path__ = []
     storage_module = ModuleType("application.chat.session_store")
-    storage_module.save_template_session = lambda _path, data: saved.update(data)
-    storage_module.load_template_session = lambda _path: dict(saved)
+    storage_module.save_template_session = (
+        lambda _path, data, **_kwargs: saved.update(data)
+    )
+    storage_module.load_template_session = (
+        lambda _path, **_kwargs: dict(saved)
+    )
     monkeypatch.setitem(sys.modules, "ui.settings_ui", settings_package)
     monkeypatch.setitem(sys.modules, "ui.settings_ui.services", services_package)
     monkeypatch.setitem(sys.modules, "application.chat.session_store", storage_module)
@@ -249,8 +253,12 @@ def test_character_rename_updates_persisted_template_selection(monkeypatch):
         "scenario_text": "scene",
     }
     storage_module = ModuleType("application.chat.session_store")
-    storage_module.load_template_session = lambda _path: dict(stored)
-    storage_module.save_template_session = lambda _path, data: stored.update(data)
+    storage_module.load_template_session = (
+        lambda _path, **_kwargs: dict(stored)
+    )
+    storage_module.save_template_session = (
+        lambda _path, data, **_kwargs: stored.update(data)
+    )
     monkeypatch.setitem(sys.modules, "application.chat.session_store", storage_module)
     state = SimpleNamespace(
         config_manager=SimpleNamespace(
@@ -272,8 +280,12 @@ def test_loading_template_session_removes_historical_stale_names(monkeypatch):
         "scenario_text": "scene",
     }
     storage_module = ModuleType("application.chat.session_store")
-    storage_module.load_template_session = lambda _path: dict(stored)
-    storage_module.save_template_session = lambda _path, data: stored.update(data)
+    storage_module.load_template_session = (
+        lambda _path, **_kwargs: dict(stored)
+    )
+    storage_module.save_template_session = (
+        lambda _path, data, **_kwargs: stored.update(data)
+    )
     monkeypatch.setitem(sys.modules, "application.chat.session_store", storage_module)
     state = SimpleNamespace(
         config_manager=SimpleNamespace(

--- a/test/unit/application/test_plugin_updates.py
+++ b/test/unit/application/test_plugin_updates.py
@@ -13,6 +13,7 @@ from application.plugins.updates import (
     _lookup_registry_plugin,
     _plugin_class_from_file,
     _repo_slug_from_source,
+    _restore_package_target,
     _synthetic_plugin_result,
 )
 from application.runtime.state import BridgeState
@@ -21,9 +22,10 @@ from application.runtime.state import BridgeState
 def test_repo_slug_from_source_accepts_common_github_forms():
     assert _repo_slug_from_source("owner/repo") == "owner/repo"
     assert _repo_slug_from_source("https://github.com/owner/repo.git") == "owner/repo"
-    assert _repo_slug_from_source("github.com/owner/repo/tree/main") == "owner/repo"
+    assert _repo_slug_from_source("github.com/owner/repo") == "owner/repo"
     assert _repo_slug_from_source("git@github.com:owner/repo.git") == "owner/repo"
-    assert _repo_slug_from_source("http://github.com/owner/repo/tree/main?x=1#readme") == "owner/repo"
+    assert _repo_slug_from_source("github.com/owner/repo/tree/main") == ""
+    assert _repo_slug_from_source("http://github.com/owner/repo/tree/main?x=1#readme") == ""
     assert _repo_slug_from_source("owner") == ""
 
 
@@ -33,6 +35,21 @@ def test_repo_source_rejects_manifest_entries():
     assert _is_repo_source("git@github.com:owner/repo.git") is True
     assert _is_repo_source("plugins.demo.plugin:DemoPlugin") is False
     assert _is_repo_source("not-enough") is False
+    assert _is_repo_source(" owner/repo") is False
+
+
+def test_install_plugin_source_rejects_whitespace_alias_before_lookup():
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _install_plugin_source(_state_with_task(), "task", " owner/demo")
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _install_plugin_source(
+            _state_with_task(),
+            "task",
+            "owner/demo",
+            ref_kind="tag",
+            tag_name=" v1.0",
+        )
 
 
 def test_plugin_class_from_file_detects_pluginbase_subclasses(tmp_path):
@@ -68,6 +85,49 @@ def test_infer_plugin_entry_uses_top_level_or_nested_plugin_file(tmp_path):
     (nested / "plugin.py").write_text("class NestedPlugin(shin.PluginBase):\n    pass\n", encoding="utf-8")
 
     assert _infer_plugin_entry(nested_root) == "plugins.nested_plugin.package.plugin:NestedPlugin"
+
+
+def test_infer_plugin_entry_rejects_replaced_plugin_directory(
+    tmp_path,
+    monkeypatch,
+):
+    plugin_root = tmp_path / "demo_plugin"
+    preserved = tmp_path / "demo_plugin-preserved"
+    plugin_root.mkdir()
+    (plugin_root / "plugin.py").write_text(
+        "class OriginalPlugin(PluginBase):\n    pass\n",
+        encoding="utf-8",
+    )
+    real_read = plugin_updates.read_text_without_links
+    replaced = False
+
+    def replace_before_read(*args, **kwargs):
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            plugin_root.rename(preserved)
+            plugin_root.mkdir()
+            (plugin_root / "plugin.py").write_text(
+                "class PeerPlugin(PluginBase):\n    pass\n",
+                encoding="utf-8",
+            )
+        return real_read(*args, **kwargs)
+
+    monkeypatch.setattr(
+        plugin_updates,
+        "read_text_without_links",
+        replace_before_read,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        _infer_plugin_entry(plugin_root)
+
+    assert (plugin_root / "plugin.py").read_text(encoding="utf-8").startswith(
+        "class PeerPlugin"
+    )
+    assert (preserved / "plugin.py").read_text(encoding="utf-8").startswith(
+        "class OriginalPlugin"
+    )
 
 
 def test_synthetic_plugin_result_uses_safe_defaults():
@@ -148,24 +208,18 @@ def _patch_manifest_and_state(monkeypatch, marks: list[dict]):
     monkeypatch.setattr(
         plugin_updates,
         "_plugin_result_from_manifest",
-        lambda entry: {"entry": entry, "enabled": True},
+        lambda entry, **_kwargs: {"entry": entry, "enabled": True},
     )
 
     def fake_mark_repo_downloaded(repo, **kwargs):
         marks.append({"repo": repo, **kwargs})
 
-    monkeypatch.setattr(
-        "plugin_system.registry.download.mark_repo_downloaded",
-        fake_mark_repo_downloaded,
-    )
+    monkeypatch.setattr("plugin_system.registry.download.mark_repo_downloaded", fake_mark_repo_downloaded)
 
 
 def test_lookup_registry_plugin_matches_id_and_display_name(monkeypatch):
     record = _registry_record()
-    monkeypatch.setattr(
-        "plugin_system.registry.catalog.fetch_registry_plugins",
-        lambda timeout_sec=12: [record],
-    )
+    monkeypatch.setattr("plugin_system.registry.catalog.fetch_registry_plugins", lambda timeout_sec=12: [record])
 
     assert _lookup_registry_plugin("demo-id") is record
     assert _lookup_registry_plugin("Demo Plugin") is record
@@ -179,11 +233,12 @@ def test_install_plugin_source_prefers_registry_package_over_github(tmp_path, mo
 
     monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
     _patch_manifest_and_state(monkeypatch, marks)
+    state = _state_with_task()
 
     def fake_package_install(rec, **kwargs):
         calls.append(("package", kwargs.get("overwrite")))
         assert rec is record
-        assert kwargs.get("plugins_parent") == Path("plugins")
+        assert kwargs.get("plugins_parent") == Path(state.project_root_dir) / "plugins"
         return package_root
 
     def fail_github(*_args, **_kwargs):
@@ -193,16 +248,13 @@ def test_install_plugin_source_prefers_registry_package_over_github(tmp_path, mo
         "plugin_system.install.package.install_registry_package_under_plugins",
         fake_package_install,
     )
-    monkeypatch.setattr(
-        "plugin_system.update.github.install_github_plugin_under_plugins",
-        fail_github,
-    )
+    monkeypatch.setattr("plugin_system.update.github.install_github_plugin_under_plugins", fail_github)
     monkeypatch.setattr(
         "plugin_system.requirements.install.install_plugin_requirements_txt",
-        lambda root, **_kwargs: calls.append(("pip", root)) or ("pip_ok", ""),
+        lambda plugin_root, **_kwargs: calls.append(("pip", plugin_root)) or ("pip_ok", ""),
     )
 
-    result = _install_plugin_source(_state_with_task(), "task", "owner/demo", overwrite=True)
+    result = _install_plugin_source(state, "task", "owner/demo", overwrite=True)
 
     assert result["entry"] == "plugins.demo.plugin:DemoPlugin"
     assert result["enabled"] is True
@@ -223,6 +275,7 @@ def test_install_plugin_source_prefers_registry_package_over_github(tmp_path, mo
     assert marks[0]["repo"] == "owner/demo"
     assert marks[0]["manifest_entry"] == "plugins.demo.plugin:DemoPlugin"
     assert marks[0]["install_metadata"] == result["install"]
+    assert marks[0]["root"] == Path(state.project_root_dir)
 
 
 def test_install_plugin_source_does_not_mark_existing_directory_as_verified(tmp_path, monkeypatch):
@@ -232,10 +285,7 @@ def test_install_plugin_source_does_not_mark_existing_directory_as_verified(tmp_
     package_root = _plugin_root(tmp_path, "package-plugin")
 
     monkeypatch.setattr(plugin_updates, "_lookup_registry_plugin", lambda _source: record)
-    monkeypatch.setattr(
-        "plugin_system.install.package.registry_package_target",
-        lambda *_args, **_kwargs: package_root,
-    )
+    monkeypatch.setattr("plugin_system.install.package.registry_package_target", lambda *_args, **_kwargs: package_root)
     _patch_manifest_and_state(monkeypatch, marks)
 
     def fake_package_install(rec, **kwargs):
@@ -249,7 +299,7 @@ def test_install_plugin_source_does_not_mark_existing_directory_as_verified(tmp_
     )
     monkeypatch.setattr(
         "plugin_system.requirements.install.install_plugin_requirements_txt",
-        lambda root, **_kwargs: calls.append(("pip", root)) or ("pip_ok", ""),
+        lambda plugin_root, **_kwargs: calls.append(("pip", plugin_root)) or ("pip_ok", ""),
     )
 
     result = _install_plugin_source(_state_with_task(), "task", "owner/demo", overwrite=False)
@@ -293,10 +343,7 @@ def test_install_plugin_source_falls_back_to_github_for_registry_package_network
         "plugin_system.install.package.install_registry_package_under_plugins",
         fail_package,
     )
-    monkeypatch.setattr(
-        "plugin_system.update.github.install_github_plugin_under_plugins",
-        fake_github,
-    )
+    monkeypatch.setattr("plugin_system.update.github.install_github_plugin_under_plugins", fake_github)
     monkeypatch.setattr(
         "plugin_system.requirements.install.install_plugin_requirements_txt",
         lambda *_args, **_kwargs: ("pip_ok", ""),
@@ -354,10 +401,7 @@ def test_install_plugin_source_does_not_fallback_to_github_for_package_safety_er
         "plugin_system.install.package.install_registry_package_under_plugins",
         fail_package,
     )
-    monkeypatch.setattr(
-        "plugin_system.update.github.install_github_plugin_under_plugins",
-        fail_github,
-    )
+    monkeypatch.setattr("plugin_system.update.github.install_github_plugin_under_plugins", fail_github)
 
     state = _state_with_task()
 
@@ -386,10 +430,7 @@ def test_install_plugin_source_does_not_fallback_to_github_when_package_dependen
     def fail_github(*_args, **_kwargs):
         raise AssertionError("dependency failures after package install must not fallback to GitHub")
 
-    monkeypatch.setattr(
-        "plugin_system.update.github.install_github_plugin_under_plugins",
-        fail_github,
-    )
+    monkeypatch.setattr("plugin_system.update.github.install_github_plugin_under_plugins", fail_github)
     monkeypatch.setattr(
         "plugin_system.requirements.install.install_plugin_requirements_txt",
         lambda *_args, **_kwargs: ("pip_failed", "dependency boom"),
@@ -425,3 +466,33 @@ def test_install_plugin_source_treats_github_dependency_conflicts_as_failures(
 
     with pytest.raises(RuntimeError, match="dependency conflict"):
         _install_plugin_source(_state_with_task(), "task", "owner/demo")
+
+
+def test_package_target_restore_atomically_reinstates_backup(tmp_path):
+    target = _plugin_root(tmp_path, "demo-plugin")
+    (target / "plugin.py").write_text("new\n", encoding="utf-8")
+    backup = _plugin_root(tmp_path, ".demo-plugin.backup-test")
+    (backup / "plugin.py").write_text("old\n", encoding="utf-8")
+
+    _restore_package_target(target, backup, remove_new_target=True)
+
+    assert (target / "plugin.py").read_text(encoding="utf-8") == "old\n"
+    assert not backup.exists()
+
+
+@pytest.mark.skipif(not hasattr(Path, "symlink_to"), reason="symbolic links unavailable")
+def test_package_target_restore_refuses_link_without_touching_external_tree(tmp_path):
+    external = _plugin_root(tmp_path, "external")
+    marker = external / "plugin.py"
+    target = tmp_path / "demo-plugin"
+    backup = _plugin_root(tmp_path, ".demo-plugin.backup-test")
+    try:
+        target.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _restore_package_target(target, backup, remove_new_target=True)
+
+    assert marker.read_text(encoding="utf-8").startswith("class DemoPlugin")
+    assert backup.is_dir()

--- a/test/unit/application/test_restart_debug.py
+++ b/test/unit/application/test_restart_debug.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from application.runtime.restart_debug import (
+    _restart_debug_log_path,
+    write_restart_debug_log,
+)
+
+
+def test_restart_debug_log_ignores_relative_environment_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHINSEKAI_RESTART_LOG", "relative.log")
+    unrelated = tmp_path / "unrelated"
+    temporary = tmp_path / "temporary"
+    unrelated.mkdir()
+    temporary.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    assert _restart_debug_log_path(temp_dir=temporary) == (
+        temporary / "shinsekai-restart-debug.log"
+    )
+
+
+def test_restart_debug_log_does_not_expand_user_home_alias(tmp_path, monkeypatch):
+    temporary = tmp_path / "temporary"
+    temporary.mkdir()
+    monkeypatch.setenv("SHINSEKAI_RESTART_LOG", "~/restart.log")
+
+    assert _restart_debug_log_path(temp_dir=temporary) == (
+        temporary / "shinsekai-restart-debug.log"
+    )
+
+
+def test_restart_debug_log_disables_relative_fallback(tmp_path, monkeypatch):
+    monkeypatch.delenv("SHINSEKAI_RESTART_LOG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert _restart_debug_log_path(temp_dir="relative-temp") is None
+
+
+def test_restart_debug_log_ignores_nonportable_environment_path(tmp_path, monkeypatch):
+    temporary = tmp_path / "temporary"
+    temporary.mkdir()
+    monkeypatch.setenv("SHINSEKAI_RESTART_LOG", str(tmp_path / "bad\nrestart.log"))
+
+    assert _restart_debug_log_path(temp_dir=temporary) == (
+        temporary / "shinsekai-restart-debug.log"
+    )
+
+
+def test_restart_debug_log_ignores_lexical_absolute_alias(tmp_path, monkeypatch):
+    temporary = tmp_path / "temporary"
+    temporary.mkdir()
+    monkeypatch.setenv(
+        "SHINSEKAI_RESTART_LOG",
+        f"{tmp_path.as_posix()}/./restart.log",
+    )
+
+    assert _restart_debug_log_path(temp_dir=temporary) == (
+        temporary / "shinsekai-restart-debug.log"
+    )
+
+
+def test_restart_debug_log_cannot_inject_a_desktop_recovery_line(tmp_path, monkeypatch):
+    log = tmp_path / "restart.log"
+    monkeypatch.setenv("SHINSEKAI_RESTART_LOG", str(log))
+
+    write_restart_debug_log(
+        "bridge",
+        "failed\ncomponent=desktop setup resolved project_root=/fake app_root=/fake",
+    )
+
+    contents = log.read_text(encoding="utf-8")
+    assert contents.count("\n") == 1
+    assert "failed\\ncomponent=desktop" in contents
+
+
+def test_restart_debug_log_does_not_follow_configured_symlink(tmp_path, monkeypatch):
+    target = tmp_path / "target.log"
+    link = tmp_path / "restart.log"
+    target.write_text("keep\n", encoding="utf-8")
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError):
+        import pytest
+
+        pytest.skip("symbolic links are unavailable")
+    fallback = tmp_path / "temporary"
+    fallback.mkdir()
+    monkeypatch.setenv("SHINSEKAI_RESTART_LOG", str(link))
+    monkeypatch.setattr(
+        "application.runtime.restart_debug.tempfile.gettempdir",
+        lambda: str(fallback),
+    )
+
+    write_restart_debug_log("bridge", "safe")
+
+    assert target.read_text(encoding="utf-8") == "keep\n"
+    assert (fallback / "shinsekai-restart-debug.log").is_file()
+
+
+def test_restart_debug_log_falls_back_from_intermediate_symlink(tmp_path, monkeypatch):
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    fallback = tmp_path / "temporary"
+    external.mkdir()
+    fallback.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        import pytest
+
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_RESTART_LOG", str(alias / "restart.log"))
+    monkeypatch.setattr(
+        "application.runtime.restart_debug.tempfile.gettempdir",
+        lambda: str(fallback),
+    )
+
+    write_restart_debug_log("bridge", "safe")
+
+    assert not (external / "restart.log").exists()
+    assert (fallback / "shinsekai-restart-debug.log").is_file()
+
+
+def test_restart_debug_log_canonicalizes_the_platform_temp_alias(
+    tmp_path,
+    monkeypatch,
+):
+    external = tmp_path / "platform-temp"
+    alias = tmp_path / "platform-temp-alias"
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        import pytest
+
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.delenv("SHINSEKAI_RESTART_LOG", raising=False)
+    monkeypatch.setattr(
+        "application.runtime.restart_debug.tempfile.gettempdir",
+        lambda: str(alias),
+    )
+
+    assert _restart_debug_log_path() == (
+        external / "shinsekai-restart-debug.log"
+    )

--- a/test/unit/config/test_background_manager.py
+++ b/test/unit/config/test_background_manager.py
@@ -1,4 +1,9 @@
 from types import SimpleNamespace
+from pathlib import Path
+import zipfile
+
+import pytest
+import yaml
 
 from config.background_manager import BackgroundManager
 from config.schema import Background
@@ -16,9 +21,10 @@ class FakeConfigManager:
         self.save_count += 1
 
 
-def build_manager(backgrounds):
+def build_manager(backgrounds, project_root=None):
     manager = BackgroundManager.__new__(BackgroundManager)
     manager._config_manager = FakeConfigManager(backgrounds)
+    manager._project_root = Path(project_root or Path.cwd()).resolve()
     return manager
 
 
@@ -55,3 +61,300 @@ def test_add_background_creates_when_edit_target_is_missing():
     assert manager._config_manager.config.background_list[0].bg_tags == "Scene 1: street\n"
     assert manager._config_manager.config.background_list[0].bgm_tags == "Music 1: traffic\n"
     assert manager._config_manager.save_count == 1
+
+
+def test_add_background_rejects_whitespace_retargeted_storage_prefix():
+    manager = build_manager([])
+
+    message, _names = manager.add_background("City", " city ")
+
+    assert "目录名无效" in message
+    assert manager._config_manager.config.background_list == []
+
+
+def test_add_background_rejects_shared_storage_prefix():
+    existing = Background(name="School", sprite_prefix="shared")
+    manager = build_manager([existing])
+
+    message, _names = manager.add_background("City", "shared")
+
+    assert "已被背景组" in message
+    assert manager._config_manager.config.background_list == [existing]
+
+
+def test_edit_background_cannot_detach_existing_paths_by_changing_storage_prefix(tmp_path):
+    asset = tmp_path / "data/backgrounds/school/room.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"image")
+    background = Background(
+        name="School",
+        sprite_prefix="school",
+        sprites=[{"path": "data/backgrounds/school/room.png"}],
+    )
+    manager = build_manager([background], tmp_path)
+
+    message, _names = manager.add_background(
+        "School",
+        "renamed",
+        edit_as_name="School",
+    )
+
+    assert "不可直接修改" in message
+    assert background.sprite_prefix == "school"
+    sprite = background.sprites[0]
+    assert (sprite.path if hasattr(sprite, "path") else sprite.get("path")) == (
+        "data/backgrounds/school/room.png"
+    )
+    assert asset.read_bytes() == b"image"
+    assert manager._config_manager.save_count == 0
+
+
+def test_delete_background_sprite_never_unlinks_external_config_path(tmp_path):
+    external = tmp_path / "external.png"
+    external.write_bytes(b"image")
+    background = Background(
+        name="School",
+        sprite_prefix="school",
+        sprites=[{"path": external.as_posix()}],
+    )
+    manager = build_manager([background], tmp_path / "project")
+
+    manager.delete_single_sprite("School", 0)
+
+    assert external.read_bytes() == b"image"
+    assert background.sprites == []
+
+
+def test_delete_background_rejects_traversal_prefix(tmp_path):
+    project_root = tmp_path / "project"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    background = Background(name="School", sprite_prefix="../../outside")
+    manager = build_manager([background], project_root)
+
+    manager.delete_background("School")
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert manager._config_manager.config.background_list == []
+
+
+def test_import_background_save_failure_restores_memory_and_files(tmp_path):
+    project = tmp_path / "project"
+    package = tmp_path / "scene.bg"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            "background.yaml",
+            yaml.safe_dump(
+                [{"name": "Scene", "sprite_prefix": "scene", "sprites": [{"path": "room.png"}]}],
+                allow_unicode=True,
+            ),
+        )
+        archive.writestr("sprites/scene/room.png", b"image")
+    original = Background(name="Existing", sprite_prefix="existing")
+    manager = build_manager([original], project)
+
+    def fail_save():
+        raise OSError("disk full")
+
+    manager._config_manager.save_background_config = fail_save
+
+    message, names = manager.import_background_file(package.as_posix())
+
+    assert "disk full" in message
+    assert names == ["Existing"]
+    assert manager._config_manager.config.background_list == [original]
+    assert not (project / "data/backgrounds/scene").exists()
+
+
+def test_upload_background_never_overwrites_same_named_managed_file(tmp_path):
+    project = tmp_path / "project"
+    existing = project / "data/backgrounds/school/room.png"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"old")
+    source = tmp_path / "incoming/room.png"
+    source.parent.mkdir()
+    source.write_bytes(b"new")
+    background = Background(
+        name="School",
+        sprite_prefix="school",
+        sprites=[{"path": "data/backgrounds/school/room.png"}],
+    )
+    manager = build_manager([background], project)
+
+    _message, paths, _tags = manager.upload_sprites(
+        "School",
+        [SimpleNamespace(name=source.as_posix())],
+        "",
+    )
+
+    assert existing.read_bytes() == b"old"
+    assert paths == [
+        "data/backgrounds/school/room.png",
+        "data/backgrounds/school/room_1.png",
+    ]
+    assert (project / paths[1]).read_bytes() == b"new"
+
+
+def test_background_uploads_resolve_relative_sources_from_project_not_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    image = project / "data/incoming/room.png"
+    audio = project / "data/incoming/theme.ogg"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"project image")
+    audio.write_bytes(b"project audio")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+    background = Background(name="School", sprite_prefix="school")
+    manager = build_manager([background], project)
+
+    _message, paths, _tags = manager.upload_sprites(
+        "School",
+        [SimpleNamespace(name="data/incoming/room.png")],
+        "",
+    )
+    manager.upload_bgms(
+        "School",
+        [SimpleNamespace(name="data/incoming/theme.ogg")],
+        "",
+    )
+
+    assert paths == ["data/backgrounds/school/room.png"]
+    assert (project / paths[0]).read_bytes() == b"project image"
+    assert background.bgm_list == ["data/bgm/school/theme.ogg"]
+    assert (project / background.bgm_list[0]).read_bytes() == b"project audio"
+    assert not (unrelated / "data/backgrounds/school").exists()
+    assert not (unrelated / "data/bgm/school").exists()
+
+
+@pytest.mark.parametrize("media_kind", ("sprite", "bgm"))
+def test_background_uploads_reject_linked_source_directories(
+    tmp_path,
+    media_kind,
+):
+    project = tmp_path / "project"
+    external = tmp_path / "incoming"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    filename = "room.png" if media_kind == "sprite" else "theme.ogg"
+    (external / filename).write_bytes(b"external media")
+    try:
+        (project / "data/incoming").symlink_to(
+            external,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    background = Background(name="School", sprite_prefix="school")
+    manager = build_manager([background], project)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        if media_kind == "sprite":
+            manager.upload_sprites(
+                "School",
+                [SimpleNamespace(name=f"data/incoming/{filename}")],
+                "",
+            )
+        else:
+            manager.upload_bgms(
+                "School",
+                [SimpleNamespace(name=f"data/incoming/{filename}")],
+                "",
+            )
+
+    assert background.sprites == []
+    assert background.bgm_list == []
+    assert not (project / "data/backgrounds/school").exists()
+    assert not (project / "data/bgm/school").exists()
+
+
+def test_upload_background_save_failure_rolls_back_memory_and_new_files(tmp_path):
+    project = tmp_path / "project"
+    source = tmp_path / "incoming/room.png"
+    source.parent.mkdir()
+    source.write_bytes(b"new")
+    background = Background(name="School", sprite_prefix="school")
+    manager = build_manager([background], project)
+    manager._config_manager.save_background_config = lambda: (_ for _ in ()).throw(
+        OSError("disk full")
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        manager.upload_sprites(
+            "School",
+            [SimpleNamespace(name=source.as_posix())],
+            "",
+        )
+
+    assert background.sprites == []
+    assert background.bg_tags == ""
+    assert not (project / "data/backgrounds/school").exists()
+
+
+def test_delete_background_sprite_save_failure_keeps_reference_and_file(tmp_path):
+    project = tmp_path / "project"
+    sprite = project / "data/backgrounds/school/room.png"
+    sprite.parent.mkdir(parents=True)
+    sprite.write_bytes(b"image")
+    background = Background(
+        name="School",
+        sprite_prefix="school",
+        sprites=[{"path": "data/backgrounds/school/room.png"}],
+        bg_tags="场景 1：room\n",
+    )
+    manager = build_manager([background], project)
+    manager._config_manager.save_background_config = lambda: (_ for _ in ()).throw(
+        OSError("read only")
+    )
+
+    with pytest.raises(OSError, match="read only"):
+        manager.delete_single_sprite("School", 0)
+
+    assert sprite.read_bytes() == b"image"
+    stored = background.sprites[0]
+    assert (stored.path if hasattr(stored, "path") else stored.get("path")) == (
+        "data/backgrounds/school/room.png"
+    )
+    assert background.bg_tags == "场景 1：room\n"
+
+
+def test_delete_background_sprite_preserves_replacement_created_during_save(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    sprite = project / "data/backgrounds/school/room.png"
+    preserved = project / "data/backgrounds/school/original-room.png"
+    sprite.parent.mkdir(parents=True)
+    sprite.write_bytes(b"original")
+    background = Background(
+        name="School",
+        sprite_prefix="school",
+        sprites=[{"path": "data/backgrounds/school/room.png"}],
+    )
+    manager = build_manager([background], project)
+
+    def replace_during_save():
+        sprite.rename(preserved)
+        sprite.write_bytes(b"peer")
+
+    manager._config_manager.save_background_config = replace_during_save
+
+    manager.delete_single_sprite("School", 0)
+
+    assert sprite.read_bytes() == b"peer"
+    assert preserved.read_bytes() == b"original"
+    assert background.sprites == []
+
+
+def test_background_prefix_collision_is_portably_case_insensitive():
+    existing = Background(name="School", sprite_prefix="Scene")
+    manager = build_manager([existing])
+
+    message, _names = manager.add_background("City", "scene")
+
+    assert "已被背景组" in message

--- a/test/unit/config/test_character_manager.py
+++ b/test/unit/config/test_character_manager.py
@@ -1,7 +1,11 @@
 from types import SimpleNamespace
+from pathlib import Path
 
-from config.character_manager import CharacterManager
+import pytest
+
+from config.character_manager import CharacterManager, _voice_filename_for_sprite
 from config.schema import Character
+from core.paths import safe_path_component
 
 
 class FakeConfigManager:
@@ -16,14 +20,44 @@ class FakeConfigManager:
         self.save_count += 1
 
 
-def build_manager(characters):
+def build_manager(characters, project_root=None):
     manager = CharacterManager.__new__(CharacterManager)
     manager._config_manager = FakeConfigManager(characters)
+    manager._project_root = Path(project_root or Path.cwd()).resolve()
     return manager
 
 
 def sprite_field(sprite, key):
     return getattr(sprite, key, None) if hasattr(sprite, key) else sprite.get(key)
+
+
+def test_voice_filename_reserves_bytes_for_digest_and_extension():
+    filename = _voice_filename_for_sprite(
+        {"path": f"{'a' * 250}.png"},
+        0,
+        ".wav",
+    )
+
+    assert filename.startswith("voice_")
+    assert filename.endswith(".wav")
+    assert len(filename.encode("utf-8")) == 255
+    assert safe_path_component(filename) == filename
+
+
+def test_voice_filename_uses_portable_sprite_path_identity():
+    posix_name = _voice_filename_for_sprite(
+        {"path": "data/sprite/mika/idle.png"},
+        0,
+        ".wav",
+    )
+    windows_name = _voice_filename_for_sprite(
+        {"path": r"data\sprite\mika\idle.png"},
+        0,
+        ".wav",
+    )
+
+    assert windows_name == posix_name
+    assert windows_name.startswith("voice_idle_")
 
 
 def test_add_character_updates_existing_emotion_tags():
@@ -68,6 +102,25 @@ def test_add_character_applies_emotion_tags_to_new_character():
     assert manager._config_manager.save_count == 1
 
 
+def test_add_character_rejects_whitespace_retargeted_storage_prefix():
+    manager = build_manager([])
+
+    message, _names = manager.add_character(
+        "Mika",
+        "#66ccff",
+        " mika ",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "Quiet student.",
+    )
+
+    assert "目录名无效" in message
+    assert manager._config_manager.config.characters == []
+
+
 def test_add_character_creates_when_edit_target_is_missing():
     manager = build_manager([])
 
@@ -89,6 +142,38 @@ def test_add_character_creates_when_edit_target_is_missing():
     assert manager._config_manager.config.characters[0].name == "Sora"
     assert manager._config_manager.config.characters[0].emotion_tags == "Sprite 1: smile\n"
     assert manager._config_manager.save_count == 1
+
+
+def test_edit_character_cannot_detach_existing_paths_by_changing_storage_prefix(tmp_path):
+    asset = tmp_path / "data/sprite/mika/idle.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"image")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[{"path": "data/sprite/mika/idle.png"}],
+    )
+    manager = build_manager([character], tmp_path)
+
+    message, _names = manager.add_character(
+        "Mika",
+        "#66ccff",
+        "renamed",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "Quiet student.",
+        edit_as_name="Mika",
+    )
+
+    assert "不可直接修改" in message
+    assert character.sprite_prefix == "mika"
+    assert sprite_field(character.sprites[0], "path") == "data/sprite/mika/idle.png"
+    assert asset.read_bytes() == b"image"
+    assert manager._config_manager.save_count == 0
 
 
 def test_upload_voice_after_sprite_delete_does_not_overwrite_shifted_sprite_voice(tmp_path, monkeypatch):
@@ -114,7 +199,7 @@ def test_upload_voice_after_sprite_delete_does_not_overwrite_shifted_sprite_voic
             {"path": "data/sprite/mika/sprite-c.png", "voice_path": str(old_c), "voice_type": "preset"},
         ],
     )
-    manager = build_manager([character])
+    manager = build_manager([character], tmp_path)
 
     manager.delete_single_sprite("Mika", 0)
     _message, uploaded_path = manager.upload_voice("Mika", 1, str(new_c), "", "preset")
@@ -125,6 +210,7 @@ def test_upload_voice_after_sprite_delete_does_not_overwrite_shifted_sprite_voic
     assert sprite_field(character.sprites[1], "voice_path") == uploaded_path
     assert uploaded_path != str(old_b)
     assert "voice_01" not in uploaded_path
+    assert (tmp_path / uploaded_path).is_file()
     assert old_c.exists() is False
     assert old_a.exists() is False
     assert manager._config_manager.save_count == 2
@@ -150,12 +236,346 @@ def test_upload_voice_does_not_delete_original_voice_outside_character_voice_dir
             },
         ],
     )
-    manager = build_manager([character])
+    manager = build_manager([character], tmp_path)
 
     _message, uploaded_path = manager.upload_voice("Mika", 0, str(new_voice), "", "preset")
 
     assert external_voice.read_bytes() == b"external"
     assert uploaded_path
-    assert uploaded_path.startswith(str(voice_dir / "mika"))
+    assert (tmp_path / uploaded_path).is_file()
     assert sprite_field(character.sprites[0], "voice_path") == uploaded_path
     assert manager._config_manager.save_count == 1
+
+
+def test_delete_sprite_never_unlinks_external_config_path(tmp_path):
+    external_sprite = tmp_path / "external.png"
+    external_voice = tmp_path / "external.wav"
+    external_sprite.write_bytes(b"image")
+    external_voice.write_bytes(b"voice")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[
+            {
+                "path": external_sprite.as_posix(),
+                "voice_path": external_voice.as_posix(),
+            }
+        ],
+    )
+    manager = build_manager([character], tmp_path / "project")
+
+    manager.delete_single_sprite("Mika", 0)
+
+    assert external_sprite.read_bytes() == b"image"
+    assert external_voice.read_bytes() == b"voice"
+    assert character.sprites == []
+
+
+def test_delete_character_rejects_traversal_prefix_and_keeps_external_directory(tmp_path):
+    project_root = tmp_path / "project"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="../../outside",
+    )
+    manager = build_manager([character], project_root)
+
+    manager.delete_character("Mika")
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert manager._config_manager.config.characters == []
+
+
+def test_upload_sprites_never_overwrites_same_named_managed_file(tmp_path):
+    project = tmp_path / "project"
+    existing = project / "data/sprite/mika/idle.png"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"old")
+    source = tmp_path / "incoming/idle.png"
+    source.parent.mkdir()
+    source.write_bytes(b"new")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[{"path": "data/sprite/mika/idle.png"}],
+    )
+    manager = build_manager([character], project)
+
+    _message, paths, _tags = manager.upload_sprites(
+        "Mika",
+        [SimpleNamespace(name=source.as_posix())],
+        "",
+    )
+
+    assert existing.read_bytes() == b"old"
+    assert paths == [
+        "data/sprite/mika/idle.png",
+        "data/sprite/mika/idle_1.png",
+    ]
+    assert (project / paths[1]).read_bytes() == b"new"
+
+
+def test_upload_sprites_resolves_relative_source_from_project_not_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    source = project / "data/incoming/idle.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"project image")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+    character = Character(name="Mika", color="#66ccff", sprite_prefix="mika")
+    manager = build_manager([character], project)
+
+    _message, paths, _tags = manager.upload_sprites(
+        "Mika",
+        [SimpleNamespace(name="data/incoming/idle.png")],
+        "",
+    )
+
+    assert paths == ["data/sprite/mika/idle.png"]
+    assert (project / paths[0]).read_bytes() == b"project image"
+    assert not (unrelated / "data/sprite/mika/idle.png").exists()
+
+
+def test_upload_sprites_rejects_linked_source_directory(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "incoming"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    (external / "idle.png").write_bytes(b"external image")
+    try:
+        (project / "data/incoming").symlink_to(
+            external,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    character = Character(name="Mika", color="#66ccff", sprite_prefix="mika")
+    manager = build_manager([character], project)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        manager.upload_sprites(
+            "Mika",
+            [SimpleNamespace(name="data/incoming/idle.png")],
+            "",
+        )
+
+    assert character.sprites == []
+    assert not (project / "data/sprite/mika").exists()
+
+
+def test_upload_voice_resolves_relative_source_from_project_not_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    source = project / "data/incoming/line.wav"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"voice")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[{"path": "data/sprite/mika/idle.png"}],
+    )
+    manager = build_manager([character], project)
+
+    _message, stored = manager.upload_voice(
+        "Mika",
+        0,
+        "data/incoming/line.wav",
+        "",
+        "preset",
+    )
+
+    assert stored is not None
+    assert stored.startswith("data/speech/mika/")
+    assert (project / stored).read_bytes() == b"voice"
+    assert not (unrelated / "data/speech/mika").exists()
+
+
+def test_upload_voice_rejects_linked_source_directory(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "incoming"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    (external / "line.wav").write_bytes(b"external voice")
+    try:
+        (project / "data/incoming").symlink_to(
+            external,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[{"path": "data/sprite/mika/idle.png"}],
+    )
+    manager = build_manager([character], project)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        manager.upload_voice(
+            "Mika",
+            0,
+            "data/incoming/line.wav",
+            "",
+            "preset",
+        )
+
+    assert not (project / "data/speech/mika").exists()
+    assert sprite_field(character.sprites[0], "voice_path") in {None, ""}
+
+
+def test_upload_sprites_save_failure_rolls_back_memory_and_new_files(tmp_path):
+    project = tmp_path / "project"
+    source = tmp_path / "incoming/idle.png"
+    source.parent.mkdir()
+    source.write_bytes(b"new")
+    character = Character(name="Mika", color="#66ccff", sprite_prefix="mika")
+    manager = build_manager([character], project)
+    manager._config_manager.save_characters_config = lambda: (_ for _ in ()).throw(
+        OSError("disk full")
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        manager.upload_sprites(
+            "Mika",
+            [SimpleNamespace(name=source.as_posix())],
+            "",
+        )
+
+    assert character.sprites == []
+    assert character.emotion_tags == ""
+    assert not (project / "data/sprite/mika").exists()
+
+
+def test_delete_sprite_save_failure_keeps_reference_and_file(tmp_path):
+    project = tmp_path / "project"
+    sprite = project / "data/sprite/mika/idle.png"
+    sprite.parent.mkdir(parents=True)
+    sprite.write_bytes(b"image")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[{"path": "data/sprite/mika/idle.png"}],
+        emotion_tags="立绘 1：idle\n",
+    )
+    manager = build_manager([character], project)
+    manager._config_manager.save_characters_config = lambda: (_ for _ in ()).throw(
+        OSError("read only")
+    )
+
+    with pytest.raises(OSError, match="read only"):
+        manager.delete_single_sprite("Mika", 0)
+
+    assert sprite.read_bytes() == b"image"
+    assert sprite_field(character.sprites[0], "path") == "data/sprite/mika/idle.png"
+    assert character.emotion_tags == "立绘 1：idle\n"
+
+
+def test_delete_sprite_preserves_file_replaced_during_config_save(tmp_path):
+    project = tmp_path / "project"
+    sprite = project / "data/sprite/mika/idle.png"
+    preserved = project / "data/sprite/mika/original-idle.png"
+    sprite.parent.mkdir(parents=True)
+    sprite.write_bytes(b"original")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+        sprites=[{"path": "data/sprite/mika/idle.png"}],
+    )
+    manager = build_manager([character], project)
+
+    def replace_during_save():
+        sprite.rename(preserved)
+        sprite.write_bytes(b"peer")
+
+    manager._config_manager.save_characters_config = replace_during_save
+
+    manager.delete_single_sprite("Mika", 0)
+
+    assert sprite.read_bytes() == b"peer"
+    assert preserved.read_bytes() == b"original"
+    assert character.sprites == []
+
+
+def test_delete_character_preserves_directory_replaced_during_config_save(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    sprite_dir = project / "data/sprite/mika"
+    preserved = project / "data/sprite/preserved-mika"
+    sprite_dir.mkdir(parents=True)
+    (sprite_dir / "idle.png").write_bytes(b"original")
+    character = Character(
+        name="Mika",
+        color="#66ccff",
+        sprite_prefix="mika",
+    )
+    manager = build_manager([character], project)
+
+    def replace_during_save():
+        sprite_dir.rename(preserved)
+        sprite_dir.mkdir()
+        (sprite_dir / "peer.png").write_bytes(b"peer")
+
+    manager._config_manager.save_characters_config = replace_during_save
+
+    manager.delete_character("Mika")
+
+    assert (sprite_dir / "peer.png").read_bytes() == b"peer"
+    assert (preserved / "idle.png").read_bytes() == b"original"
+    assert manager._config_manager.config.characters == []
+
+
+def test_delete_sprite_keeps_file_still_referenced_by_legacy_character(tmp_path):
+    project = tmp_path / "project"
+    sprite = project / "data/sprite/shared/idle.png"
+    sprite.parent.mkdir(parents=True)
+    sprite.write_bytes(b"image")
+    first = Character(
+        name="First",
+        color="#fff",
+        sprite_prefix="shared",
+        sprites=[{"path": "data/sprite/shared/idle.png"}],
+    )
+    second = Character(
+        name="Second",
+        color="#000",
+        sprite_prefix="shared",
+        sprites=[{"path": "data/sprite/shared/idle.png"}],
+    )
+    manager = build_manager([first, second], project)
+
+    manager.delete_single_sprite("First", 0)
+
+    assert sprite.read_bytes() == b"image"
+    assert first.sprites == []
+    assert sprite_field(second.sprites[0], "path") == "data/sprite/shared/idle.png"
+
+
+def test_character_prefix_collision_is_portably_case_insensitive():
+    existing = Character(name="Mika", color="#fff", sprite_prefix="Mika")
+    manager = build_manager([existing])
+
+    message, _names = manager.add_character(
+        "Other", "#000", "mika", "", "", "", "", "", ""
+    )
+
+    assert "已被角色" in message

--- a/test/unit/config/test_mirror_env.py
+++ b/test/unit/config/test_mirror_env.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import logging
 
+import pytest
+
 from config.mirror_env import (
     DEFAULT_GITHUB_MIRROR_URL,
     DEFAULT_HUGGINGFACE_CACHE_DIR,
@@ -105,6 +107,97 @@ def test_apply_mirror_environment_manual_values_override_region(monkeypatch, tmp
     )
 
 
+def test_apply_mirror_environment_uses_explicit_config_owner_root(
+    monkeypatch,
+    tmp_path,
+):
+    _clear_mirror_env(monkeypatch)
+    ambient_root = tmp_path / "ambient-project"
+    config_root = tmp_path / "selected-project"
+    ambient_root.mkdir()
+    config_root.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient_root.as_posix())
+
+    apply_mirror_environment(
+        SystemConfig(
+            huggingface_cache_dir="data/cache/huggingface",
+            mirror_auto_detect_china=False,
+        ),
+        root=config_root,
+    )
+
+    assert os.environ["HF_HOME"] == (
+        config_root / "data/cache/huggingface"
+    ).as_posix()
+    assert not (ambient_root / "data/cache/huggingface").exists()
+
+
+def test_relative_huggingface_cache_cannot_escape_project_root(monkeypatch, tmp_path):
+    _clear_mirror_env(monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        apply_mirror_environment(
+            SystemConfig(
+                huggingface_cache_dir="../external-cache",
+                mirror_auto_detect_china=False,
+            )
+        )
+
+
+def test_absolute_project_cache_path_rejects_internal_symlink_alias(monkeypatch, tmp_path):
+    _clear_mirror_env(monkeypatch)
+    project = tmp_path / "project"
+    data = project / "data"
+    alternate = project / "alternate-cache"
+    data.mkdir(parents=True)
+    alternate.mkdir()
+    try:
+        (data / "cache").symlink_to(alternate, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        apply_mirror_environment(
+            SystemConfig(
+                huggingface_cache_dir=(data / "cache/huggingface").as_posix(),
+                mirror_auto_detect_china=False,
+            )
+        )
+
+    assert list(alternate.iterdir()) == []
+
+
+def test_project_cache_rejects_linked_hub_child_before_exporting_environment(
+    monkeypatch,
+    tmp_path,
+):
+    _clear_mirror_env(monkeypatch)
+    project = tmp_path / "project"
+    cache = project / "data" / "cache" / "huggingface"
+    external = tmp_path / "external-hub"
+    cache.mkdir(parents=True)
+    external.mkdir()
+    try:
+        (cache / "hub").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        apply_mirror_environment(
+            SystemConfig(
+                huggingface_cache_dir="data/cache/huggingface",
+                mirror_auto_detect_china=False,
+            )
+        )
+
+    assert list(external.iterdir()) == []
+
+
 def test_apply_mirror_environment_from_system_config_reads_yaml(monkeypatch, tmp_path):
     _clear_mirror_env(monkeypatch)
     config_path = tmp_path / "system_config.yaml"
@@ -129,6 +222,56 @@ def test_apply_mirror_environment_from_system_config_reads_yaml(monkeypatch, tmp
     assert os.environ["HF_HOME"] == cache_dir.as_posix()
     assert os.environ["SHINSEKAI_GITHUB_MIRROR_URL"] == "https://mirror.example/{url}"
     assert os.environ["SHINSEKAI_PIP_INDEX_URL"] == "https://pypi.example/simple"
+
+
+def test_config_reader_anchors_relative_cache_to_explicit_project_root(
+    monkeypatch,
+    tmp_path,
+):
+    _clear_mirror_env(monkeypatch)
+    ambient_root = tmp_path / "ambient-project"
+    selected_root = tmp_path / "selected-project"
+    config_path = selected_root / "data/config/system_config.yaml"
+    ambient_root.mkdir()
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "mirror_auto_detect_china: false\n"
+        "huggingface_cache_dir: data/cache/huggingface\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient_root.as_posix())
+
+    apply_mirror_environment_from_system_config(root=selected_root)
+
+    assert os.environ["HF_HOME"] == (
+        selected_root / "data/cache/huggingface"
+    ).as_posix()
+    assert not (ambient_root / "data/cache/huggingface").exists()
+
+
+def test_mirror_config_reader_does_not_follow_symlink(monkeypatch, tmp_path):
+    _clear_mirror_env(monkeypatch)
+    config_path = tmp_path / "system_config.yaml"
+    config_path.write_text(
+        "mirror_auto_detect_china: false\n"
+        "huggingface_mirror_url: https://hf.example\n",
+        encoding="utf-8",
+    )
+    alias = tmp_path / "system_config_alias.yaml"
+    try:
+        alias.symlink_to(config_path)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        apply_mirror_environment_from_system_config(alias)
+
+
+def test_explicit_empty_mirror_config_path_does_not_fall_back(monkeypatch):
+    _clear_mirror_env(monkeypatch)
+
+    with pytest.raises(ValueError, match="path is empty"):
+        apply_mirror_environment_from_system_config("")
 
 
 def test_apply_mirror_environment_does_not_override_standard_pip_env(monkeypatch):

--- a/test/unit/config/test_network_proxy_env.py
+++ b/test/unit/config/test_network_proxy_env.py
@@ -190,6 +190,31 @@ def test_apply_network_proxy_environment_from_system_config_reads_yaml(monkeypat
     assert os.environ["ALL_PROXY"] == "socks5h://127.0.0.1:7891"
 
 
+def test_network_proxy_config_reader_does_not_follow_symlink(monkeypatch, tmp_path):
+    _clear_proxy_env(monkeypatch)
+    config_path = tmp_path / "system_config.yaml"
+    config_path.write_text(
+        "network_proxy_enabled: true\n"
+        "http_proxy_url: http://127.0.0.1:7890\n",
+        encoding="utf-8",
+    )
+    alias = tmp_path / "system_config_alias.yaml"
+    try:
+        alias.symlink_to(config_path)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        apply_network_proxy_environment_from_system_config(alias)
+
+
+def test_explicit_empty_network_proxy_config_path_does_not_fall_back(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+
+    with pytest.raises(ValueError, match="path is empty"):
+        apply_network_proxy_environment_from_system_config("")
+
+
 def test_detect_network_proxy_configuration_prefers_original_environment(monkeypatch):
     _clear_proxy_env(monkeypatch)
     monkeypatch.setattr(network_proxy.platform_module, "system", lambda: "UnknownOS")

--- a/test/unit/config/test_schema.py
+++ b/test/unit/config/test_schema.py
@@ -35,6 +35,19 @@ class TestSprite:
         with pytest.raises(ValidationError):
             Sprite()
 
+    def test_missing_asset_references_do_not_invalidate_the_config(self, tmp_path, monkeypatch):
+        unrelated = tmp_path / "unrelated-cwd"
+        unrelated.mkdir()
+        monkeypatch.chdir(unrelated)
+
+        sprite = Sprite(
+            path="data/sprite/offline/idle.png",
+            voice_path="data/speech/offline/idle.wav",
+        )
+
+        assert sprite.path == "data/sprite/offline/idle.png"
+        assert sprite.voice_path == "data/speech/offline/idle.wav"
+
 
 class TestCharacter:
     def test_minimal_character(self):

--- a/test/unit/config/test_tts_provider_config.py
+++ b/test/unit/config/test_tts_provider_config.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from config import tts_provider_config
+from config.tts_provider_config import default_tts_work_path, installed_tts_bundles_path
+
+
+def test_installed_tts_bundle_is_resolved_from_project_root_not_cwd(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    bundle = project / "data/tts_bundles/installed/gpt_sovits_v2pro"
+    unrelated = tmp_path / "unrelated"
+    bundle.mkdir(parents=True)
+    unrelated.mkdir()
+    (bundle / "api_v2.py").write_text("", encoding="utf-8")
+    monkeypatch.chdir(unrelated)
+
+    assert installed_tts_bundles_path("gpt-sovits", project) == bundle.as_posix()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation differs on Windows")
+def test_installed_tts_bundle_ignores_symlinked_managed_storage(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    (project / "data").mkdir(parents=True)
+    bundle = external / "installed/gpt_sovits_v2pro"
+    bundle.mkdir(parents=True)
+    (bundle / "api_v2.py").write_text("", encoding="utf-8")
+    (project / "data/tts_bundles").symlink_to(external, target_is_directory=True)
+
+    assert installed_tts_bundles_path("gpt-sovits", project) == ""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation differs on Windows")
+def test_installed_tts_bundle_ignores_symlinked_inner_bundle_root(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external-engine"
+    bundle = project / "data/tts_bundles/installed/gpt_sovits_v2pro"
+    bundle.mkdir(parents=True)
+    external.mkdir()
+    (external / "api_v2.py").write_text("", encoding="utf-8")
+    (bundle / "engine").symlink_to(external, target_is_directory=True)
+
+    assert installed_tts_bundles_path("gpt-sovits", project) == ""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation differs on Windows")
+def test_installed_tts_bundle_ignores_symlinked_required_file(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external-api.py"
+    bundle = project / "data/tts_bundles/installed/gpt_sovits_v2pro"
+    bundle.mkdir(parents=True)
+    external.write_text("", encoding="utf-8")
+    (bundle / "api_v2.py").symlink_to(external)
+
+    assert installed_tts_bundles_path("gpt-sovits", project) == ""
+
+
+def test_installed_tts_bundle_rejects_replaced_root_after_inventory(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    bundle = project / "data/tts_bundles/installed/gpt_sovits_v2pro"
+    preserved = bundle.with_name("gpt_sovits_v2pro-preserved")
+    bundle.mkdir(parents=True)
+    (bundle / "api_v2.py").write_text("original", encoding="utf-8")
+    real_inventory = (
+        tts_provider_config.inspect_portable_directory_tree_with_metadata
+    )
+    replaced = False
+
+    def inventory_then_replace(path):
+        nonlocal replaced
+        result = real_inventory(path)
+        if Path(path) == bundle and not replaced:
+            replaced = True
+            bundle.rename(preserved)
+            bundle.mkdir()
+            (bundle / "api_v2.py").write_text("peer", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(
+        tts_provider_config,
+        "inspect_portable_directory_tree_with_metadata",
+        inventory_then_replace,
+    )
+
+    assert installed_tts_bundles_path("gpt-sovits", project) == ""
+    assert (bundle / "api_v2.py").read_text(encoding="utf-8") == "peer"
+    assert (preserved / "api_v2.py").read_text(encoding="utf-8") == "original"
+
+
+def test_tts_bundle_lookup_rejects_ambiguous_project_root(tmp_path):
+    with pytest.raises(ValueError, match="project root"):
+        installed_tts_bundles_path("gpt-sovits", f" {tmp_path}")
+
+
+def test_default_tts_work_path_does_not_silently_trim_a_different_path():
+    with pytest.raises(ValueError, match="non-portable"):
+        default_tts_work_path("gpt-sovits", " data/tts_bundles/engine")

--- a/test/unit/core/media/test_auto_annotation.py
+++ b/test/unit/core/media/test_auto_annotation.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from core.media import auto_annotation
 from core.media.asset_tags import normalize_generated_tags, tag_contents
 from core.media.auto_annotation import auto_label_background_images, auto_label_character_sprites
 
@@ -90,6 +91,41 @@ def test_background_auto_label_reports_invalid_asset_without_overwriting(tmp_pat
     assert background.bg_tags == ""
 
 
+def test_default_vision_runtime_receives_annotation_project_root(
+    tmp_path: Path,
+    monkeypatch,
+):
+    character = SimpleNamespace(
+        name="Nanami",
+        sprites=[SimpleNamespace(path=_image(tmp_path, "one.png"))],
+        emotion_tags="",
+    )
+    config = FakeConfigManager(character=character)
+    captured = {}
+
+    class FakeVisionManager:
+        def __init__(self, provider, *, root):
+            captured["provider"] = provider
+            captured["root"] = root
+
+        def describe(self, _image, _prompt):
+            return "smiling"
+
+    monkeypatch.setattr(auto_annotation, "VisionManager", FakeVisionManager)
+
+    result = auto_label_character_sprites(
+        config,
+        "Nanami",
+        project_root=tmp_path,
+    )
+
+    assert result["annotatedCount"] == 1
+    assert captured == {
+        "provider": "moondream",
+        "root": tmp_path,
+    }
+
+
 def test_inference_runtime_errors_abort_without_saving(tmp_path: Path):
     character = SimpleNamespace(
         name="Nanami",
@@ -125,6 +161,160 @@ def test_asset_paths_cannot_escape_the_project_root(tmp_path: Path):
     assert result["failedCount"] == 1
     assert "项目目录" in result["failures"][0]["message"]
     assert config.character_saves == 0
+
+
+def test_immutable_application_asset_can_be_annotated(
+    tmp_path: Path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    image = source / "assets" / "present_example.png"
+    image.parent.mkdir(parents=True)
+    project.mkdir()
+    image.write_bytes(b"image")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    character = SimpleNamespace(
+        name="Example",
+        sprites=[SimpleNamespace(path="assets/present_example.png")],
+        emotion_tags="",
+    )
+    config = FakeConfigManager(character=character)
+
+    result = auto_label_character_sprites(
+        config,
+        "Example",
+        project_root=project,
+        infer=lambda payload, _prompt: "example" if payload == b"image" else "",
+    )
+
+    assert result["annotatedCount"] == 1
+    assert config.character_saves == 1
+
+
+def test_immutable_application_asset_does_not_follow_symlink(
+    tmp_path: Path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    (source / "assets").mkdir(parents=True)
+    project.mkdir()
+    external.mkdir()
+    (external / "present.png").write_bytes(b"image")
+    try:
+        (source / "assets/linked").symlink_to(
+            external,
+            target_is_directory=True,
+        )
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    character = SimpleNamespace(
+        name="Example",
+        sprites=[SimpleNamespace(path="assets/linked/present.png")],
+        emotion_tags="",
+    )
+    config = FakeConfigManager(character=character)
+
+    result = auto_label_character_sprites(
+        config,
+        "Example",
+        project_root=project,
+        infer=lambda _payload, _prompt: pytest.fail("linked resource must not be read"),
+    )
+
+    assert result["annotatedCount"] == 0
+    assert result["failedCount"] == 1
+    assert config.character_saves == 0
+
+
+def test_asset_paths_are_not_silently_trimmed(tmp_path: Path):
+    image = _image(tmp_path, "one.png")
+    character = SimpleNamespace(
+        name="Nanami",
+        sprites=[SimpleNamespace(path=f" {image}")],
+        emotion_tags="",
+    )
+    config = FakeConfigManager(character=character)
+
+    result = auto_label_character_sprites(
+        config,
+        "Nanami",
+        project_root=tmp_path,
+        infer=lambda _image, _prompt: pytest.fail("ambiguous path must not be read"),
+    )
+
+    assert result["failedCount"] == 1
+    assert "路径无效" in result["failures"][0]["message"]
+
+
+def test_asset_paths_cannot_read_through_project_symlinks(tmp_path: Path):
+    external = tmp_path.parent / f"external-{tmp_path.name}"
+    external.mkdir()
+    (external / "one.png").write_bytes(b"image")
+    try:
+        (tmp_path / "alias").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+    character = SimpleNamespace(
+        name="Nanami",
+        sprites=[SimpleNamespace(path="alias/one.png")],
+        emotion_tags="",
+    )
+    config = FakeConfigManager(character=character)
+
+    result = auto_label_character_sprites(
+        config,
+        "Nanami",
+        project_root=tmp_path,
+        infer=lambda _image, _prompt: pytest.fail("linked image must not be read"),
+    )
+
+    assert result["failedCount"] == 1
+    assert "项目目录" in result["failures"][0]["message"]
+
+
+def test_auto_annotation_rejects_image_changed_after_path_validation(
+    tmp_path: Path,
+    monkeypatch,
+):
+    image_path = tmp_path / "one.png"
+    image_path.write_bytes(b"approved")
+    character = SimpleNamespace(
+        name="Nanami",
+        sprites=[SimpleNamespace(path=image_path.name)],
+        emotion_tags="",
+    )
+    config = FakeConfigManager(character=character)
+    real_safe_asset = auto_annotation._safe_asset_file
+
+    def resolve_then_change(*args, **kwargs):
+        resolved = real_safe_asset(*args, **kwargs)
+        image_path.write_bytes(b"replacement-is-longer")
+        return resolved
+
+    monkeypatch.setattr(
+        auto_annotation,
+        "_safe_asset_file",
+        resolve_then_change,
+    )
+
+    result = auto_label_character_sprites(
+        config,
+        "Nanami",
+        project_root=tmp_path,
+        infer=lambda _payload, _prompt: pytest.fail(
+            "changed image must not reach inference"
+        ),
+    )
+
+    assert result["annotatedCount"] == 0
+    assert result["failedCount"] == 1
+    assert "identity changed" in result["failures"][0]["message"]
 
 
 def test_normalize_generated_tags_removes_wrappers():

--- a/test/unit/core/media/test_chat_attachments.py
+++ b/test/unit/core/media/test_chat_attachments.py
@@ -23,9 +23,13 @@ def clear_attachment_root_cache():
     _chat_attachment_root.cache_clear()
 
 
-def test_resolve_chat_attachments_derives_trusted_metadata_and_deduplicates(tmp_path: Path):
+def test_resolve_chat_attachments_derives_trusted_metadata_and_deduplicates(
+    tmp_path: Path,
+    monkeypatch,
+):
     image = tmp_path / "scene.png"
     image.write_bytes(b"png")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, tmp_path.as_posix())
 
     attachments = resolve_chat_attachments(
         [
@@ -38,16 +42,63 @@ def test_resolve_chat_attachments_derives_trusted_metadata_and_deduplicates(tmp_
     assert attachments[0].name == "scene.png"
     assert attachments[0].mime_type == "image/png"
     assert attachments[0].path == image.resolve()
+    assert attachments[0].to_payload()["path"] == "scene.png"
 
 
-def test_resolve_chat_attachments_rejects_relative_and_non_image_paths(tmp_path: Path):
+def test_resolve_chat_attachments_accepts_portable_relative_paths(
+    tmp_path: Path,
+    monkeypatch,
+):
     text_file = tmp_path / "notes.txt"
     text_file.write_text("notes", encoding="utf-8")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, tmp_path.as_posix())
 
-    with pytest.raises(ValueError, match="absolute"):
-        resolve_chat_attachments([{"kind": "file", "path": "notes.txt"}])
+    attachment = resolve_chat_attachments(
+        [{"kind": "file", "path": "notes.txt"}]
+    )[0]
+
+    assert attachment.path == text_file
+    assert attachment.to_payload()["path"] == "notes.txt"
     with pytest.raises(ValueError, match="Unsupported chat image type"):
         resolve_chat_attachments([{"kind": "image", "path": str(text_file)}])
+
+
+def test_relative_attachment_reference_survives_project_move(tmp_path: Path):
+    key = "0123456789abcdef0123456789abcdef"
+    old_path = tmp_path / "old/data/chat_attachments" / key / "notes.txt"
+    new_root = tmp_path / "new/data/chat_attachments"
+    new_path = new_root / key / "notes.txt"
+    new_path.parent.mkdir(parents=True)
+    new_path.write_text("migrated", encoding="utf-8")
+
+    attachment = resolve_chat_attachments(
+        [{"kind": "file", "path": old_path.as_posix()}],
+        root=new_root,
+    )[0]
+
+    assert attachment.path == new_path
+    assert attachment.to_payload()["path"] == f"{key}/notes.txt"
+
+
+def test_attachment_paths_do_not_expand_user_home_aliases(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, "~/attachments")
+
+    with pytest.raises(ValueError, match="absolute"):
+        resolve_chat_attachments([{"kind": "file", "path": "~/notes.txt"}])
+    with pytest.raises(ValueError, match="absolute"):
+        stage_uploaded_chat_attachments(["~/upload.txt"], project_root=tmp_path)
+
+
+def test_resolve_chat_attachments_rejects_outer_whitespace_without_retargeting(
+    tmp_path: Path,
+    monkeypatch,
+):
+    document = tmp_path / "notes.txt"
+    document.write_text("notes", encoding="utf-8")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, tmp_path.as_posix())
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        resolve_chat_attachments([{"kind": "file", "path": f" {document}"}])
 
 
 def test_resolve_chat_attachments_rejects_explicit_traversal_segments(tmp_path: Path):
@@ -81,6 +132,46 @@ def test_resolve_chat_attachments_requires_configured_root(tmp_path: Path, monke
         resolve_chat_attachments([{"kind": "file", "path": str(document)}])
 
 
+def test_resolve_chat_attachments_rejects_linked_configured_root(
+    tmp_path: Path,
+    monkeypatch,
+):
+    real_root = tmp_path / "real-root"
+    root_alias = tmp_path / "root-alias"
+    real_root.mkdir()
+    document = real_root / "notes.txt"
+    document.write_text("notes", encoding="utf-8")
+    try:
+        root_alias.symlink_to(real_root, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, root_alias.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_chat_attachments([{"kind": "file", "path": document.as_posix()}])
+
+
+def test_resolve_chat_attachments_rejects_linked_selected_file(
+    tmp_path: Path,
+    monkeypatch,
+):
+    root = tmp_path / "allowed"
+    root.mkdir()
+    real_document = root / "real-notes.txt"
+    document_alias = root / "notes.txt"
+    real_document.write_text("notes", encoding="utf-8")
+    try:
+        document_alias.symlink_to(real_document)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, root.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_chat_attachments(
+            [{"kind": "file", "path": document_alias.as_posix()}]
+        )
+
+
 def test_chat_attachment_display_uses_trusted_file_name(tmp_path: Path):
     document = tmp_path / "story.txt"
     document.write_text("Once upon a time", encoding="utf-8")
@@ -107,6 +198,45 @@ def test_stage_uploaded_attachments_rejects_count_before_copying(tmp_path: Path,
     assert not root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR).exists()
 
 
+def test_stage_uploaded_attachments_rejects_source_alias_before_copying(
+    tmp_path: Path,
+    monkeypatch,
+):
+    root = tmp_path / "project"
+    upload = tmp_path / "uploads/note.txt"
+    root.mkdir()
+    upload.parent.mkdir()
+    upload.write_text("note", encoding="utf-8")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, str(root))
+    alias = f"{upload.parent.as_posix()}/./{upload.name}"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        stage_uploaded_chat_attachments([alias])
+
+    assert not root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR).exists()
+
+
+def test_stage_uploaded_attachments_rejects_source_symlink_before_copying(
+    tmp_path: Path,
+    monkeypatch,
+):
+    root = tmp_path / "project"
+    external = tmp_path / "external.txt"
+    alias = tmp_path / "upload.txt"
+    root.mkdir()
+    external.write_text("secret", encoding="utf-8")
+    try:
+        alias.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, str(root))
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        stage_uploaded_chat_attachments([alias])
+
+    assert not root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR).exists()
+
+
 def test_stage_uploaded_attachments_copies_validated_batch_inside_allowed_root(
     tmp_path: Path,
     monkeypatch,
@@ -122,7 +252,8 @@ def test_stage_uploaded_attachments_copies_validated_batch_inside_allowed_root(
     monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, str(root))
 
     payloads = stage_uploaded_chat_attachments([image, document])
-    resolved = resolve_chat_attachments(payloads)
+    stage_root = root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR)
+    resolved = resolve_chat_attachments(payloads, root=stage_root)
 
     assert [attachment.kind for attachment in resolved] == ["image", "file"]
     assert [attachment.name for attachment in resolved] == ["scene.png", "notes.txt"]
@@ -150,6 +281,74 @@ def test_stage_uploaded_attachments_rejects_aggregate_size_before_copying(
     assert not root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR).exists()
 
 
+def test_stage_uploaded_attachments_rechecks_copied_size_before_publication(
+    tmp_path: Path,
+    monkeypatch,
+):
+    root = tmp_path / "project"
+    upload = tmp_path / "uploads" / "growing.txt"
+    root.mkdir()
+    upload.parent.mkdir()
+    upload.write_bytes(b"x")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, str(root))
+    monkeypatch.setattr(chat_attachments, "MAX_CHAT_ATTACHMENT_BYTES", 5)
+
+    def copy_grown_file(_source, directory, requested_name, **_kwargs):
+        destination = Path(directory) / requested_name
+        destination.write_bytes(b"123456")
+        return destination, destination.lstat()
+
+    monkeypatch.setattr(
+        chat_attachments,
+        "copy_file_exclusive_with_identity",
+        copy_grown_file,
+    )
+
+    with pytest.raises(ValueError, match="too large"):
+        stage_uploaded_chat_attachments([upload])
+
+    stage_root = root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR)
+    assert stage_root.is_dir()
+    assert list(stage_root.iterdir()) == []
+
+
+def test_stage_uploaded_attachments_rejects_source_changed_after_validation(
+    tmp_path: Path,
+    monkeypatch,
+):
+    root = tmp_path / "project"
+    upload = tmp_path / "uploads" / "changing.txt"
+    root.mkdir()
+    upload.parent.mkdir()
+    upload.write_text("approved", encoding="utf-8")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, str(root))
+    real_copy = chat_attachments.copy_file_exclusive_with_identity
+    changed = False
+
+    def change_before_copy(source, *args, **kwargs):
+        nonlocal changed
+        if not changed:
+            changed = True
+            Path(source).write_text(
+                "replacement-is-longer",
+                encoding="utf-8",
+            )
+        return real_copy(source, *args, **kwargs)
+
+    monkeypatch.setattr(
+        chat_attachments,
+        "copy_file_exclusive_with_identity",
+        change_before_copy,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        stage_uploaded_chat_attachments([upload])
+
+    stage_root = root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR)
+    assert stage_root.is_dir()
+    assert list(stage_root.iterdir()) == []
+
+
 def test_stage_uploaded_attachments_rolls_back_partial_copy(tmp_path: Path, monkeypatch):
     root = tmp_path / "project"
     uploads = tmp_path / "uploads"
@@ -160,17 +359,21 @@ def test_stage_uploaded_attachments_rolls_back_partial_copy(tmp_path: Path, monk
     first.write_text("first", encoding="utf-8")
     second.write_text("second", encoding="utf-8")
     monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, str(root))
-    real_copy = chat_attachments.shutil.copyfile
+    real_copy = chat_attachments.copy_file_exclusive_with_identity
     copy_count = 0
 
-    def fail_second_copy(source, destination):
+    def fail_second_copy(*args, **kwargs):
         nonlocal copy_count
         copy_count += 1
         if copy_count == 2:
             raise OSError("copy failed")
-        return real_copy(source, destination)
+        return real_copy(*args, **kwargs)
 
-    monkeypatch.setattr(chat_attachments.shutil, "copyfile", fail_second_copy)
+    monkeypatch.setattr(
+        chat_attachments,
+        "copy_file_exclusive_with_identity",
+        fail_second_copy,
+    )
 
     with pytest.raises(OSError, match="copy failed"):
         stage_uploaded_chat_attachments([first, second])
@@ -178,3 +381,84 @@ def test_stage_uploaded_attachments_rolls_back_partial_copy(tmp_path: Path, monk
     stage_root = root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR)
     assert stage_root.is_dir()
     assert list(stage_root.iterdir()) == []
+
+
+def test_explicit_project_root_overrides_stale_attachment_environment(tmp_path: Path, monkeypatch):
+    stale_root = tmp_path / "stale"
+    selected_root = tmp_path / "selected"
+    upload = tmp_path / "note.txt"
+    stale_root.mkdir()
+    selected_root.mkdir()
+    upload.write_text("note", encoding="utf-8")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, str(stale_root))
+
+    payloads = stage_uploaded_chat_attachments([upload], project_root=selected_root)
+
+    relative = Path(str(payloads[0]["path"]))
+    assert not relative.is_absolute()
+    assert (
+        selected_root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR, relative).read_text(
+            encoding="utf-8"
+        )
+        == "note"
+    )
+    assert not stale_root.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR).exists()
+
+
+def test_relative_attachment_root_environment_is_rejected(tmp_path: Path, monkeypatch):
+    upload = tmp_path / "note.txt"
+    upload.write_text("note", encoding="utf-8")
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, "relative-root")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="absolute"):
+        stage_uploaded_chat_attachments([upload])
+
+    assert not (tmp_path / "relative-root").exists()
+
+
+def test_attachment_paths_reject_lexical_aliases_before_resolution(
+    tmp_path: Path,
+    monkeypatch,
+):
+    root = tmp_path / "allowed"
+    root.mkdir()
+    document = root / "note.txt"
+    document.write_text("note", encoding="utf-8")
+
+    monkeypatch.setenv(
+        CHAT_ATTACHMENTS_ROOT_ENV,
+        f"{tmp_path.as_posix()}/./allowed",
+    )
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        resolve_chat_attachments([{"kind": "file", "path": document.as_posix()}])
+
+    _chat_attachment_root.cache_clear()
+    monkeypatch.setenv(CHAT_ATTACHMENTS_ROOT_ENV, root.as_posix())
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        resolve_chat_attachments(
+            [{"kind": "file", "path": f"{root.as_posix()}//note.txt"}]
+        )
+
+
+def test_attachment_stage_symlink_cannot_escape_project(tmp_path: Path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    upload = tmp_path / "note.txt"
+    project.joinpath("data").mkdir(parents=True)
+    external.mkdir()
+    marker = external / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    upload.write_text("note", encoding="utf-8")
+    try:
+        project.joinpath(*CHAT_ATTACHMENT_STAGE_SUBDIR).symlink_to(
+            external,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        stage_uploaded_chat_attachments([upload], project_root=project)
+
+    assert marker.read_text(encoding="utf-8") == "keep"

--- a/test/unit/core/media/test_media_snapshots.py
+++ b/test/unit/core/media/test_media_snapshots.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from core.media import snapshots as media_snapshots
+
+
+def test_runtime_media_snapshot_reads_exact_bytes_without_cwd_lookup(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    media = project / "data" / "audio" / "声音.ogg"
+    media.parent.mkdir(parents=True)
+    unrelated.mkdir()
+    media.write_bytes(b"approved-media")
+    monkeypatch.chdir(unrelated)
+
+    snapshot = media_snapshots.capture_runtime_media(
+        "data/audio/声音.ogg",
+        root=project,
+    )
+
+    assert snapshot.path == media
+    assert snapshot.payload == b"approved-media"
+
+
+def test_runtime_media_snapshot_rejects_linked_input(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external.ogg"
+    alias = project / "data" / "audio" / "alias.ogg"
+    alias.parent.mkdir(parents=True)
+    external.write_bytes(b"external")
+    try:
+        alias.symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        media_snapshots.capture_runtime_media(
+            "data/audio/alias.ogg",
+            root=project,
+        )
+
+
+def test_runtime_media_snapshot_rejects_parent_replacement_after_read(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    media_parent = project / "data" / "audio"
+    preserved_parent = project / "data" / "preserved-audio"
+    media = media_parent / "voice.wav"
+    media_parent.mkdir(parents=True)
+    media.write_bytes(b"approved")
+    real_read = media_snapshots.read_bytes_snapshot_without_links
+
+    def replace_parent(path, **kwargs):
+        result = real_read(path, **kwargs)
+        media_parent.rename(preserved_parent)
+        media_parent.mkdir()
+        (media_parent / "voice.wav").write_bytes(b"replacement")
+        return result
+
+    monkeypatch.setattr(
+        media_snapshots,
+        "read_bytes_snapshot_without_links",
+        replace_parent,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        media_snapshots.capture_runtime_media(
+            "data/audio/voice.wav",
+            root=project,
+        )

--- a/test/unit/core/model_assets/test_service.py
+++ b/test/unit/core/model_assets/test_service.py
@@ -112,6 +112,72 @@ def test_inspect_local_model_reports_existing_and_missing_directories(tmp_path):
     assert missing["downloadable"] is False
 
 
+def test_snapshot_readiness_allows_only_bounded_huggingface_file_links(tmp_path):
+    cache_root = tmp_path / "hub"
+    snapshot = cache_root / "models--owner--model" / "snapshots" / "revision"
+    blobs = cache_root / "blobs"
+    snapshot.mkdir(parents=True)
+    blobs.mkdir(parents=True)
+    for name in ("config.json", "model.bin", "tokenizer.json"):
+        target = blobs / name
+        target.write_text(name, encoding="utf-8")
+        try:
+            (snapshot / name).symlink_to(target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symbolic links are unavailable")
+
+    assert service._snapshot_is_complete(
+        snapshot,
+        _spec().required_file_groups,
+        allowed_link_root=cache_root,
+    )
+
+    outside = tmp_path / "outside-model.bin"
+    outside.write_bytes(b"outside")
+    (snapshot / "model.bin").unlink()
+    (snapshot / "model.bin").symlink_to(outside)
+
+    assert not service._snapshot_is_complete(
+        snapshot,
+        _spec().required_file_groups,
+        allowed_link_root=cache_root,
+    )
+
+
+def test_snapshot_readiness_rejects_replaced_directory(
+    tmp_path,
+    monkeypatch,
+):
+    snapshot = tmp_path / "snapshot"
+    preserved = tmp_path / "snapshot-preserved"
+    _write_complete_snapshot(snapshot)
+    real_snapshot = service.snapshot_directory_entries_without_links
+    replaced = False
+
+    def replace_after_inventory(path, **kwargs):
+        nonlocal replaced
+        result = real_snapshot(path, **kwargs)
+        if Path(path) == snapshot and not replaced:
+            replaced = True
+            snapshot.rename(preserved)
+            _write_complete_snapshot(snapshot)
+        return result
+
+    monkeypatch.setattr(
+        service,
+        "snapshot_directory_entries_without_links",
+        replace_after_inventory,
+    )
+
+    assert not service._snapshot_is_complete(
+        snapshot,
+        _spec().required_file_groups,
+        allowed_link_root=tmp_path,
+    )
+    assert (snapshot / "model.bin").is_file()
+    assert (preserved / "model.bin").is_file()
+
+
 def test_snapshot_validator_can_reject_structurally_invalid_assets(tmp_path, monkeypatch):
     monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
     model_dir = tmp_path / "models--owner--model"
@@ -128,9 +194,10 @@ def test_snapshot_validator_can_reject_structurally_invalid_assets(tmp_path, mon
 
 
 def test_download_model_asset_uses_shared_progress_downloader_and_token(tmp_path, monkeypatch):
-    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-cache"))
+    cache_root = tmp_path / "active-cache"
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache_root))
     monkeypatch.setenv("HF_HOME", str(tmp_path / "unused-home"))
-    snapshot = tmp_path / "downloaded"
+    snapshot = cache_root / "models--owner--model" / "snapshots" / "downloaded"
     calls = []
 
     def fake_preload(repo_id, **kwargs):
@@ -154,7 +221,30 @@ def test_download_model_asset_uses_shared_progress_downloader_and_token(tmp_path
     assert calls[0][1]["token"] == "hf-secret"
     assert calls[0][1]["post_download_phase"] == "verify"
     assert calls[0][1]["allow_patterns"] == ["config.json", "model.bin", "tokenizer.json"]
+    assert calls[0][1]["cache_dir"] == str(cache_root)
     assert updates[-1]["progress"] == 0.5
+
+
+def test_download_model_asset_rejects_downloader_snapshot_outside_active_cache(
+    tmp_path,
+    monkeypatch,
+):
+    cache_root = tmp_path / "active-cache"
+    outside = tmp_path / "outside-snapshot"
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        service,
+        "preload_huggingface_snapshot",
+        lambda *_args, **_kwargs: (
+            _write_complete_snapshot(outside) or outside.as_posix()
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="outside the active cache root"):
+        service.download_model_asset(
+            _spec(),
+            update_task=lambda **_changes: None,
+        )
 
 
 def test_download_model_asset_forces_refresh_of_incomplete_main_snapshot(tmp_path, monkeypatch):
@@ -256,10 +346,10 @@ def test_invalid_snapshot_cleanup_failure_stops_before_download(tmp_path, monkey
         lambda *_args, **_kwargs: preload_calls.append(True),
     )
 
-    def fail_remove(_path):
+    def fail_remove(_path, **_kwargs):
         raise OSError("locked")
 
-    monkeypatch.setattr(service.shutil, "rmtree", fail_remove)
+    monkeypatch.setattr(service, "remove_directory_without_links", fail_remove)
 
     with pytest.raises(OSError, match="locked"):
         service.download_model_asset(_spec(), update_task=lambda **_changes: None)
@@ -291,3 +381,146 @@ def test_download_model_asset_rejects_missing_local_directory(tmp_path):
 
     with pytest.raises(ValueError, match="Local model directory does not exist"):
         service.download_model_asset(spec, update_task=lambda **_changes: None)
+
+
+def test_relative_huggingface_cache_is_project_rooted_not_cwd(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(project))
+    monkeypatch.setenv("HF_HUB_CACHE", "data/cache/huggingface/hub")
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    monkeypatch.chdir(unrelated)
+
+    assert service._huggingface_cache_roots() == (
+        project / "data/cache/huggingface/hub",
+    )
+
+
+def test_relative_huggingface_cache_prefers_explicit_root_over_ambient_root(
+    tmp_path,
+    monkeypatch,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    unrelated = tmp_path / "unrelated"
+    ambient.mkdir()
+    selected.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(ambient))
+    monkeypatch.setenv("HF_HUB_CACHE", "data/cache/huggingface/hub")
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    monkeypatch.chdir(unrelated)
+
+    assert service._huggingface_cache_roots(root=selected) == (
+        selected / "data/cache/huggingface/hub",
+    )
+
+
+def test_download_model_asset_uses_explicit_root_for_relative_cache(
+    tmp_path,
+    monkeypatch,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    cache_root = selected / "data/cache/huggingface/hub"
+    snapshot = cache_root / "models--owner--model" / "snapshots" / "downloaded"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(ambient))
+    monkeypatch.setenv("HF_HUB_CACHE", "data/cache/huggingface/hub")
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    calls = []
+
+    def fake_preload(repo_id, **kwargs):
+        calls.append((repo_id, kwargs))
+        _write_complete_snapshot(snapshot)
+        return str(snapshot)
+
+    monkeypatch.setattr(service, "preload_huggingface_snapshot", fake_preload)
+
+    result = service.download_model_asset(
+        _spec(),
+        update_task=lambda **_changes: None,
+        root=selected,
+    )
+
+    assert result["path"] == str(snapshot.resolve())
+    assert calls[0][1]["cache_dir"] == str(cache_root)
+
+
+def test_empty_current_huggingface_cache_does_not_fall_back_to_legacy(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(project))
+    monkeypatch.setenv("HF_HUB_CACHE", "")
+    monkeypatch.setenv(
+        "HUGGINGFACE_HUB_CACHE",
+        str(tmp_path / "legacy-cache"),
+    )
+
+    with pytest.raises(ValueError, match="HF_HUB_CACHE"):
+        service.active_huggingface_hub_cache_root()
+
+
+def test_relative_huggingface_cache_rejects_symlinked_project_storage(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    try:
+        (project / "data/cache").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(project))
+    monkeypatch.setenv("HF_HUB_CACHE", "data/cache/huggingface/hub")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        service._huggingface_cache_roots()
+
+
+def test_project_owned_hf_home_rejects_symlinked_hub_child(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    hf_home = project / "data/cache/huggingface"
+    external = tmp_path / "external"
+    hf_home.mkdir(parents=True)
+    external.mkdir()
+    try:
+        (hf_home / "hub").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(project))
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    monkeypatch.setenv("HF_HOME", "data/cache/huggingface")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        service._huggingface_cache_roots()
+
+
+def test_invalid_user_home_falls_back_to_project_model_cache(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    invalid_home = Path(f"{tmp_path / 'home'} ")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    monkeypatch.delenv("HF_HOME", raising=False)
+    monkeypatch.setattr(
+        Path,
+        "home",
+        classmethod(lambda _cls: invalid_home),
+    )
+
+    assert service._huggingface_cache_roots() == (
+        project / "data/cache/huggingface/hub",
+    )

--- a/test/unit/core/runtime_env/test_pip_index.py
+++ b/test/unit/core/runtime_env/test_pip_index.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from core.runtime_env import pip_index as pip_index_config
@@ -45,6 +47,10 @@ def _clear_index_env(monkeypatch):
         "SHINSEKAI_PIP_INDEX_URLS",
         "SHINSEKAI_RUNTIME_SOURCE",
         "SHINSEKAI_MIRROR_REGION",
+        "SHINSEKAI_RUNTIME_MANIFEST",
+        "SHINSEKAI_SOURCE_ROOT",
+        "SHINSEKAI_PROJECT_ROOT",
+        "EASYAI_PROJECT_ROOT",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -85,6 +91,132 @@ def test_pip_index_urls_runtime_source_overrides_mirror_region(monkeypatch):
 
     assert urls[0] == "https://pypi.tuna.tsinghua.edu.cn/simple/"
     assert "https://pypi.org/simple/" in urls
+
+
+def test_runtime_manifest_is_read_from_packaged_source_root_not_project_or_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    _clear_index_env(monkeypatch)
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    cwd = tmp_path / "cwd"
+    source.mkdir()
+    project.mkdir()
+    cwd.mkdir()
+
+    def write_manifest(root, url):
+        (root / "runtime_manifest.json").write_text(
+            json.dumps(
+                {
+                    "pip_indexes": {
+                        "official": url,
+                        "china": url,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    write_manifest(source, "https://source.example/simple/")
+    write_manifest(project, "https://project.example/simple/")
+    write_manifest(cwd, "https://cwd.example/simple/")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(cwd)
+
+    assert pip_index_config.pip_index_urls() == ["https://source.example/simple/"]
+
+
+def test_relative_manifest_and_source_environment_paths_are_rejected(monkeypatch):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv("SHINSEKAI_RUNTIME_MANIFEST", "runtime_manifest.json")
+    with pytest.raises(ValueError, match="SHINSEKAI_RUNTIME_MANIFEST"):
+        pip_index_config.pip_index_urls()
+
+    monkeypatch.delenv("SHINSEKAI_RUNTIME_MANIFEST")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", "relative-source")
+    with pytest.raises(ValueError, match="SHINSEKAI_SOURCE_ROOT"):
+        pip_index_config.pip_index_urls()
+
+
+def test_runtime_manifest_environment_rejects_user_home_alias(monkeypatch):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv("SHINSEKAI_RUNTIME_MANIFEST", "~/runtime_manifest.json")
+
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        pip_index_config.pip_index_urls()
+
+
+def test_empty_runtime_manifest_environment_is_rejected_without_default_fallback(
+    monkeypatch,
+):
+    _clear_index_env(monkeypatch)
+    monkeypatch.setenv("SHINSEKAI_RUNTIME_MANIFEST", "")
+
+    with pytest.raises(ValueError, match="SHINSEKAI_RUNTIME_MANIFEST"):
+        pip_index_config.pip_index_urls()
+
+
+def test_explicit_runtime_manifest_read_failure_does_not_fall_back(
+    tmp_path,
+    monkeypatch,
+):
+    _clear_index_env(monkeypatch)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "runtime_manifest.json").write_text("{}", encoding="utf-8")
+    missing = tmp_path / "missing-runtime-manifest.json"
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_RUNTIME_MANIFEST", missing.as_posix())
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_RUNTIME_MANIFEST"):
+        pip_index_config.pip_index_urls()
+
+
+def test_explicit_runtime_manifest_invalid_json_does_not_fall_back(
+    tmp_path,
+    monkeypatch,
+):
+    _clear_index_env(monkeypatch)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "runtime_manifest.json").write_text("{}", encoding="utf-8")
+    invalid = tmp_path / "invalid-runtime-manifest.json"
+    invalid.write_text("{", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_RUNTIME_MANIFEST", invalid.as_posix())
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        pip_index_config.pip_index_urls()
+
+
+def test_runtime_manifest_environment_rejects_absolute_lexical_alias(
+    tmp_path,
+    monkeypatch,
+):
+    _clear_index_env(monkeypatch)
+    manifest = tmp_path / "runtime_manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(
+        "SHINSEKAI_RUNTIME_MANIFEST",
+        f"{tmp_path.as_posix()}/./runtime_manifest.json",
+    )
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        pip_index_config.pip_index_urls()
+
+
+def test_source_candidate_deduplication_does_not_follow_links(tmp_path):
+    source = tmp_path / "source"
+    alias = tmp_path / "source-alias"
+    source.mkdir()
+    try:
+        alias.symlink_to(source, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    assert pip_index_config._unique_paths([alias, source]) == [alias, source]
 
 
 @pytest.mark.parametrize(

--- a/test/unit/core/runtime_env/test_pip_runner.py
+++ b/test/unit/core/runtime_env/test_pip_runner.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import logging
+import os
+import sys
 
 import pytest
 
@@ -48,7 +50,7 @@ def test_apply_pip_index_and_extra_args_uses_primary_flag(monkeypatch):
     monkeypatch.setenv("SHINSEKAI_PIP_INDEX_URL", "https://mirror.example/simple")
 
     cmd = pip_runner.apply_pip_index_and_extra_args(
-        ["python", "-m", "pip", "install", "demo"],
+        [sys.executable, "-m", "pip", "install", "demo"],
         primary_flag="-i",
     )
 
@@ -124,6 +126,64 @@ def test_pip_subprocess_env_keeps_user_values(monkeypatch):
     assert pip_runner.pip_subprocess_env()["PYTHONUTF8"] == "0"
 
 
+def test_pip_subprocess_env_removes_ambient_python_path_overrides(monkeypatch):
+    for name in (
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONUSERBASE",
+        "PYTHONPYCACHEPREFIX",
+        "PYTHONEXECUTABLE",
+        "__PYVENV_LAUNCHER__",
+    ):
+        monkeypatch.setenv(name, f"/ambient/{name.lower()}")
+
+    env = pip_runner.pip_subprocess_env()
+
+    assert all(name not in env for name in (
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONUSERBASE",
+        "PYTHONPYCACHEPREFIX",
+        "PYTHONEXECUTABLE",
+        "__PYVENV_LAUNCHER__",
+    ))
+    assert env["PYTHONNOUSERSITE"] == "1"
+
+
+def test_pip_environment_file_alias_is_replaced_with_canonical_path(tmp_path):
+    certificate = tmp_path / "certificate.pem"
+    alias = tmp_path / "certificate-alias.pem"
+    certificate.write_text("certificate", encoding="utf-8")
+    alias.symlink_to(certificate)
+    env = {"SSL_CERT_FILE": os.fspath(alias)}
+
+    files, directories = pip_runner._capture_pip_environment_paths(env)
+
+    assert env["SSL_CERT_FILE"] == os.fspath(certificate.resolve())
+    assert [snapshot.path for snapshot in files] == [certificate.resolve()]
+    assert directories == ()
+
+
+def test_pip_environment_paths_reject_relative_child_cwd_dependencies():
+    with pytest.raises(ValueError, match="pip working directory"):
+        pip_runner._capture_pip_environment_paths(
+            {"SSL_CERT_FILE": "certificates/ca.pem"}
+        )
+
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        pip_runner._capture_pip_environment_paths({"PIP_CACHE_DIR": ".pip-cache"})
+
+
+def test_pip_config_file_allows_the_platform_null_device():
+    env = {"PIP_CONFIG_FILE": os.devnull}
+
+    files, directories = pip_runner._capture_pip_environment_paths(env)
+
+    assert env["PIP_CONFIG_FILE"] == os.devnull
+    assert files == ()
+    assert directories == ()
+
+
 class _FakePopen:
     def __init__(self, stdout_text: str, returncode: int):
         self.stdout = io.StringIO(stdout_text)
@@ -154,7 +214,7 @@ def test_run_pip_install_redacts_relayed_lines(monkeypatch, tmp_path):
     lines: list[str] = []
 
     code, detail = pip_runner.run_pip_install(
-        ["python", "-m", "pip", "install", "demo"],
+        [sys.executable, "-m", "pip", "install", "demo"],
         cwd=tmp_path,
         timeout_sec=30,
         on_output_line=lines.append,
@@ -168,7 +228,7 @@ def test_run_pip_install_classifies_conflicts(monkeypatch, tmp_path):
     _patch_popen(monkeypatch, "ERROR: ResolutionImpossible: for help visit pip docs\n", 1)
 
     code, detail = pip_runner.run_pip_install(
-        ["python", "-m", "pip", "install", "demo"],
+        [sys.executable, "-m", "pip", "install", "demo"],
         cwd=tmp_path,
         timeout_sec=30,
     )
@@ -185,7 +245,7 @@ def test_run_pip_install_reports_redacted_failure_tail(monkeypatch, tmp_path):
     )
 
     code, detail = pip_runner.run_pip_install(
-        ["python", "-m", "pip", "install", "demo"],
+        [sys.executable, "-m", "pip", "install", "demo"],
         cwd=tmp_path,
         timeout_sec=30,
     )
@@ -200,7 +260,7 @@ def test_run_pip_install_allows_longer_failure_detail(monkeypatch, tmp_path):
     _patch_popen(monkeypatch, output, 1)
 
     code, detail = pip_runner.run_pip_install(
-        ["python", "-m", "pip", "install", "demo"],
+        [sys.executable, "-m", "pip", "install", "demo"],
         cwd=tmp_path,
         timeout_sec=30,
         detail_max=4000,
@@ -209,3 +269,43 @@ def test_run_pip_install_allows_longer_failure_detail(monkeypatch, tmp_path):
     assert code == "pip_failed"
     assert "KEEP-ME" in detail
     assert len(detail) > 1600
+
+
+def test_run_pip_install_rejects_nested_requirements_changed_during_spawn(
+    monkeypatch,
+    tmp_path,
+):
+    requirements = tmp_path / "requirements.txt"
+    nested = tmp_path / "nested.txt"
+    requirements.write_text("-r nested.txt\n", encoding="utf-8")
+    nested.write_text("demo==1\n", encoding="utf-8")
+
+    class Process:
+        stopped = False
+
+        def terminate(self):
+            self.stopped = True
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.stopped = True
+
+    process = Process()
+
+    def replace_during_spawn(*_args, **_kwargs):
+        nested.write_text("replacement-package==2\n", encoding="utf-8")
+        return process
+
+    monkeypatch.setattr(pip_runner.subprocess, "Popen", replace_during_spawn)
+
+    code, detail = pip_runner.run_pip_install(
+        [sys.executable, "-m", "pip", "install", "-r", str(requirements)],
+        cwd=tmp_path,
+        timeout_sec=30,
+    )
+
+    assert code == "pip_exception"
+    assert "identity changed" in detail
+    assert process.stopped is True

--- a/test/unit/core/test_archive_paths.py
+++ b/test/unit/core/test_archive_paths.py
@@ -1,0 +1,590 @@
+from __future__ import annotations
+
+import io
+import stat
+import tarfile
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.archive_paths import (
+    UnsafeArchiveError,
+    extract_tar_safely,
+    extract_zip_safely,
+    validate_archive_member_names,
+    write_directory_to_zip_without_links,
+    write_zip_files_without_links,
+)
+
+
+def test_safe_zip_extraction_writes_only_validated_regular_files(tmp_path):
+    archive = tmp_path / "valid.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("repo-main/plugin.py", "plugin")
+        zf.writestr("repo-main/assets/icon.png", b"png")
+    target = tmp_path / "extract"
+
+    with zipfile.ZipFile(archive) as zf:
+        result = extract_zip_safely(zf, target, require_single_root=True)
+
+    assert result.top_level == "repo-main"
+    assert result.file_count == 2
+    assert (target / "repo-main/plugin.py").read_text(encoding="utf-8") == "plugin"
+
+
+def test_safe_zip_extraction_rejects_target_alias_before_writing(tmp_path):
+    archive = tmp_path / "valid.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("repo/plugin.py", "plugin")
+    target_alias = f"{tmp_path.as_posix()}/nested/../extract"
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(
+        ValueError,
+        match="lexical path aliases",
+    ):
+        extract_zip_safely(zf, target_alias)
+
+    assert not (tmp_path / "extract").exists()
+
+
+def test_safe_zip_extraction_rejects_relative_target_instead_of_using_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    archive = tmp_path / "valid.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("repo/plugin.py", "plugin")
+    monkeypatch.chdir(tmp_path)
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(ValueError, match="absolute"):
+        extract_zip_safely(zf, "extract")
+
+    assert not (tmp_path / "extract").exists()
+
+
+def test_safe_zip_extraction_rejects_linked_target_parent(tmp_path):
+    archive = tmp_path / "valid.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("repo/plugin.py", "plugin")
+    external = tmp_path / "external"
+    external.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(
+        PermissionError,
+        match="symbolic link component",
+    ):
+        extract_zip_safely(zf, alias / "extract")
+
+    assert not (external / "extract").exists()
+
+
+@pytest.mark.parametrize("archive_kind", ("zip", "tar"))
+def test_safe_extraction_revalidates_target_after_creating_it(
+    tmp_path,
+    monkeypatch,
+    archive_kind,
+):
+    archive = tmp_path / f"valid.{archive_kind}"
+    if archive_kind == "zip":
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("repo/plugin.py", "plugin")
+    else:
+        with tarfile.open(archive, "w") as tf:
+            content = b"plugin"
+            member = tarfile.TarInfo("repo/plugin.py")
+            member.size = len(content)
+            tf.addfile(member, io.BytesIO(content))
+
+    target = tmp_path / "extract"
+    external = tmp_path / "external"
+    external.mkdir()
+    real_mkdir = Path.mkdir
+    redirected = False
+
+    def replace_new_target_with_link(path, *args, **kwargs):
+        nonlocal redirected
+        result = real_mkdir(path, *args, **kwargs)
+        if path == target and not redirected:
+            redirected = True
+            path.rmdir()
+            path.symlink_to(external, target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", replace_new_target_with_link)
+
+    with pytest.raises(PermissionError, match="symbolic link component"):
+        if archive_kind == "zip":
+            with zipfile.ZipFile(archive) as zf:
+                extract_zip_safely(zf, target)
+        else:
+            with tarfile.open(archive) as tf:
+                extract_tar_safely(tf, target)
+
+    assert target.is_symlink()
+    assert list(external.iterdir()) == []
+
+
+@pytest.mark.parametrize("archive_kind", ("zip", "tar"))
+def test_safe_extraction_rejects_target_directory_replaced_after_preflight(
+    archive_kind,
+    tmp_path,
+    monkeypatch,
+):
+    archive = tmp_path / f"valid.{archive_kind}"
+    if archive_kind == "zip":
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("repo/plugin.py", "plugin")
+    else:
+        with tarfile.open(archive, "w") as tf:
+            _write_tar_member(tf, "repo/plugin.py", b"plugin")
+
+    target = tmp_path / "extract"
+    target.mkdir()
+    preserved = tmp_path / "preserved-extract"
+    import core.archive_paths as archive_paths
+
+    real_preflight = archive_paths._preflight_destinations
+
+    def preflight_then_replace(*args, **kwargs):
+        result = real_preflight(*args, **kwargs)
+        target.rename(preserved)
+        target.mkdir()
+        return result
+
+    monkeypatch.setattr(
+        archive_paths,
+        "_preflight_destinations",
+        preflight_then_replace,
+    )
+
+    with pytest.raises(UnsafeArchiveError, match="changed identity"):
+        if archive_kind == "zip":
+            with zipfile.ZipFile(archive) as zf:
+                extract_zip_safely(zf, target)
+        else:
+            with tarfile.open(archive) as tf:
+                extract_tar_safely(tf, target)
+
+    assert list(target.iterdir()) == []
+    assert list(preserved.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "../escape.py",
+        r"..\escape.py",
+        "/absolute.py",
+        "/",
+        "repo//",
+        "~/repo/file.py",
+        "repo/CON/file.py",
+        "repo/trailing /file.py",
+    ],
+)
+def test_safe_zip_extraction_rejects_nonportable_paths_before_writing(tmp_path, member):
+    archive = tmp_path / "invalid.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("repo/valid.py", "valid")
+        zf.writestr(member, "bad")
+    target = tmp_path / "extract"
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(UnsafeArchiveError):
+        extract_zip_safely(zf, target)
+
+    assert not target.exists()
+
+
+def test_safe_zip_extraction_rejects_symbolic_link_entries(tmp_path):
+    archive = tmp_path / "link.zip"
+    link = zipfile.ZipInfo("repo/link")
+    link.create_system = 3
+    link.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("repo/plugin.py", "plugin")
+        zf.writestr(link, "../../outside")
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(UnsafeArchiveError, match="link"):
+        extract_zip_safely(zf, tmp_path / "extract")
+
+
+def test_safe_zip_extraction_rejects_regular_file_with_directory_name(tmp_path):
+    archive = tmp_path / "ambiguous.zip"
+    regular = zipfile.ZipInfo("repo/file.txt/")
+    regular.create_system = 3
+    regular.external_attr = (stat.S_IFREG | 0o644) << 16
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr(regular, "not a directory")
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(
+        UnsafeArchiveError,
+        match="directory-shaped",
+    ):
+        extract_zip_safely(zf, tmp_path / "extract")
+
+    assert not (tmp_path / "extract").exists()
+
+
+def test_safe_zip_extraction_rejects_case_collisions_and_file_directory_collisions(tmp_path):
+    case_archive = tmp_path / "case.zip"
+    with zipfile.ZipFile(case_archive, "w") as zf:
+        zf.writestr("repo/Assets/a.txt", "a")
+        zf.writestr("repo/assets/b.txt", "b")
+    with zipfile.ZipFile(case_archive) as zf, pytest.raises(UnsafeArchiveError, match="case"):
+        extract_zip_safely(zf, tmp_path / "case-out")
+
+    collision_archive = tmp_path / "collision.zip"
+    with zipfile.ZipFile(collision_archive, "w") as zf:
+        zf.writestr("repo/item/child.txt", "child")
+        zf.writestr("repo/item", "file")
+    with zipfile.ZipFile(collision_archive) as zf, pytest.raises(UnsafeArchiveError, match="conflicts"):
+        extract_zip_safely(zf, tmp_path / "collision-out")
+
+
+def test_safe_zip_extraction_rejects_unicode_normalization_collisions(tmp_path):
+    archive = tmp_path / "unicode.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("repo/caf\u00e9.txt", "composed")
+        zf.writestr("repo/cafe\u0301.txt", "decomposed")
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(UnsafeArchiveError, match="case"):
+        extract_zip_safely(zf, tmp_path / "unicode-out")
+
+    assert not (tmp_path / "unicode-out").exists()
+
+
+def test_safe_zip_extraction_rejects_existing_link_ancestor_before_writing(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = tmp_path / "extract"
+    target.mkdir()
+    (target / "repo").symlink_to(outside, target_is_directory=True)
+    archive = tmp_path / "link-target.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("safe.txt", "safe")
+        zf.writestr("repo/plugin.py", "bad")
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(UnsafeArchiveError, match="symbolic link"):
+        extract_zip_safely(zf, target)
+
+    assert not (target / "safe.txt").exists()
+    assert not (outside / "plugin.py").exists()
+
+
+def test_safe_zip_extraction_preflights_windows_reparse_ancestor_before_writing(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "extract"
+    junction = target / "repo"
+    junction.mkdir(parents=True)
+    archive = tmp_path / "junction-target.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("safe.txt", "must-not-be-written")
+        zf.writestr("repo/plugin.py", "bad")
+    original_lstat = Path.lstat
+
+    def fake_lstat(path: Path):
+        if path == junction:
+            return SimpleNamespace(
+                st_mode=stat.S_IFDIR,
+                st_file_attributes=getattr(
+                    stat,
+                    "FILE_ATTRIBUTE_REPARSE_POINT",
+                    0x00000400,
+                ),
+            )
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", fake_lstat)
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(
+        UnsafeArchiveError,
+        match="reparse point",
+    ):
+        extract_zip_safely(zf, target)
+
+    assert not (target / "safe.txt").exists()
+
+
+def test_safe_zip_extraction_preflights_existing_file_ancestors_before_writing(tmp_path):
+    target = tmp_path / "extract"
+    target.mkdir()
+    occupied_parent = target / "repo"
+    occupied_parent.write_text("keep", encoding="utf-8")
+    archive = tmp_path / "file-parent-target.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("safe.txt", "must-not-be-written")
+        zf.writestr("repo/plugin.py", "bad")
+
+    with zipfile.ZipFile(archive) as zf, pytest.raises(
+        UnsafeArchiveError,
+        match="parent conflicts",
+    ):
+        extract_zip_safely(zf, target)
+
+    assert occupied_parent.read_text(encoding="utf-8") == "keep"
+    assert not (target / "safe.txt").exists()
+
+
+def _write_tar_member(tf: tarfile.TarFile, name: str, content: bytes = b"data") -> None:
+    member = tarfile.TarInfo(name)
+    member.size = len(content)
+    tf.addfile(member, io.BytesIO(content))
+
+
+def test_safe_tar_extraction_writes_regular_files(tmp_path):
+    archive = tmp_path / "valid.tar"
+    with tarfile.open(archive, "w") as tf:
+        _write_tar_member(tf, "repo/file.txt", b"ok")
+
+    with tarfile.open(archive, "r") as tf:
+        result = extract_tar_safely(tf, tmp_path / "out")
+
+    assert result.top_level == "repo"
+    assert result.file_count == 1
+    assert (tmp_path / "out/repo/file.txt").read_bytes() == b"ok"
+
+
+def test_safe_tar_extraction_rejects_target_alias_before_writing(tmp_path):
+    archive = tmp_path / "valid.tar"
+    with tarfile.open(archive, "w") as tf:
+        _write_tar_member(tf, "repo/file.txt", b"ok")
+    target_alias = f"{tmp_path.as_posix()}/./out"
+
+    with tarfile.open(archive, "r") as tf, pytest.raises(
+        ValueError,
+        match="lexical path aliases",
+    ):
+        extract_tar_safely(tf, target_alias)
+
+    assert not (tmp_path / "out").exists()
+
+
+@pytest.mark.parametrize("member_name", ["../escape.txt", r"..\escape.txt", "repo/CON"])
+def test_safe_tar_extraction_rejects_unsafe_paths_before_writing(tmp_path, member_name):
+    archive = tmp_path / "bad.tar"
+    with tarfile.open(archive, "w") as tf:
+        _write_tar_member(tf, "safe.txt")
+        _write_tar_member(tf, member_name)
+
+    with tarfile.open(archive, "r") as tf, pytest.raises(UnsafeArchiveError):
+        extract_tar_safely(tf, tmp_path / "out")
+
+    assert not (tmp_path / "out").exists()
+
+
+def test_safe_tar_extraction_rejects_links_before_writing(tmp_path):
+    archive = tmp_path / "link.tar"
+    with tarfile.open(archive, "w") as tf:
+        _write_tar_member(tf, "repo/file.txt")
+        link = tarfile.TarInfo("repo/link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../outside"
+        tf.addfile(link)
+
+    with tarfile.open(archive, "r") as tf, pytest.raises(UnsafeArchiveError, match="link"):
+        extract_tar_safely(tf, tmp_path / "out")
+
+    assert not (tmp_path / "out").exists()
+
+
+def test_safe_tar_extraction_rejects_regular_file_with_directory_name(tmp_path):
+    archive = tmp_path / "ambiguous.tar"
+    with tarfile.open(archive, "w") as tf:
+        _write_tar_member(tf, "repo/file.txt/")
+
+    with tarfile.open(archive, "r") as tf, pytest.raises(
+        UnsafeArchiveError,
+        match="directory-shaped",
+    ):
+        extract_tar_safely(tf, tmp_path / "out")
+
+    assert not (tmp_path / "out").exists()
+
+
+@pytest.mark.parametrize(
+    "names",
+    [
+        ["../escape.txt"],
+        [r"folder\..\escape.txt"],
+        ["Folder/a.txt", "folder/b.txt"],
+        ["folder", "folder/file.txt"],
+        ["folder/file.txt", "folder/file.txt"],
+        ["caf\u00e9/file.txt", "cafe\u0301/other.txt"],
+        ["bundle//", "bundle/file.txt"],
+        ["/", "bundle/file.txt"],
+    ],
+)
+def test_generic_archive_member_preflight_rejects_unsafe_names(names):
+    with pytest.raises(UnsafeArchiveError):
+        validate_archive_member_names(names)
+
+
+def test_generic_archive_member_preflight_accepts_portable_tree():
+    validate_archive_member_names(["bundle/", "bundle/bin/", "bundle/bin/server.exe"])
+
+
+def test_link_free_zip_writers_stream_portable_regular_files(tmp_path):
+    source = tmp_path / "source"
+    nested = source / "nested"
+    nested.mkdir(parents=True)
+    first = source / "manifest.json"
+    second = nested / "asset.bin"
+    first.write_text("{}", encoding="utf-8")
+    second.write_bytes(b"asset")
+    archive_path = tmp_path / "bundle.zip"
+
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        assert write_directory_to_zip_without_links(archive, source) == 2
+
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.namelist() == ["manifest.json", "nested/asset.bin"]
+        assert archive.read("nested/asset.bin") == b"asset"
+
+
+def test_link_free_zip_writer_validates_complete_member_set_before_writing(tmp_path):
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    archive_path = tmp_path / "bundle.zip"
+
+    with zipfile.ZipFile(archive_path, "w") as archive, pytest.raises(
+        UnsafeArchiveError,
+        match="case",
+    ):
+        write_zip_files_without_links(
+            archive,
+            [(first, "Assets/File.txt"), (second, "assets/file.txt")],
+        )
+
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.namelist() == []
+
+
+def test_directory_zip_writer_rejects_file_replaced_by_symlink_after_inventory(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    source.mkdir()
+    candidate = source / "asset.txt"
+    external = tmp_path / "external.txt"
+    candidate.write_text("safe", encoding="utf-8")
+    external.write_text("secret", encoding="utf-8")
+    try:
+        probe = tmp_path / "probe"
+        probe.symlink_to(external)
+        probe.unlink()
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    import core.archive_paths as archive_paths
+
+    real_inventory = archive_paths.inspect_portable_directory_tree_with_metadata
+
+    def inventory_then_replace(root):
+        inventory = real_inventory(root)
+        candidate.unlink()
+        candidate.symlink_to(external)
+        return inventory
+
+    monkeypatch.setattr(
+        archive_paths,
+        "inspect_portable_directory_tree_with_metadata",
+        inventory_then_replace,
+    )
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive, pytest.raises(
+        PermissionError,
+        match="symbolic link",
+    ):
+        write_directory_to_zip_without_links(archive, source)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.namelist() == []
+
+
+def test_directory_zip_writer_rejects_regular_file_replaced_after_inventory(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    source.mkdir()
+    candidate = source / "asset.txt"
+    preserved = source / "preserved.txt"
+    candidate.write_text("safe", encoding="utf-8")
+    import core.archive_paths as archive_paths
+
+    real_inventory = archive_paths.inspect_portable_directory_tree_with_metadata
+
+    def inventory_then_replace(root):
+        inventory = real_inventory(root)
+        candidate.rename(preserved)
+        candidate.write_text("peer", encoding="utf-8")
+        return inventory
+
+    monkeypatch.setattr(
+        archive_paths,
+        "inspect_portable_directory_tree_with_metadata",
+        inventory_then_replace,
+    )
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive, pytest.raises(
+        PermissionError,
+        match="identity changed",
+    ):
+        write_directory_to_zip_without_links(archive, source)
+
+    assert candidate.read_text(encoding="utf-8") == "peer"
+    assert preserved.read_text(encoding="utf-8") == "safe"
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.namelist() == []
+
+
+def test_zip_writer_rejects_in_place_source_mutation_before_member_publish(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "asset.txt"
+    source.write_text("safe", encoding="utf-8")
+    archive_path = tmp_path / "bundle.zip"
+    import core.archive_paths as archive_paths
+
+    real_copy = archive_paths.shutil.copyfileobj
+    calls = 0
+
+    def mutate_after_source_copy(input_file, output_file, *args, **kwargs):
+        nonlocal calls
+        result = real_copy(input_file, output_file, *args, **kwargs)
+        calls += 1
+        if calls == 1:
+            source.write_text("replacement-is-longer", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(
+        archive_paths.shutil,
+        "copyfileobj",
+        mutate_after_source_copy,
+    )
+
+    with zipfile.ZipFile(archive_path, "w") as archive, pytest.raises(
+        PermissionError,
+        match="changed while it was being read",
+    ):
+        write_zip_files_without_links(
+            archive,
+            [(source, "asset.txt")],
+        )
+
+    assert source.read_text(encoding="utf-8") == "replacement-is-longer"
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.namelist() == []

--- a/test/unit/core/test_chat_branch_storage.py
+++ b/test/unit/core/test_chat_branch_storage.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import tempfile
 import time
@@ -7,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import core.sprite.chat_branch_storage as chat_branch_storage
 from core.sprite.chat_branch_storage import (
     ACTIVE_HISTORY_FILENAME,
     BRANCH_TREE_FILENAME,
@@ -17,6 +19,7 @@ from core.sprite.chat_branch_storage import (
     remove_chat_history_storage,
     save_branch_state,
 )
+from sdk.path_contract import project_root
 from application.chat.runtime_process import _chat_history_path
 from application.chat.templates import _latest_history_json
 
@@ -101,25 +104,126 @@ class ChatBranchStorageTests(unittest.TestCase):
             branches = root / BRANCH_TREE_FILENAME
             active.write_text("[]", encoding="utf-8")
             branches.write_text("{}", encoding="utf-8")
-            original_unlink = Path.unlink
+            original_remove = chat_branch_storage.remove_file_without_links
 
             def fail_locked_branches(path: Path, *args, **kwargs):
                 if path == branches:
                     raise PermissionError("branches.json is locked")
-                return original_unlink(path, *args, **kwargs)
+                return original_remove(path, *args, **kwargs)
 
-            with patch.object(Path, "unlink", fail_locked_branches):
+            with patch.object(
+                chat_branch_storage,
+                "remove_file_without_links",
+                fail_locked_branches,
+            ):
                 with self.assertRaisesRegex(PermissionError, "locked"):
                     remove_chat_history_storage(root)
 
             self.assertTrue(active.is_file())
             self.assertTrue(branches.is_file())
 
+    def test_managed_cleanup_reports_locked_metadata_without_removing_active(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            collection = Path(tmp_dir) / "chat-history"
+            session = collection / "session"
+            session.mkdir(parents=True)
+            active = session / ACTIVE_HISTORY_FILENAME
+            branches = session / BRANCH_TREE_FILENAME
+            active.write_text("[]", encoding="utf-8")
+            branches.write_text("{}", encoding="utf-8")
+            original_remove = chat_branch_storage.remove_file_without_links
+
+            def fail_locked_branches(path: Path, *args, **kwargs):
+                if path == branches:
+                    raise PermissionError("branches.json is locked")
+                return original_remove(path, *args, **kwargs)
+
+            with patch.object(
+                chat_branch_storage,
+                "remove_file_without_links",
+                fail_locked_branches,
+            ):
+                with self.assertRaisesRegex(PermissionError, "locked"):
+                    remove_chat_history_storage(session, root=collection)
+
+            self.assertTrue(active.is_file())
+            self.assertTrue(branches.is_file())
+
+    def test_managed_cleanup_preserves_unrelated_session_content(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            collection = Path(tmp_dir) / "chat-history"
+            session = collection / "session"
+            session.mkdir(parents=True)
+            (session / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+            (session / BRANCH_TREE_FILENAME).write_text("{}", encoding="utf-8")
+            marker = session / "user-owned.txt"
+            marker.write_text("keep", encoding="utf-8")
+
+            remove_chat_history_storage(session, root=collection)
+
+            self.assertFalse((session / ACTIVE_HISTORY_FILENAME).exists())
+            self.assertFalse((session / BRANCH_TREE_FILENAME).exists())
+            self.assertEqual(marker.read_text(encoding="utf-8"), "keep")
+
     def test_non_existing_json_path_maps_to_session_folder(self):
         path = Path("data/chat_history/session.json")
+        expected = project_root() / "data/chat_history/session"
 
-        self.assertEqual(chat_history_active_path(path), Path("data/chat_history/session") / ACTIVE_HISTORY_FILENAME)
-        self.assertEqual(chat_history_branch_tree_path(path), Path("data/chat_history/session") / BRANCH_TREE_FILENAME)
+        self.assertEqual(chat_history_active_path(path), expected / ACTIVE_HISTORY_FILENAME)
+        self.assertEqual(chat_history_branch_tree_path(path), expected / BRANCH_TREE_FILENAME)
+
+    def test_relative_history_helpers_use_project_root_instead_of_process_cwd(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            base = Path(temporary_directory)
+            project = base / "project"
+            unrelated_cwd = base / "unrelated-cwd"
+            project.mkdir()
+            unrelated_cwd.mkdir()
+            previous_cwd = Path.cwd()
+            try:
+                with patch.dict(
+                    os.environ,
+                    {"SHINSEKAI_PROJECT_ROOT": project.as_posix()},
+                ):
+                    os.chdir(unrelated_cwd)
+                    result = chat_history_active_path("data/chat_history/session.json")
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertEqual(
+            result,
+            project / "data/chat_history/session" / ACTIVE_HISTORY_FILENAME,
+        )
+
+    def test_history_storage_helpers_reject_lexical_aliases_before_path_construction(self):
+        for path in (
+            "data/chat_history/./session.json",
+            "data/chat_history//session.json",
+        ):
+            with self.subTest(path=path), self.assertRaises(ValueError):
+                chat_history_active_path(path)
+
+    def test_history_storage_helpers_reject_linked_session_path(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            base = Path(temporary_directory)
+            project = base / "project"
+            external = base / "external"
+            history = project / "data/chat_history"
+            history.mkdir(parents=True)
+            external.mkdir()
+            (external / "active.json").write_text("[]", encoding="utf-8")
+            alias = history / "session"
+            try:
+                alias.symlink_to(external, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                self.skipTest("directory symlinks are unavailable")
+
+            with patch.dict(
+                os.environ,
+                {"SHINSEKAI_PROJECT_ROOT": project.as_posix()},
+            ):
+                with self.assertRaises(PermissionError):
+                    chat_history_active_path("data/chat_history/session")
 
     def test_existing_json_file_stays_legacy_history(self):
         with self.subTest("legacy"):
@@ -128,13 +232,130 @@ class ChatBranchStorageTests(unittest.TestCase):
             path = root / "session.json"
             path.write_text("[]", encoding="utf-8")
             try:
-                self.assertEqual(chat_history_active_path(path), path)
+                self.assertEqual(chat_history_active_path(path), path.resolve())
             finally:
                 remove_chat_history_storage(path)
                 try:
                     root.rmdir()
                 except OSError:
                     pass
+
+    def test_removing_legacy_file_preserves_unrelated_same_named_directory(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "chat-history"
+            root.mkdir()
+            legacy = root / "session.json"
+            unrelated = root / "session"
+            legacy.write_text("[]", encoding="utf-8")
+            unrelated.mkdir()
+            marker = unrelated / "user-owned.txt"
+            marker.write_text("keep", encoding="utf-8")
+
+            remove_chat_history_storage(legacy, root=root)
+
+            self.assertFalse(legacy.exists())
+            self.assertEqual(marker.read_text(encoding="utf-8"), "keep")
+
+    def test_history_removal_preserves_replacement_file_identity(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "chat-history"
+            target = root / "session.json"
+            preserved = root / "session-preserved.json"
+            root.mkdir()
+            target.write_text("original", encoding="utf-8")
+            real_remove = chat_branch_storage.remove_file_without_links
+
+            def replace_before_remove(path, **kwargs):
+                target.rename(preserved)
+                target.write_text("peer", encoding="utf-8")
+                return real_remove(path, **kwargs)
+
+            with patch.object(
+                chat_branch_storage,
+                "remove_file_without_links",
+                replace_before_remove,
+            ):
+                with self.assertRaises(PermissionError):
+                    remove_chat_history_storage(target, root=root)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "peer")
+            self.assertEqual(preserved.read_text(encoding="utf-8"), "original")
+
+    def test_removal_boundary_rejects_collection_root_and_external_target(self):
+        root = Path("data/chat_history/test-removal-boundary").resolve()
+        remove_chat_history_storage(root)
+        root.mkdir(parents=True)
+        outside = root.parent / "must-survive.json"
+        outside.write_text("[]", encoding="utf-8")
+        root_active = root / ACTIVE_HISTORY_FILENAME
+        root_active.write_text("[]", encoding="utf-8")
+        try:
+            with self.assertRaises(PermissionError):
+                remove_chat_history_storage(root, root=root)
+            with self.assertRaises(PermissionError):
+                remove_chat_history_storage(root_active, root=root)
+            with self.assertRaises(PermissionError):
+                remove_chat_history_storage(outside, root=root)
+            self.assertTrue(root_active.is_file())
+            self.assertTrue(outside.is_file())
+        finally:
+            outside.unlink(missing_ok=True)
+            remove_chat_history_storage(root)
+
+    def test_removal_boundary_rejects_internal_directory_alias(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "chat-history"
+            real_parent = root / "real-parent"
+            real_session = real_parent / "session"
+            real_session.mkdir(parents=True)
+            marker = real_session / ACTIVE_HISTORY_FILENAME
+            marker.write_text("[]", encoding="utf-8")
+            alias = root / "alias"
+            try:
+                alias.symlink_to(real_parent, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                self.skipTest("symbolic links are unavailable")
+
+            with self.assertRaises(PermissionError):
+                remove_chat_history_storage(alias / "session", root=root)
+
+            self.assertEqual(marker.read_text(encoding="utf-8"), "[]")
+
+    def test_removal_boundary_rejects_lexical_alias_before_path_construction(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "chat-history"
+            session = root / "session"
+            session.mkdir(parents=True)
+            marker = session / ACTIVE_HISTORY_FILENAME
+            marker.write_text("[]", encoding="utf-8")
+
+            for aliased in (
+                f"{root.as_posix()}/./session",
+                f"{root.as_posix()}//session",
+            ):
+                with self.assertRaises(ValueError):
+                    remove_chat_history_storage(aliased, root=root)
+
+            self.assertEqual(marker.read_text(encoding="utf-8"), "[]")
+
+    def test_relative_removal_target_is_anchored_to_history_root_not_cwd(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            base = Path(temporary_directory)
+            root = base / "chat-history"
+            unrelated_cwd = base / "unrelated-cwd"
+            session = root / "session"
+            session.mkdir(parents=True)
+            unrelated_cwd.mkdir()
+            (session / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+
+            previous_cwd = Path.cwd()
+            try:
+                os.chdir(unrelated_cwd)
+                remove_chat_history_storage("session", root=root)
+            finally:
+                os.chdir(previous_cwd)
+
+            self.assertFalse(session.exists())
 
     def test_saves_and_loads_branch_tree_under_session_folder(self):
         root = Path("data/chat_history/test-branch-tree")
@@ -168,7 +389,7 @@ class ChatBranchStorageTests(unittest.TestCase):
             tree_path = save_branch_state(root, branch_state)
             restored = load_branch_state(root)
 
-            self.assertEqual(tree_path, root / BRANCH_TREE_FILENAME)
+            self.assertEqual(tree_path, root.resolve() / BRANCH_TREE_FILENAME)
             self.assertEqual(restored["active"], "branch-2")
             self.assertEqual(restored["branches"]["branch-2"]["label"], "七海路线")
             self.assertEqual(restored["branches"]["branch-2"]["messages"][0]["content"], "hello")
@@ -177,6 +398,36 @@ class ChatBranchStorageTests(unittest.TestCase):
                 restored["branches"]["branch-2"]["messages"][0]["attachments"][0]["name"],
                 "scene.png",
             )
+        finally:
+            remove_chat_history_storage(root)
+
+    def test_branch_tree_publish_failure_preserves_previous_file(self):
+        root = Path("data/chat_history/test-branch-atomic")
+        remove_chat_history_storage(root)
+        root.mkdir(parents=True, exist_ok=True)
+        try:
+            original = {
+                "active": "main",
+                "counter": 1,
+                "branches": {"main": {"id": "main"}},
+            }
+            save_branch_state(root, original)
+            tree = root / BRANCH_TREE_FILENAME
+            previous = tree.read_text(encoding="utf-8")
+            with patch(
+                "core.sprite.chat_branch_storage.atomic_write_text",
+                side_effect=OSError("disk full"),
+            ):
+                with self.assertRaisesRegex(OSError, "disk full"):
+                    save_branch_state(
+                        root,
+                        {
+                            "active": "other",
+                            "counter": 2,
+                            "branches": {"other": {"id": "other"}},
+                        },
+                    )
+            self.assertEqual(tree.read_text(encoding="utf-8"), previous)
         finally:
             remove_chat_history_storage(root)
 
@@ -193,9 +444,54 @@ class ChatBranchStorageTests(unittest.TestCase):
             (session / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
             (session / BRANCH_TREE_FILENAME).write_text(json.dumps({"branches": []}), encoding="utf-8")
 
-            self.assertEqual(_latest_history_json(root.as_posix()), session)
+            self.assertEqual(_latest_history_json(root.as_posix()), session.resolve())
         finally:
             shutil.rmtree(root, ignore_errors=True)
+
+    def test_latest_history_ignores_reserved_root_files(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project = Path(temporary_directory)
+            root = project / "chat-history"
+            session = root / "valid-session"
+            session.mkdir(parents=True)
+            (session / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+            time.sleep(0.01)
+            (root / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+            (root / BRANCH_TREE_FILENAME).write_text("{}", encoding="utf-8")
+
+            self.assertEqual(
+                _latest_history_json(
+                    "chat-history",
+                    project_root=project,
+                ),
+                session.resolve(),
+            )
+
+    def test_latest_history_ignores_root_level_legacy_temp_fragment(self):
+        root = Path("data/chat_history/test-latest-temp-fragment")
+        remove_chat_history_storage(root)
+        root.mkdir(parents=True, exist_ok=True)
+        fragment = root / "orphan.json.tmp"
+        fragment.write_text("[]", encoding="utf-8")
+        try:
+            self.assertIsNone(_latest_history_json(root.as_posix()))
+        finally:
+            remove_chat_history_storage(root)
+
+    def test_latest_history_rejects_directory_outside_explicit_project_root(self):
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            project = base / "project"
+            outside = base / "outside"
+            project.mkdir()
+            outside.mkdir()
+            (outside / "session.json").write_text("[]", encoding="utf-8")
+
+            with self.assertRaises(PermissionError):
+                _latest_history_json(
+                    outside.as_posix(),
+                    project_root=project,
+                )
 
     def test_bridge_history_path_prefers_session_directories_for_new_paths(self):
         root = Path("data/chat_history/test-bridge-path")

--- a/test/unit/core/test_chat_history.py
+++ b/test/unit/core/test_chat_history.py
@@ -5,8 +5,18 @@ import json
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
+import sys
+
+import pytest
+
+# PySide6 is unavailable in CI — fake it before importing history_manager
+sys.modules.setdefault("PySide6", MagicMock())
+sys.modules.setdefault("PySide6.QtWidgets", MagicMock())
+sys.modules.setdefault("PySide6.QtCore", MagicMock())
 
 from ai.llm.history_manager import (
+    _managed_history_file_path,
     _repair_json_string,
     parse_assistant_dialog_content,
     HistoryManager,
@@ -290,6 +300,22 @@ class TestRepairJsonString:
 
 # ====================== 新增：HistoryManager 增量保存与恢复测试 ======================
 
+
+class _ManagedHistoryCase:
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.project_root = Path(self.tmp_dir) / "project"
+        self.history_dir = self.project_root / "data/chat_history"
+        self.history_dir.mkdir(parents=True)
+        self.history_file = str(self.history_dir / "test.json")
+        self._environment = pytest.MonkeyPatch()
+        self._environment.setenv("SHINSEKAI_PROJECT_ROOT", self.project_root.as_posix())
+        self._environment.setenv("EASYAI_PROJECT_ROOT", self.project_root.as_posix())
+
+    def teardown_method(self):
+        self._environment.undo()
+
+
 class TestTmpPath:
     """_tmp_path 静态方法"""
 
@@ -302,12 +328,8 @@ class TestTmpPath:
         assert str(path).endswith(".json.tmp")
 
 
-class TestAppendMessageToTmp:
+class TestAppendMessageToTmp(_ManagedHistoryCase):
     """append_message_to_tmp 静态方法"""
-
-    def setup_method(self):
-        self.tmp_dir = tempfile.mkdtemp()
-        self.history_file = str(Path(self.tmp_dir) / "test.json")
 
     def test_creates_tmp_file_and_writes_line(self):
         msg = {"role": "user", "content": "hello"}
@@ -329,7 +351,7 @@ class TestAppendMessageToTmp:
         assert len(lines) == 2
 
     def test_creates_parent_dirs(self):
-        deep_file = str(Path(self.tmp_dir) / "sub" / "deep" / "test.json")
+        deep_file = str(self.history_dir / "sub" / "deep" / "test.json")
         HistoryManager.append_message_to_tmp(deep_file, {"role": "user", "content": "x"})
         assert Path(deep_file + ".tmp").exists()
 
@@ -339,13 +361,25 @@ class TestAppendMessageToTmp:
     def test_does_not_raise_on_empty_path(self):
         HistoryManager.append_message_to_tmp("", {"role": "user", "content": "x"})
 
+    def test_symlinked_tmp_never_appends_to_external_file(self):
+        external = Path(self.tmp_dir) / "external.txt"
+        external.write_text("keep", encoding="utf-8")
+        tmp_path = Path(self.history_file + ".tmp")
+        try:
+            tmp_path.symlink_to(external)
+        except (OSError, NotImplementedError):
+            return
 
-class TestLoadChatHistoryRecovery:
+        HistoryManager.append_message_to_tmp(
+            self.history_file,
+            {"role": "user", "content": "secret"},
+        )
+
+        assert external.read_text(encoding="utf-8") == "keep"
+
+
+class TestLoadChatHistoryRecovery(_ManagedHistoryCase):
     """load_chat_history 崩溃恢复逻辑"""
-
-    def setup_method(self):
-        self.tmp_dir = tempfile.mkdtemp()
-        self.history_file = str(Path(self.tmp_dir) / "test.json")
 
     def _make_history_manager(self):
         return HistoryManager([])
@@ -430,12 +464,8 @@ class TestLoadChatHistoryRecovery:
         assert result[0]["content"] == "fallback"
 
 
-class TestSaveChatHistory:
+class TestSaveChatHistory(_ManagedHistoryCase):
     """save_chat_history 返回 bool，tmp 由 delete_tmp 独立删除"""
-
-    def setup_method(self):
-        self.tmp_dir = tempfile.mkdtemp()
-        self.history_file = str(Path(self.tmp_dir) / "test.json")
 
     def _make_history_manager(self):
         return HistoryManager([])
@@ -451,7 +481,25 @@ class TestSaveChatHistory:
         result = hm.save_chat_history(None, [{"role": "user", "content": "x"}])
         assert result is True
 
-    def test_application_history_state_returns_manager_result(self, monkeypatch):
+    def test_publish_failure_preserves_previous_history(self, monkeypatch):
+        history_path = Path(self.history_file)
+        history_path.write_text('[{"content":"old"}]', encoding="utf-8")
+
+        def fail_write(_path, _text):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("ai.llm.history_manager.atomic_write_text", fail_write)
+        hm = self._make_history_manager()
+
+        result = hm.save_chat_history(
+            self.history_file,
+            [{"role": "user", "content": "new"}],
+        )
+
+        assert result is False
+        assert json.loads(history_path.read_text(encoding="utf-8")) == [{"content": "old"}]
+
+    def test_sprite_wrapper_returns_manager_result(self, monkeypatch):
         from application.chat import history_state as chat_history_mod
 
         monkeypatch.setattr(
@@ -478,12 +526,8 @@ class TestSaveChatHistory:
         assert not tmp_path.exists()
 
 
-class TestClearChatHistory:
+class TestClearChatHistory(_ManagedHistoryCase):
     """clear_chat_history 清理正式历史和增量 tmp。"""
-
-    def setup_method(self):
-        self.tmp_dir = tempfile.mkdtemp()
-        self.history_file = str(Path(self.tmp_dir) / "test.json")
 
     def test_persists_empty_json_and_removes_tmp(self):
         history_path = Path(self.history_file)
@@ -497,3 +541,26 @@ class TestClearChatHistory:
         assert hm.get_history() == []
         assert json.loads(history_path.read_text(encoding="utf-8")) == []
         assert not tmp_path.exists()
+
+
+@pytest.mark.parametrize(
+    "alias",
+    (
+        "data/chat_history/./test.json",
+        "data/chat_history//test.json",
+        "data/chat_history/session/../test.json",
+    ),
+)
+def test_history_io_boundary_rejects_lexical_aliases(tmp_path, monkeypatch, alias):
+    project = tmp_path / "project"
+    history_dir = project / "data/chat_history"
+    history_dir.mkdir(parents=True)
+    marker = history_dir / "test.json"
+    marker.write_text("keep", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises((PermissionError, ValueError), match="resolved|exact|escapes"):
+        _managed_history_file_path(alias)
+
+    assert marker.read_text(encoding="utf-8") == "keep"

--- a/test/unit/core/test_chat_initial_sprite.py
+++ b/test/unit/core/test_chat_initial_sprite.py
@@ -45,7 +45,32 @@ def test_find_character_sprite_by_path_matches_relative_and_absolute(tmp_path, m
     assert find_character_sprite_by_path(
         _config(characters=[character]),
         sprite_abs.as_posix(),
+        project_root=tmp_path,
     ) == ("七海千秋", 0)
+
+
+def test_find_character_sprite_by_path_resolves_immutable_assets_outside_project(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    sprite = source / "assets" / "present_example.png"
+    sprite.parent.mkdir(parents=True)
+    project.mkdir()
+    sprite.write_bytes(b"png")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    character = SimpleNamespace(
+        name="示例",
+        sprites=[SimpleNamespace(path="assets/present_example.png")],
+    )
+
+    assert find_character_sprite_by_path(
+        _config(characters=[character]),
+        sprite.as_posix(),
+        project_root=project,
+    ) == ("示例", 0)
 
 
 def test_find_character_sprite_by_path_uses_host_case_semantics_and_normalizes_slashes(tmp_path, monkeypatch):
@@ -73,6 +98,61 @@ def test_find_character_sprite_by_path_preserves_case_distinct_files_on_sensitiv
     matched = find_character_sprite_by_path(_config(characters=characters), "sprites/face.png")
     expected = ("Upper", 0) if os.path.normcase("A") == os.path.normcase("a") else ("Lower", 0)
     assert matched == expected
+
+
+def test_initial_sprite_path_rejects_outer_whitespace(tmp_path):
+    config = _config(characters=[])
+    config.get_character_by_name = lambda _name: None
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        initial_sprite_path_for_characters(
+            config,
+            " data/sprite/nanami/idle.webp",
+            [],
+            project_root=tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "C:/Sprites/./Nanami/idle.png",
+        "C:/Sprites//Nanami/idle.png",
+        r"C:\Sprites\..\Nanami\idle.png",
+    ),
+)
+def test_initial_sprite_path_rejects_cross_platform_lexical_aliases(tmp_path, raw):
+    config = _config(characters=[])
+    config.get_character_by_name = lambda _name: None
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        initial_sprite_path_for_characters(
+            config,
+            raw,
+            [],
+            project_root=tmp_path,
+        )
+
+
+def test_initial_sprite_path_rejects_project_symlink_escape(tmp_path):
+    external = tmp_path / "external"
+    project = tmp_path / "project"
+    external.mkdir()
+    project.mkdir()
+    try:
+        (project / "sprites").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+    config = _config(characters=[])
+    config.get_character_by_name = lambda _name: None
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        initial_sprite_path_for_characters(
+            config,
+            "sprites/custom.png",
+            [],
+            project_root=project,
+        )
 
 
 def test_display_initial_sprite_prefers_character_sprite_index(tmp_path, monkeypatch):

--- a/test/unit/core/test_file_transactions.py
+++ b/test/unit/core/test_file_transactions.py
@@ -1,0 +1,1862 @@
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import core.file_transactions as file_transactions
+from core.file_transactions import (
+    atomic_binary_writer,
+    atomic_write_bytes,
+    atomic_write_text,
+    clear_directory_without_links,
+    copy_directory_without_links,
+    copy_file_exclusive,
+    copy_file_transactionally,
+    create_private_temporary_directory,
+    inspect_portable_directory_tree,
+    open_binary_read_without_links,
+    open_binary_write_exclusive_without_links,
+    open_text_append_without_links,
+    private_temporary_directory,
+    read_bytes_snapshot_without_links,
+    read_bytes_without_links,
+    read_text_without_links,
+    remove_directory_without_links,
+    remove_empty_directory_without_links,
+    remove_file_without_links,
+    remove_link_without_following,
+    rename_path_without_overwrite,
+    replace_file_transactionally,
+    portable_name_key,
+    replace_directory_transactionally,
+    snapshot_directory_entries_without_links,
+    write_bytes_exclusive,
+)
+
+
+def test_atomic_write_text_preserves_previous_file_when_publish_fails(tmp_path, monkeypatch):
+    target = tmp_path / "template.txt"
+    target.write_text("old", encoding="utf-8")
+    real_rename = rename_path_without_overwrite
+
+    def fail_replace(source, destination, *, expected_identity=None):
+        if destination == target and Path(source).name.endswith(".tmp"):
+            raise OSError("publish failed")
+        return real_rename(
+            source,
+            destination,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.file_transactions.rename_path_without_overwrite",
+        fail_replace,
+    )
+
+    with pytest.raises(OSError, match="publish failed"):
+        atomic_write_text(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "old"
+    assert list(tmp_path.glob(".template.txt.*.tmp")) == []
+
+
+def test_atomic_write_and_remove_support_maximum_length_filename(tmp_path):
+    target = tmp_path / (("界" * 83) + "ab.txt")
+
+    atomic_write_text(target, "first")
+    atomic_write_text(target, "second")
+
+    assert target.read_text(encoding="utf-8") == "second"
+    assert len(target.name.encode("utf-8")) == 255
+    remove_file_without_links(target, expected_identity=target.lstat())
+    assert not target.exists()
+
+
+def test_private_temporary_directory_fits_an_oversized_prefix(tmp_path):
+    temporary, identity = create_private_temporary_directory(
+        prefix="界" * 100,
+        directory=tmp_path,
+    )
+    try:
+        assert len(temporary.name.encode("utf-8")) <= 255
+        assert temporary.is_dir()
+    finally:
+        remove_directory_without_links(
+            temporary,
+            expected_identity=identity,
+        )
+
+
+def test_rename_path_without_overwrite_publishes_exact_source_identity(tmp_path):
+    source = tmp_path / "source.txt"
+    destination = tmp_path / "destination.txt"
+    source.write_text("complete", encoding="utf-8")
+    source_identity = source.lstat()
+
+    published = rename_path_without_overwrite(
+        source,
+        destination,
+        expected_identity=source_identity,
+    )
+
+    assert published == destination
+    assert not source.exists()
+    assert destination.read_text(encoding="utf-8") == "complete"
+    assert os.path.samestat(source_identity, destination.lstat())
+
+
+def test_rename_path_without_overwrite_preserves_occupied_destination(tmp_path):
+    source = tmp_path / "source.txt"
+    destination = tmp_path / "destination.txt"
+    source.write_text("source", encoding="utf-8")
+    destination.write_text("peer", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        rename_path_without_overwrite(source, destination)
+
+    assert source.read_text(encoding="utf-8") == "source"
+    assert destination.read_text(encoding="utf-8") == "peer"
+
+
+def test_rename_path_without_overwrite_rejects_stale_source_identity(tmp_path):
+    source = tmp_path / "source.txt"
+    destination = tmp_path / "destination.txt"
+    source.write_text("original", encoding="utf-8")
+    stale_identity = source.lstat()
+    source.replace(tmp_path / "preserved.txt")
+    source.write_text("replacement", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        rename_path_without_overwrite(
+            source,
+            destination,
+            expected_identity=stale_identity,
+        )
+
+    assert source.read_text(encoding="utf-8") == "replacement"
+    assert not destination.exists()
+
+
+def test_rename_path_without_overwrite_rejects_stale_expected_parent(tmp_path):
+    managed = tmp_path / "managed"
+    preserved_parent = tmp_path / "preserved-managed"
+    managed.mkdir()
+    expected_parent_identity = managed.lstat()
+    managed.rename(preserved_parent)
+    managed.mkdir()
+    source = managed / "source.txt"
+    destination = managed / "destination.txt"
+    source.write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="source parent identity changed"):
+        rename_path_without_overwrite(
+            source,
+            destination,
+            expected_source_parent_identity=expected_parent_identity,
+            expected_destination_parent_identity=expected_parent_identity,
+        )
+
+    assert source.read_text(encoding="utf-8") == "peer"
+    assert not destination.exists()
+
+
+def test_rename_path_without_overwrite_binds_parent_before_native_call(
+    tmp_path,
+    monkeypatch,
+):
+    managed = tmp_path / "managed"
+    preserved_parent = tmp_path / "preserved-managed"
+    managed.mkdir()
+    source = managed / "source.bin"
+    destination = managed / "destination.bin"
+    source.write_bytes(b"original")
+    real_native_rename = file_transactions._native_rename_without_overwrite
+
+    def replace_parent_then_rename(source_path, destination_path, **identities):
+        managed.rename(preserved_parent)
+        managed.mkdir()
+        source.write_bytes(b"peer")
+        return real_native_rename(
+            source_path,
+            destination_path,
+            **identities,
+        )
+
+    monkeypatch.setattr(
+        file_transactions,
+        "_native_rename_without_overwrite",
+        replace_parent_then_rename,
+    )
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        rename_path_without_overwrite(source, destination)
+
+    assert source.read_bytes() == b"peer"
+    assert not destination.exists()
+    assert (preserved_parent / "source.bin").read_bytes() == b"original"
+
+
+def test_rename_path_without_overwrite_rejects_parent_replaced_after_publication(
+    tmp_path,
+    monkeypatch,
+):
+    managed = tmp_path / "managed"
+    preserved_parent = tmp_path / "preserved-managed"
+    managed.mkdir()
+    source = managed / "source.bin"
+    destination = managed / "destination.bin"
+    source.write_bytes(b"original")
+    real_native_rename = file_transactions._native_rename_without_overwrite
+
+    def rename_then_replace_parent(source_path, destination_path, **identities):
+        real_native_rename(
+            source_path,
+            destination_path,
+            **identities,
+        )
+        managed.rename(preserved_parent)
+        managed.mkdir()
+        destination.write_bytes(b"peer")
+
+    monkeypatch.setattr(
+        file_transactions,
+        "_native_rename_without_overwrite",
+        rename_then_replace_parent,
+    )
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        rename_path_without_overwrite(source, destination)
+
+    assert destination.read_bytes() == b"peer"
+    assert (preserved_parent / "destination.bin").read_bytes() == b"original"
+
+
+def test_atomic_write_text_rejects_lexical_alias_before_write(tmp_path):
+    alias = f"{tmp_path.as_posix()}/./template.txt"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        atomic_write_text(alias, "new")
+
+    assert not (tmp_path / "template.txt").exists()
+
+
+def test_atomic_write_text_rejects_relative_targets_instead_of_using_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="absolute"):
+        atomic_write_text("template.txt", "new")
+
+    assert not (tmp_path / "template.txt").exists()
+
+
+def test_atomic_write_text_rejects_filesystem_root(tmp_path):
+    root = tmp_path.anchor
+
+    with pytest.raises(PermissionError, match="filesystem root"):
+        atomic_write_text(root, "new")
+
+
+def test_atomic_write_text_rejects_intermediate_symlink(tmp_path):
+    external = tmp_path / "external"
+    external.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link component"):
+        atomic_write_text(alias / "template.txt", "new")
+
+    assert not (external / "template.txt").exists()
+
+
+def test_link_free_read_helpers_preserve_exact_regular_file_identity(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("内容", encoding="utf-8")
+
+    assert read_text_without_links(source) == "内容"
+    assert read_bytes_without_links(source) == "内容".encode()
+
+
+def test_link_free_read_helpers_reject_leaf_symlink(tmp_path):
+    source = tmp_path / "source.txt"
+    alias = tmp_path / "alias.txt"
+    source.write_text("secret", encoding="utf-8")
+    try:
+        alias.symlink_to(source)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        read_bytes_without_links(alias)
+
+
+def test_link_free_reader_rejects_a_replacement_expected_file(tmp_path):
+    source = tmp_path / "source.txt"
+    preserved = tmp_path / "preserved.txt"
+    source.write_text("original", encoding="utf-8")
+    expected_identity = source.lstat()
+    source.rename(preserved)
+    source.write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        with open_binary_read_without_links(
+            source,
+            expected_identity=expected_identity,
+        ):
+            pass
+
+    assert source.read_text(encoding="utf-8") == "peer"
+    assert preserved.read_text(encoding="utf-8") == "original"
+
+
+def test_link_free_reader_rejects_in_place_change_after_expected_snapshot(
+    tmp_path,
+):
+    source = tmp_path / "source.txt"
+    source.write_text("original", encoding="utf-8")
+    expected_identity = source.lstat()
+    source.write_text("replacement-is-longer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        with open_binary_read_without_links(
+            source,
+            expected_identity=expected_identity,
+        ):
+            pass
+
+
+def test_link_free_reader_rejects_a_replacement_expected_parent(tmp_path):
+    parent = tmp_path / "inputs"
+    preserved_parent = tmp_path / "preserved-inputs"
+    parent.mkdir()
+    source = parent / "source.txt"
+    source.write_text("original", encoding="utf-8")
+    expected_parent_identity = parent.lstat()
+    parent.rename(preserved_parent)
+    parent.mkdir()
+    source.write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        with open_binary_read_without_links(
+            source,
+            expected_parent_identity=expected_parent_identity,
+        ):
+            pass
+
+    assert source.read_text(encoding="utf-8") == "peer"
+    assert (preserved_parent / "source.txt").read_text(encoding="utf-8") == "original"
+
+
+def test_snapshot_read_rejects_in_place_mutation(tmp_path, monkeypatch):
+    source = tmp_path / "source.txt"
+    source.write_bytes(b"original")
+    real_open = file_transactions.open_binary_read_without_links
+
+    @contextmanager
+    def mutate_after_read(*args, **kwargs):
+        with real_open(*args, **kwargs) as handle:
+            class MutatingReader:
+                def fileno(self):
+                    return handle.fileno()
+
+                def read(self):
+                    payload = handle.read()
+                    source.write_bytes(b"replacement-is-longer")
+                    return payload
+
+            yield MutatingReader()
+
+    monkeypatch.setattr(
+        file_transactions,
+        "open_binary_read_without_links",
+        mutate_after_read,
+    )
+
+    with pytest.raises(PermissionError, match="changed while it was being read"):
+        read_bytes_snapshot_without_links(source)
+
+    assert source.read_bytes() == b"replacement-is-longer"
+
+
+def test_directory_snapshot_rejects_replaced_directory(tmp_path, monkeypatch):
+    directory = tmp_path / "catalog"
+    preserved = tmp_path / "catalog-preserved"
+    directory.mkdir()
+    (directory / "original.txt").write_text("original", encoding="utf-8")
+    real_scandir = file_transactions.os.scandir
+
+    @contextmanager
+    def replace_after_scan(path):
+        with real_scandir(path) as scanner:
+            yield scanner
+        directory.rename(preserved)
+        directory.mkdir()
+        (directory / "peer.txt").write_text("peer", encoding="utf-8")
+
+    monkeypatch.setattr(file_transactions.os, "scandir", replace_after_scan)
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        snapshot_directory_entries_without_links(directory)
+
+    assert (directory / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (preserved / "original.txt").read_text(encoding="utf-8") == "original"
+
+
+def test_portable_tree_inventory_never_restats_scanned_names_by_public_path(
+    tmp_path,
+    monkeypatch,
+):
+    if (
+        os.scandir not in os.supports_fd
+        or os.stat not in os.supports_dir_fd
+    ):
+        pytest.skip("descriptor-relative directory scans are unavailable")
+
+    source = tmp_path / "source"
+    nested = source / "nested"
+    nested.mkdir(parents=True)
+    (source / "root.txt").write_text("root", encoding="utf-8")
+    (nested / "child.txt").write_text("child", encoding="utf-8")
+    real_scandir = file_transactions.os.scandir
+
+    class EntryWithoutPublicRestat:
+        def __init__(self, entry):
+            self._entry = entry
+            self.name = entry.name
+            self.path = entry.path
+
+        def stat(self, *, follow_symlinks=False):
+            raise AssertionError(
+                "DirEntry.stat() would resolve the public directory name again"
+            )
+
+    @contextmanager
+    def scan_without_public_restat(path):
+        with real_scandir(path) as scanner:
+            yield (
+                EntryWithoutPublicRestat(entry)
+                for entry in scanner
+            )
+
+    monkeypatch.setattr(
+        file_transactions.os,
+        "scandir",
+        scan_without_public_restat,
+    )
+    monkeypatch.setattr(
+        file_transactions.os,
+        "supports_fd",
+        {*os.supports_fd, scan_without_public_restat},
+    )
+
+    directories, files = inspect_portable_directory_tree(source)
+
+    assert directories == [Path("nested")]
+    assert set(files) == {Path("root.txt"), Path("nested/child.txt")}
+
+
+def test_exclusive_write_helper_creates_one_exact_regular_file(tmp_path):
+    target = tmp_path / "managed.bin"
+
+    with open_binary_write_exclusive_without_links(target) as output:
+        output.write(b"content")
+
+    assert target.read_bytes() == b"content"
+    with pytest.raises(FileExistsError):
+        open_binary_write_exclusive_without_links(target)
+
+
+def test_exclusive_write_helper_rejects_a_linked_parent(tmp_path):
+    external = tmp_path / "external"
+    external.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        open_binary_write_exclusive_without_links(alias / "managed.bin")
+
+    assert not (external / "managed.bin").exists()
+
+
+def test_exclusive_write_helper_rejects_replaced_expected_parent(tmp_path):
+    parent = tmp_path / "managed"
+    parent.mkdir()
+    expected_parent_identity = parent.lstat()
+    preserved_parent = tmp_path / "preserved-managed"
+    parent.rename(preserved_parent)
+    parent.mkdir()
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        open_binary_write_exclusive_without_links(
+            parent / "managed.bin",
+            expected_parent_identity=expected_parent_identity,
+        )
+
+    assert list(parent.iterdir()) == []
+    assert list(preserved_parent.iterdir()) == []
+
+
+def test_atomic_write_text_revalidates_parent_after_creating_it(tmp_path, monkeypatch):
+    parent = tmp_path / "managed"
+    external = tmp_path / "external"
+    external.mkdir()
+    original_mkdir = Path.mkdir
+    swapped = False
+
+    def create_then_swap(path, *args, **kwargs):
+        nonlocal swapped
+        result = original_mkdir(path, *args, **kwargs)
+        if path == parent and not swapped:
+            swapped = True
+            path.rmdir()
+            try:
+                path.symlink_to(external, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                pytest.skip("symbolic links are unavailable")
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", create_then_swap)
+
+    with pytest.raises(PermissionError, match="symbolic link component"):
+        atomic_write_text(parent / "template.txt", "new")
+
+    assert not (external / "template.txt").exists()
+
+
+def test_atomic_write_text_rejects_replaced_expected_parent(tmp_path):
+    parent = tmp_path / "managed"
+    preserved = tmp_path / "managed-preserved"
+    parent.mkdir()
+    expected_parent = parent.lstat()
+    rename_path_without_overwrite(
+        parent,
+        preserved,
+        expected_identity=expected_parent,
+    )
+    parent.mkdir()
+    peer = parent / "template.txt"
+    peer.write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        atomic_write_text(
+            peer,
+            "stale",
+            expected_parent_identity=expected_parent,
+        )
+
+    assert peer.read_text(encoding="utf-8") == "peer"
+
+
+def test_atomic_write_bytes_rejects_leaf_symlink(tmp_path):
+    external = tmp_path / "external.bin"
+    target = tmp_path / "managed.bin"
+    external.write_bytes(b"private")
+    try:
+        target.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        atomic_write_bytes(target, b"replacement")
+
+    assert external.read_bytes() == b"private"
+
+
+def test_atomic_binary_writer_preserves_previous_file_when_stream_fails(tmp_path):
+    target = tmp_path / "download.bin"
+    target.write_bytes(b"complete")
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        with atomic_binary_writer(target) as handle:
+            handle.write(b"partial")
+            raise RuntimeError("stream failed")
+
+    assert target.read_bytes() == b"complete"
+    assert list(tmp_path.glob(".download.bin.*.tmp")) == []
+
+
+def test_replace_file_transactionally_publishes_complete_sibling(tmp_path):
+    target = tmp_path / "cache.wav"
+    staging = tmp_path / ".cache.wav.encoder-part"
+    target.write_bytes(b"old")
+    staging.write_bytes(b"complete")
+
+    published = replace_file_transactionally(staging, target)
+
+    assert published == target
+    assert target.read_bytes() == b"complete"
+    assert not staging.exists()
+
+
+def test_replace_file_transactionally_preserves_target_on_publish_failure(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "archive.zip"
+    staging = tmp_path / ".archive.zip.writer-part"
+    target.write_bytes(b"old")
+    staging.write_bytes(b"complete")
+    real_rename = rename_path_without_overwrite
+
+    def fail_replace(source, destination, *, expected_identity=None):
+        if source == staging and destination == target:
+            raise OSError("publish failed")
+        return real_rename(
+            source,
+            destination,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.file_transactions.rename_path_without_overwrite",
+        fail_replace,
+    )
+
+    with pytest.raises(OSError, match="publish failed"):
+        replace_file_transactionally(staging, target)
+
+    assert target.read_bytes() == b"old"
+    assert staging.read_bytes() == b"complete"
+    assert not list(tmp_path.glob(".archive.zip.backup-*"))
+
+
+def test_replace_file_transactionally_rejects_stale_expected_staging_identity(
+    tmp_path,
+):
+    target = tmp_path / "archive.zip"
+    staging = tmp_path / ".archive.zip.writer-part"
+    preserved = tmp_path / "preserved.zip"
+    target.write_bytes(b"old")
+    staging.write_bytes(b"complete")
+    staging_identity = staging.lstat()
+    staging.rename(preserved)
+    staging.write_bytes(b"replacement")
+
+    with pytest.raises(PermissionError, match="staging file identity changed"):
+        replace_file_transactionally(
+            staging,
+            target,
+            expected_staging_identity=staging_identity,
+        )
+
+    assert target.read_bytes() == b"old"
+    assert staging.read_bytes() == b"replacement"
+    assert preserved.read_bytes() == b"complete"
+
+
+def test_replace_file_transactionally_preserves_changed_expected_destination(
+    tmp_path,
+):
+    target = tmp_path / "archive.zip"
+    staging = tmp_path / ".archive.zip.writer-part"
+    preserved = tmp_path / "preserved.zip"
+    target.write_bytes(b"old")
+    target_identity = target.lstat()
+    staging.write_bytes(b"complete")
+    target.rename(preserved)
+    target.write_bytes(b"peer")
+
+    with pytest.raises(PermissionError, match="destination file identity changed"):
+        replace_file_transactionally(
+            staging,
+            target,
+            expected_destination_identity=target_identity,
+        )
+
+    assert target.read_bytes() == b"peer"
+    assert staging.read_bytes() == b"complete"
+    assert preserved.read_bytes() == b"old"
+
+
+def test_replace_file_transactionally_preserves_destination_that_was_expected_absent(
+    tmp_path,
+):
+    target = tmp_path / "archive.zip"
+    staging = tmp_path / ".archive.zip.writer-part"
+    staging.write_bytes(b"complete")
+    target.write_bytes(b"peer")
+
+    with pytest.raises(FileExistsError, match="appeared before publication"):
+        replace_file_transactionally(
+            staging,
+            target,
+            expected_destination_identity=None,
+        )
+
+    assert target.read_bytes() == b"peer"
+    assert staging.read_bytes() == b"complete"
+
+
+def test_replace_file_transactionally_rejects_destination_symlink(tmp_path):
+    external = tmp_path / "external.wav"
+    target = tmp_path / "cache.wav"
+    staging = tmp_path / ".cache.wav.encoder-part"
+    external.write_bytes(b"private")
+    staging.write_bytes(b"complete")
+    try:
+        target.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        replace_file_transactionally(staging, target)
+
+    assert target.is_symlink()
+    assert external.read_bytes() == b"private"
+    assert staging.read_bytes() == b"complete"
+
+
+def test_replace_file_transactionally_requires_same_parent(tmp_path):
+    staging = tmp_path / "temporary" / "cache.wav"
+    target = tmp_path / "managed" / "cache.wav"
+    staging.parent.mkdir()
+    target.parent.mkdir()
+    staging.write_bytes(b"complete")
+
+    with pytest.raises(ValueError, match="share a parent"):
+        replace_file_transactionally(staging, target)
+
+    assert staging.read_bytes() == b"complete"
+    assert not target.exists()
+
+
+def test_replace_file_transactionally_rejects_stale_expected_parent(tmp_path):
+    parent = tmp_path / "publication"
+    preserved = tmp_path / "publication-preserved"
+    parent.mkdir()
+    expected_parent = parent.lstat()
+    rename_path_without_overwrite(
+        parent,
+        preserved,
+        expected_identity=expected_parent,
+    )
+    parent.mkdir()
+    staging = parent / "staging.bin"
+    target = parent / "target.bin"
+    staging.write_bytes(b"stale")
+    target.write_bytes(b"peer")
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        replace_file_transactionally(
+            staging,
+            target,
+            expected_parent_identity=expected_parent,
+        )
+
+    assert staging.read_bytes() == b"stale"
+    assert target.read_bytes() == b"peer"
+
+
+def test_replace_file_transactionally_rejects_replaced_staging_identity(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "archive.zip"
+    staging = tmp_path / ".archive.zip.writer-part"
+    replacement = tmp_path / "replacement.zip"
+    preserved_original = tmp_path / "original-staging.zip"
+    target.write_bytes(b"old")
+    staging.write_bytes(b"complete")
+    replacement.write_bytes(b"replacement")
+    real_fsync = os.fsync
+    replaced = False
+
+    def replace_after_sync(descriptor):
+        nonlocal replaced
+        real_fsync(descriptor)
+        if not replaced:
+            replaced = True
+            staging.rename(preserved_original)
+            replacement.rename(staging)
+
+    monkeypatch.setattr("core.file_transactions.os.fsync", replace_after_sync)
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        replace_file_transactionally(staging, target)
+
+    assert target.read_bytes() == b"old"
+    assert staging.read_bytes() == b"replacement"
+    assert preserved_original.read_bytes() == b"complete"
+
+
+def test_copy_file_transactionally_replaces_only_after_complete_copy(tmp_path):
+    source = tmp_path / "source.bin"
+    target = tmp_path / "target.bin"
+    source.write_bytes(b"complete")
+    target.write_bytes(b"old")
+
+    published = copy_file_transactionally(source, target)
+
+    assert published == target
+    assert target.read_bytes() == b"complete"
+    assert list(tmp_path.glob(".target.bin.*.copy")) == []
+
+
+def test_copy_file_transactionally_preserves_target_when_copy_fails(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source.bin"
+    target = tmp_path / "target.bin"
+    source.write_bytes(b"complete")
+    target.write_bytes(b"old")
+
+    def fail_copy(input_file, output_file):
+        output_file.write(input_file.read(2))
+        raise OSError("copy failed")
+
+    monkeypatch.setattr("core.file_transactions.shutil.copyfileobj", fail_copy)
+
+    with pytest.raises(OSError, match="copy failed"):
+        copy_file_transactionally(source, target)
+
+    assert target.read_bytes() == b"old"
+    assert list(tmp_path.glob(".target.bin.*.copy")) == []
+
+
+def test_copy_file_transactionally_rejects_in_place_source_mutation(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source.bin"
+    target = tmp_path / "target.bin"
+    source.write_bytes(b"complete")
+    target.write_bytes(b"old")
+    real_copy = file_transactions.shutil.copyfileobj
+
+    def copy_then_mutate_source(input_file, output_file):
+        real_copy(input_file, output_file)
+        source.write_bytes(b"changed")
+
+    monkeypatch.setattr(
+        "core.file_transactions.shutil.copyfileobj",
+        copy_then_mutate_source,
+    )
+
+    with pytest.raises(PermissionError, match="changed while it was being copied"):
+        copy_file_transactionally(source, target)
+
+    assert source.read_bytes() == b"changed"
+    assert target.read_bytes() == b"old"
+    assert list(tmp_path.glob(".target.bin.*.copy")) == []
+
+
+@pytest.mark.skipif(not hasattr(os, "fchmod"), reason="descriptor chmod is unavailable")
+def test_copy_file_transactionally_never_changes_replacement_staging_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source.bin"
+    target = tmp_path / "target.bin"
+    preserved_staging = tmp_path / "preserved-staging.bin"
+    source.write_bytes(b"complete")
+    source.chmod(0o755)
+    target.write_bytes(b"old")
+    real_copy = file_transactions.shutil.copyfileobj
+    replacement_path: Path | None = None
+
+    def replace_staging_after_copy(input_file, output_file):
+        nonlocal replacement_path
+        real_copy(input_file, output_file)
+        replacement_path = Path(output_file.name)
+        replacement_path.rename(preserved_staging)
+        replacement_path.write_bytes(b"peer")
+        replacement_path.chmod(0o600)
+
+    monkeypatch.setattr(
+        "core.file_transactions.shutil.copyfileobj",
+        replace_staging_after_copy,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        copy_file_transactionally(source, target)
+
+    assert replacement_path is not None
+    assert replacement_path.read_bytes() == b"peer"
+    assert stat.S_IMODE(replacement_path.stat().st_mode) == 0o600
+    assert preserved_staging.read_bytes() == b"complete"
+    assert stat.S_IMODE(preserved_staging.stat().st_mode) == 0o755
+    assert target.read_bytes() == b"old"
+
+
+def test_copy_file_transactionally_rejects_source_symlink(tmp_path):
+    external = tmp_path / "external.bin"
+    source = tmp_path / "source.bin"
+    target = tmp_path / "target.bin"
+    external.write_bytes(b"private")
+    try:
+        source.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        copy_file_transactionally(source, target)
+
+    assert not target.exists()
+
+
+def test_copy_file_transactionally_rejects_stale_source_and_destination_parent(
+    tmp_path,
+):
+    source_parent = tmp_path / "source"
+    destination_parent = tmp_path / "destination"
+    preserved_source_parent = tmp_path / "source-preserved"
+    preserved_destination_parent = tmp_path / "destination-preserved"
+    source_parent.mkdir()
+    destination_parent.mkdir()
+    source = source_parent / "payload.bin"
+    source.write_bytes(b"original")
+    source_identity = source.lstat()
+    source_parent_identity = source_parent.lstat()
+    destination_parent_identity = destination_parent.lstat()
+
+    source_parent.rename(preserved_source_parent)
+    source_parent.mkdir()
+    peer_source = source_parent / "payload.bin"
+    peer_source.write_bytes(b"peer")
+    with pytest.raises(PermissionError, match="source file parent identity changed"):
+        copy_file_transactionally(
+            peer_source,
+            destination_parent / "payload.bin",
+            expected_source_identity=source_identity,
+            expected_source_parent_identity=source_parent_identity,
+            expected_destination_parent_identity=destination_parent_identity,
+        )
+    assert peer_source.read_bytes() == b"peer"
+    assert not (destination_parent / "payload.bin").exists()
+
+    destination_parent.rename(preserved_destination_parent)
+    destination_parent.mkdir()
+    peer_destination = destination_parent / "payload.bin"
+    peer_destination.write_bytes(b"destination peer")
+    with pytest.raises(PermissionError, match="destination parent identity changed"):
+        copy_file_transactionally(
+            preserved_source_parent / "payload.bin",
+            peer_destination,
+            expected_destination_parent_identity=destination_parent_identity,
+        )
+    assert peer_destination.read_bytes() == b"destination peer"
+    assert (preserved_source_parent / "payload.bin").read_bytes() == b"original"
+
+
+def test_open_text_append_without_links_rejects_leaf_symlink(tmp_path):
+    external = tmp_path / "external.log"
+    target = tmp_path / "managed.log"
+    external.write_text("private", encoding="utf-8")
+    try:
+        target.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises((OSError, PermissionError)):
+        open_text_append_without_links(target)
+
+    assert external.read_text(encoding="utf-8") == "private"
+
+
+def test_open_text_append_without_links_appends_to_regular_file(tmp_path):
+    target = tmp_path / "logs/runtime.log"
+
+    with open_text_append_without_links(target) as handle:
+        handle.write("first\n")
+    with open_text_append_without_links(target) as handle:
+        handle.write("second\n")
+
+    assert target.read_text(encoding="utf-8") == "first\nsecond\n"
+
+
+def test_open_text_append_without_links_rejects_replaced_parent_identity(
+    tmp_path,
+):
+    parent = tmp_path / "logs"
+    preserved = tmp_path / "logs-preserved"
+    parent.mkdir()
+    expected_parent_identity = parent.lstat()
+    parent.rename(preserved)
+    parent.mkdir()
+    peer = parent / "runtime.log"
+    peer.write_text("peer\n", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        open_text_append_without_links(
+            peer,
+            expected_parent_identity=expected_parent_identity,
+        )
+
+    assert peer.read_text(encoding="utf-8") == "peer\n"
+    assert list(preserved.iterdir()) == []
+
+
+def test_private_temporary_directory_removes_its_owned_tree(tmp_path):
+    with private_temporary_directory(
+        prefix="owned-temp-",
+        directory=tmp_path,
+    ) as temporary:
+        identity = temporary.lstat()
+        (temporary / "nested").mkdir()
+        (temporary / "nested" / "payload.txt").write_text("payload", encoding="utf-8")
+
+    assert not temporary.exists()
+    assert stat.S_ISDIR(identity.st_mode)
+
+
+def test_private_temporary_directory_preserves_a_replacement_identity(tmp_path):
+    with private_temporary_directory(
+        prefix="owned-temp-",
+        directory=tmp_path,
+    ) as temporary:
+        original = temporary.with_name(f"{temporary.name}-original")
+        temporary.rename(original)
+        temporary.mkdir()
+        (temporary / "peer.txt").write_text("peer", encoding="utf-8")
+
+    assert (temporary / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert original.is_dir()
+
+
+def test_clear_directory_without_links_preserves_root_identity(tmp_path):
+    root = tmp_path / "owned"
+    root.mkdir()
+    identity = root.lstat()
+    (root / "nested").mkdir()
+    (root / "nested" / "payload.txt").write_text("nested", encoding="utf-8")
+    (root / "payload.txt").write_text("file", encoding="utf-8")
+
+    clear_directory_without_links(root, expected_identity=identity)
+
+    assert root.is_dir()
+    assert os.path.samestat(identity, root.lstat())
+    assert list(root.iterdir()) == []
+
+
+def test_clear_directory_without_links_preserves_replacement_root(tmp_path):
+    root = tmp_path / "owned"
+    root.mkdir()
+    identity = root.lstat()
+    preserved = tmp_path / "preserved"
+    root.rename(preserved)
+    root.mkdir()
+    (root / "peer.txt").write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        clear_directory_without_links(root, expected_identity=identity)
+
+    assert (root / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert preserved.is_dir()
+
+
+def test_create_private_temporary_directory_rejects_relative_parent():
+    with pytest.raises(ValueError, match="absolute"):
+        create_private_temporary_directory(
+            prefix="owned-temp-",
+            directory=Path("relative"),
+        )
+
+
+def test_copy_file_exclusive_uses_distinct_names_under_concurrency(tmp_path):
+    source = tmp_path / "incoming/image.png"
+    source.parent.mkdir()
+    source.write_bytes(b"image")
+    destination = tmp_path / "managed"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        paths = list(
+            executor.map(
+                lambda _index: copy_file_exclusive(
+                    source,
+                    destination,
+                    "Image.png",
+                ),
+                range(2),
+            )
+        )
+
+    assert {path.name for path in paths} == {"Image.png", "Image_1.png"}
+    assert all(path.read_bytes() == b"image" for path in paths)
+
+
+def test_copy_file_exclusive_avoids_case_only_collision(tmp_path):
+    source = tmp_path / "incoming/image.png"
+    source.parent.mkdir()
+    source.write_bytes(b"new")
+    destination = tmp_path / "managed"
+    destination.mkdir()
+    (destination / "IMAGE.PNG").write_bytes(b"old")
+
+    copied = copy_file_exclusive(source, destination, "image.png")
+
+    assert copied.name == "image_1.png"
+    assert (destination / "IMAGE.PNG").read_bytes() == b"old"
+    assert copied.read_bytes() == b"new"
+
+
+def test_copy_file_exclusive_rejects_source_symlink_without_partial_output(tmp_path):
+    source = tmp_path / "incoming/image.png"
+    external = tmp_path / "external.png"
+    destination = tmp_path / "managed"
+    source.parent.mkdir()
+    external.write_bytes(b"private")
+    try:
+        source.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        copy_file_exclusive(source, destination, "image.png")
+
+    assert not destination.exists()
+
+
+def test_write_bytes_exclusive_preserves_duplicate_uploads(tmp_path):
+    first = write_bytes_exclusive(tmp_path, "memory.json", b"first")
+    second = write_bytes_exclusive(tmp_path, "memory.json", b"second")
+
+    assert first.name == "memory.json"
+    assert second.name == "memory_1.json"
+    assert first.read_bytes() == b"first"
+    assert second.read_bytes() == b"second"
+
+
+def test_write_bytes_exclusive_fits_collision_suffix_within_byte_limit(tmp_path):
+    requested_name = ("界" * 83) + "ab.png"
+
+    first = write_bytes_exclusive(tmp_path, requested_name, b"first")
+    second = write_bytes_exclusive(tmp_path, requested_name, b"second")
+
+    assert first.name == requested_name
+    assert second.name == ("界" * 83) + "_1.png"
+    assert len(second.name.encode("utf-8")) == 255
+    assert first.read_bytes() == b"first"
+    assert second.read_bytes() == b"second"
+
+
+def test_write_bytes_exclusive_rejects_parent_replaced_during_write(
+    tmp_path,
+    monkeypatch,
+):
+    destination = tmp_path / "managed"
+    destination.mkdir()
+    preserved_destination = tmp_path / "preserved-managed"
+    real_fsync = file_transactions.os.fsync
+    replaced = False
+
+    def fsync_then_replace(descriptor):
+        nonlocal replaced
+        real_fsync(descriptor)
+        if not replaced:
+            replaced = True
+            destination.rename(preserved_destination)
+            destination.mkdir()
+            (destination / "memory.json").write_bytes(b"peer")
+
+    monkeypatch.setattr(file_transactions.os, "fsync", fsync_then_replace)
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        write_bytes_exclusive(destination, "memory.json", b"original")
+
+    assert (destination / "memory.json").read_bytes() == b"peer"
+    assert (preserved_destination / "memory.json").read_bytes() == b"original"
+
+
+def test_exclusive_write_revalidates_destination_after_creating_it(tmp_path, monkeypatch):
+    destination = tmp_path / "managed"
+    external = tmp_path / "external"
+    external.mkdir()
+    original_mkdir = Path.mkdir
+    swapped = False
+
+    def create_then_swap(path, *args, **kwargs):
+        nonlocal swapped
+        result = original_mkdir(path, *args, **kwargs)
+        if path == destination and not swapped:
+            swapped = True
+            path.rmdir()
+            try:
+                path.symlink_to(external, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                pytest.skip("symbolic links are unavailable")
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", create_then_swap)
+
+    with pytest.raises(PermissionError, match="symbolic link component"):
+        write_bytes_exclusive(destination, "memory.json", b"new")
+
+    assert not (external / "memory.json").exists()
+
+
+def test_write_bytes_exclusive_serializes_portable_name_collisions(tmp_path):
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(write_bytes_exclusive, tmp_path, "Image.png", b"upper"),
+            executor.submit(write_bytes_exclusive, tmp_path, "image.png", b"lower"),
+        ]
+        paths = [future.result() for future in futures]
+
+    assert len({portable_name_key(path.name) for path in paths}) == 2
+    assert {path.read_bytes() for path in paths} == {b"upper", b"lower"}
+
+
+def test_copy_directory_without_links_rejects_nested_symlink(tmp_path):
+    source = tmp_path / "source"
+    external = tmp_path / "external.txt"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    external.write_text("private", encoding="utf-8")
+    try:
+        (source / "linked.txt").symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        copy_directory_without_links(source, destination)
+
+    assert not destination.exists()
+
+
+def test_copy_directory_without_links_rejects_windows_reparse_entry_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    source.mkdir()
+    junction = source / "junction"
+    destination = tmp_path / "destination"
+    real_scandir = os.scandir
+
+    class FakeEntry:
+        name = junction.name
+        path = str(junction)
+
+        @staticmethod
+        def stat(*, follow_symlinks=False):
+            assert follow_symlinks is False
+            return SimpleNamespace(
+                st_mode=stat.S_IFDIR,
+                st_file_attributes=getattr(
+                    stat,
+                    "FILE_ATTRIBUTE_REPARSE_POINT",
+                    0x00000400,
+                ),
+            )
+
+    class FakeScanner:
+        def __enter__(self):
+            return iter([FakeEntry()])
+
+        def __exit__(self, *_args):
+            return False
+
+    def fake_scandir(path):
+        if path == source:
+            return FakeScanner()
+        return real_scandir(path)
+
+    monkeypatch.setattr("core.file_transactions.os.scandir", fake_scandir)
+    monkeypatch.setattr(file_transactions.os, "supports_fd", set())
+
+    with pytest.raises(PermissionError, match="reparse point"):
+        copy_directory_without_links(source, destination)
+
+    assert not destination.exists()
+
+
+def test_copy_directory_without_links_rejects_portable_name_collision(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "Image.png").write_bytes(b"upper")
+    (source / "image.png").write_bytes(b"lower")
+
+    with pytest.raises(FileExistsError, match="portable filename collision"):
+        copy_directory_without_links(source, destination)
+
+    assert not destination.exists()
+
+
+def test_copy_directory_without_links_rejects_destination_alias_before_copy(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "item.txt").write_text("content", encoding="utf-8")
+    destination_alias = f"{tmp_path.as_posix()}/nested/../destination"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        copy_directory_without_links(source, destination_alias)
+
+    assert not (tmp_path / "destination").exists()
+
+
+def test_copy_directory_without_links_rejects_stale_expected_source_identity(
+    tmp_path,
+):
+    source = tmp_path / "source"
+    preserved = tmp_path / "preserved-source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "original.txt").write_text("original", encoding="utf-8")
+    source_identity = source.lstat()
+    source.rename(preserved)
+    source.mkdir()
+    (source / "replacement.txt").write_text("replacement", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="source directory identity changed"):
+        copy_directory_without_links(
+            source,
+            destination,
+            expected_source_identity=source_identity,
+        )
+
+    assert not destination.exists()
+    assert (source / "replacement.txt").read_text(encoding="utf-8") == "replacement"
+    assert (preserved / "original.txt").read_text(encoding="utf-8") == "original"
+
+
+def test_copy_directory_without_links_rejects_file_replaced_after_inventory(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    preserved = tmp_path / "preserved.txt"
+    source.mkdir()
+    source_file = source / "payload.txt"
+    source_file.write_text("original", encoding="utf-8")
+    real_inventory = file_transactions._inspect_portable_directory_tree_with_metadata
+    inspected = False
+
+    def inspect_then_replace(path):
+        nonlocal inspected
+        result = real_inventory(path)
+        if Path(path) == source and not inspected:
+            inspected = True
+            source_file.rename(preserved)
+            source_file.write_text("replacement", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(
+        file_transactions,
+        "_inspect_portable_directory_tree_with_metadata",
+        inspect_then_replace,
+    )
+
+    with pytest.raises(PermissionError, match="file identity changed"):
+        copy_directory_without_links(source, destination)
+
+    assert not destination.exists()
+    assert source_file.read_text(encoding="utf-8") == "replacement"
+    assert preserved.read_text(encoding="utf-8") == "original"
+
+
+def test_copy_directory_without_links_preserves_replaced_destination_root(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    preserved = tmp_path / "preserved-destination"
+    source.mkdir()
+    (source / "payload.txt").write_text("original", encoding="utf-8")
+    real_copy = file_transactions.shutil.copyfileobj
+    replaced = False
+
+    def replace_destination_during_copy(input_file, output_file):
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            destination.rename(preserved)
+            destination.mkdir()
+            (destination / "peer.txt").write_text("peer", encoding="utf-8")
+        return real_copy(input_file, output_file)
+
+    monkeypatch.setattr(
+        file_transactions.shutil,
+        "copyfileobj",
+        replace_destination_during_copy,
+    )
+
+    with pytest.raises((FileNotFoundError, PermissionError)):
+        copy_directory_without_links(source, destination)
+
+    assert (destination / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (preserved / "payload.txt").read_text(encoding="utf-8") == "original"
+
+
+def test_remove_file_without_links_removes_exact_file(tmp_path):
+    target = tmp_path / "managed.json"
+    target.write_text("content", encoding="utf-8")
+
+    remove_file_without_links(target)
+
+    assert not target.exists()
+    assert not list(tmp_path.glob(".managed.json.delete-*"))
+
+
+def test_remove_file_without_links_rejects_leaf_symlink(tmp_path):
+    target = tmp_path / "managed.json"
+    external = tmp_path / "external.json"
+    external.write_text("keep", encoding="utf-8")
+    try:
+        target.symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        remove_file_without_links(target)
+
+    assert target.is_symlink()
+    assert external.read_text(encoding="utf-8") == "keep"
+
+
+def test_remove_file_without_links_restores_a_concurrent_replacement(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "managed.json"
+    peer = tmp_path / "peer.json"
+    preserved_original = tmp_path / "original.json"
+    target.write_text("original", encoding="utf-8")
+    peer.write_text("peer", encoding="utf-8")
+    real_rename = rename_path_without_overwrite
+    replaced = False
+
+    def replace_before_rename(source, destination, *, expected_identity=None):
+        nonlocal replaced
+        if source == target and not replaced:
+            replaced = True
+            real_rename(target, preserved_original)
+            real_rename(peer, target)
+        return real_rename(
+            source,
+            destination,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.file_transactions.rename_path_without_overwrite",
+        replace_before_rename,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        remove_file_without_links(target)
+
+    assert target.read_text(encoding="utf-8") == "peer"
+    assert preserved_original.read_text(encoding="utf-8") == "original"
+    assert not list(tmp_path.glob(".managed.json.delete-*"))
+
+
+def test_remove_file_without_links_honors_expected_identity(tmp_path):
+    target = tmp_path / "managed.json"
+    replacement = tmp_path / "replacement.json"
+    target.write_text("original", encoding="utf-8")
+    expected = target.lstat()
+    target.rename(tmp_path / "preserved.json")
+    replacement.write_text("replacement", encoding="utf-8")
+    replacement.rename(target)
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        remove_file_without_links(target, expected_identity=expected)
+
+    assert target.read_text(encoding="utf-8") == "replacement"
+
+
+def test_remove_file_without_links_rejects_replaced_expected_parent(tmp_path):
+    parent = tmp_path / "managed"
+    preserved_parent = tmp_path / "managed-preserved"
+    parent.mkdir()
+    target = parent / "probe"
+    target.write_text("original", encoding="utf-8")
+    target_identity = target.lstat()
+    parent_identity = parent.lstat()
+    parent.rename(preserved_parent)
+    parent.mkdir()
+    peer = parent / "probe"
+    peer.write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        remove_file_without_links(
+            peer,
+            expected_identity=target_identity,
+            expected_parent_identity=parent_identity,
+        )
+
+    assert peer.read_text(encoding="utf-8") == "peer"
+    assert (preserved_parent / "probe").read_text(encoding="utf-8") == "original"
+
+
+def test_remove_link_without_following_removes_only_the_link(tmp_path):
+    target = tmp_path / "managed-link"
+    external = tmp_path / "external.txt"
+    external.write_text("keep", encoding="utf-8")
+    try:
+        target.symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    remove_link_without_following(target, expected_identity=target.lstat())
+
+    assert not os.path.lexists(target)
+    assert external.read_text(encoding="utf-8") == "keep"
+
+
+def test_remove_empty_directory_without_links_rejects_nonempty_directory(tmp_path):
+    target = tmp_path / "managed"
+    target.mkdir()
+    (target / "keep.txt").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(OSError):
+        remove_empty_directory_without_links(
+            target,
+            expected_identity=target.lstat(),
+        )
+
+    assert (target / "keep.txt").read_text(encoding="utf-8") == "keep"
+    assert not list(tmp_path.glob(".managed.delete-*"))
+
+
+def test_remove_directory_without_links_removes_exact_tree(tmp_path):
+    target = tmp_path / "managed"
+    target.mkdir()
+    (target / "item.txt").write_text("content", encoding="utf-8")
+
+    remove_directory_without_links(target)
+
+    assert not target.exists()
+    assert not list(tmp_path.glob(".managed.delete-*"))
+
+
+def test_remove_directory_without_links_rejects_linked_parent(tmp_path):
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "managed").mkdir()
+    marker = external / "managed" / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        remove_directory_without_links(alias / "managed")
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_remove_directory_without_links_does_not_follow_nested_link(tmp_path):
+    target = tmp_path / "managed"
+    external = tmp_path / "external"
+    target.mkdir()
+    external.mkdir()
+    marker = external / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    try:
+        (target / "external-link").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symbolic links are unavailable")
+
+    remove_directory_without_links(target)
+
+    assert not target.exists()
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_remove_directory_without_links_restores_name_when_cleanup_fails(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "managed"
+    target.mkdir()
+    marker = target / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    def fail_remove(_path):
+        raise OSError("cleanup failed")
+
+    monkeypatch.setattr("core.file_transactions.shutil.rmtree", fail_remove)
+
+    with pytest.raises(OSError, match="cleanup failed"):
+        remove_directory_without_links(target)
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert not list(tmp_path.glob(".managed.delete-*"))
+
+
+def test_remove_directory_without_links_restores_a_concurrent_replacement(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "managed"
+    peer = tmp_path / "peer"
+    preserved_original = tmp_path / "original"
+    target.mkdir()
+    peer.mkdir()
+    (target / "original.txt").write_text("original", encoding="utf-8")
+    (peer / "peer.txt").write_text("peer", encoding="utf-8")
+    real_rename = rename_path_without_overwrite
+    replaced = False
+
+    def replace_before_rename(source, destination, *, expected_identity=None):
+        nonlocal replaced
+        if source == target and not replaced:
+            replaced = True
+            real_rename(target, preserved_original)
+            real_rename(peer, target)
+        return real_rename(
+            source,
+            destination,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.file_transactions.rename_path_without_overwrite",
+        replace_before_rename,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        remove_directory_without_links(target)
+
+    assert (target / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (preserved_original / "original.txt").read_text(encoding="utf-8") == "original"
+    assert not list(tmp_path.glob(".managed.delete-*"))
+
+
+def test_replace_directory_transactionally_swaps_complete_sibling_tree(tmp_path):
+    destination = tmp_path / "plugin"
+    staging = tmp_path / ".plugin.install"
+    destination.mkdir()
+    staging.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    (staging / "new.txt").write_text("new", encoding="utf-8")
+
+    published = replace_directory_transactionally(staging, destination)
+
+    assert published == destination
+    assert not staging.exists()
+    assert not (destination / "old.txt").exists()
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".plugin.backup-*"))
+
+
+def test_replace_directory_transactionally_restores_previous_tree_on_publish_failure(
+    tmp_path,
+    monkeypatch,
+):
+    destination = tmp_path / "plugin"
+    staging = tmp_path / ".plugin.install"
+    destination.mkdir()
+    staging.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    (staging / "new.txt").write_text("new", encoding="utf-8")
+    real_rename = rename_path_without_overwrite
+
+    def fail_staging_publish(path, target, *, expected_identity=None):
+        if path == staging and target == destination:
+            raise OSError("publish failed")
+        return real_rename(
+            path,
+            target,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.file_transactions.rename_path_without_overwrite",
+        fail_staging_publish,
+    )
+
+    with pytest.raises(OSError, match="publish failed"):
+        replace_directory_transactionally(staging, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (staging / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".plugin.backup-*"))
+
+
+def test_replace_directory_transactionally_rejects_replaced_staging_identity(
+    tmp_path,
+    monkeypatch,
+):
+    destination = tmp_path / "plugin"
+    staging = tmp_path / ".plugin.install"
+    replacement = tmp_path / "replacement"
+    preserved_original = tmp_path / "original-staging"
+    destination.mkdir()
+    staging.mkdir()
+    replacement.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    (staging / "new.txt").write_text("new", encoding="utf-8")
+    (replacement / "replacement.txt").write_text("replacement", encoding="utf-8")
+    real_inspect = inspect_portable_directory_tree
+    replaced = False
+
+    def inspect_then_replace(path):
+        nonlocal replaced
+        result = real_inspect(path)
+        if Path(path) == staging and not replaced:
+            replaced = True
+            staging.rename(preserved_original)
+            replacement.rename(staging)
+        return result
+
+    monkeypatch.setattr(
+        "core.file_transactions.inspect_portable_directory_tree",
+        inspect_then_replace,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        replace_directory_transactionally(staging, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (staging / "replacement.txt").read_text(encoding="utf-8") == "replacement"
+    assert (preserved_original / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_replace_directory_transactionally_rejects_stale_expected_staging_identity(
+    tmp_path,
+):
+    destination = tmp_path / "plugin"
+    staging = tmp_path / ".plugin.install"
+    preserved = tmp_path / "preserved-staging"
+    destination.mkdir()
+    staging.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    (staging / "new.txt").write_text("new", encoding="utf-8")
+    staging_identity = staging.lstat()
+    staging.rename(preserved)
+    staging.mkdir()
+    (staging / "peer.txt").write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="staging directory identity changed"):
+        replace_directory_transactionally(
+            staging,
+            destination,
+            expected_staging_identity=staging_identity,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (staging / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (preserved / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_replace_directory_transactionally_preserves_changed_expected_destination(
+    tmp_path,
+):
+    destination = tmp_path / "plugin"
+    staging = tmp_path / ".plugin.install"
+    preserved = tmp_path / "preserved-destination"
+    destination.mkdir()
+    staging.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    (staging / "new.txt").write_text("new", encoding="utf-8")
+    destination_identity = destination.lstat()
+    destination.rename(preserved)
+    destination.mkdir()
+    (destination / "peer.txt").write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="destination directory identity changed"):
+        replace_directory_transactionally(
+            staging,
+            destination,
+            expected_destination_identity=destination_identity,
+        )
+
+    assert (destination / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (staging / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (preserved / "old.txt").read_text(encoding="utf-8") == "old"
+
+
+def test_replace_directory_transactionally_preserves_replaced_destination(
+    tmp_path,
+    monkeypatch,
+):
+    destination = tmp_path / "plugin"
+    staging = tmp_path / ".plugin.install"
+    replacement = tmp_path / "replacement"
+    preserved_original = tmp_path / "original-destination"
+    destination.mkdir()
+    staging.mkdir()
+    replacement.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    (staging / "new.txt").write_text("new", encoding="utf-8")
+    (replacement / "peer.txt").write_text("peer", encoding="utf-8")
+    real_rename = rename_path_without_overwrite
+    replaced = False
+
+    def replace_before_backup(source, target, *, expected_identity=None):
+        nonlocal replaced
+        if source == destination and not replaced:
+            replaced = True
+            real_rename(destination, preserved_original)
+            real_rename(replacement, destination)
+        return real_rename(
+            source,
+            target,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.file_transactions.rename_path_without_overwrite",
+        replace_before_backup,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        replace_directory_transactionally(staging, destination)
+
+    assert (destination / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (preserved_original / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (staging / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_replace_directory_transactionally_requires_same_parent(tmp_path):
+    staging = tmp_path / "temporary" / "plugin"
+    destination = tmp_path / "managed" / "plugin"
+    staging.mkdir(parents=True)
+    destination.parent.mkdir()
+
+    with pytest.raises(ValueError, match="share a parent"):
+        replace_directory_transactionally(staging, destination)
+
+    assert staging.is_dir()
+    assert not destination.exists()
+
+
+def test_replace_directory_transactionally_rejects_stale_expected_parent(
+    tmp_path,
+):
+    parent = tmp_path / "publication"
+    preserved = tmp_path / "publication-preserved"
+    parent.mkdir()
+    expected_parent = parent.lstat()
+    rename_path_without_overwrite(
+        parent,
+        preserved,
+        expected_identity=expected_parent,
+    )
+    parent.mkdir()
+    staging = parent / "staging"
+    destination = parent / "destination"
+    staging.mkdir()
+    destination.mkdir()
+    (staging / "new.txt").write_text("stale", encoding="utf-8")
+    (destination / "old.txt").write_text("peer", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="parent identity changed"):
+        replace_directory_transactionally(
+            staging,
+            destination,
+            expected_parent_identity=expected_parent,
+        )
+
+    assert (staging / "new.txt").read_text(encoding="utf-8") == "stale"
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "peer"

--- a/test/unit/core/test_frozen_log.py
+++ b/test/unit/core/test_frozen_log.py
@@ -1,0 +1,12 @@
+from core.bootstrap.frozen_log import _frozen_log_filename
+from core.paths import safe_path_component
+
+
+def test_frozen_log_filename_fits_suffix_and_avoids_device_aliases():
+    assert _frozen_log_filename("CON") == "app-CON.log"
+
+    filename = _frozen_log_filename("界" * 100)
+
+    assert filename.endswith(".log")
+    assert len(filename.encode("utf-8")) <= 255
+    assert safe_path_component(filename) == filename

--- a/test/unit/core/test_process_launch.py
+++ b/test/unit/core/test_process_launch.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core import process_launch
+from core.process_launch import (
+    capture_launch_directory,
+    capture_launch_file,
+    open_url_with_default_application,
+    open_with_default_application,
+    popen_with_stable_paths,
+    run_with_stable_paths,
+)
+
+
+class _Process:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def terminate(self) -> None:
+        self.stopped = True
+
+    def wait(self, timeout=None) -> int:
+        return 0
+
+    def kill(self) -> None:
+        self.stopped = True
+
+
+def _executable(path):
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def test_popen_with_stable_paths_uses_captured_command_and_cwd(tmp_path):
+    executable = capture_launch_file(
+        _executable(tmp_path / "runtime"),
+        field="runtime executable",
+        executable=True,
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    cwd = capture_launch_directory(work, field="runtime directory")
+    captured = {}
+    process = _Process()
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured.update(kwargs)
+        return process
+
+    assert (
+        popen_with_stable_paths(
+            [executable.path, "--ready"],
+            cwd=cwd,
+            executable=executable,
+            env={"MODE": "test"},
+            popen_factory=fake_popen,
+        )
+        is process
+    )
+    assert captured["command"] == [str(executable.path), "--ready"]
+    assert captured["cwd"] == str(work)
+    assert captured["env"] == {"MODE": "test"}
+    assert process.stopped is False
+
+
+def test_popen_with_stable_paths_stops_child_after_required_file_replacement(
+    tmp_path,
+):
+    executable = capture_launch_file(
+        _executable(tmp_path / "runtime"),
+        field="runtime executable",
+        executable=True,
+    )
+    script_path = tmp_path / "server.py"
+    script_path.write_text("print('approved')", encoding="utf-8")
+    script = capture_launch_file(script_path, field="runtime script")
+    work = tmp_path / "work"
+    work.mkdir()
+    cwd = capture_launch_directory(work, field="runtime directory")
+    process = _Process()
+
+    def replace_during_spawn(*_args, **_kwargs):
+        script_path.write_text("print('replacement-is-longer')", encoding="utf-8")
+        return process
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        popen_with_stable_paths(
+            [executable.path, script.path],
+            cwd=cwd,
+            executable=executable,
+            required_files=(script,),
+            popen_factory=replace_during_spawn,
+        )
+
+    assert process.stopped is True
+
+
+def test_popen_with_stable_paths_stops_child_after_cwd_replacement(tmp_path):
+    executable = capture_launch_file(
+        _executable(tmp_path / "runtime"),
+        field="runtime executable",
+        executable=True,
+    )
+    work = tmp_path / "work"
+    preserved = tmp_path / "work-preserved"
+    work.mkdir()
+    cwd = capture_launch_directory(work, field="runtime directory")
+    process = _Process()
+
+    def replace_during_spawn(*_args, **_kwargs):
+        work.rename(preserved)
+        work.mkdir()
+        return process
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        popen_with_stable_paths(
+            [executable.path],
+            cwd=cwd,
+            executable=executable,
+            popen_factory=replace_during_spawn,
+        )
+
+    assert process.stopped is True
+
+
+def test_run_with_stable_paths_rejects_required_file_changed_by_command(tmp_path):
+    executable = capture_launch_file(
+        _executable(tmp_path / "runtime"),
+        field="runtime executable",
+        executable=True,
+    )
+    source_path = tmp_path / "source.txt"
+    source_path.write_text("approved", encoding="utf-8")
+    source = capture_launch_file(source_path, field="command input")
+    work = tmp_path / "work"
+    work.mkdir()
+    cwd = capture_launch_directory(work, field="runtime directory")
+
+    def mutate_input(*_args, **_kwargs):
+        source_path.write_text("replacement-is-longer", encoding="utf-8")
+        return object()
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        run_with_stable_paths(
+            [executable.path],
+            cwd=cwd,
+            executable=executable,
+            required_files=(source,),
+            run_factory=mutate_input,
+        )
+
+
+def test_default_application_launch_stops_when_target_changes_during_spawn(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "document.txt"
+    target.write_text("approved", encoding="utf-8")
+    launcher_dir = tmp_path / "bin"
+    launcher_dir.mkdir()
+    _executable(launcher_dir / "xdg-open")
+    process = _Process()
+    monkeypatch.setenv("PATH", os.fspath(launcher_dir))
+
+    def replace_during_spawn(*_args, **_kwargs):
+        target.write_text("replacement-is-longer", encoding="utf-8")
+        return process
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        open_with_default_application(
+            target,
+            system_name="linux",
+            popen_factory=replace_during_spawn,
+        )
+
+    assert process.stopped is True
+
+
+def test_command_discovery_skips_cwd_dependent_path_entries(tmp_path):
+    invalid = tmp_path / "invalid"
+    valid = tmp_path / "valid"
+    invalid.mkdir()
+    valid.mkdir()
+    executable_path = _executable(valid / "tool")
+
+    snapshot = process_launch.capture_command_executable(
+        "tool",
+        field="test command",
+        search_path=f".{os.pathsep}{valid}",
+    )
+
+    assert snapshot.path == executable_path
+
+
+def test_command_discovery_rejects_only_relative_path_entries():
+    with pytest.raises(FileNotFoundError, match="deterministic absolute PATH"):
+        process_launch.capture_command_executable(
+            "tool",
+            field="test command",
+            search_path=f".{os.pathsep}",
+        )
+
+
+def test_command_discovery_rejects_user_home_aliases():
+    with pytest.raises(ValueError, match="must be absolute"):
+        process_launch.capture_command_executable(
+            "~/tool",
+            field="test command",
+            search_path="",
+        )
+
+
+def test_windows_path_extensions_are_single_portable_suffixes():
+    assert process_launch._portable_windows_path_extension(".EXE")
+    for extension in (".", "..EXE", ".EXE.", ".EX E", ".工具", " .EXE", ".EXE "):
+        assert not process_launch._portable_windows_path_extension(extension)
+
+
+def test_windows_path_extension_candidates_fit_final_component():
+    assert process_launch._portable_windows_executable_candidate_names(
+        "a" * 251,
+        ".EXE;.工具",
+    ) == (f"{'a' * 251}.EXE",)
+    assert process_launch._portable_windows_executable_candidate_names(
+        "a" * 252,
+        ".EXE",
+    ) == ()
+
+
+def test_python_child_environment_cannot_inherit_another_python_tree():
+    source = {
+        "KEEP": "value",
+        "PYTHONEXECUTABLE": "/old/python",
+        "PYTHONHOME": "/old/runtime",
+        "PYTHONNOUSERSITE": "0",
+        "PYTHONPATH": "/old/project",
+        "PYTHONPYCACHEPREFIX": "/old/cache",
+        "PYTHONUSERBASE": "/old/user",
+        "__PYVENV_LAUNCHER__": "/old/launcher",
+    }
+
+    environment = process_launch.isolated_python_environment(source)
+
+    assert environment == {"KEEP": "value", "PYTHONNOUSERSITE": "1"}
+    assert source["PYTHONHOME"] == "/old/runtime"
+
+
+def test_default_url_launcher_uses_captured_absolute_executable(
+    tmp_path,
+    monkeypatch,
+):
+    launcher_dir = tmp_path / "bin"
+    launcher_dir.mkdir()
+    launcher = _executable(launcher_dir / "xdg-open")
+    monkeypatch.setenv("PATH", f".{os.pathsep}{launcher_dir}")
+    captured = {}
+    process = _Process()
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured.update(kwargs)
+        return process
+
+    assert (
+        open_url_with_default_application(
+            "http://127.0.0.1:8787/",
+            system_name="linux",
+            popen_factory=fake_popen,
+        )
+        is process
+    )
+    assert captured["command"] == [str(launcher), "http://127.0.0.1:8787/"]
+    assert captured["cwd"] == str(launcher_dir)
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "file:///tmp/project",
+        "relative/path",
+        "https://user:secret@example.com/",
+        " https://example.com/",
+    ),
+)
+def test_default_url_launcher_rejects_non_http_or_ambiguous_values(url):
+    with pytest.raises(ValueError):
+        open_url_with_default_application(url, system_name="linux")

--- a/test/unit/core/test_project_root_paths.py
+++ b/test/unit/core/test_project_root_paths.py
@@ -1,6 +1,75 @@
 from __future__ import annotations
 
-from core.paths import project_root
+import os
+import stat
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import core.paths as core_paths
+from core.paths import (
+    _metadata_is_link_or_reparse_point,
+    activate_project_root,
+    app_root,
+    managed_child_path,
+    managed_project_directory,
+    managed_project_file,
+    path_is_link_or_reparse_point,
+    portable_path_component_prefix,
+    portable_project_path,
+    project_root,
+    resolve_managed_project_path,
+    resolve_project_output_path,
+    resolve_project_path,
+    resolve_project_read_path,
+    resolve_executable_file,
+    resolve_runtime_asset_path,
+    resolve_runtime_asset_read_path,
+    require_directory_without_links,
+    require_regular_file_without_links,
+    safe_path_component,
+    safe_path_component_with_suffix,
+    source_root,
+    truncate_utf8_bytes,
+    user_home_directory,
+    validate_exact_path_text,
+)
+
+
+def test_link_metadata_recognizes_windows_reparse_points():
+    metadata = SimpleNamespace(
+        st_mode=stat.S_IFDIR,
+        st_file_attributes=getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x00000400),
+    )
+
+    assert _metadata_is_link_or_reparse_point(metadata)
+
+
+def test_path_link_check_recognizes_windows_reparse_point_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    candidate = tmp_path / "junction"
+    original_lstat = Path.lstat
+
+    def fake_lstat(path: Path):
+        if path == candidate:
+            return SimpleNamespace(
+                st_mode=stat.S_IFDIR,
+                st_file_attributes=getattr(
+                    stat,
+                    "FILE_ATTRIBUTE_REPARSE_POINT",
+                    0x00000400,
+                ),
+            )
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", fake_lstat)
+
+    assert path_is_link_or_reparse_point(candidate) is True
+    assert path_is_link_or_reparse_point(tmp_path / "missing") is False
 
 
 def test_project_root_prefers_shinsekai_override_to_legacy_easyai(tmp_path, monkeypatch):
@@ -12,9 +81,127 @@ def test_project_root_prefers_shinsekai_override_to_legacy_easyai(tmp_path, monk
     assert project_root() == shinsekai_root.resolve()
 
 
-def test_project_root_keeps_legacy_easyai_and_cwd_fallbacks(tmp_path, monkeypatch):
+def test_runtime_roots_reject_environment_symlink_aliases(tmp_path, monkeypatch):
+    real_root = tmp_path / "real-root"
+    alias = tmp_path / "root-alias"
+    real_root.mkdir()
+    try:
+        alias.symlink_to(real_root, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    for name, getter in (
+        ("SHINSEKAI_SOURCE_ROOT", source_root),
+        ("SHINSEKAI_APP_ROOT", app_root),
+        ("SHINSEKAI_PROJECT_ROOT", project_root),
+    ):
+        monkeypatch.setenv(name, alias.as_posix())
+        with pytest.raises(PermissionError, match="symbolic link"):
+            getter()
+        monkeypatch.delenv(name)
+
+
+def test_user_home_directory_rejects_nonportable_identity(tmp_path, monkeypatch):
+    invalid = Path(f"{tmp_path / 'home'} ")
+    monkeypatch.setattr(
+        Path,
+        "home",
+        classmethod(lambda _cls: invalid),
+    )
+
+    with pytest.raises(ValueError, match="user home directory"):
+        user_home_directory()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        r"\\.\C:\device",
+        r"\??\C:\native-device",
+        r"\\?\GLOBALROOT\Device\HarddiskVolume1",
+    ],
+)
+def test_exact_path_text_rejects_windows_non_filesystem_namespaces(raw):
+    with pytest.raises(ValueError, match="Windows .*namespace"):
+        validate_exact_path_text(
+            raw,
+            field="test path",
+            allow_non_native_absolute=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "component",
+    ["CON", "NUL.txt", "trailing.", "trailing ", "alternate:stream"],
+)
+def test_exact_absolute_paths_reject_nonportable_components(tmp_path, component):
+    with pytest.raises(ValueError):
+        validate_exact_path_text(tmp_path / component, field="test path")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="backslash is a native separator on Windows")
+def test_posix_absolute_paths_reject_backslash_identity_split(tmp_path):
+    raw = f"{tmp_path.as_posix()}/literal\\child"
+
+    with pytest.raises(ValueError, match="non-portable"):
+        validate_exact_path_text(raw, field="test path")
+    with pytest.raises(ValueError, match="non-portable"):
+        resolve_project_path(raw, root=tmp_path)
+    with pytest.raises(ValueError, match="non-portable"):
+        resolve_project_output_path(raw, root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "//server/../asset",
+        "//server/share/../asset",
+        "//server/CON/asset",
+    ],
+)
+def test_non_native_unc_roots_reject_aliases_and_device_components(raw):
+    with pytest.raises(ValueError):
+        validate_exact_path_text(
+            raw,
+            field="test path",
+            allow_non_native_absolute=True,
+        )
+
+
+def test_exact_paths_reject_other_user_home_aliases_consistently():
+    with pytest.raises(ValueError, match="current user-home alias"):
+        validate_exact_path_text("~another-user/data/file.txt", field="test path")
+
+    with pytest.raises(ValueError, match="exact absolute path"):
+        resolve_project_path("data/file.txt", root="~another-user/project")
+
+
+@pytest.mark.parametrize(
+    ("environment_name", "resolver"),
+    [
+        ("SHINSEKAI_PROJECT_ROOT", project_root),
+        ("SHINSEKAI_APP_ROOT", app_root),
+        ("SHINSEKAI_SOURCE_ROOT", source_root),
+    ],
+)
+def test_authoritative_environment_roots_reject_user_home_aliases(
+    tmp_path,
+    monkeypatch,
+    environment_name,
+    resolver,
+):
+    monkeypatch.setenv("HOME", tmp_path.as_posix())
+    monkeypatch.setenv(environment_name, "~/shinsekai")
+
+    with pytest.raises(ValueError, match="exact absolute path"):
+        resolver()
+
+
+def test_project_root_keeps_legacy_easyai_and_uses_stable_app_fallback(tmp_path, monkeypatch):
     easyai_root = tmp_path / "legacy root"
-    cwd_root = tmp_path / "current working root"
+    app_fallback = tmp_path / "application root"
+    cwd_root = tmp_path / "unrelated working root"
+    app_fallback.mkdir()
     cwd_root.mkdir()
     monkeypatch.delenv("SHINSEKAI_PROJECT_ROOT", raising=False)
     monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(easyai_root))
@@ -22,5 +209,886 @@ def test_project_root_keeps_legacy_easyai_and_cwd_fallbacks(tmp_path, monkeypatc
     assert project_root() == easyai_root.resolve()
 
     monkeypatch.delenv("EASYAI_PROJECT_ROOT")
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", str(app_fallback))
     monkeypatch.chdir(cwd_root)
-    assert project_root() == cwd_root.resolve()
+    assert project_root() == app_fallback.resolve()
+
+
+def test_project_root_rejects_relative_environment_instead_of_rebasing_on_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "relative-project")
+
+    with pytest.raises(ValueError, match="absolute"):
+        project_root()
+
+
+def test_project_root_rejects_filesystem_root(monkeypatch):
+    filesystem_root = Path(Path.cwd().anchor)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(filesystem_root))
+
+    with pytest.raises(ValueError, match="filesystem root"):
+        project_root()
+    with pytest.raises(ValueError, match="filesystem root"):
+        resolve_project_path("data/config/api.yaml", root=filesystem_root)
+
+
+def test_project_root_rejects_whitespace_override_without_falling_through(
+    tmp_path,
+    monkeypatch,
+):
+    fallback = tmp_path / "must-not-be-selected"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "   ")
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", fallback.as_posix())
+
+    with pytest.raises(ValueError, match="non-portable"):
+        project_root()
+
+
+def test_project_root_rejects_empty_current_override_without_using_legacy(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "")
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(tmp_path / "must-not-be-selected"))
+
+    with pytest.raises(ValueError, match="non-portable"):
+        project_root()
+
+
+def test_project_root_rejects_control_characters(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", f"{tmp_path}/bad\nroot")
+
+    with pytest.raises(ValueError, match="non-portable"):
+        project_root()
+
+
+def test_project_root_rejects_non_utf8_surrogate_text(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", f"{tmp_path}/bad\udcffroot")
+
+    with pytest.raises(ValueError, match="non-portable"):
+        project_root()
+
+
+def test_activate_project_root_syncs_environment_and_cwd(tmp_path, monkeypatch):
+    selected = tmp_path / "selected project"
+    legacy = tmp_path / "legacy project"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(selected))
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(legacy))
+    # Register cwd restoration with pytest before the production helper
+    # intentionally switches to the selected root.
+    monkeypatch.chdir(tmp_path)
+
+    resolved = activate_project_root(tmp_path / "default")
+
+    assert resolved == selected.resolve()
+    assert Path.cwd() == selected.resolve()
+    assert (selected / "data").is_dir()
+    assert Path(project_root()) == selected.resolve()
+    assert Path(os.environ["EASYAI_PROJECT_ROOT"]) == selected.resolve()
+
+
+def test_activate_project_root_rejects_replaced_root_before_chdir(
+    tmp_path,
+    monkeypatch,
+):
+    launch_root = tmp_path / "launch"
+    selected = tmp_path / "selected"
+    preserved = tmp_path / "selected-preserved"
+    launch_root.mkdir()
+    monkeypatch.chdir(launch_root)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", selected.as_posix())
+    real_change = core_paths._change_working_directory_to_identity
+    replaced = False
+
+    def replace_before_chdir(root, expected_identity, *, field):
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            root.rename(preserved)
+            (root / "data").mkdir(parents=True)
+            (root / "peer.txt").write_text("peer", encoding="utf-8")
+        return real_change(root, expected_identity, field=field)
+
+    monkeypatch.setattr(
+        core_paths,
+        "_change_working_directory_to_identity",
+        replace_before_chdir,
+    )
+
+    with pytest.raises(RuntimeError, match="identity changed"):
+        activate_project_root(tmp_path / "default")
+
+    assert Path.cwd() == launch_root.resolve()
+    assert (selected / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (preserved / "data").is_dir()
+
+
+def test_activate_project_root_rejects_relative_authoritative_environment(tmp_path, monkeypatch):
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    monkeypatch.chdir(fallback)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "relative-project")
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(tmp_path / "must-not-be-used"))
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_PROJECT_ROOT"):
+        activate_project_root(tmp_path / "default")
+
+    assert Path.cwd() == fallback
+
+
+def test_activate_project_root_rejects_empty_current_environment_without_legacy_fallback(
+    tmp_path,
+    monkeypatch,
+):
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    monkeypatch.chdir(fallback)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "")
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(tmp_path / "must-not-be-used"))
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_PROJECT_ROOT"):
+        activate_project_root(tmp_path / "default")
+
+    assert Path.cwd() == fallback
+    assert not (tmp_path / "must-not-be-used").exists()
+
+
+def test_frozen_runtime_requires_an_explicit_project_root(tmp_path, monkeypatch):
+    monkeypatch.delenv("SHINSEKAI_PROJECT_ROOT", raising=False)
+    monkeypatch.delenv("EASYAI_PROJECT_ROOT", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+
+    with pytest.raises(RuntimeError, match="explicit SHINSEKAI_PROJECT_ROOT"):
+        activate_project_root(tmp_path / "install-root")
+    with pytest.raises(RuntimeError, match="explicit SHINSEKAI_PROJECT_ROOT"):
+        project_root()
+
+    assert not (tmp_path / "install-root" / "data").exists()
+
+
+def test_activate_project_root_rejects_relative_default_instead_of_using_cwd(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("SHINSEKAI_PROJECT_ROOT", raising=False)
+    monkeypatch.delenv("EASYAI_PROJECT_ROOT", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(RuntimeError, match="default project root"):
+        activate_project_root("relative-default")
+
+    assert not (tmp_path / "relative-default").exists()
+
+
+def test_activate_project_root_rejects_a_file_without_falling_back(tmp_path, monkeypatch):
+    invalid = tmp_path / "not-a-directory"
+    invalid.write_text("x", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(invalid))
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(tmp_path / "must-not-be-used"))
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_PROJECT_ROOT"):
+        activate_project_root(tmp_path / "default")
+
+
+def test_activate_project_root_rejects_symlinked_data_directory(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    external = tmp_path / "external-data"
+    project.mkdir()
+    external.mkdir()
+    marker = external / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    try:
+        (project / "data").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_PROJECT_ROOT"):
+        activate_project_root(tmp_path / "default")
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_activate_project_root_rejects_symlinked_root(tmp_path, monkeypatch):
+    external = tmp_path / "external-project"
+    alias = tmp_path / "project-alias"
+    external.mkdir()
+    marker = external / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", alias.as_posix())
+
+    with pytest.raises(RuntimeError, match="symbolic link"):
+        activate_project_root(tmp_path / "default")
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert not (external / "data").exists()
+
+
+def test_activate_project_root_rejects_contained_data_alias(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    storage = project / "storage"
+    project.mkdir()
+    storage.mkdir()
+    try:
+        (project / "data").symlink_to(storage, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(RuntimeError, match="symbolic link"):
+        activate_project_root(tmp_path / "default")
+
+    assert list(storage.iterdir()) == []
+
+
+def test_managed_project_file_rebases_stale_windows_asset_path(tmp_path):
+    expected = tmp_path / "data" / "sprite" / "mika" / "smile.png"
+
+    resolved = managed_project_file(
+        r"D:\old-install\data\sprite\mika\smile.png",
+        "data/sprite",
+        root=tmp_path,
+    )
+
+    assert resolved == expected
+
+
+def test_managed_project_file_rejects_external_and_drive_relative_paths(tmp_path):
+    assert managed_project_file(tmp_path.parent / "outside.png", "data/sprite", root=tmp_path) is None
+    assert managed_project_file("D:relative.png", "data/sprite", root=tmp_path) is None
+
+
+def test_managed_project_file_never_rebases_an_existing_external_suffix_collision(tmp_path):
+    project = tmp_path / "project"
+    managed = project / "data/sprite/mika/smile.png"
+    external = tmp_path / "external/data/sprite/mika/smile.png"
+    managed.parent.mkdir(parents=True)
+    external.parent.mkdir(parents=True)
+    managed.write_text("managed", encoding="utf-8")
+    external.write_text("external", encoding="utf-8")
+
+    assert managed_project_file(external, "data/sprite", root=project) is None
+    assert managed.read_text(encoding="utf-8") == "managed"
+    assert external.read_text(encoding="utf-8") == "external"
+
+
+def test_managed_storage_rejects_symlinked_subdirectory_even_inside_project(tmp_path):
+    project = tmp_path / "project"
+    alias_target = project / "other-storage"
+    data = project / "data"
+    data.mkdir(parents=True)
+    alias_target.mkdir()
+    try:
+        (data / "sprite").symlink_to(alias_target, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        managed_project_directory("data/sprite", "character", root=project)
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        managed_project_file("data/sprite/character/a.png", "data/sprite", root=project)
+
+
+def test_managed_child_rejects_link_hidden_in_base_ancestor(tmp_path):
+    external = tmp_path / "external"
+    external_base = external / "nested"
+    alias = tmp_path / "alias"
+    external_base.mkdir(parents=True)
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        managed_child_path(alias / "nested", "output.txt")
+
+    assert not (external_base / "output.txt").exists()
+
+
+def test_regular_file_contract_rejects_linked_leaf_and_parent(tmp_path):
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    target = real_parent / "main.py"
+    target.write_text("print('safe')", encoding="utf-8")
+    linked_file = tmp_path / "linked-main.py"
+    linked_parent = tmp_path / "linked-parent"
+    try:
+        linked_file.symlink_to(target)
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    assert require_regular_file_without_links(target) == target
+    with pytest.raises(PermissionError, match="symbolic link"):
+        require_regular_file_without_links(linked_file)
+    with pytest.raises(PermissionError, match="symbolic link"):
+        require_regular_file_without_links(linked_parent / "main.py")
+
+
+def test_directory_contract_rejects_files_and_linked_directories(tmp_path):
+    directory = tmp_path / "runtime"
+    file = tmp_path / "runtime.txt"
+    linked = tmp_path / "runtime-link"
+    directory.mkdir()
+    file.write_text("not a directory", encoding="utf-8")
+    try:
+        linked.symlink_to(directory, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symbolic links are unavailable")
+
+    assert require_directory_without_links(directory) == directory
+    with pytest.raises(NotADirectoryError):
+        require_directory_without_links(file)
+    with pytest.raises(PermissionError, match="symbolic link"):
+        require_directory_without_links(linked)
+
+
+def test_executable_contract_allows_only_a_leaf_alias(tmp_path):
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    target = real_parent / "python"
+    non_executable = real_parent / "not-python"
+    target.write_text("", encoding="utf-8")
+    target.chmod(target.stat().st_mode | stat.S_IXUSR)
+    non_executable.write_text("", encoding="utf-8")
+    linked_file = tmp_path / "venv-python"
+    linked_parent = tmp_path / "linked-parent"
+    try:
+        linked_file.symlink_to(target)
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    assert resolve_executable_file(target) == target
+    assert resolve_executable_file(linked_file) == target
+    if os.name != "nt":
+        with pytest.raises(PermissionError, match="not executable"):
+            resolve_executable_file(non_executable)
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_executable_file(linked_parent / "python")
+
+
+def test_managed_project_file_rejects_alias_below_storage_root(tmp_path):
+    project = tmp_path / "project"
+    real = project / "data" / "sprite" / "real"
+    real.mkdir(parents=True)
+    asset = real / "smile.png"
+    asset.write_text("keep", encoding="utf-8")
+    try:
+        (real.parent / "alias").symlink_to(real, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    assert (
+        managed_project_file(
+            "data/sprite/alias/smile.png",
+            "data/sprite",
+            root=project,
+        )
+        is None
+    )
+    assert asset.read_text(encoding="utf-8") == "keep"
+
+
+def test_managed_project_file_rejects_external_alias_back_into_project(tmp_path):
+    project = tmp_path / "project"
+    managed = project / "data" / "sprite" / "mika" / "smile.png"
+    managed.parent.mkdir(parents=True)
+    managed.write_text("keep", encoding="utf-8")
+    external_alias = tmp_path / "external-alias.png"
+    try:
+        external_alias.symlink_to(managed)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    assert managed_project_file(external_alias, "data/sprite", root=project) is None
+    assert managed.read_text(encoding="utf-8") == "keep"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "..",
+        "nested/path",
+        r"nested\path",
+        "CON",
+        "CLOCK$",
+        "CONIN$.txt",
+        "COM¹.log",
+        "LPT³",
+        "bad?.png",
+        " leading",
+        "trailing ",
+        "bad\x7fname",
+        "bad\udcffname",
+        "a" * 256,
+        "界" * 86,
+    ],
+)
+def test_safe_path_component_rejects_nonportable_names(name):
+    with pytest.raises(ValueError):
+        safe_path_component(name)
+
+
+def test_safe_path_component_accepts_the_portable_utf8_byte_boundary():
+    assert safe_path_component("界" * 85) == "界" * 85
+
+
+def test_truncate_utf8_bytes_never_splits_a_unicode_character():
+    assert truncate_utf8_bytes("界" * 86, 255) == "界" * 85
+
+
+def test_safe_path_component_with_suffix_reserves_bytes_for_suffix():
+    candidate = safe_path_component_with_suffix("界" * 85, "_1.png")
+
+    assert candidate == ("界" * 83) + "_1.png"
+    assert len(candidate.encode("utf-8")) == 255
+    assert safe_path_component(candidate) == candidate
+
+
+def test_safe_path_component_with_suffix_rejects_an_unfittable_suffix():
+    with pytest.raises(ValueError, match="suffix is too long"):
+        safe_path_component_with_suffix("file", "x" * 255)
+
+
+def test_portable_path_component_prefix_reserves_creator_bytes():
+    prefix = portable_path_component_prefix(
+        f".{'界' * 85}.",
+        reserved_suffix_bytes=20,
+    )
+    eventual_name = f"{prefix}{'x' * 20}"
+
+    assert len(eventual_name.encode("utf-8")) <= 255
+    assert safe_path_component(eventual_name) == eventual_name
+
+
+def test_explicit_helper_root_cannot_be_relative_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="project root must be an absolute path"):
+        resolve_project_path("data/file.txt", root="relative-project")
+
+
+def test_explicit_root_rejects_symlink_before_canonical_target_validation(tmp_path):
+    target = tmp_path / "target:with-colon"
+    target.mkdir()
+    alias = tmp_path / "portable-alias"
+    try:
+        alias.symlink_to(target, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_project_path(".", root=alias)
+
+
+def test_relative_project_path_cannot_escape_explicit_root(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        resolve_project_path("../outside.txt", root=project)
+
+
+def test_relative_project_path_normalizes_portable_backslash_separators(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    assert resolve_project_path(r"data\sprite\mika.png", root=project) == (
+        project / "data/sprite/mika.png"
+    )
+
+
+@pytest.mark.parametrize(
+    "resolver",
+    [resolve_project_path, resolve_project_output_path],
+)
+@pytest.mark.parametrize("value", [" data/file.txt", "data/file.txt "])
+def test_project_path_resolvers_reject_surrounding_whitespace(
+    tmp_path,
+    resolver,
+    value,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        resolver(value, root=project)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "data/./file.txt",
+        "data//file.txt",
+        "data/file.txt/",
+        "./data/file.txt",
+    ],
+)
+def test_managed_project_path_rejects_lexical_aliases_before_path_normalization(
+    tmp_path,
+    value,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(ValueError, match="exact relative components"):
+        resolve_managed_project_path(value, root=project)
+    with pytest.raises(ValueError, match="exact relative components"):
+        resolve_project_output_path(value, root=project)
+
+
+def test_managed_project_path_still_accepts_portable_windows_separators(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    assert resolve_managed_project_path(
+        r"data\sprite\mika.png",
+        root=project,
+    ) == project / "data/sprite/mika.png"
+
+
+def test_managed_absolute_path_rejects_lexical_alias_text(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    raw = f"{project.as_posix()}/data/./file.txt"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        resolve_managed_project_path(raw, root=project)
+
+
+def test_relative_project_path_cannot_escape_through_symlink(tmp_path):
+    project = tmp_path / "project"
+    outside = tmp_path / "outside"
+    project.mkdir()
+    outside.mkdir()
+    try:
+        (project / "linked").symlink_to(outside, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        resolve_project_path("linked/file.txt", root=project)
+
+
+def test_project_output_rejects_internal_symlink_alias_for_relative_and_absolute_paths(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    storage = project / "storage"
+    data = project / "data"
+    storage.mkdir(parents=True)
+    data.mkdir()
+    alias = data / "cache"
+    try:
+        alias.symlink_to(storage, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        resolve_project_output_path("data/cache/result.bin", root=project)
+    with pytest.raises(PermissionError, match="symbolic links"):
+        resolve_project_output_path(alias / "result.bin", root=project)
+
+
+def test_managed_project_path_rejects_windows_reparse_point_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    junction = project / "data" / "cache"
+    junction.mkdir(parents=True)
+    original_lstat = Path.lstat
+
+    def fake_lstat(path: Path):
+        if path == junction:
+            return SimpleNamespace(
+                st_mode=stat.S_IFDIR,
+                st_file_attributes=getattr(
+                    stat,
+                    "FILE_ATTRIBUTE_REPARSE_POINT",
+                    0x00000400,
+                ),
+            )
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", fake_lstat)
+
+    with pytest.raises(PermissionError, match="reparse points"):
+        resolve_managed_project_path("data/cache/result.bin", root=project)
+
+
+def test_project_output_preserves_explicit_external_absolute_path_semantics(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    external = tmp_path / "external" / "result.bin"
+
+    assert resolve_project_output_path(external, root=project) == external.resolve()
+
+    external.parent.mkdir()
+    target = external.parent / "target.bin"
+    target.write_bytes(b"keep")
+    try:
+        external.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+    assert resolve_project_output_path(external, root=project) == target.resolve()
+
+
+def test_explicit_absolute_project_path_may_reference_external_storage(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external" / "asset.bin"
+    project.mkdir()
+
+    assert resolve_project_path(external, root=project) == external.resolve()
+
+
+def test_project_read_path_keeps_exact_external_identity_without_following_links(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    external = tmp_path / "external" / "asset.bin"
+    project.mkdir()
+    external.parent.mkdir()
+    external.write_bytes(b"asset")
+
+    assert resolve_project_read_path(external, root=project) == external
+
+    alias = tmp_path / "asset-alias.bin"
+    try:
+        alias.symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_project_read_path(alias, root=project)
+
+
+def test_project_read_path_rejects_project_internal_link_component(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    try:
+        (project / "data/alias").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_project_read_path("data/alias/asset.bin", root=project)
+
+
+def test_runtime_asset_path_keeps_resource_project_and_external_roots_distinct(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    external = tmp_path / "external" / "sprite.png"
+    resource = source / "assets" / "sprite.png"
+    managed = project / "data" / "sprite" / "mio.png"
+    resource.parent.mkdir(parents=True)
+    managed.parent.mkdir(parents=True)
+    external.parent.mkdir(parents=True)
+    resource.write_bytes(b"resource")
+    managed.write_bytes(b"managed")
+    external.write_bytes(b"external")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+
+    assert resolve_runtime_asset_path("assets/sprite.png", root=project) == resource
+    assert resolve_runtime_asset_path("data/sprite/mio.png", root=project) == managed
+    assert resolve_runtime_asset_path(external.as_posix(), root=project) == external
+
+
+def test_runtime_asset_paths_canonicalize_known_prefix_case_after_migration(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    resource = source / "assets/system/picture/Icon.png"
+    resource.parent.mkdir(parents=True)
+    project.mkdir()
+    resource.write_bytes(b"resource")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+
+    migrated = r"Assets\System\Picture\Icon.png"
+    prefixes = (("assets", "system", "picture"),)
+
+    assert (
+        resolve_runtime_asset_path(
+            migrated,
+            root=project,
+            resource_prefixes=prefixes,
+        )
+        == resource
+    )
+    assert (
+        resolve_runtime_asset_read_path(
+            migrated,
+            root=project,
+            resource_prefixes=prefixes,
+        )
+        == resource
+    )
+
+
+def test_runtime_asset_read_path_keeps_resource_project_and_external_roots_distinct(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    external = tmp_path / "external" / "sprite.png"
+    resource = source / "assets" / "sprite.png"
+    managed = project / "data" / "sprite" / "mio.png"
+    resource.parent.mkdir(parents=True)
+    managed.parent.mkdir(parents=True)
+    external.parent.mkdir(parents=True)
+    resource.write_bytes(b"resource")
+    managed.write_bytes(b"managed")
+    external.write_bytes(b"external")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+
+    assert (
+        resolve_runtime_asset_read_path("assets/sprite.png", root=project)
+        == resource
+    )
+    assert (
+        resolve_runtime_asset_read_path("data/sprite/mio.png", root=project)
+        == managed
+    )
+    assert resolve_runtime_asset_read_path(external, root=project) == external
+
+
+@pytest.mark.parametrize("location", ("resource", "managed", "external"))
+def test_runtime_asset_read_path_rejects_link_components(
+    tmp_path,
+    monkeypatch,
+    location,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    source.mkdir()
+    project.mkdir()
+    external.mkdir()
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+
+    target = tmp_path / "target"
+    target.mkdir()
+    if location == "resource":
+        alias = source / "assets"
+        raw = "assets/sprite.png"
+    elif location == "managed":
+        (project / "data").mkdir()
+        alias = project / "data" / "sprite"
+        raw = "data/sprite/mio.png"
+    else:
+        alias = external / "sprite"
+        raw = alias / "mio.png"
+    try:
+        alias.symlink_to(target, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_runtime_asset_read_path(raw, root=project)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "./assets/sprite.png",
+        "assets//sprite.png",
+        "assets/./sprite.png",
+        "data/sprite/../sprite.png",
+    ),
+)
+def test_runtime_asset_path_rejects_lexical_aliases(tmp_path, raw):
+    with pytest.raises((PermissionError, ValueError)):
+        resolve_runtime_asset_path(raw, root=tmp_path)
+
+
+def test_portable_project_path_rejects_internal_alias_and_keeps_external_alias_absolute(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    managed = project / "data" / "sprite" / "mika.png"
+    external = tmp_path / "external"
+    managed.parent.mkdir(parents=True)
+    external.mkdir()
+    managed.write_bytes(b"png")
+    internal_alias = project / "data" / "external-alias"
+    external_alias = tmp_path / "managed-alias.png"
+    try:
+        internal_alias.symlink_to(external, target_is_directory=True)
+        external_alias.symlink_to(managed)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        portable_project_path(internal_alias / "asset.png", root=project)
+    assert portable_project_path(external_alias, root=project) == external_alias.as_posix()
+
+
+@pytest.mark.parametrize("location", ("managed", "external"))
+def test_portable_project_path_rejects_absolute_lexical_alias_text(
+    tmp_path,
+    location,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    base = project if location == "managed" else tmp_path / "external"
+    raw = f"{base.as_posix()}/./asset.png"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        portable_project_path(raw, root=project)
+
+
+@pytest.mark.parametrize(
+    ("environment_name", "resolver"),
+    [
+        ("SHINSEKAI_SOURCE_ROOT", source_root),
+        ("SHINSEKAI_APP_ROOT", app_root),
+    ],
+)
+def test_runtime_code_roots_reject_relative_environment_values(
+    tmp_path,
+    monkeypatch,
+    environment_name,
+    resolver,
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(environment_name, "relative-root")
+
+    with pytest.raises(ValueError, match="absolute"):
+        resolver()
+
+
+@pytest.mark.parametrize(
+    ("environment_name", "resolver"),
+    [
+        ("SHINSEKAI_SOURCE_ROOT", source_root),
+        ("SHINSEKAI_APP_ROOT", app_root),
+    ],
+)
+def test_runtime_code_roots_reject_present_but_empty_environment_values(
+    monkeypatch,
+    environment_name,
+    resolver,
+):
+    monkeypatch.setenv(environment_name, "")
+
+    with pytest.raises(ValueError, match="non-portable"):
+        resolver()

--- a/test/unit/core/test_tts_bundle_io.py
+++ b/test/unit/core/test_tts_bundle_io.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+import hashlib
+import json
+
+import pytest
+
+from core import tts_bundle_catalog, tts_bundle_io
+
+
+class _Response:
+    def __init__(
+        self,
+        payload: bytes,
+        *,
+        url: str = "https://example.invalid/bundle.7z",
+    ) -> None:
+        self._payload = payload
+        self.url = url
+        self.headers = {"Content-Length": str(len(payload))}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, _chunk_size: int):
+        yield self._payload
+
+
+def test_tts_download_verifies_staging_before_replacing_existing_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = tmp_path / "bundle.7z"
+    archive.write_bytes(b"previous")
+    monkeypatch.setattr(
+        tts_bundle_io.requests,
+        "get",
+        lambda *_args, **_kwargs: _Response(b"replacement"),
+    )
+
+    with pytest.raises(ValueError, match="sha256 mismatch"):
+        tts_bundle_io._download_archive(
+            "https://example.invalid/bundle.7z",
+            archive,
+            {},
+            expected_size=len(b"replacement"),
+            expected_sha256="0" * 64,
+        )
+
+    assert archive.read_bytes() == b"previous"
+    assert list(tmp_path.glob(".bundle.7z.*.tmp")) == []
+
+
+def test_tts_download_rejects_credentialed_redirect_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = tmp_path / "bundle.7z"
+    monkeypatch.setattr(
+        tts_bundle_io.requests,
+        "get",
+        lambda *_args, **_kwargs: _Response(
+            b"bundle",
+            url="https://token@example.invalid/bundle.7z",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="credentials"):
+        tts_bundle_io._download_archive(
+            "https://example.invalid/bundle.7z",
+            archive,
+            {},
+        )
+
+    assert not archive.exists()
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "file:///tmp/bundle.7z",
+        "https://example.invalid/%2e%2e",
+        "https://example.invalid/CON",
+    ),
+)
+def test_tts_archive_filename_rejects_nonportable_urls(url: str) -> None:
+    with pytest.raises(ValueError):
+        tts_bundle_io._archive_filename(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "https://example.invalid/a%2Fb.7z",
+        "https://example.invalid/a%5Cb.7z",
+        "https://example.invalid/bundle%ZZ.7z",
+        "https://example.invalid/bundle%FF.7z",
+    ),
+)
+def test_tts_archive_filename_rejects_ambiguous_encoded_components(
+    url: str,
+) -> None:
+    with pytest.raises(ValueError):
+        tts_bundle_io._archive_filename(url)
+
+
+def test_tts_archive_filename_strictly_decodes_one_utf8_component() -> None:
+    assert (
+        tts_bundle_io._archive_filename(
+            "https://example.invalid/releases/%E6%96%B0%E4%B8%96%E7%95%8C.7z"
+        )
+        == "新世界.7z"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "https://example.invalid:invalid/bundle.7z",
+        "https://example.invalid:99999/bundle.7z",
+        "https://exa mple.invalid/bundle.7z",
+        "https://%65xample.invalid/bundle.7z",
+        "https://example.invalid\\@other.invalid/bundle.7z",
+    ),
+)
+def test_tts_catalog_and_downloader_share_strict_url_authority_contract(
+    url: str,
+) -> None:
+    with pytest.raises(ValueError):
+        tts_bundle_catalog._validated_download_url(url)
+    with pytest.raises(ValueError):
+        tts_bundle_io._validated_download_url(url)
+
+
+@pytest.mark.parametrize(
+    ("first_key", "second_key", "first_filename", "second_filename"),
+    (
+        ("Bundle", "bundle", "first.7z", "second.7z"),
+        ("caf\u00e9", "cafe\u0301", "first.7z", "second.7z"),
+        ("first", "second", "CAF\u00c9.7z", "cafe\u0301.7z"),
+    ),
+)
+def test_tts_manifest_rejects_portable_path_name_collisions(
+    tmp_path: Path,
+    first_key: str,
+    second_key: str,
+    first_filename: str,
+    second_filename: str,
+) -> None:
+    payload = b"bundle"
+    digest = hashlib.sha256(payload).hexdigest()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "bundles": [
+                    {
+                        "kind": "first",
+                        "bundle_dir_key": first_key,
+                        "filename": first_filename,
+                        "download_url": "https://example.invalid/first.7z",
+                        "size": len(payload),
+                        "sha256": digest,
+                    },
+                    {
+                        "kind": "second",
+                        "bundle_dir_key": second_key,
+                        "filename": second_filename,
+                        "download_url": "https://example.invalid/second.7z",
+                        "size": len(payload),
+                        "sha256": digest,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate TTS bundle"):
+        tts_bundle_catalog.load_tts_bundle_manifest(manifest_path)

--- a/test/unit/frontend_bridge_core/test_chat_stream_commands.py
+++ b/test/unit/frontend_bridge_core/test_chat_stream_commands.py
@@ -279,10 +279,21 @@ class ChatStreamCommandTests(unittest.TestCase):
 
     def test_handle_chat_command_validates_and_forwards_attachments(self):
         chat_stream = _StubChatStream()
-        state = SimpleNamespace(chat_session={"sessionId": "session-1"}, chat_stream=chat_stream)
         with tempfile.TemporaryDirectory() as temp_dir:
-            image = Path(temp_dir) / "scene.png"
+            project = Path(temp_dir)
+            attachment_root = project / "data" / "chat_attachments"
+            image = (
+                attachment_root
+                / "0123456789abcdef0123456789abcdef"
+                / "scene.png"
+            )
+            image.parent.mkdir(parents=True)
             image.write_bytes(b"image")
+            state = SimpleNamespace(
+                chat_session={"sessionId": "session-1"},
+                chat_stream=chat_stream,
+                project_root_dir=project.as_posix(),
+            )
 
             snapshot = _handle_chat_command(
                 state,
@@ -617,14 +628,18 @@ class ChatStreamCommandTests(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmp_dir:
-            history_path = Path(tmp_dir) / "session-history"
-            history_path.mkdir()
+            project_root = Path(tmp_dir)
+            history_root = project_root / "data" / "chat_history"
+            history_path = history_root / "session-history"
+            history_path.mkdir(parents=True)
             (history_path / "active.json").write_text("[]", encoding="utf-8")
             (history_path / "branches.json").write_text("{}", encoding="utf-8")
             state = SimpleNamespace(
                 chat_session={"historyPath": history_path.as_posix()},
                 chat_stream=None,
                 config_manager=config_manager,
+                history_dir=history_root.as_posix(),
+                project_root_dir=project_root.as_posix(),
             )
 
             snapshot = _handle_chat_command(state, {"type": "clear-history"})
@@ -633,6 +648,37 @@ class ChatStreamCommandTests(unittest.TestCase):
             self.assertEqual(snapshot["historyEntries"], [])
             self.assertEqual(snapshot["options"], [])
             self.assertEqual(snapshot["dialogText"], "历史记录已经清空。")
+
+    def test_handle_chat_command_never_clears_the_history_collection_root(self):
+        class _Config:
+            characters = []
+            background_list = []
+            system_config = SimpleNamespace(chat_ui_runtime_mode="react", voice_language="ja")
+
+        config_manager = SimpleNamespace(
+            config=_Config(),
+            get_background_by_name=lambda _name: None,
+            get_character_by_name=lambda _name: None,
+        )
+
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmp_dir:
+            project_root = Path(tmp_dir)
+            history_root = project_root / "data" / "chat_history"
+            sibling = history_root / "must-survive"
+            sibling.mkdir(parents=True)
+            (sibling / "active.json").write_text("[]", encoding="utf-8")
+            state = SimpleNamespace(
+                chat_session={"historyPath": history_root.as_posix()},
+                chat_stream=None,
+                config_manager=config_manager,
+                history_dir=history_root.as_posix(),
+                project_root_dir=project_root.as_posix(),
+            )
+
+            with self.assertRaisesRegex(PermissionError, "history root"):
+                _handle_chat_command(state, {"type": "clear-history"})
+
+            self.assertTrue((sibling / "active.json").is_file())
 
     def test_chat_stream_sends_commands_and_broadcasts_ack_events(self):
         service = ChatStreamService(host="127.0.0.1", bridge_port=8787)
@@ -975,6 +1021,22 @@ class ChatStreamCommandTests(unittest.TestCase):
                 _close_ws(producer)
             service.stop()
 
+    def test_media_url_rejects_whitespace_instead_of_retargeting_path(self):
+        service = ChatStreamService(host="127.0.0.1", bridge_port=_free_bridge_port())
+
+        self.assertEqual(
+            service.media_url("HTTPS://media.example.test/room.png"),
+            "HTTPS://media.example.test/room.png",
+        )
+        with self.assertRaisesRegex(ValueError, "non-portable"):
+            service.media_url(" data/speech/nanami/hello.wav")
+        with self.assertRaisesRegex(ValueError, "exact"):
+            service.media_url("data/speech/./nanami/hello.wav")
+        with self.assertRaisesRegex(ValueError, "without credentials"):
+            service.media_url(
+                "https://user:secret@media.example.test/room.png",
+            )
+
     def test_media_url_registers_absolute_media_path_for_later_authenticated_read(
         self,
     ):
@@ -1011,6 +1073,25 @@ class ChatStreamCommandTests(unittest.TestCase):
             if viewer is not None:
                 _close_ws(viewer)
             service.stop()
+
+    def test_media_event_approval_does_not_trim_url_identity(self):
+        service = ChatStreamService(
+            host="127.0.0.1",
+            bridge_port=_free_bridge_port(),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            media_path = str(Path(temp_dir) / "generated" / "line.wav")
+            media_url = f"/api/media?{urlencode({'path': media_path})}"
+
+            service._approve_event_media_path(
+                {"type": "tts.play", "url": f" {media_url} "}
+            )
+            self.assertNotIn(media_path, service.approved_external_media_paths())
+
+            service._approve_event_media_path(
+                {"type": "tts.play", "url": media_url}
+            )
+            self.assertIn(media_path, service.approved_external_media_paths())
 
     def test_ws_client_sink_transports_events_over_real_socket(self):
         service = ChatStreamService(host="127.0.0.1", bridge_port=_free_bridge_port())

--- a/test/unit/frontend_bridge_core/test_chat_themes.py
+++ b/test/unit/frontend_bridge_core/test_chat_themes.py
@@ -1,17 +1,24 @@
+import json
 import os
 import shutil
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import frontend_bridge_core.chat_themes as chat_themes_module
+from core.file_transactions import rename_path_without_overwrite
 from frontend_bridge_core.chat_themes import (
     BUILTIN_THEME_OWNER_MARKER,
+    _builtin_themes_root,
     _copy_theme_source,
     _is_builtin_theme_dir,
     delete_chat_theme,
+    get_active_chat_theme_id,
     get_chat_theme_manifest,
+    install_theme_from_zip,
     list_chat_themes,
     save_chat_theme,
     set_active_chat_theme,
@@ -32,11 +39,31 @@ class ChatThemeBridgeTests(unittest.TestCase):
         )
         return SimpleNamespace(config_manager=config_manager)
 
+    def test_builtin_theme_root_uses_application_resource_contract(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            source = Path(tempdir) / "source"
+            project = Path(tempdir) / "project"
+            source.mkdir()
+            project.mkdir()
+            with patch.dict(
+                os.environ,
+                {
+                    "SHINSEKAI_SOURCE_ROOT": source.as_posix(),
+                    "SHINSEKAI_APP_ROOT": source.as_posix(),
+                    "SHINSEKAI_PROJECT_ROOT": project.as_posix(),
+                },
+            ):
+                self.assertEqual(
+                    _builtin_themes_root(),
+                    source / "assets/chat_ui_themes",
+                )
+
     def test_list_chat_themes_seeds_builtin_and_marks_source(self):
         state = self._make_state()
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 themes = list_chat_themes(state)
                 theme_index = {item["id"]: item for item in themes}
@@ -96,11 +123,127 @@ class ChatThemeBridgeTests(unittest.TestCase):
             finally:
                 os.chdir(previous_cwd)
 
+    def test_theme_storage_uses_state_project_root_when_cwd_changes(self):
+        state = self._make_state()
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as project_dir, tempfile.TemporaryDirectory() as unrelated_dir:
+            state.project_root_dir = project_dir
+            os.chdir(unrelated_dir)
+            try:
+                themes = list_chat_themes(state)
+                self.assertTrue(themes)
+                self.assertTrue(
+                    (
+                        Path(project_dir)
+                        / "data"
+                        / "chat_ui_themes"
+                        / "neon-night-city"
+                        / "theme.json"
+                    ).is_file()
+                )
+                self.assertFalse((Path(unrelated_dir) / "data" / "chat_ui_themes").exists())
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_theme_scan_ignores_external_directory_symlink(self):
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as project_dir, tempfile.TemporaryDirectory() as external_dir:
+            state.project_root_dir = project_dir
+            external = Path(external_dir)
+            (external / "theme.json").write_text(
+                '{"schemaVersion": 1, "id": "external", "name": {"zh_CN": "External"}, "tokens": {}}',
+                encoding="utf-8",
+            )
+            themes_root = Path(project_dir) / "data" / "chat_ui_themes"
+            themes_root.mkdir(parents=True)
+            try:
+                (themes_root / "external").symlink_to(external, target_is_directory=True)
+            except (NotImplementedError, OSError):
+                self.skipTest("directory symlinks are unavailable")
+
+            themes = list_chat_themes(state)
+
+            self.assertNotIn("external", {item["id"] for item in themes})
+
+    def test_builtin_seed_never_refreshes_through_legacy_id_symlink(self):
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as project_dir, tempfile.TemporaryDirectory() as external_dir:
+            state.project_root_dir = project_dir
+            external = Path(external_dir)
+            marker = external / "keep.txt"
+            marker.write_text("external", encoding="utf-8")
+            themes_root = Path(project_dir) / "data" / "chat_ui_themes"
+            themes_root.mkdir(parents=True)
+            try:
+                (themes_root / "neon-night-city").symlink_to(
+                    external,
+                    target_is_directory=True,
+                )
+            except (NotImplementedError, OSError):
+                self.skipTest("directory symlinks are unavailable")
+
+            themes = list_chat_themes(state)
+
+            self.assertNotIn("neon-night-city", {item["id"] for item in themes})
+            self.assertEqual(marker.read_text(encoding="utf-8"), "external")
+            self.assertFalse((external / "theme.json").exists())
+
+    def test_builtin_refresh_publish_failure_restores_complete_old_tree(self):
+        state = self._make_state()
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            state.project_root_dir = tempdir
+            try:
+                list_chat_themes(state)
+                target = Path(tempdir) / "data/chat_ui_themes/neon-night-city"
+                manifest_path = target / "theme.json"
+                old_manifest = manifest_path.read_text(encoding="utf-8").replace(
+                    '"version": "1.3.4"',
+                    '"version": "0.0.1"',
+                )
+                manifest_path.write_text(old_manifest, encoding="utf-8")
+                old_frame = target / "frame-dialog.svg"
+                old_frame.write_text("old-frame", encoding="utf-8")
+                original_rename = rename_path_without_overwrite
+
+                def fail_seed_publish(
+                    path,
+                    destination,
+                    *,
+                    expected_identity=None,
+                ):
+                    if (
+                        path.name.startswith(".neon-night-city.seed-")
+                        and destination == target
+                    ):
+                        raise OSError("seed publish failed")
+                    return original_rename(
+                        path,
+                        destination,
+                        expected_identity=expected_identity,
+                    )
+
+                with patch(
+                    "core.file_transactions.rename_path_without_overwrite",
+                    new=fail_seed_publish,
+                ):
+                    with self.assertRaisesRegex(OSError, "seed publish failed"):
+                        list_chat_themes(state)
+
+                self.assertEqual(manifest_path.read_text(encoding="utf-8"), old_manifest)
+                self.assertEqual(old_frame.read_text(encoding="utf-8"), "old-frame")
+                self.assertEqual(list(target.parent.glob(".neon-night-city.backup-*")), [])
+                self.assertEqual(list(target.parent.glob(".neon-night-city.seed-*")), [])
+            finally:
+                os.chdir(previous_cwd)
+
     def test_missing_builtin_assets_do_not_create_python_manifest_fallbacks(self):
         state = self._make_state()
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 with patch("frontend_bridge_core.chat_themes._builtin_themes_root", return_value=Path(tempdir) / "missing"):
                     themes = list_chat_themes(state)
@@ -117,6 +260,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 target = Path(tempdir) / "data" / "chat_ui_themes" / "neon-night-city"
                 target.mkdir(parents=True)
@@ -139,6 +283,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 target = Path(tempdir) / "data" / "chat_ui_themes" / "sakura-dream"
                 target.mkdir(parents=True)
@@ -162,9 +307,11 @@ class ChatThemeBridgeTests(unittest.TestCase):
                 os.chdir(previous_cwd)
 
     def test_builtin_owner_marker_is_only_trusted_under_the_registered_theme_root(self):
+        state = self._make_state()
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 spoofed_dir = Path(tempdir) / "outside" / "sakura-dream"
                 spoofed_dir.mkdir(parents=True)
@@ -172,7 +319,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
                     "sakura-dream\n", encoding="utf-8"
                 )
 
-                self.assertFalse(_is_builtin_theme_dir("sakura-dream"))
+                self.assertFalse(_is_builtin_theme_dir("sakura-dream", state))
             finally:
                 os.chdir(previous_cwd)
 
@@ -187,6 +334,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
                 builtin_root / "windborne-adventure",
             )
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 with patch("frontend_bridge_core.chat_themes._builtin_themes_root", return_value=builtin_root):
                     themes = list_chat_themes(state)
@@ -206,6 +354,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 result = set_active_chat_theme(state, {"id": "windborne-adventure"})
                 self.assertEqual(result, {"id": "windborne-adventure"})
@@ -214,11 +363,181 @@ class ChatThemeBridgeTests(unittest.TestCase):
             finally:
                 os.chdir(previous_cwd)
 
+    def test_theme_id_outer_whitespace_is_rejected_and_stale_config_falls_back(self):
+        state = self._make_state()
+        state.config_manager.config.system_config.chat_ui_theme_id = " windborne-adventure "
+
+        self.assertEqual(
+            get_active_chat_theme_id(state),
+            {"id": "windborne-adventure"},
+        )
+        with self.assertRaises(ValueError):
+            set_active_chat_theme(state, {"id": " windborne-adventure "})
+
+    def test_set_active_theme_restores_previous_id_when_save_fails(self):
+        state = self._make_state()
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            state.project_root_dir = tempdir
+            try:
+                list_chat_themes(state)
+                state.config_manager.config.system_config.chat_ui_theme_id = "windborne-adventure"
+
+                def fail_save():
+                    raise OSError("disk full")
+
+                state.config_manager.save_system_config = fail_save
+                with self.assertRaisesRegex(OSError, "disk full"):
+                    set_active_chat_theme(state, {"id": "neon-night-city"})
+
+                self.assertEqual(
+                    state.config_manager.config.system_config.chat_ui_theme_id,
+                    "windborne-adventure",
+                )
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_theme_root_rejects_project_data_symlink(self):
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as project_dir, tempfile.TemporaryDirectory() as external_dir:
+            project = Path(project_dir)
+            external = Path(external_dir)
+            try:
+                (project / "data").symlink_to(external, target_is_directory=True)
+            except (NotImplementedError, OSError):
+                self.skipTest("directory symlinks are unavailable")
+            state.project_root_dir = project.as_posix()
+
+            with self.assertRaises(PermissionError):
+                list_chat_themes(state)
+
+            self.assertEqual(list(external.iterdir()), [])
+
+    def test_zip_overwrite_restores_old_theme_when_publish_fails(self):
+        state = self._make_state()
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            state.project_root_dir = tempdir
+            try:
+                list_chat_themes(state)
+                target = Path(tempdir) / "data/chat_ui_themes/custom-theme"
+                target.mkdir()
+                old_manifest = '{"schema":1,"id":"custom-theme","name":{"en":"Old"},"tokens":{}}'
+                (target / "theme.json").write_text(old_manifest, encoding="utf-8")
+                archive = Path(tempdir) / "custom.zip"
+                with zipfile.ZipFile(archive, "w") as zf:
+                    zf.writestr(
+                        "theme/theme.json",
+                        '{"schema":1,"id":"custom-theme","name":{"en":"New"},"tokens":{}}',
+                    )
+
+                original_rename = rename_path_without_overwrite
+
+                def fail_staging_publish(
+                    path,
+                    destination,
+                    *,
+                    expected_identity=None,
+                ):
+                    if (
+                        path.name.startswith(".custom-theme.install-")
+                        and destination == target
+                    ):
+                        raise OSError("publish failed")
+                    return original_rename(
+                        path,
+                        destination,
+                        expected_identity=expected_identity,
+                    )
+
+                with patch(
+                    "core.file_transactions.rename_path_without_overwrite",
+                    new=fail_staging_publish,
+                ):
+                    with self.assertRaisesRegex(OSError, "publish failed"):
+                        install_theme_from_zip(state, archive, overwrite=True)
+
+                self.assertEqual((target / "theme.json").read_text(encoding="utf-8"), old_manifest)
+                self.assertEqual(list(target.parent.glob(".custom-theme.backup-*")), [])
+                self.assertEqual(list(target.parent.glob(".custom-theme.install-*")), [])
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_zip_install_uses_one_portable_id_for_directory_manifest_and_summary(self):
+        state = self._make_state()
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            state.project_root_dir = tempdir
+            try:
+                archive = Path(tempdir) / "reserved-id.zip"
+                with zipfile.ZipFile(archive, "w") as zf:
+                    zf.writestr(
+                        "theme/theme.json",
+                        '{"schema":1,"id":"con","name":{"en":"Portable"},"tokens":{}}',
+                    )
+
+                summary = install_theme_from_zip(state, archive)
+
+                target = Path(tempdir) / "data/chat_ui_themes/theme-con"
+                persisted = json.loads(
+                    (target / "theme.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(summary["id"], "theme-con")
+                self.assertEqual(persisted["id"], "theme-con")
+                self.assertTrue(target.is_dir())
+                self.assertFalse(
+                    (Path(tempdir) / "data/chat_ui_themes/con").exists()
+                )
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_delete_active_theme_restores_directory_when_config_save_fails(self):
+        state = self._make_state()
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            state.project_root_dir = tempdir
+            try:
+                list_chat_themes(state)
+                save_chat_theme(
+                    state,
+                    {
+                        "baseId": "windborne-adventure",
+                        "manifest": {
+                            "schema": 1,
+                            "id": "custom-active",
+                            "name": {"en": "Custom"},
+                            "tokens": {},
+                        },
+                    },
+                )
+                target = Path(tempdir) / "data/chat_ui_themes/custom-active"
+                state.config_manager.config.system_config.chat_ui_theme_id = "custom-active"
+
+                def fail_save():
+                    raise OSError("disk full")
+
+                state.config_manager.save_system_config = fail_save
+                with self.assertRaisesRegex(OSError, "disk full"):
+                    delete_chat_theme(state, "custom-active")
+
+                self.assertTrue((target / "theme.json").is_file())
+                self.assertEqual(
+                    state.config_manager.config.system_config.chat_ui_theme_id,
+                    "custom-active",
+                )
+            finally:
+                os.chdir(previous_cwd)
+
     def test_save_chat_theme_clones_builtin_assets_without_builtin_ownership(self):
         state = self._make_state()
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 summary = save_chat_theme(
                     state,
@@ -274,6 +593,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 save_chat_theme(
                     state,
@@ -308,14 +628,117 @@ class ChatThemeBridgeTests(unittest.TestCase):
             finally:
                 os.chdir(previous_cwd)
 
+    def test_existing_theme_save_preserves_replacement_directory(self):
+        state = self._make_state()
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chdir(tempdir)
+            state.project_root_dir = tempdir
+            try:
+                save_chat_theme(
+                    state,
+                    {
+                        "baseId": "neon-night-city",
+                        "manifest": {
+                            "schema": 1,
+                            "id": "identity-custom",
+                            "name": {"en": "Original"},
+                            "tokens": {},
+                        },
+                    },
+                )
+                target = Path(tempdir) / "data/chat_ui_themes/identity-custom"
+                preserved = target.with_name("identity-custom-preserved")
+                original_write = chat_themes_module._atomic_write_manifest
+
+                def replace_before_write(
+                    theme_dir,
+                    manifest,
+                    *,
+                    expected_theme_identity=None,
+                ):
+                    rename_path_without_overwrite(
+                        theme_dir,
+                        preserved,
+                        expected_identity=expected_theme_identity,
+                    )
+                    theme_dir.mkdir()
+                    (theme_dir / "theme.json").write_text(
+                        '{"peer": true}\n',
+                        encoding="utf-8",
+                    )
+                    return original_write(
+                        theme_dir,
+                        manifest,
+                        expected_theme_identity=expected_theme_identity,
+                    )
+
+                with patch(
+                    "frontend_bridge_core.chat_themes._atomic_write_manifest",
+                    new=replace_before_write,
+                ):
+                    with self.assertRaisesRegex(PermissionError, "身份已变化"):
+                        save_chat_theme(
+                            state,
+                            {
+                                "baseId": "identity-custom",
+                                "manifest": {
+                                    "schema": 1,
+                                    "id": "identity-custom",
+                                    "name": {"en": "Stale edit"},
+                                    "tokens": {},
+                                },
+                            },
+                        )
+
+                self.assertEqual(
+                    (target / "theme.json").read_text(encoding="utf-8"),
+                    '{"peer": true}\n',
+                )
+                self.assertEqual(
+                    get_chat_theme_manifest(
+                        SimpleNamespace(
+                            project_root_dir=tempdir,
+                            config_manager=state.config_manager,
+                        ),
+                        "identity-custom-preserved",
+                    )["name"]["en"],
+                    "Original",
+                )
+            finally:
+                os.chdir(previous_cwd)
+
     def test_new_theme_publish_failure_leaves_no_partial_target(self):
         state = self._make_state()
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 target = Path(tempdir) / "data" / "chat_ui_themes" / "atomic-custom"
-                with patch("pathlib.Path.rename", side_effect=OSError("publish interrupted")):
+                original_rename = rename_path_without_overwrite
+
+                def fail_new_theme_publish(
+                    path,
+                    destination,
+                    *,
+                    expected_identity=None,
+                ):
+                    if (
+                        path.name.startswith(".atomic-custom.publish-")
+                        and destination == target
+                    ):
+                        raise OSError("publish interrupted")
+                    return original_rename(
+                        path,
+                        destination,
+                        expected_identity=expected_identity,
+                    )
+
+                with patch(
+                    "core.file_transactions.rename_path_without_overwrite",
+                    new=fail_new_theme_publish,
+                ):
                     with self.assertRaisesRegex(OSError, "publish interrupted"):
                         save_chat_theme(
                             state,
@@ -339,6 +762,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 list_chat_themes(state)
                 with self.assertRaises(PermissionError):
@@ -362,8 +786,14 @@ class ChatThemeBridgeTests(unittest.TestCase):
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
-                for theme_id in ("../escaped-theme", "nested/escaped-theme", "nested\\escaped-theme"):
+                for theme_id in (
+                    "../escaped-theme",
+                    "nested/escaped-theme",
+                    "nested\\escaped-theme",
+                    " escaped-theme ",
+                ):
                     with self.subTest(theme_id=theme_id), self.assertRaises(ValueError):
                         save_chat_theme(
                             state,
@@ -413,11 +843,84 @@ class ChatThemeBridgeTests(unittest.TestCase):
 
             self.assertFalse(staging.exists())
 
+    def test_copy_theme_source_rejects_descendant_symlinks_without_following_them(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            themes_root = root / "themes"
+            source = themes_root / "source-theme"
+            assets = source / "assets"
+            assets.mkdir(parents=True)
+            (source / "theme.json").write_text("{}", encoding="utf-8")
+            external = root / "secret.txt"
+            external.write_text("secret", encoding="utf-8")
+            try:
+                (assets / "linked.txt").symlink_to(external)
+            except (NotImplementedError, OSError):
+                self.skipTest("file symlinks are unavailable")
+
+            with self.assertRaises(PermissionError):
+                _copy_theme_source(source, themes_root / "staging", themes_root)
+
+            self.assertEqual(external.read_text(encoding="utf-8"), "secret")
+
+    def test_copy_theme_source_rejects_source_directory_symlink_alias(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            themes_root = Path(tempdir) / "themes"
+            source = themes_root / "source-theme"
+            source.mkdir(parents=True)
+            (source / "theme.json").write_text("{}", encoding="utf-8")
+            alias = themes_root / "alias-theme"
+            try:
+                alias.symlink_to(source, target_is_directory=True)
+            except (NotImplementedError, OSError):
+                self.skipTest("directory symlinks are unavailable")
+
+            with self.assertRaises(PermissionError):
+                _copy_theme_source(alias, themes_root / "staging", themes_root)
+
+            self.assertFalse((themes_root / "staging").exists())
+
+    def test_save_chat_theme_rejects_internal_directory_symlink_alias(self):
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as tempdir:
+            state.project_root_dir = tempdir
+            list_chat_themes(state)
+            themes_root = Path(tempdir) / "data/chat_ui_themes"
+            builtin = themes_root / "neon-night-city"
+            original_manifest = (builtin / "theme.json").read_text(encoding="utf-8")
+            try:
+                (themes_root / "alias-theme").symlink_to(
+                    builtin,
+                    target_is_directory=True,
+                )
+            except (NotImplementedError, OSError):
+                self.skipTest("directory symlinks are unavailable")
+
+            with self.assertRaises(PermissionError):
+                save_chat_theme(
+                    state,
+                    {
+                        "baseId": "alias-theme",
+                        "manifest": {
+                            "schema": 1,
+                            "id": "alias-theme",
+                            "name": {"en": "Alias"},
+                            "tokens": {},
+                        },
+                    },
+                )
+
+            self.assertEqual(
+                (builtin / "theme.json").read_text(encoding="utf-8"),
+                original_manifest,
+            )
+
     def test_delete_builtin_theme_is_rejected(self):
         state = self._make_state()
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 list_chat_themes(state)
                 with self.assertRaises(PermissionError):
@@ -434,6 +937,7 @@ class ChatThemeBridgeTests(unittest.TestCase):
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 invalid_theme_dir = Path(tempdir) / "data" / "chat_ui_themes" / "broken-theme"
                 invalid_theme_dir.mkdir(parents=True, exist_ok=True)
@@ -447,11 +951,52 @@ class ChatThemeBridgeTests(unittest.TestCase):
             finally:
                 os.chdir(previous_cwd)
 
+    def test_list_chat_themes_rejects_replaced_catalog_root(self):
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as tempdir:
+            state.project_root_dir = tempdir
+            list_chat_themes(state)
+            themes_root = Path(tempdir) / "data/chat_ui_themes"
+            preserved_root = Path(tempdir) / "preserved-chat-ui-themes"
+            real_snapshot = (
+                chat_themes_module.snapshot_directory_entries_without_links
+            )
+            replaced = False
+
+            def snapshot_then_replace(path, **kwargs):
+                nonlocal replaced
+                result = real_snapshot(path, **kwargs)
+                if Path(path) == themes_root and not replaced:
+                    replaced = True
+                    themes_root.rename(preserved_root)
+                    themes_root.mkdir()
+                    peer = themes_root / "peer-theme"
+                    peer.mkdir()
+                    (peer / "theme.json").write_text(
+                        '{"schema":1,"id":"peer-theme","name":{"en":"Peer"},"tokens":{}}',
+                        encoding="utf-8",
+                    )
+                return result
+
+            with patch.object(
+                chat_themes_module,
+                "snapshot_directory_entries_without_links",
+                snapshot_then_replace,
+            ):
+                with self.assertRaises(PermissionError):
+                    list_chat_themes(state)
+
+            self.assertTrue((themes_root / "peer-theme/theme.json").is_file())
+            self.assertTrue(
+                (preserved_root / "neon-night-city/theme.json").is_file()
+            )
+
     def test_get_chat_theme_manifest_returns_normalized_manifest(self):
         state = self._make_state()
         previous_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as tempdir:
             os.chdir(tempdir)
+            state.project_root_dir = tempdir
             try:
                 theme_dir = Path(tempdir) / "data" / "chat_ui_themes" / "custom-theme"
                 theme_dir.mkdir(parents=True, exist_ok=True)

--- a/test/unit/frontend_bridge_core/test_effects_comprehensive.py
+++ b/test/unit/frontend_bridge_core/test_effects_comprehensive.py
@@ -426,6 +426,22 @@ def test_save_effect_rejects_path_traversal_name(tmp_path, monkeypatch):
     assert not (tmp_path / "outside").exists()
 
 
+def test_save_effect_rejects_outer_whitespace_without_retargeting(tmp_path):
+    """An effect directory name must never be silently trimmed."""
+    from frontend_bridge_core.effects import _save_effect
+
+    state = make_state([make_effect("Spark")])
+    state.project_root_dir = tmp_path.as_posix()
+
+    with pytest.raises(ValueError, match="portable path component"):
+        _save_effect(state, {"name": " Spark ", "color": "#ffffff"})
+
+    assert [effect.name for effect in state.config_manager.config.effect_list] == [
+        "Spark"
+    ]
+    assert not state.config_manager.saved
+
+
 def test_delete_effect_removes_from_list():
     """Delete removes the correct effect."""
     effect_list = [make_effect("A"), make_effect("B"), make_effect("C")]
@@ -512,6 +528,284 @@ def test_delete_effect_audio_does_not_unlink_external_file(tmp_path, monkeypatch
     assert state.config_manager.saved
 
 
+def test_delete_effect_audio_does_not_retarget_missing_external_path(tmp_path):
+    from frontend_bridge_core.effects import _delete_effect_audio
+
+    project = tmp_path / "project"
+    managed_peer = project / "data/effects/rain/drop.wav"
+    managed_peer.parent.mkdir(parents=True)
+    managed_peer.write_bytes(b"managed peer")
+    missing_external = tmp_path / "offline-disk/data/effects/rain/drop.wav"
+    effect = make_effect(
+        "rain",
+        audio_list=[missing_external.as_posix()],
+        audio_tags="Effect 1: external\n",
+    )
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+
+    _delete_effect_audio(state, {"name": "rain", "index": 0})
+
+    assert managed_peer.read_bytes() == b"managed peer"
+    assert effect.audio_list == []
+    assert state.config_manager.saved
+
+
+def test_effect_upload_uses_state_root_and_persists_portable_path(tmp_path, monkeypatch):
+    from frontend_bridge_core.effects import _upload_effect_audio
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"audio")
+    effect = make_effect("rain")
+    state = make_state([effect])
+    state.project_root_dir = project_root.as_posix()
+    monkeypatch.chdir(unrelated)
+
+    _upload_effect_audio(state, {"name": "rain", "paths": [source.as_posix()]})
+
+    assert effect.audio_list == ["data/effects/rain/source.wav"]
+    assert (project_root / effect.audio_list[0]).read_bytes() == b"audio"
+    assert not (unrelated / "data").exists()
+
+
+def test_effect_upload_never_overwrites_same_named_audio(tmp_path):
+    from frontend_bridge_core.effects import _upload_effect_audio
+
+    project = tmp_path / "project"
+    existing = project / "data/effects/rain/drop.wav"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"old")
+    source = tmp_path / "incoming/drop.wav"
+    source.parent.mkdir()
+    source.write_bytes(b"new")
+    effect = make_effect("rain", audio_list=["data/effects/rain/drop.wav"])
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+
+    _upload_effect_audio(state, {"name": "rain", "paths": [source.as_posix()]})
+
+    assert existing.read_bytes() == b"old"
+    assert effect.audio_list == [
+        "data/effects/rain/drop.wav",
+        "data/effects/rain/drop_1.wav",
+    ]
+    assert (project / effect.audio_list[1]).read_bytes() == b"new"
+
+
+def test_effect_upload_does_not_follow_linked_source_directory(tmp_path):
+    from frontend_bridge_core.effects import _upload_effect_audio
+
+    project = tmp_path / "project"
+    external = tmp_path / "incoming"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    (external / "drop.wav").write_bytes(b"external")
+    try:
+        (project / "data/incoming").symlink_to(
+            external,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    effect = make_effect("rain")
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+
+    _upload_effect_audio(
+        state,
+        {"name": "rain", "paths": ["data/incoming/drop.wav"]},
+    )
+
+    assert effect.audio_list == []
+    assert not (project / "data/effects/rain/drop.wav").exists()
+
+
+def test_effect_upload_save_failure_restores_memory_and_files(tmp_path):
+    from frontend_bridge_core.effects import _upload_effect_audio
+
+    project = tmp_path / "project"
+    source = tmp_path / "incoming/drop.wav"
+    source.parent.mkdir()
+    source.write_bytes(b"new")
+    effect = make_effect("rain")
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+    state.config_manager.save_effect_config = lambda: (_ for _ in ()).throw(
+        OSError("disk full")
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        _upload_effect_audio(state, {"name": "rain", "paths": [source.as_posix()]})
+
+    assert effect.audio_list == []
+    assert effect.audio_tags == ""
+    assert not (project / "data/effects/rain").exists()
+
+
+def test_effect_delete_audio_save_failure_keeps_reference_and_file(tmp_path):
+    from frontend_bridge_core.effects import _delete_effect_audio
+
+    project = tmp_path / "project"
+    audio = project / "data/effects/rain/drop.wav"
+    audio.parent.mkdir(parents=True)
+    audio.write_bytes(b"audio")
+    effect = make_effect(
+        "rain",
+        audio_list=["data/effects/rain/drop.wav"],
+        audio_tags="特效 1：drop\n",
+    )
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+    state.config_manager.save_effect_config = lambda: (_ for _ in ()).throw(
+        OSError("read only")
+    )
+
+    with pytest.raises(OSError, match="read only"):
+        _delete_effect_audio(state, {"name": "rain", "index": 0})
+
+    assert audio.read_bytes() == b"audio"
+    assert effect.audio_list == ["data/effects/rain/drop.wav"]
+    assert effect.audio_tags == "特效 1：drop\n"
+
+
+def test_effect_delete_audio_preserves_replacement_created_during_save(tmp_path):
+    from frontend_bridge_core.effects import _delete_effect_audio
+
+    project = tmp_path / "project"
+    audio = project / "data/effects/rain/drop.wav"
+    preserved = project / "data/effects/rain/original-drop.wav"
+    audio.parent.mkdir(parents=True)
+    audio.write_bytes(b"original")
+    effect = make_effect(
+        "rain",
+        audio_list=["data/effects/rain/drop.wav"],
+        audio_tags="特效 1：drop\n",
+    )
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+
+    def replace_during_save():
+        audio.rename(preserved)
+        audio.write_bytes(b"peer")
+
+    state.config_manager.save_effect_config = replace_during_save
+
+    _delete_effect_audio(state, {"name": "rain", "index": 0})
+
+    assert audio.read_bytes() == b"peer"
+    assert preserved.read_bytes() == b"original"
+    assert effect.audio_list == []
+
+
+def test_effect_delete_audio_never_follows_alias_below_effect_directory(tmp_path):
+    from frontend_bridge_core.effects import _delete_effect_audio
+
+    project = tmp_path / "project"
+    real = project / "data/effects/rain/real"
+    real.mkdir(parents=True)
+    audio = real / "drop.wav"
+    audio.write_bytes(b"keep")
+    try:
+        (real.parent / "alias").symlink_to(real, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+    effect = make_effect(
+        "rain",
+        audio_list=["data/effects/rain/alias/drop.wav"],
+        audio_tags="特效 1：drop\n",
+    )
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+
+    _delete_effect_audio(state, {"name": "rain", "index": 0})
+
+    assert audio.read_bytes() == b"keep"
+    assert effect.audio_list == []
+
+
+def test_effect_rename_save_failure_restores_original_directory(tmp_path):
+    from frontend_bridge_core.effects import _save_effect
+
+    project = tmp_path / "project"
+    old_audio = project / "data/effects/rain/drop.wav"
+    old_audio.parent.mkdir(parents=True)
+    old_audio.write_bytes(b"audio")
+    effect = make_effect(
+        "rain",
+        audio_list=["data/effects/rain/drop.wav"],
+        audio_tags="特效 1：drop\n",
+    )
+    state = make_state([effect])
+    state.project_root_dir = project.as_posix()
+    state.config_manager.save_effect_config = lambda: (_ for _ in ()).throw(
+        OSError("disk full")
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        _save_effect(
+            state,
+            {
+                "originalName": "rain",
+                "effect": {
+                    "name": "storm",
+                    "audio_list": ["data/effects/rain/drop.wav"],
+                    "audio_tags": "特效 1：drop\n",
+                },
+            },
+        )
+
+    assert state.config_manager.config.effect_list == [effect]
+    assert old_audio.read_bytes() == b"audio"
+    assert not (project / "data/effects/storm").exists()
+
+
+def test_effect_paths_from_old_project_root_are_rebased_before_launch(tmp_path):
+    from frontend_bridge_core.effects import _build_effect_usage_guide
+
+    project_root = tmp_path / "project"
+    managed = project_root / "data" / "effects" / "rain" / "drop.wav"
+    managed.parent.mkdir(parents=True)
+    managed.write_bytes(b"audio")
+    effect = make_effect(
+        "rain",
+        audio_list=[r"D:\old-project\data\effects\rain\drop.wav"],
+        audio_tags="Effect 1: drop\n",
+    )
+    state = make_state([effect])
+    state.project_root_dir = project_root.as_posix()
+
+    _build_effect_usage_guide(state, ["rain"])
+
+    assert effect.audio_list == ["data/effects/rain/drop.wav"]
+    assert state.config_manager.saved
+
+
+def test_effect_paths_keep_existing_external_audio_before_launch(tmp_path):
+    from frontend_bridge_core.effects import _build_effect_usage_guide
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    external = tmp_path / "external" / "data" / "effects" / "rain" / "drop.wav"
+    external.parent.mkdir(parents=True)
+    external.write_bytes(b"external audio")
+    effect = make_effect(
+        "rain",
+        audio_list=[external.as_posix()],
+        audio_tags="Effect 1: drop\n",
+    )
+    state = make_state([effect])
+    state.project_root_dir = project_root.as_posix()
+
+    _build_effect_usage_guide(state, ["rain"])
+
+    assert effect.audio_list == [external.as_posix()]
+    assert not state.config_manager.saved
+
+
 def test_import_effect_rejects_path_traversal_name(tmp_path, monkeypatch):
     """Effect packages must not create managed directories outside data/effects."""
     from tools.file_util import import_effect
@@ -525,6 +819,75 @@ def test_import_effect_rejects_path_traversal_name(tmp_path, monkeypatch):
         import_effect(str(package), [])
 
     assert not (tmp_path / "outside").exists()
+
+
+def test_failed_effect_validation_rolls_back_copied_audio(tmp_path):
+    from tools.file_util import import_effect
+
+    project = tmp_path / "project"
+    package = tmp_path / "invalid.ef"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "effect.yaml",
+            yaml.safe_dump(
+                [{"name": "invalid", "audio_list": ["sound.wav"], "audio_tags": []}],
+                allow_unicode=True,
+            ),
+        )
+        zf.writestr("audio/sound.wav", b"audio")
+
+    with pytest.raises(Exception):
+        import_effect(str(package), [], project_root=project.resolve())
+
+    assert not (project / "data/effects/invalid").exists()
+
+
+def test_effect_import_uses_project_root_instead_of_cwd(tmp_path, monkeypatch):
+    from tools.file_util import import_effect
+
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    package = tmp_path / "rain.ef"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "effect.yaml",
+            yaml.safe_dump([{"name": "rain", "audio_list": ["drop.wav"]}], allow_unicode=True),
+        )
+        zf.writestr("audio/drop.wav", b"audio")
+    monkeypatch.chdir(unrelated)
+
+    result = import_effect(str(package), [], project_root=project.resolve())
+
+    assert result[0].audio_list == ["data/effects/rain/drop.wav"]
+    assert (project / result[0].audio_list[0]).is_file()
+    assert not (unrelated / "data").exists()
+
+
+def test_effect_import_transaction_rolls_back_after_config_save_failure(tmp_path):
+    from tools.file_util import import_effect, package_import_transaction
+
+    project = tmp_path / "project"
+    package = tmp_path / "rain.ef"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "effect.yaml",
+            yaml.safe_dump([{"name": "rain", "audio_list": ["drop.wav"]}], allow_unicode=True),
+        )
+        zf.writestr("audio/drop.wav", b"audio")
+
+    with pytest.raises(OSError, match="disk full"):
+        with package_import_transaction() as transaction_paths:
+            imported = import_effect(
+                str(package),
+                [],
+                project_root=project.resolve(),
+                transaction_paths=transaction_paths,
+            )
+            assert imported
+            raise OSError("disk full")
+
+    assert not (project / "data/effects/rain").exists()
 
 
 # ── Keyword parsing from main.py ───────────────────────────────

--- a/test/unit/frontend_bridge_core/test_frontend_bridge_characters.py
+++ b/test/unit/frontend_bridge_core/test_frontend_bridge_characters.py
@@ -2,7 +2,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from frontend_bridge_core.characters import _save_character, _validate_character_payload
+from frontend_bridge_core.characters import (
+    _save_character,
+    _stored_character_path,
+    _validate_character_payload,
+)
 
 
 def _character_payload(**overrides):
@@ -33,6 +37,124 @@ def test_remote_voice_paths_still_validate_model_suffixes():
             _character_payload(sovits_model_path="/kaggle/input/voice-model/model.ckpt"),
             allow_remote_voice_paths=True,
         )
+
+
+def test_local_character_validation_resolves_relative_paths_from_project_not_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    model_dir = project / "data/models/mika"
+    model_dir.mkdir(parents=True)
+    unrelated.mkdir()
+    (model_dir / "model.ckpt").write_bytes(b"gpt")
+    (model_dir / "model.pth").write_bytes(b"sovits")
+    (model_dir / "ref.wav").write_bytes(b"audio")
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setattr(
+        "sdk.ui.validators.audio_duration_between",
+        lambda *_args, **_kwargs: (True, ""),
+    )
+
+    _validate_character_payload(
+        _character_payload(
+            gpt_model_path="data/models/mika/model.ckpt",
+            sovits_model_path="data/models/mika/model.pth",
+            refer_audio_path="data/models/mika/ref.wav",
+        ),
+        project_root=project,
+    )
+
+
+def test_local_character_validation_rejects_linked_model_directory(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    external = tmp_path / "models"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    (external / "model.ckpt").write_bytes(b"gpt")
+    (external / "model.pth").write_bytes(b"sovits")
+    (external / "ref.wav").write_bytes(b"audio")
+    try:
+        (project / "data/models").symlink_to(
+            external,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setattr(
+        "sdk.ui.validators.audio_duration_between",
+        lambda *_args, **_kwargs: (True, ""),
+    )
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _validate_character_payload(
+            _character_payload(
+                gpt_model_path="data/models/model.ckpt",
+                sovits_model_path="data/models/model.pth",
+                refer_audio_path="data/models/ref.wav",
+            ),
+            project_root=project,
+        )
+
+
+def test_save_character_serializes_project_owned_model_paths_as_relative(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    model_dir = project / "data/models/mika"
+    model_dir.mkdir(parents=True)
+    model_paths = {
+        "gpt_model_path": model_dir / "model.ckpt",
+        "sovits_model_path": model_dir / "model.pth",
+        "refer_audio_path": model_dir / "ref.wav",
+    }
+    for path in model_paths.values():
+        path.write_bytes(b"data")
+
+    captured = {}
+    character_manager = SimpleNamespace()
+
+    def add_character(*args, **_kwargs):
+        captured["paths"] = args[3:6]
+        return "人物已添加！", ["Remote Voice"]
+
+    character_manager.add_character = add_character
+    config_manager = SimpleNamespace(
+        config=SimpleNamespace(
+            api_config=SimpleNamespace(tts_provider="gpt-sovits", gpt_sovits_url="https://remote.example")
+        ),
+        reload=lambda: None,
+        get_character_by_name=lambda _name: None,
+    )
+    state = SimpleNamespace(
+        project_root_dir=project.as_posix(),
+        character_manager=character_manager,
+        config_manager=config_manager,
+    )
+
+    result = _save_character(
+        state,
+        {"character": _character_payload(**{key: path.as_posix() for key, path in model_paths.items()})},
+    )
+
+    assert captured["paths"] == (
+        "data/models/mika/model.ckpt",
+        "data/models/mika/model.pth",
+        "data/models/mika/ref.wav",
+    )
+    assert result["name"] == "Remote Voice"
+
+
+def test_save_character_preserves_missing_external_model_identity(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    external = tmp_path / "offline-disk/data/models/mika/model.ckpt"
+
+    assert _stored_character_path(external.as_posix(), project) == (
+        external.as_posix()
+    )
 
 
 def test_character_save_propagates_rename_to_template_session(monkeypatch):

--- a/test/unit/frontend_bridge_core/test_frontend_bridge_config_validation.py
+++ b/test/unit/frontend_bridge_core/test_frontend_bridge_config_validation.py
@@ -79,6 +79,35 @@ def test_tts_server_path_is_validated_when_provided(tmp_path):
         _validate_api_config_for_save(_valid_config(gpt_sovits_api_path=str(tmp_path / "missing")))
 
 
+def test_tts_server_path_validation_does_not_follow_symlink(tmp_path):
+    server = tmp_path / "gpt-sovits"
+    alias = tmp_path / "gpt-sovits-alias"
+    server.mkdir()
+    try:
+        alias.symlink_to(server, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _validate_api_config_for_save(
+            _valid_config(gpt_sovits_api_path=alias.as_posix())
+        )
+
+
+def test_relative_tts_server_path_is_resolved_from_selected_project_root(tmp_path, monkeypatch):
+    project = tmp_path / "selected-project"
+    server = project / "data/tts-server"
+    server.mkdir(parents=True)
+    unrelated = tmp_path / "unrelated-cwd"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    _validate_api_config_for_save(
+        _valid_config(gpt_sovits_api_path="data/tts-server"),
+        project_root=project,
+    )
+
+
 def test_kaggle_tts_provider_does_not_require_local_server_path(tmp_path):
     _validate_api_config_for_save(
         _valid_config(
@@ -86,6 +115,93 @@ def test_kaggle_tts_provider_does_not_require_local_server_path(tmp_path):
             gpt_sovits_api_path=str(tmp_path / "missing"),
         )
     )
+
+
+def test_default_empty_t2i_configuration_remains_an_explicit_skip():
+    _validate_api_config_for_save(
+        _valid_config(
+            tts_provider="none",
+            t2i_provider="comfyui",
+            t2i_api_url="http://127.0.0.1:8188",
+            t2i_work_path="",
+            t2i_default_workflow_path="",
+        )
+    )
+
+
+def test_configured_comfyui_requires_an_existing_workflow(tmp_path):
+    with pytest.raises(ValueError, match="默认工作流"):
+        _validate_api_config_for_save(
+            _valid_config(
+                tts_provider="none",
+                t2i_provider="comfyui",
+                t2i_api_url="http://localhost:8188",
+                t2i_work_path="",
+                t2i_default_workflow_path="",
+            ),
+            project_root=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="已存在的文件"):
+        _validate_api_config_for_save(
+            _valid_config(
+                tts_provider="none",
+                t2i_provider="comfyui",
+                t2i_api_url="http://127.0.0.1:8188",
+                t2i_work_path="",
+                t2i_default_workflow_path="data/workflows/missing.json",
+            ),
+            project_root=tmp_path,
+        )
+
+
+def test_comfyui_paths_resolve_from_selected_project_root(tmp_path, monkeypatch):
+    project = tmp_path / "selected-project"
+    workflow = project / "data" / "workflows" / "sprite.json"
+    work_directory = project / "data" / "comfyui"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    work_directory.mkdir(parents=True)
+    unrelated = tmp_path / "unrelated-cwd"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    _validate_api_config_for_save(
+        _valid_config(
+            tts_provider="none",
+            t2i_provider="comfyui",
+            t2i_api_url="http://127.0.0.1:8188",
+            t2i_work_path="data/comfyui",
+            t2i_default_workflow_path="data/workflows/sprite.json",
+        ),
+        project_root=project,
+    )
+
+
+def test_comfyui_path_validation_does_not_follow_links(tmp_path):
+    project = tmp_path / "project"
+    workflow = project / "data" / "workflows" / "sprite.json"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    external = tmp_path / "external"
+    external.mkdir()
+    linked_work = project / "data" / "comfyui"
+    try:
+        linked_work.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _validate_api_config_for_save(
+            _valid_config(
+                tts_provider="none",
+                t2i_provider="comfyui",
+                t2i_api_url="http://127.0.0.1:8188",
+                t2i_work_path="data/comfyui",
+                t2i_default_workflow_path="data/workflows/sprite.json",
+            ),
+            project_root=project,
+        )
 
 
 def _api_config_with_local_tts() -> ApiConfig:
@@ -166,7 +282,25 @@ def test_save_api_config_defaults_tts_path_under_project_root(tmp_path):
     assert manager.saved is True
 
 
-def test_project_root_lookup_supports_legacy_state_and_cwd_fallback(tmp_path, monkeypatch):
+def test_save_api_config_failure_restores_previous_in_memory_config(tmp_path):
+    app_root = tmp_path / "app"
+    project_root = tmp_path / "project"
+    app_root.mkdir()
+    _create_gpt_sovits_bundle(project_root)
+    state, manager = _bridge_state_for_config(project_root, app_root)
+    previous = manager.config.api_config
+    payload = _api_config_with_local_tts().model_dump(mode="json")
+    payload["llm_model"] = {"Deepseek": "changed-model"}
+    manager.save_api_config = lambda: (_ for _ in ()).throw(OSError("disk full"))
+
+    with pytest.raises(OSError, match="disk full"):
+        _save_api_config(state, payload)
+
+    assert manager.config.api_config is previous
+    assert manager.config.api_config.llm_model["Deepseek"] == "deepseek-chat"
+
+
+def test_project_root_lookup_supports_legacy_state_and_stable_app_fallback(tmp_path, monkeypatch):
     env_root = tmp_path / "legacy env" / "数据 Root"
     easyai_root = tmp_path / "legacy EASYAI env"
     cwd_root = tmp_path / "legacy cwd" / "Project Data"
@@ -186,4 +320,5 @@ def test_project_root_lookup_supports_legacy_state_and_cwd_fallback(tmp_path, mo
     assert _state_project_root(legacy_state) == easyai_root.resolve()
 
     monkeypatch.delenv("EASYAI_PROJECT_ROOT")
-    assert _state_project_root(legacy_state) == cwd_root.resolve()
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", str(app_root))
+    assert _state_project_root(legacy_state) == app_root.resolve()

--- a/test/unit/frontend_bridge_core/test_frontend_bridge_media.py
+++ b/test/unit/frontend_bridge_core/test_frontend_bridge_media.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from frontend_bridge_core.media import _media_thumbnail, _media_thumbnail_batch
@@ -21,6 +23,30 @@ def test_media_thumbnail_generates_cached_small_image(tmp_path):
         assert generated.format == "PNG"
 
     assert _media_thumbnail(source, project_root=tmp_path, size=96) == thumbnail
+
+
+def test_media_thumbnail_cache_key_tracks_file_identity_not_only_mtime_and_size(
+    tmp_path,
+):
+    source = tmp_path / "data" / "background.bmp"
+    preserved = tmp_path / "preserved.bmp"
+    source.parent.mkdir()
+    Image.new("RGB", (16, 16), "red").save(source)
+    original = source.stat()
+    first = _media_thumbnail(source, project_root=tmp_path, size=97)
+    source.rename(preserved)
+    Image.new("RGB", (16, 16), "blue").save(source)
+    assert source.stat().st_size == original.st_size
+    os.utime(
+        source,
+        ns=(original.st_atime_ns, original.st_mtime_ns),
+    )
+
+    second = _media_thumbnail(source, project_root=tmp_path, size=97)
+
+    assert second != first
+    with Image.open(second) as generated:
+        assert generated.getpixel((0, 0)) == (0, 0, 255)
 
 
 def test_media_thumbnail_batch_returns_data_urls(tmp_path):
@@ -57,3 +83,35 @@ def test_media_thumbnail_batch_can_return_cache_paths_without_data_urls(tmp_path
     assert item["path"] == "data/background.png"
     assert item["cachePath"].startswith(".cache/frontend-media-thumbnails/")
     assert "dataUrl" not in item
+
+
+def test_media_thumbnail_rejects_symlinked_cache_storage(tmp_path):
+    source = tmp_path / "source.png"
+    external = tmp_path / "external"
+    external.mkdir()
+    Image.new("RGB", (16, 16), "red").save(source)
+    try:
+        (tmp_path / ".cache").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        _media_thumbnail(source, project_root=tmp_path, size=96)
+
+    assert list(external.iterdir()) == []
+
+
+def test_media_thumbnail_rejects_symlinked_cache_file_alias(tmp_path):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (16, 16), "red").save(source)
+    thumbnail = _media_thumbnail(source, project_root=tmp_path, size=96)
+    thumbnail.unlink()
+    other = thumbnail.parent / "other.png"
+    Image.new("RGB", (8, 8), "blue").save(other)
+    try:
+        thumbnail.symlink_to(other)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _media_thumbnail(source, project_root=tmp_path, size=96)

--- a/test/unit/frontend_bridge_core/test_frontend_bridge_memory.py
+++ b/test/unit/frontend_bridge_core/test_frontend_bridge_memory.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -181,7 +184,11 @@ def test_check_mem0_status_does_not_retry_an_unresolved_dependency(monkeypatch):
     monkeypatch.setattr(runtime, "_mem0_load_error", error)
     monkeypatch.setattr(runtime, "current_mem0_task", lambda: None)
     monkeypatch.setattr(runtime, "_module_is_available", lambda module_name: False)
-    monkeypatch.setattr(runtime, "start_mem0_loading", lambda: starts.append(True))
+    monkeypatch.setattr(
+        runtime,
+        "start_mem0_loading",
+        lambda **_kwargs: starts.append(True),
+    )
 
     result = runtime.check_mem0_status(start_loading=True)
 
@@ -208,8 +215,16 @@ def test_check_mem0_status_recovers_after_dependency_install(monkeypatch):
     monkeypatch.setattr(runtime, "_mem0_load_error", error)
     monkeypatch.setattr(runtime, "current_mem0_task", lambda: None)
     monkeypatch.setattr(runtime, "_module_is_available", lambda module_name: True)
-    monkeypatch.setattr(runtime, "is_embedding_model_cached", lambda: False)
-    monkeypatch.setattr(runtime, "start_mem0_loading", lambda: starts.append(True))
+    monkeypatch.setattr(
+        runtime,
+        "is_embedding_model_cached",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "start_mem0_loading",
+        lambda **_kwargs: starts.append(True),
+    )
 
     assert runtime.check_mem0_status(start_loading=False) == {
         "status": "not_started",
@@ -236,8 +251,16 @@ def test_check_mem0_status_returns_loading_when_retrying_an_error(monkeypatch):
     monkeypatch.setattr(runtime, "_mem0_loading", False)
     monkeypatch.setattr(runtime, "_mem0_load_error", RuntimeError("initialization failed"))
     monkeypatch.setattr(runtime, "current_mem0_task", lambda: task)
-    monkeypatch.setattr(runtime, "is_embedding_model_cached", lambda: True)
-    monkeypatch.setattr(runtime, "start_mem0_loading", lambda: starts.append(True))
+    monkeypatch.setattr(
+        runtime,
+        "is_embedding_model_cached",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "start_mem0_loading",
+        lambda **_kwargs: starts.append(True),
+    )
 
     result = runtime.check_mem0_status(start_loading=True)
 
@@ -263,8 +286,16 @@ def test_start_mem0_loading_preserves_internal_missing_dependency(monkeypatch):
     monkeypatch.setattr(runtime, "_mem0", None)
     monkeypatch.setattr(runtime, "_mem0_loading", False)
     monkeypatch.setattr(runtime, "_mem0_load_error", None)
-    monkeypatch.setattr(runtime, "is_embedding_model_cached", lambda: True)
-    monkeypatch.setattr(runtime, "_preload_embedding_model", lambda: r"\\?\D:\model")
+    monkeypatch.setattr(
+        runtime,
+        "is_embedding_model_cached",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_preload_embedding_model",
+        lambda **_kwargs: r"\\?\D:\model",
+    )
     monkeypatch.setattr(runtime, "_create_mem0_instance", _raise_missing_dependency)
     monkeypatch.setattr(runtime, "set_mem0_task", lambda **update: updates.append(update))
     monkeypatch.setattr(runtime.threading, "Thread", _ImmediateThread)
@@ -295,8 +326,16 @@ def test_start_mem0_loading_reports_post_download_failure_as_initialization(monk
     monkeypatch.setattr(runtime, "_mem0", None)
     monkeypatch.setattr(runtime, "_mem0_loading", False)
     monkeypatch.setattr(runtime, "_mem0_load_error", None)
-    monkeypatch.setattr(runtime, "is_embedding_model_cached", lambda: True)
-    monkeypatch.setattr(runtime, "_preload_embedding_model", lambda: r"\\?\D:\model")
+    monkeypatch.setattr(
+        runtime,
+        "is_embedding_model_cached",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_preload_embedding_model",
+        lambda **_kwargs: r"\\?\D:\model",
+    )
     monkeypatch.setattr(runtime, "_create_mem0_instance", _raise_initialization_error)
     monkeypatch.setattr(runtime, "set_mem0_task", lambda **update: updates.append(update))
     monkeypatch.setattr(runtime.threading, "Thread", _ImmediateThread)
@@ -318,7 +357,11 @@ def test_check_mem0_status_exposes_cache_state_while_loading(monkeypatch):
     monkeypatch.setattr(runtime, "current_mem0_task", lambda: task)
 
     for cached in (False, True):
-        monkeypatch.setattr(runtime, "is_embedding_model_cached", lambda cached=cached: cached)
+        monkeypatch.setattr(
+            runtime,
+            "is_embedding_model_cached",
+            lambda cached=cached, **_kwargs: cached,
+        )
 
         assert runtime.check_mem0_status() == {
             "status": "loading",
@@ -327,40 +370,103 @@ def test_check_mem0_status_exposes_cache_state_while_loading(monkeypatch):
         }
 
 
-def test_preload_embedding_model_uses_shared_asset_service(monkeypatch):
+def test_preload_embedding_model_uses_shared_asset_service(tmp_path, monkeypatch):
     from ai.memory import runtime
 
     captured = {}
     snapshot_path = r"\\?\C:\very\deep\cache\snapshots\abc123"
 
-    def _fake_download_model_asset(spec, *, update_task):
+    def _fake_download_model_asset(spec, *, update_task, root):
         captured["spec"] = spec
         captured["update_task"] = update_task
+        captured["root"] = root
         return {"path": snapshot_path}
 
     monkeypatch.setattr(runtime, "download_model_asset", _fake_download_model_asset)
 
-    result = runtime._preload_embedding_model()
+    result = runtime._preload_embedding_model(root=tmp_path)
 
     assert result == snapshot_path
     assert captured == {
         "spec": runtime.EMBEDDING_MODEL_ASSET,
         "update_task": runtime.set_mem0_task,
+        "root": tmp_path,
+    }
+
+def test_frontend_memory_status_passes_state_root_and_config_manager(
+    tmp_path,
+    monkeypatch,
+):
+    import importlib
+
+    from frontend_bridge_core.memory import _get_mem0_status
+
+    selected = tmp_path / "selected"
+    selected.mkdir()
+    config_manager = object()
+    state = SimpleNamespace(
+        project_root_dir=selected.as_posix(),
+        config_manager=config_manager,
+    )
+    captured = {}
+
+    def fake_find_spec(name):
+        if name == "mem0":
+            return object()
+        return importlib.util.find_spec(name)
+
+    def fake_status(**kwargs):
+        captured.update(kwargs)
+        return {"status": "not_started", "modelCached": False}
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr("ai.memory.runtime.check_mem0_status", fake_status)
+
+    result = _get_mem0_status(state, start_loading=False)
+
+    assert result["status"] == "not_started"
+    assert captured == {
+        "start_loading": False,
+        "root": Path(selected),
+        "config_manager": config_manager,
     }
 
 
-def test_preload_embedding_model_requires_a_resolved_path(monkeypatch):
-    import pytest
+def test_memory_runtime_rejects_reuse_across_project_roots(
+    tmp_path,
+    monkeypatch,
+):
+    from ai.memory import runtime
 
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(runtime, "_mem0", object())
+    monkeypatch.setattr(runtime, "_mem0_loading", False)
+    monkeypatch.setattr(runtime, "_mem0_project_root", first)
+
+    try:
+        runtime.ensure_mem0(root=second)
+    except RuntimeError as exc:
+        assert "different project root" in str(exc)
+    else:
+        raise AssertionError("memory runtime silently reused another project's store")
+
+
+def test_preload_embedding_model_requires_a_resolved_path(tmp_path, monkeypatch):
     from ai.memory import runtime
 
     monkeypatch.setattr(runtime, "download_model_asset", lambda *args, **kwargs: {})
 
     with pytest.raises(RuntimeError, match="could not be located"):
-        runtime._preload_embedding_model()
+        runtime._preload_embedding_model(root=tmp_path)
 
 
-def test_create_mem0_instance_uses_local_snapshot_instead_of_repo_id(monkeypatch):
+def test_create_mem0_instance_uses_local_snapshot_instead_of_repo_id(
+    tmp_path,
+    monkeypatch,
+):
     from ai.memory import runtime
 
     snapshot_path = r"\\?\C:\very\deep\cache\snapshots\abc123"
@@ -379,8 +485,22 @@ def test_create_mem0_instance_uses_local_snapshot_instead_of_repo_id(monkeypatch
             captured["config"] = value
             return "memory-instance"
 
-    monkeypatch.setattr(runtime, "build_mem0_config", lambda: config)
-    result = runtime._create_mem0_instance(_FakeMemory, snapshot_path)
+    config_manager = object()
+
+    def fake_build_mem0_config(*, root, config_manager):
+        captured["root"] = root
+        captured["config_manager"] = config_manager
+        return config
+
+    monkeypatch.setattr(runtime, "build_mem0_config", fake_build_mem0_config)
+    result = runtime._create_mem0_instance(
+        _FakeMemory,
+        snapshot_path,
+        root=tmp_path,
+        config_manager=config_manager,
+    )
 
     assert result == "memory-instance"
     assert captured["config"]["embedder"]["config"]["model"] == snapshot_path
+    assert captured["root"] == tmp_path
+    assert captured["config_manager"] is config_manager

--- a/test/unit/frontend_bridge_core/test_frontend_bridge_music.py
+++ b/test/unit/frontend_bridge_core/test_frontend_bridge_music.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from frontend_bridge_core.music import _run_music_cover
+
+
+def _music_state(project_root_dir=None):
+    values = dict(
+        config_manager=SimpleNamespace(
+            config=SimpleNamespace(system_config=SimpleNamespace()),
+        ),
+        task_lock=threading.Lock(),
+        tasks={"music-task": {"logs": []}},
+    )
+    if project_root_dir is not None:
+        values["project_root_dir"] = project_root_dir
+    return SimpleNamespace(**values)
+
+
+def _patch_pipeline(monkeypatch, final_mix):
+    monkeypatch.setattr(
+        "live.music_cover_pipeline.run_pipeline",
+        lambda *_args, **_kwargs: SimpleNamespace(final_mix=final_mix),
+    )
+    monkeypatch.setattr(
+        "live.music_cover_pipeline.format_pipeline_log",
+        lambda _result: "pipeline complete",
+    )
+
+
+def test_music_cover_result_uses_the_validated_regular_final_mix(
+    monkeypatch,
+    tmp_path,
+):
+    final_mix = tmp_path / "final mix.wav"
+    final_mix.write_bytes(b"RIFF")
+    _patch_pipeline(monkeypatch, final_mix)
+
+    result = _run_music_cover(
+        _music_state(),
+        "music-task",
+        {"query": "song", "source": "youtube"},
+    )
+
+    assert result == {
+        "audioPath": str(final_mix),
+        "log": "pipeline complete",
+    }
+
+
+@pytest.mark.parametrize("invalid_kind", ["missing", "directory"])
+def test_music_cover_result_rejects_a_non_file_final_mix(
+    monkeypatch,
+    tmp_path,
+    invalid_kind,
+):
+    final_mix = tmp_path / "final_mix.wav"
+    if invalid_kind == "directory":
+        final_mix.mkdir()
+    _patch_pipeline(monkeypatch, final_mix)
+
+    with pytest.raises(FileNotFoundError):
+        _run_music_cover(
+            _music_state(),
+            "music-task",
+            {"query": "song", "source": "youtube"},
+        )
+
+
+def test_music_cover_result_rejects_a_linked_final_mix(
+    monkeypatch,
+    tmp_path,
+):
+    target = tmp_path / "actual.wav"
+    target.write_bytes(b"RIFF")
+    final_mix = tmp_path / "final_mix.wav"
+    try:
+        final_mix.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+    _patch_pipeline(monkeypatch, final_mix)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _run_music_cover(
+            _music_state(),
+            "music-task",
+            {"query": "song", "source": "youtube"},
+        )
+
+
+def test_music_cover_result_requires_the_pipeline_to_return_a_final_mix(
+    monkeypatch,
+):
+    _patch_pipeline(monkeypatch, None)
+
+    with pytest.raises(FileNotFoundError, match="did not produce"):
+        _run_music_cover(
+            _music_state(),
+            "music-task",
+            {"query": "song", "source": "youtube"},
+        )
+
+
+def test_music_cover_pipeline_receives_bridge_project_root(
+    monkeypatch,
+    tmp_path,
+):
+    ambient = tmp_path / "ambient-project"
+    selected = tmp_path / "selected-project"
+    final_mix = selected / "data/music_cover/final.wav"
+    ambient.mkdir()
+    final_mix.parent.mkdir(parents=True)
+    final_mix.write_bytes(b"RIFF")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+    observed = {}
+
+    def fake_pipeline(*_args, **kwargs):
+        observed["root"] = kwargs.get("root")
+        return SimpleNamespace(final_mix=final_mix)
+
+    monkeypatch.setattr(
+        "live.music_cover_pipeline.run_pipeline",
+        fake_pipeline,
+    )
+    monkeypatch.setattr(
+        "live.music_cover_pipeline.format_pipeline_log",
+        lambda _result: "pipeline complete",
+    )
+
+    _run_music_cover(
+        _music_state(selected),
+        "music-task",
+        {"query": "song", "source": "youtube"},
+    )
+
+    assert observed["root"] == selected.resolve()

--- a/test/unit/frontend_bridge_core/test_frontend_bridge_sprite_voice_type.py
+++ b/test/unit/frontend_bridge_core/test_frontend_bridge_sprite_voice_type.py
@@ -44,10 +44,11 @@ class FakeConfigManager:
         pass
 
 
-def make_state(character):
+def make_state(character, project_root):
     return SimpleNamespace(
         character_manager=FakeCharacterManager(character),
         config_manager=FakeConfigManager(character),
+        project_root_dir=project_root,
     )
 
 
@@ -65,7 +66,7 @@ def make_character(**sprite_fields):
 def test_upload_sprite_voice_rejects_invalid_voice_type(tmp_path):
     voice = tmp_path / "voice.mp3"
     voice.write_bytes(b"not really audio")
-    state = make_state(make_character())
+    state = make_state(make_character(), tmp_path.as_posix())
 
     with pytest.raises(ValueError, match="voice type"):
         _upload_sprite_voice(
@@ -84,7 +85,7 @@ def test_upload_sprite_voice_defaults_to_fallback_without_gpt_sovits_model(tmp_p
     voice = tmp_path / "voice.mp3"
     voice.write_bytes(b"not really audio")
     character = make_character()
-    state = make_state(character)
+    state = make_state(character, tmp_path.as_posix())
 
     _upload_sprite_voice(
         state,
@@ -96,7 +97,7 @@ def test_upload_sprite_voice_defaults_to_fallback_without_gpt_sovits_model(tmp_p
         },
     )
 
-    assert character.sprites[0]["voice_type"] == "fallback"
+    assert character.sprites[0].voice_type == "fallback"
 
 
 def test_upload_sprite_voice_defaults_to_reference_with_gpt_sovits_model(tmp_path, monkeypatch):
@@ -105,7 +106,7 @@ def test_upload_sprite_voice_defaults_to_reference_with_gpt_sovits_model(tmp_pat
     voice = tmp_path / "voice.wav"
     voice.write_bytes(b"not really audio")
     character = make_character(gpt_model_path="model.ckpt", sovits_model_path="model.pth")
-    state = make_state(character)
+    state = make_state(character, tmp_path.as_posix())
     monkeypatch.setattr(characters, "_validate_reference_audio", lambda _path: None)
 
     _upload_sprite_voice(
@@ -118,27 +119,56 @@ def test_upload_sprite_voice_defaults_to_reference_with_gpt_sovits_model(tmp_pat
         },
     )
 
-    assert character.sprites[0]["voice_type"] == "reference"
+    assert character.sprites[0].voice_type == "reference"
 
 
-def test_save_sprite_voice_type_rejects_invalid_voice_type():
-    state = make_state(make_character())
+def test_save_sprite_voice_type_rejects_invalid_voice_type(tmp_path):
+    state = make_state(make_character(), tmp_path.as_posix())
 
     with pytest.raises(ValueError, match="voice type"):
         _save_sprite_voice_type(state, {"name": "Mika", "spriteIndex": 0, "voiceType": "bad"})
 
 
-def test_save_sprite_voice_type_accepts_fallback():
+def test_save_sprite_voice_type_accepts_fallback(tmp_path):
     character = make_character()
-    state = make_state(character)
+    state = make_state(character, tmp_path.as_posix())
 
     _save_sprite_voice_type(state, {"name": "Mika", "spriteIndex": 0, "voiceType": "fallback"})
 
-    assert character.sprites[0]["voice_type"] == "fallback"
+    assert character.sprites[0].voice_type == "fallback"
 
 
-def test_save_sprite_voice_type_rejects_missing_reference_audio():
-    state = make_state(make_character(voice_path="missing.wav"))
+def test_save_sprite_voice_type_rejects_missing_reference_audio(tmp_path):
+    state = make_state(
+        make_character(voice_path="missing.wav"),
+        tmp_path.as_posix(),
+    )
 
     with pytest.raises(ValueError, match="does not exist"):
         _save_sprite_voice_type(state, {"name": "Mika", "spriteIndex": 0, "voiceType": "reference"})
+
+
+def test_save_sprite_voice_type_resolves_project_relative_audio_after_cwd_drift(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    voice = project / "data/speech/mika/voice.wav"
+    voice.parent.mkdir(parents=True)
+    voice.write_bytes(b"audio")
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setattr(
+        "frontend_bridge_core.characters._validate_reference_audio",
+        lambda path: path == voice.as_posix() or pytest.fail(path),
+    )
+    character = make_character(voice_path="data/speech/mika/voice.wav")
+    state = make_state(character, project.as_posix())
+
+    _save_sprite_voice_type(
+        state,
+        {"name": "Mika", "spriteIndex": 0, "voiceType": "reference"},
+    )
+
+    assert character.sprites[0].voice_type == "reference"

--- a/test/unit/frontend_bridge_core/test_frontend_chat_launch_paths.py
+++ b/test/unit/frontend_bridge_core/test_frontend_chat_launch_paths.py
@@ -3,9 +3,11 @@ import signal
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from core.sprite.sprite_cli import CHAT_LAUNCH_CONFIG_ENV
+import pytest
+
 from application.chat import runtime_process as chat
 from application.runtime.dependencies import runtime_dependency_error_from_text
+from core.sprite.sprite_cli import CHAT_LAUNCH_CONFIG_ENV
 
 
 class _SystemConfig:
@@ -34,6 +36,18 @@ class _ConfigManager:
 
     def save_system_config(self):
         pass
+
+
+def test_chat_app_root_rejects_whitespace_instead_of_falling_back(
+    tmp_path,
+    monkeypatch,
+):
+    fallback = tmp_path / "fallback-app"
+    fallback.mkdir()
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", fallback.as_posix())
+
+    with pytest.raises(ValueError, match="app root"):
+        chat._app_root(SimpleNamespace(app_root_dir="   "))
 
 
 class _DummyProcess:
@@ -110,6 +124,175 @@ class _ChatStreamForClose:
         self.deleted.append(session_id)
 
 
+def test_chat_log_path_rejects_symlinked_log_storage(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    try:
+        (project / "logs").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        chat._chat_log_path(project)
+
+    assert list(external.iterdir()) == []
+
+
+def test_chat_log_path_rejects_symlinked_log_file(tmp_path):
+    project = tmp_path / "project"
+    log_dir = project / "logs"
+    log_dir.mkdir(parents=True)
+    target = log_dir / "other.log"
+    target.write_text("keep", encoding="utf-8")
+    try:
+        (log_dir / "main.log").symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        chat._chat_log_path(project)
+
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+def test_chat_launch_file_rejects_linked_leaf_and_parent(tmp_path):
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    target = real_parent / "main.py"
+    target.write_text("print('safe')", encoding="utf-8")
+    linked_file = tmp_path / "linked-main.py"
+    linked_parent = tmp_path / "linked-parent"
+    try:
+        linked_file.symlink_to(target)
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    assert chat._launch_file(target) == target
+    assert chat._launch_file(linked_file) is None
+    assert chat._launch_file(linked_parent / "main.py") is None
+
+
+def test_chat_launch_candidate_deduplication_does_not_hide_link_target(
+    tmp_path,
+):
+    target = tmp_path / "main.exe"
+    alias = tmp_path / "linked-main.exe"
+    target.write_bytes(b"safe")
+    try:
+        alias.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+
+    assert chat._unique_paths([alias, target]) == [alias, target]
+
+
+def test_chat_process_is_stopped_when_entry_changes_during_spawn(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    entry = tmp_path / "main.py"
+    project.mkdir()
+    entry.write_text("print('approved')", encoding="utf-8")
+    entry_snapshot = chat._launch_file_snapshot(entry)
+    assert entry_snapshot is not None
+    process = _DummyClosableProcess()
+
+    def replace_during_spawn(*_args, **_kwargs):
+        entry.write_text(
+            "print('replacement-is-longer')",
+            encoding="utf-8",
+        )
+        return process
+
+    monkeypatch.setattr(
+        chat.subprocess,
+        "Popen",
+        replace_during_spawn,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        chat._popen_chat_process(
+            [str(entry)],
+            cwd=project,
+            env={},
+            required_files=(entry_snapshot,),
+        )
+
+    assert process.running is False
+    assert chat._main_chat_log_file is None
+
+
+def test_chat_process_is_stopped_when_application_root_changes_during_spawn(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    application = tmp_path / "application"
+    preserved = tmp_path / "application-preserved"
+    project.mkdir()
+    application.mkdir()
+    application, application_identity = chat.capture_directory_identity(
+        application,
+        field="chat application root",
+    )
+    process = _DummyClosableProcess()
+
+    def replace_during_spawn(*_args, **_kwargs):
+        application.rename(preserved)
+        application.mkdir()
+        return process
+
+    monkeypatch.setattr(chat.subprocess, "Popen", replace_during_spawn)
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        chat._popen_chat_process(
+            ["chat"],
+            cwd=project,
+            env={},
+            required_directories=((application, application_identity),),
+        )
+
+    assert process.running is False
+    assert chat._main_chat_log_file is None
+
+
+def test_chat_process_is_stopped_when_history_session_changes_during_spawn(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    session = project / "data" / "chat_history" / "session"
+    preserved = project / "data" / "chat_history" / "session-preserved"
+    session.mkdir(parents=True)
+    required_files, required_directories = chat._history_launch_snapshots(
+        session
+    )
+    process = _DummyClosableProcess()
+
+    def replace_during_spawn(*_args, **_kwargs):
+        session.rename(preserved)
+        session.mkdir()
+        return process
+
+    monkeypatch.setattr(chat.subprocess, "Popen", replace_during_spawn)
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        chat._popen_chat_process(
+            ["chat"],
+            cwd=project,
+            env={},
+            required_files=required_files,
+            required_directories=required_directories,
+        )
+
+    assert process.running is False
+    assert chat._main_chat_log_file is None
+
+
 def test_launch_chat_uses_source_main_py_with_project_root_cwd(tmp_path, monkeypatch):
     project_root = tmp_path / "project"
     app_root = tmp_path / "Shinsekai"
@@ -157,12 +340,61 @@ def test_launch_chat_uses_source_main_py_with_project_root_cwd(tmp_path, monkeyp
     assert captured["env"]["SHINSEKAI_PROJECT_ROOT"] == str(project_root)
     assert captured["env"]["EASYAI_PROJECT_ROOT"] == str(project_root)
     assert captured["env"]["SHINSEKAI_APP_ROOT"] == str(app_root)
-    assert captured["env"]["SHINSEKAI_CHAT_ATTACHMENTS_ROOT"] == str(project_root)
+    assert captured["env"]["SHINSEKAI_CHAT_ATTACHMENTS_ROOT"] == str(
+        project_root / "data" / "chat_attachments"
+    )
     assert not (app_root / "data").exists()
     assert captured["env"]["SHINSEKAI_SUPPRESS_MAIN_ERROR_DIALOG"] == "1"
     assert captured["cmd"][1] != str(project_root / "main.py")
-    assert len(captured["cmd"]) == 2
     assert json.loads(captured["env"][CHAT_LAUNCH_CONFIG_ENV])["template"] == "_temp"
+
+
+def test_launch_chat_stops_child_when_runtime_template_changes_during_spawn(
+    tmp_path,
+    monkeypatch,
+):
+    project_root = tmp_path / "project"
+    app_root = tmp_path / "Shinsekai"
+    template_dir = project_root / "data" / "character_templates"
+    history_dir = project_root / "data" / "chat_history"
+    app_root.mkdir()
+    template_dir.mkdir(parents=True)
+    history_dir.mkdir(parents=True)
+    process = _DummyClosableProcess()
+
+    def replace_during_spawn(*_args, **_kwargs):
+        (template_dir / "_temp.txt").write_text(
+            "replacement-is-longer",
+            encoding="utf-8",
+        )
+        return process
+
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(project_root))
+    monkeypatch.setattr(chat.sys, "frozen", False, raising=False)
+    monkeypatch.setattr(chat.subprocess, "Popen", replace_during_spawn)
+    monkeypatch.setattr(chat, "_main_chat_process", None)
+
+    state = SimpleNamespace(
+        app_root_dir=str(app_root),
+        config_manager=_ConfigManager(),
+        history_dir=str(history_dir),
+        template_dir_path=str(template_dir),
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        chat._launch_chat(
+            state,
+            history_file="",
+            init_sprite_path="",
+            room_id="",
+            selected_bg="",
+            system_template="system",
+            use_cg=False,
+            user_scenario="scenario",
+        )
+
+    assert process.running is False
+    assert chat._main_chat_log_file is None
 
 
 def test_launch_chat_passes_stream_endpoint(tmp_path, monkeypatch):
@@ -208,10 +440,15 @@ def test_launch_chat_passes_stream_endpoint(tmp_path, monkeypatch):
     )
 
     assert message == "聊天进程已启动！PID: 12345"
+    assert "--stream-endpoint=ws://127.0.0.1:8788/ws?sessionId=test&role=producer" in captured["cmd"]
+    assert "--init-stream-endpoint=ws://127.0.0.1:8788/ws?sessionId=init&role=producer" in captured["cmd"]
     launch_config = json.loads(captured["env"][CHAT_LAUNCH_CONFIG_ENV])
-    assert launch_config["stream_endpoint"] == "ws://127.0.0.1:8788/ws?sessionId=test&role=producer"
-    assert launch_config["init_stream_endpoint"] == "ws://127.0.0.1:8788/ws?sessionId=init&role=producer"
-    assert len(captured["cmd"]) == 2
+    assert launch_config["stream_endpoint"] == (
+        "ws://127.0.0.1:8788/ws?sessionId=test&role=producer"
+    )
+    assert launch_config["init_stream_endpoint"] == (
+        "ws://127.0.0.1:8788/ws?sessionId=init&role=producer"
+    )
 
 
 def test_launch_chat_passes_memory_service_env(tmp_path, monkeypatch):
@@ -307,9 +544,47 @@ def test_launch_chat_passes_workflow_path(tmp_path, monkeypatch):
     )
 
     assert message == "聊天进程已启动！PID: 12345"
-    launch_config = json.loads(captured["env"][CHAT_LAUNCH_CONFIG_ENV])
-    assert launch_config["workflow"] == str(workflow_path)
-    assert len(captured["cmd"]) == 2
+    assert f"--workflow={workflow_path}" in captured["cmd"]
+    assert json.loads(captured["env"][CHAT_LAUNCH_CONFIG_ENV])["workflow"] == str(
+        workflow_path
+    )
+
+
+def test_launch_chat_rejects_inline_workflow_content_before_starting_process(
+    tmp_path,
+    monkeypatch,
+):
+    project_root = tmp_path / "project"
+    app_root = tmp_path / "Shinsekai"
+    template_dir = project_root / "data" / "character_templates"
+    history_dir = project_root / "data" / "chat_history"
+    app_root.mkdir()
+    template_dir.mkdir(parents=True)
+    history_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", project_root.as_posix())
+    monkeypatch.setattr(chat, "_main_chat_process", None)
+    monkeypatch.setattr(chat.subprocess, "Popen", lambda *args, **kwargs: pytest.fail("must not start"))
+
+    state = SimpleNamespace(
+        app_root_dir=app_root.as_posix(),
+        config_manager=_ConfigManager(),
+        history_dir=history_dir.as_posix(),
+        template_dir_path=template_dir.as_posix(),
+    )
+
+    with pytest.raises(ValueError, match="control characters"):
+        chat._launch_chat(
+            state,
+            history_file="",
+            init_sprite_path="",
+            room_id="",
+            selected_bg="",
+            system_template="system",
+            use_cg=False,
+            user_scenario="scenario",
+            workflow_path="nodes: []\nedges: []\n",
+        )
 
 
 def test_runtime_dependency_error_maps_opencc_package():

--- a/test/unit/frontend_bridge_core/test_frontend_media_utils.py
+++ b/test/unit/frontend_bridge_core/test_frontend_media_utils.py
@@ -19,11 +19,13 @@ def test_optional_suffix_check_reports_mismatched_suffix():
     )
 
 
-def test_path_namespace_list_trims_items_and_rejects_empty_input():
-    paths = _path_namespace_list([" /tmp/a.png ", "", None, "/tmp/b.png"])
+def test_path_namespace_list_preserves_exact_items_and_rejects_ambiguous_input():
+    paths = _path_namespace_list(["/tmp/a.png", "", None, "/tmp/b.png"])
 
     assert [item.name for item in paths] == ["/tmp/a.png", "/tmp/b.png"]
 
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _path_namespace_list([" /tmp/a.png "])
     with pytest.raises(ValueError, match="paths must be a list"):
         _path_namespace_list("not-a-list")
     with pytest.raises(ValueError, match="at least one path is required"):

--- a/test/unit/frontend_bridge_core/test_frontend_plugin_ui.py
+++ b/test/unit/frontend_bridge_core/test_frontend_plugin_ui.py
@@ -7,17 +7,262 @@ from frontend_bridge_core.plugin_ui import (
     _frontend_config_page_payload,
     _frontend_chat_ui_contribution_payloads,
     _frontend_page_payload,
+    _plugin_config_file,
     _plugin_config_field,
     _plugin_data_root,
-    _run_plugin_ui_action,
+    _resolve_plugin_frontend_file,
     _run_frontend_chat_ui_contribution,
+    _run_plugin_ui_action,
+    _stored_plugin_cache_path,
 )
 
 
-def test_plugin_data_root_sanitizes_plugin_ids():
-    assert _plugin_data_root(" com.example/demo ") == _plugin_data_root("com.example_demo")
-    assert _plugin_data_root(" / ").as_posix() == "data/plugins/_"
-    assert _plugin_data_root("  ").as_posix() == "data/plugins/unknown"
+def test_plugin_data_root_preserves_exact_safe_ids_and_rejects_aliases(tmp_path):
+    assert _plugin_data_root("com.example_demo", project_root=tmp_path) == (
+        tmp_path / "data" / "plugins" / "com.example_demo"
+    )
+    for plugin_id in (" com.example ", "com.example/demo", "com.example\\demo", ""):
+        with pytest.raises(ValueError):
+            _plugin_data_root(plugin_id, project_root=tmp_path)
+
+
+def test_plugin_data_root_uses_explicit_project_root_when_cwd_changes(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project_root.mkdir()
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    path = _plugin_data_root("demo.plugin", project_root=project_root)
+
+    assert path == project_root / "data" / "plugins" / "demo.plugin"
+
+
+def test_plugin_data_root_rejects_symlinked_project_root(tmp_path):
+    project = tmp_path / "project"
+    alias = tmp_path / "project-alias"
+    project.mkdir()
+    try:
+        alias.symlink_to(project, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _plugin_data_root("demo.plugin", project_root=alias)
+
+
+def test_plugin_data_root_rejects_portable_collision_and_symlink_storage(tmp_path):
+    plugins = tmp_path / "data" / "plugins"
+    plugins.mkdir(parents=True)
+    (plugins / "Demo.Plugin").mkdir()
+
+    with pytest.raises(FileExistsError, match="portable filename collision"):
+        _plugin_data_root("demo.plugin", project_root=tmp_path)
+
+    symlink_project = tmp_path / "symlink-project"
+    symlink_data = symlink_project / "data"
+    symlink_data.mkdir(parents=True)
+    external = tmp_path / "other-storage"
+    external.mkdir()
+    try:
+        (symlink_data / "plugins").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        _plugin_data_root("safe.plugin", project_root=symlink_project)
+
+
+def test_plugin_config_file_is_a_direct_managed_leaf(tmp_path):
+    project = tmp_path / "project"
+    root = project / "data" / "plugins" / "demo.plugin"
+    root.mkdir(parents=True)
+
+    assert _plugin_config_file(
+        root,
+        root / "config.json",
+        project_root=project,
+    ) == root / "config.json"
+
+    with pytest.raises(PermissionError, match="outside the plugin data root"):
+        _plugin_config_file(
+            root,
+            project / "data" / "plugins" / "other" / "config.json",
+            project_root=project,
+        )
+
+
+def test_plugin_config_file_rejects_a_linked_leaf(tmp_path):
+    project = tmp_path / "project"
+    root = project / "data" / "plugins" / "demo.plugin"
+    external = tmp_path / "external.json"
+    root.mkdir(parents=True)
+    external.write_text("{}", encoding="utf-8")
+    try:
+        (root / "config.json").symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        _plugin_config_file(
+            root,
+            root / "config.json",
+            project_root=project,
+        )
+
+
+def test_plugin_cache_path_does_not_repeat_legacy_recovery_and_ignores_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "current-project"
+    unrelated = tmp_path / "launcher"
+    project.mkdir()
+    unrelated.mkdir()
+    stale = tmp_path / "old-project" / "data" / "cache" / "moondream"
+    monkeypatch.chdir(unrelated)
+
+    assert _stored_plugin_cache_path(
+        stale.as_posix(),
+        project_root=project,
+    ) == stale.as_posix()
+    assert _stored_plugin_cache_path(
+        r"data\cache\moondream",
+        project_root=project,
+    ) == "data/cache/moondream"
+
+
+def test_plugin_cache_path_preserves_existing_external_storage_and_rejects_aliases(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    external = tmp_path / "external-cache"
+    project.mkdir()
+    external.mkdir()
+
+    assert _stored_plugin_cache_path(
+        external.as_posix(),
+        project_root=project,
+    ) == external.as_posix()
+    for invalid in (" data/cache/moondream", "data/cache/../outside"):
+        with pytest.raises(ValueError):
+            _stored_plugin_cache_path(invalid, project_root=project)
+
+
+def test_plugin_cache_path_rejects_linked_external_parent(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    project.mkdir()
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _stored_plugin_cache_path(
+            (alias / "moondream").as_posix(),
+            project_root=project,
+        )
+
+
+def test_plugin_frontend_relative_entry_cannot_escape_project_root(tmp_path, monkeypatch):
+    contribution = SimpleNamespace(entry="../external/index.html")
+    monkeypatch.setattr(
+        plugin_ui,
+        "_detail_for_project_root",
+        lambda *_args: {"plugin": {"id": "demo.plugin"}, "pages": []},
+    )
+    monkeypatch.setattr(
+        plugin_ui,
+        "_frontend_page_contribution",
+        lambda *_args: contribution,
+    )
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        _resolve_plugin_frontend_file(
+            "demo.plugin",
+            "page",
+            "",
+            project_root=tmp_path,
+        )
+
+
+def test_plugin_frontend_asset_path_is_exact_and_relative(tmp_path, monkeypatch):
+    frontend = tmp_path / "plugins/demo/frontend"
+    frontend.mkdir(parents=True)
+    entry = frontend / "index.html"
+    asset = frontend / "assets/app.js"
+    asset.parent.mkdir()
+    entry.write_text("index", encoding="utf-8")
+    asset.write_text("app", encoding="utf-8")
+    contribution = SimpleNamespace(entry=entry.as_posix())
+    monkeypatch.setattr(
+        plugin_ui,
+        "_detail_for_project_root",
+        lambda *_args: {"plugin": {"id": "demo.plugin"}, "pages": []},
+    )
+    monkeypatch.setattr(
+        plugin_ui,
+        "_frontend_page_contribution",
+        lambda *_args: contribution,
+    )
+
+    assert _resolve_plugin_frontend_file(
+        "demo.plugin",
+        "page",
+        "assets/app.js",
+        project_root=tmp_path,
+    ) == asset
+    for raw in (
+        " assets/app.js",
+        "assets/app.js ",
+        "/assets/app.js",
+        "assets\\app.js",
+        "assets/./app.js",
+        "assets//app.js",
+        "assets/../index.html",
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            _resolve_plugin_frontend_file(
+                "demo.plugin",
+                "page",
+                raw,
+                project_root=tmp_path,
+            )
+
+
+def test_plugin_frontend_does_not_serve_symlinked_asset(tmp_path, monkeypatch):
+    frontend = tmp_path / "plugins/demo/frontend"
+    external = tmp_path / "secret.js"
+    frontend.mkdir(parents=True)
+    entry = frontend / "index.html"
+    entry.write_text("index", encoding="utf-8")
+    external.write_text("secret", encoding="utf-8")
+    try:
+        (frontend / "app.js").symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+    contribution = SimpleNamespace(entry=entry.as_posix())
+    monkeypatch.setattr(
+        plugin_ui,
+        "_detail_for_project_root",
+        lambda *_args: {"plugin": {"id": "demo.plugin"}, "pages": []},
+    )
+    monkeypatch.setattr(
+        plugin_ui,
+        "_frontend_page_contribution",
+        lambda *_args: contribution,
+    )
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _resolve_plugin_frontend_file(
+            "demo.plugin",
+            "page",
+            "app.js",
+            project_root=tmp_path,
+        )
 
 
 def test_plugin_config_field_omits_empty_optional_metadata():
@@ -202,14 +447,14 @@ def test_frontend_chat_ui_payload_does_not_truncate_lookup_identifiers(monkeypat
     assert payload["pluginId"] == long_plugin_id
 
 
-def test_frontend_config_page_payload_normalizes_kind_and_values():
+def test_frontend_config_page_payload_preserves_exact_ids_and_normalizes_kind():
     contribution = SimpleNamespace(
         description="Config page",
         kind="invalid",
         load_values=lambda: {"enabled": True},
         order=12.5,
-        page_id=" settings ",
-        plugin_id="demo/plugin",
+        page_id="settings",
+        plugin_id="demo.plugin",
         plugin_version="1.0",
         restart_hint="Restart required",
         schema=[{"id": "main", "fields": []}],
@@ -224,13 +469,26 @@ def test_frontend_config_page_payload_normalizes_kind_and_values():
         "i18n": {},
         "kind": "settings",
         "order": 12.5,
-        "pluginId": "demo/plugin",
+        "pluginId": "demo.plugin",
         "pluginVersion": "1.0",
         "restartHint": "Restart required",
         "schema": [{"id": "main", "fields": []}],
         "title": "settings",
         "values": {"enabled": True},
     }
+
+
+def test_frontend_config_page_payload_rejects_whitespace_retargeted_id():
+    contribution = SimpleNamespace(
+        kind="settings",
+        load_values=lambda: {},
+        page_id=" settings ",
+        plugin_id="demo.plugin",
+        title="Settings",
+    )
+
+    with pytest.raises(ValueError, match="portable path component"):
+        _frontend_config_page_payload(contribution)
 
 
 def test_frontend_config_page_payload_requires_mapping_values():
@@ -252,7 +510,7 @@ def test_frontend_page_payload_builds_encoded_url_and_merges_matching_config(mon
         load_values=lambda: {"headless": False},
         order=8,
         page_id="browser page",
-        plugin_id="demo/plugin",
+        plugin_id="demo.plugin",
         plugin_version="2.0",
         restart_hint="Restart browser",
         schema=[{"id": "browser", "fields": []}],
@@ -266,14 +524,14 @@ def test_frontend_page_payload_builds_encoded_url_and_merges_matching_config(mon
             kind="tools",
             order=8,
             page_id="browser page",
-            plugin_id="demo/plugin",
+            plugin_id="demo.plugin",
             plugin_version="2.0",
             title="Browser",
         )
     )
 
     assert payload["frontendUrl"] == (
-        "/api/plugins/demo%2Fplugin/frontend/browser%20page/?pluginId=demo%2Fplugin&pageId=browser%20page"
+        "/api/plugins/demo.plugin/frontend/browser%20page/?pluginId=demo.plugin&pageId=browser%20page"
     )
     assert payload["description"] == "Config description"
     assert payload["restartHint"] == "Restart browser"

--- a/test/unit/frontend_bridge_core/test_frontend_runtime_check.py
+++ b/test/unit/frontend_bridge_core/test_frontend_runtime_check.py
@@ -136,6 +136,63 @@ def test_runtime_context_rejects_project_root_whose_data_path_is_a_file(
     assert Path.cwd() == launch_dir.resolve()
 
 
+def test_runtime_context_rejects_symlinked_project_data_directory(tmp_path, monkeypatch):
+    from frontend_bridge import _configure_runtime_context
+
+    launch_dir = tmp_path / "launch"
+    project_root = tmp_path / "project"
+    external = tmp_path / "external-data"
+    launch_dir.mkdir()
+    project_root.mkdir()
+    external.mkdir()
+    marker = external / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    try:
+        (project_root / "data").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.chdir(launch_dir)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_PROJECT_ROOT project root"):
+        _configure_runtime_context(None, None, None)
+
+    assert Path.cwd() == launch_dir.resolve()
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_project_root_probe_rejects_replaced_data_directory(tmp_path, monkeypatch):
+    from core import file_transactions
+    from frontend_bridge import _prepare_project_root
+
+    project_root = tmp_path / "project"
+    data_root = project_root / "data"
+    preserved_data = project_root / "preserved-data"
+    data_root.mkdir(parents=True)
+    real_open = file_transactions.open_binary_write_exclusive_without_links
+    replaced = False
+
+    def replace_data_before_probe(path, **kwargs):
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            data_root.rename(preserved_data)
+            data_root.mkdir()
+        return real_open(path, **kwargs)
+
+    monkeypatch.setattr(
+        file_transactions,
+        "open_binary_write_exclusive_without_links",
+        replace_data_before_probe,
+    )
+
+    with pytest.raises(RuntimeError, match="not safely writable"):
+        _prepare_project_root(project_root.as_posix(), "test")
+
+    assert list(data_root.iterdir()) == []
+    assert list(preserved_data.iterdir()) == []
+
+
 def test_runtime_context_fails_closed_when_environment_project_root_cannot_be_created(
     tmp_path, monkeypatch
 ):
@@ -205,6 +262,91 @@ def test_runtime_context_does_not_fall_back_from_invalid_public_root(
     assert os.environ["EASYAI_PROJECT_ROOT"] == str(legacy_root)
 
 
+def test_runtime_context_does_not_fall_back_from_empty_public_root(
+    tmp_path,
+    monkeypatch,
+):
+    from frontend_bridge import _configure_runtime_context
+
+    launch_dir = tmp_path / "launch"
+    legacy_root = tmp_path / "legacy-root"
+    launch_dir.mkdir()
+    monkeypatch.chdir(launch_dir)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "")
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(legacy_root))
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_PROJECT_ROOT project root"):
+        _configure_runtime_context(None, None, None)
+
+    assert Path.cwd() == launch_dir.resolve()
+    assert not legacy_root.exists()
+
+
+def test_runtime_context_rejects_empty_app_root_without_replacing_it(
+    tmp_path,
+    monkeypatch,
+):
+    from frontend_bridge import _configure_runtime_context
+
+    project_root = tmp_path / "project"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", "")
+
+    with pytest.raises(RuntimeError, match="SHINSEKAI_APP_ROOT app root"):
+        _configure_runtime_context(None, None, None)
+
+    assert os.environ["SHINSEKAI_APP_ROOT"] == ""
+    assert not project_root.exists()
+
+
+def test_runtime_context_rejects_symlinked_app_root_before_canonicalizing_it(
+    tmp_path,
+    monkeypatch,
+):
+    from frontend_bridge import _configure_runtime_context
+
+    real_app_root = tmp_path / "real-application"
+    linked_app_root = tmp_path / "linked-application"
+    real_app_root.mkdir()
+    try:
+        linked_app_root.symlink_to(real_app_root, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(RuntimeError, match="app root is invalid"):
+        _configure_runtime_context(
+            str(tmp_path / "project"),
+            None,
+            linked_app_root.as_posix(),
+        )
+
+    assert not (tmp_path / "project").exists()
+
+
+def test_frozen_runtime_context_requires_desktop_selected_roots(
+    tmp_path,
+    monkeypatch,
+):
+    import frontend_bridge
+
+    monkeypatch.setattr(frontend_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.delenv("SHINSEKAI_APP_ROOT", raising=False)
+    monkeypatch.delenv("SHINSEKAI_PROJECT_ROOT", raising=False)
+    monkeypatch.delenv("EASYAI_PROJECT_ROOT", raising=False)
+
+    with pytest.raises(RuntimeError, match="frozen bridge requires an explicit --app-root"):
+        frontend_bridge._configure_runtime_context(None, None, None)
+
+    app_root = tmp_path / "application"
+    app_root.mkdir()
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", app_root.as_posix())
+    with pytest.raises(
+        RuntimeError,
+        match="frozen bridge requires an explicit --project-root",
+    ):
+        frontend_bridge._configure_runtime_context(None, None, None)
+
+
 def test_runtime_context_rejects_relative_environment_project_root(
     tmp_path, monkeypatch
 ):
@@ -220,6 +362,108 @@ def test_runtime_context_rejects_relative_environment_project_root(
 
     assert Path.cwd() == launch_dir.resolve()
     assert os.environ["SHINSEKAI_PROJECT_ROOT"] == "relative-project"
+
+
+def test_runtime_context_rejects_relative_cli_project_root(tmp_path, monkeypatch):
+    from frontend_bridge import _configure_runtime_context
+
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    monkeypatch.chdir(launch_dir)
+
+    with pytest.raises(RuntimeError, match="must be absolute"):
+        _configure_runtime_context("relative-project", None, None)
+
+    assert Path.cwd() == launch_dir.resolve()
+
+
+def test_runtime_context_rejects_relative_frontend_dist_escape(tmp_path, monkeypatch):
+    from frontend_bridge import _configure_runtime_context
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+
+    with pytest.raises(RuntimeError, match="escapes source root"):
+        _configure_runtime_context(None, "../outside-dist", None)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_runtime_context_rejects_linked_frontend_dist(tmp_path, monkeypatch):
+    import frontend_bridge
+    from frontend_bridge import _configure_runtime_context
+
+    project_root = tmp_path / "project"
+    external_dist = tmp_path / "external-dist"
+    source_root = tmp_path / "source"
+    project_root.mkdir()
+    external_dist.mkdir()
+    source_root.mkdir()
+    (source_root / "frontend").mkdir()
+    (source_root / "frontend" / "dist").symlink_to(
+        external_dist,
+        target_is_directory=True,
+    )
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+    monkeypatch.setattr(frontend_bridge, "_repo_root", lambda: source_root)
+
+    with pytest.raises(RuntimeError, match="linked component"):
+        _configure_runtime_context(None, "frontend/dist", None)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_runtime_context_rejects_linked_frontend_index(tmp_path, monkeypatch):
+    import frontend_bridge
+    from frontend_bridge import _configure_runtime_context
+
+    project_root = tmp_path / "project"
+    source_root = tmp_path / "source"
+    frontend_dist = source_root / "frontend/dist"
+    external_index = tmp_path / "external-index.html"
+    project_root.mkdir()
+    frontend_dist.mkdir(parents=True)
+    external_index.write_text("external", encoding="utf-8")
+    (frontend_dist / "index.html").symlink_to(external_index)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+    monkeypatch.setattr(frontend_bridge, "_repo_root", lambda: source_root)
+
+    with pytest.raises(RuntimeError, match="linked component"):
+        _configure_runtime_context(None, "frontend/dist", None)
+
+
+def test_runtime_context_rejects_non_file_frontend_index(tmp_path, monkeypatch):
+    import frontend_bridge
+    from frontend_bridge import _configure_runtime_context
+
+    project_root = tmp_path / "project"
+    source_root = tmp_path / "source"
+    frontend_dist = source_root / "frontend/dist"
+    project_root.mkdir()
+    (frontend_dist / "index.html").mkdir(parents=True)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+    monkeypatch.setattr(frontend_bridge, "_repo_root", lambda: source_root)
+
+    with pytest.raises(RuntimeError, match="frontend distribution path"):
+        _configure_runtime_context(None, "frontend/dist", None)
+
+
+def test_runtime_context_rejects_present_empty_frontend_dist(tmp_path, monkeypatch):
+    from frontend_bridge import _configure_runtime_context
+
+    project_root = tmp_path / "project"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+
+    with pytest.raises(RuntimeError, match="frontend distribution path"):
+        _configure_runtime_context(None, "", None)
+
+    assert not project_root.exists()
+
+
+def test_runtime_requirements_path_rejects_present_empty_value(tmp_path):
+    from frontend_bridge import _runtime_requirements_path
+
+    with pytest.raises(ValueError, match="path is empty"):
+        _runtime_requirements_path(tmp_path, "", "desktop-core")
 
 
 def test_runtime_context_rejects_invalid_legacy_root_when_public_root_is_unset(
@@ -328,6 +572,63 @@ def test_runtime_requirements_parser_follows_recursive_includes(tmp_path):
         "pydantic",
         "fastembed",
     ]
+
+
+def test_runtime_requirements_parser_rejects_relative_entry_path():
+    from frontend_bridge import _iter_requirement_names
+
+    with pytest.raises(ValueError, match="must be absolute"):
+        list(_iter_requirement_names(Path("requirements.txt")))
+
+
+def test_runtime_requirements_parser_rejects_user_home_alias():
+    from frontend_bridge import _iter_requirement_names
+
+    with pytest.raises(ValueError, match="must be absolute"):
+        list(_iter_requirement_names(Path("~/requirements.txt")))
+
+
+def test_runtime_requirements_parser_rejects_lexical_include_alias(tmp_path):
+    from frontend_bridge import _iter_requirement_names
+
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("-r ./nested.txt\n", encoding="utf-8")
+    (tmp_path / "nested.txt").write_text("pyyaml\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="exact relative components"):
+        list(_iter_requirement_names(requirements))
+
+
+def test_runtime_requirements_parser_rejects_linked_entry_file(tmp_path):
+    from frontend_bridge import _iter_requirement_names
+
+    requirements = tmp_path / "requirements.txt"
+    alias = tmp_path / "requirements-alias.txt"
+    requirements.write_text("pyyaml\n", encoding="utf-8")
+    try:
+        alias.symlink_to(requirements)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        list(_iter_requirement_names(alias))
+
+
+def test_runtime_requirements_parser_rejects_linked_include(tmp_path):
+    from frontend_bridge import _iter_requirement_names
+
+    requirements = tmp_path / "requirements.txt"
+    included = tmp_path / "included.txt"
+    alias = tmp_path / "included-alias.txt"
+    requirements.write_text("-r included-alias.txt\n", encoding="utf-8")
+    included.write_text("pyyaml\n", encoding="utf-8")
+    try:
+        alias.symlink_to(included)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        list(_iter_requirement_names(requirements))
 
 
 def test_runtime_check_rejects_installed_distributions_with_incompatible_versions(

--- a/test/unit/frontend_bridge_core/test_handler_path_queries.py
+++ b/test/unit/frontend_bridge_core/test_handler_path_queries.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+import pytest
+
+from frontend_bridge_core.routes.api import (
+    FrontendBridgeHandler,
+    _decode_url_component_once,
+    _parse_query,
+    _query_value,
+)
+
+
+def test_path_query_is_decoded_exactly_once():
+    query = _parse_query("path=data%2Fbackgrounds%2F100%252Fready.png")
+
+    assert _query_value(query, "path") == "data/backgrounds/100%2Fready.png"
+
+
+def test_single_encoded_traversal_remains_visible_to_path_validation():
+    query = _parse_query("path=data%2F..%2Fsecret.txt")
+
+    assert _query_value(query, "path") == "data/../secret.txt"
+
+
+def test_literal_percent_escape_filename_resolves_without_retargeting(tmp_path):
+    project = tmp_path / "project"
+    literal = project / "data/backgrounds/100%2Fready.png"
+    literal.parent.mkdir(parents=True)
+    literal.write_bytes(b"png")
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+    handler.server = SimpleNamespace(
+        state=SimpleNamespace(project_root_dir=project.as_posix()),
+    )
+    query = _parse_query("path=data%2Fbackgrounds%2F100%252Fready.png")
+
+    target = handler._resolve_media_path(_query_value(query, "path"))
+
+    assert target == literal
+
+
+@pytest.mark.parametrize("raw", ("path=bad%escape", "path=%FF"))
+def test_query_rejects_malformed_percent_or_utf8_encoding(raw):
+    with pytest.raises((UnicodeDecodeError, ValueError)):
+        _parse_query(raw)
+
+
+def test_url_path_component_is_decoded_exactly_once():
+    assert _decode_url_component_once("/assets/100%252Fready.js") == (
+        "/assets/100%2Fready.js"
+    )

--- a/test/unit/frontend_bridge_core/test_handler_upload_paths.py
+++ b/test/unit/frontend_bridge_core/test_handler_upload_paths.py
@@ -1,0 +1,74 @@
+from io import BytesIO
+
+import pytest
+
+import frontend_bridge_core.routes.api as handler_module
+from frontend_bridge_core.routes.api import (
+    FrontendBridgeHandler,
+    _MULTIPART_UPLOAD_PATHS,
+)
+
+
+def test_multipart_upload_routes_include_every_file_import_endpoint():
+    assert _MULTIPART_UPLOAD_PATHS == {
+        "/api/backgrounds/import-upload",
+        "/api/characters/import-upload",
+        "/api/characters/memories/import-preview-upload",
+        "/api/characters/memories/import-upload",
+        "/api/effects/import-upload",
+        "/api/logs/import-upload",
+        "/api/chat/attachments/upload",
+        "/api/chat/themes/upload",
+    }
+
+
+def test_upload_staging_is_removed_when_publication_fails(tmp_path, monkeypatch):
+    boundary = "shinsekai-test-boundary"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="files"; filename="effect.ef"\r\n'
+        "Content-Type: application/octet-stream\r\n"
+        "\r\n"
+        "payload\r\n"
+        f"--{boundary}--\r\n"
+    ).encode()
+    staging_dir = tmp_path / "upload-staging"
+    staging_dir.mkdir()
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+    handler.headers = {
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+        "Content-Length": str(len(body)),
+    }
+    handler.rfile = BytesIO(body)
+    monkeypatch.setattr(
+        handler_module,
+        "create_private_temporary_directory",
+        lambda **_kwargs: (staging_dir, staging_dir.lstat()),
+    )
+
+    def fail_publication(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(handler_module, "write_bytes_exclusive", fail_publication)
+
+    with pytest.raises(OSError, match="disk full"):
+        handler._read_upload_files()
+
+    assert not staging_dir.exists()
+
+
+def test_upload_cleanup_preserves_a_replacement_directory(tmp_path):
+    staging = tmp_path / "upload-staging"
+    preserved = tmp_path / "preserved"
+    staging.mkdir()
+    (staging / "owned.bin").write_bytes(b"owned")
+    identity = staging.lstat()
+    staging.rename(preserved)
+    staging.mkdir()
+    replacement = staging / "replacement.bin"
+    replacement.write_bytes(b"replacement")
+
+    handler_module._cleanup_upload_directory(staging, identity)
+
+    assert replacement.read_bytes() == b"replacement"
+    assert (preserved / "owned.bin").read_bytes() == b"owned"

--- a/test/unit/frontend_bridge_core/test_history_path_policy.py
+++ b/test/unit/frontend_bridge_core/test_history_path_policy.py
@@ -99,6 +99,11 @@ def test_relative_history_is_project_managed_and_cannot_escape(tmp_path: Path) -
     assert resolve_history_path_for_project(
         state, "data/chat_history/session.json"
     ) == (tmp_path / "data" / "chat_history" / "session.json").resolve(strict=False)
+    assert resolve_history_path_for_project(
+        state, "session.json"
+    ) == (tmp_path / "data" / "chat_history" / "session.json").resolve(strict=False)
+    with pytest.raises(PermissionError, match="history directory"):
+        resolve_history_path_for_project(state, "data/config/session.json")
     with pytest.raises(PermissionError):
         resolve_history_path_for_project(state, "../outside/session.json")
 

--- a/test/unit/frontend_bridge_core/test_history_paths.py
+++ b/test/unit/frontend_bridge_core/test_history_paths.py
@@ -1,0 +1,499 @@
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from core.file_transactions import rename_path_without_overwrite
+from core.sprite.chat_branch_storage import ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME
+from application.chat.runtime_process import (
+    _chat_history_path,
+    _current_chat_history_download_file,
+)
+from application.chat.history_paths import (
+    _import_slug,
+    history_storage_exists,
+    import_external_history,
+    prepare_history_reference_for_launch,
+    project_history_value,
+    resolve_history_path_for_project,
+    resolve_history_reference,
+)
+from application.chat.templates import _load_template_session_payload
+from frontend_bridge_core.template_session import template_session_file
+
+
+def _state(project_root):
+    history_root = project_root / "data" / "chat_history"
+    history_root.mkdir(parents=True)
+    return SimpleNamespace(
+        config_manager=SimpleNamespace(get_character_by_name=lambda _name: None),
+        history_dir=history_root.as_posix(),
+        project_root_dir=project_root.as_posix(),
+    )
+
+
+def test_live_relative_history_stays_inside_the_configured_collection(tmp_path):
+    state = _state(tmp_path / "project")
+
+    assert resolve_history_path_for_project(
+        state,
+        "session.json",
+    ) == tmp_path / "project" / "data" / "chat_history" / "session.json"
+    with pytest.raises(PermissionError, match="history directory"):
+        resolve_history_path_for_project(state, "data/config/session.json")
+
+
+def test_current_history_download_does_not_trim_stored_path_identity(tmp_path):
+    state = _state(tmp_path / "project")
+    history = tmp_path / "external" / "session.json"
+    history.parent.mkdir()
+    history.write_text("[]", encoding="utf-8")
+    state.chat_session = {"historyPath": f" {history} "}
+
+    with pytest.raises(ValueError, match="whitespace"):
+        _current_chat_history_download_file(state)
+
+
+def test_external_legacy_json_is_copied_into_managed_history(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive" / "session.json"
+    source.parent.mkdir()
+    source.write_text('[{"role":"user","content":"hello"}]', encoding="utf-8")
+
+    resolved = resolve_history_reference(state, source.as_posix())
+
+    assert resolved != source
+    assert resolved.is_dir()
+    assert (resolved / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+    assert project_history_value(state, resolved).startswith("data/chat_history/imported-session-")
+    assert source.is_file()
+
+
+def test_prepare_history_launch_reference_creates_the_exact_managed_session(tmp_path):
+    state = _state(tmp_path / "project")
+
+    prepared = prepare_history_reference_for_launch(
+        state,
+        "data/chat_history/new-session",
+    )
+
+    assert prepared == tmp_path / "project" / "data" / "chat_history" / "new-session"
+    assert prepared.is_dir()
+
+
+def test_prepare_history_launch_reference_rejects_alias_at_launch_boundary(
+    tmp_path,
+    monkeypatch,
+):
+    state = _state(tmp_path / "project")
+    external = tmp_path / "external-session"
+    external.mkdir()
+    alias = tmp_path / "project" / "data" / "chat_history" / "late-alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    monkeypatch.setattr(
+        "application.chat.history_paths.resolve_history_reference",
+        lambda _state, _raw: alias,
+    )
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        prepare_history_reference_for_launch(state, "ignored")
+
+
+def test_external_import_never_overwrites_an_unowned_name_collision(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive" / "session.json"
+    source.parent.mkdir()
+    source.write_text('[{"role":"user","content":"external"}]', encoding="utf-8")
+    collision = tmp_path / "project" / "data" / "chat_history" / _import_slug(source)
+    collision.mkdir()
+    (collision / ACTIVE_HISTORY_FILENAME).write_text(
+        '[{"role":"user","content":"owned-by-user"}]',
+        encoding="utf-8",
+    )
+
+    resolved = resolve_history_reference(state, source.as_posix())
+
+    assert resolved != collision
+    assert resolved.name == f"{collision.name}-1"
+    assert "owned-by-user" in (collision / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8")
+    assert "external" in (resolved / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8")
+
+
+def test_reimporting_the_same_external_source_reuses_its_owned_snapshot(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive" / "session.json"
+    source.parent.mkdir()
+    source.write_text("[]", encoding="utf-8")
+
+    first = resolve_history_reference(state, source.as_posix())
+    second = resolve_history_reference(state, source.as_posix())
+
+    assert second == first
+    assert list((tmp_path / "project" / "data" / "chat_history").glob("imported-session-*")) == [first]
+
+
+def test_external_import_retries_a_cross_process_publication_collision(tmp_path, monkeypatch):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive" / "session.json"
+    source.parent.mkdir()
+    source.write_text("[]", encoding="utf-8")
+    real_rename = rename_path_without_overwrite
+    raced = False
+
+    def publish_peer_then_fail(staged, destination, *, expected_identity=None):
+        nonlocal raced
+        if not raced:
+            raced = True
+            destination.mkdir()
+            (destination / ACTIVE_HISTORY_FILENAME).write_text(
+                '[{"content":"peer"}]',
+                encoding="utf-8",
+            )
+            raise FileExistsError(destination)
+        return real_rename(
+            staged,
+            destination,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "application.chat.history_paths.rename_path_without_overwrite",
+        publish_peer_then_fail,
+    )
+
+    resolved = resolve_history_reference(state, source.as_posix())
+
+    collision = tmp_path / "project" / "data" / "chat_history" / _import_slug(source)
+    assert resolved.name == f"{collision.name}-1"
+    assert "peer" in (collision / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8")
+    assert (resolved / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8") == "[]"
+
+
+def test_external_import_rejects_source_replaced_after_identity_capture(
+    tmp_path,
+    monkeypatch,
+):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive" / "session.json"
+    preserved = tmp_path / "external-drive" / "session-preserved.json"
+    source.parent.mkdir()
+    source.write_text("original", encoding="utf-8")
+    from application.chat import history_paths
+
+    real_copy = history_paths.copy_file_exclusive
+    replaced = False
+
+    def replace_before_copy(*args, **kwargs):
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            source.rename(preserved)
+            source.write_text("peer", encoding="utf-8")
+        return real_copy(*args, **kwargs)
+
+    monkeypatch.setattr(
+        history_paths,
+        "copy_file_exclusive",
+        replace_before_copy,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        import_external_history(state, source)
+
+    assert source.read_text(encoding="utf-8") == "peer"
+    assert preserved.read_text(encoding="utf-8") == "original"
+    assert list((tmp_path / "project/data/chat_history").iterdir()) == []
+
+
+def test_external_branch_directory_is_copied_as_one_session(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive" / "chapter"
+    source.mkdir(parents=True)
+    (source / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+    (source / BRANCH_TREE_FILENAME).write_text('{"branches":{}}', encoding="utf-8")
+
+    resolved = resolve_history_reference(state, (source / ACTIVE_HISTORY_FILENAME).as_posix())
+
+    assert resolved.is_dir()
+    assert history_storage_exists(resolved)
+    assert (resolved / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8") == "[]"
+
+
+def test_external_branch_directory_with_symlink_is_rejected(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive" / "chapter"
+    source.mkdir(parents=True)
+    (source / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+    external = tmp_path / "private.json"
+    external.write_text('[{"secret":true}]', encoding="utf-8")
+    link = source / "linked.json"
+    try:
+        link.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="符号链接"):
+        resolve_history_reference(state, source.as_posix())
+
+    assert external.read_text(encoding="utf-8") == '[{"secret":true}]'
+
+
+def test_managed_session_with_symlinked_active_file_is_rejected(tmp_path):
+    state = _state(tmp_path / "project")
+    session = tmp_path / "project" / "data" / "chat_history" / "session"
+    session.mkdir()
+    external = tmp_path / "external.json"
+    external.write_text("[]", encoding="utf-8")
+    try:
+        (session / ACTIVE_HISTORY_FILENAME).symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        resolve_history_reference(state, "data/chat_history/session")
+
+    assert history_storage_exists(session) is False
+
+
+def test_managed_session_directory_alias_cannot_redirect_to_another_session(tmp_path):
+    state = _state(tmp_path / "project")
+    history_root = tmp_path / "project" / "data" / "chat_history"
+    real_session = history_root / "real-session"
+    real_session.mkdir()
+    (real_session / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+    try:
+        (history_root / "alias-session").symlink_to(real_session, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        resolve_history_reference(state, "data/chat_history/alias-session")
+
+    assert (real_session / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8") == "[]"
+
+
+def test_absolute_managed_history_alias_cannot_be_treated_as_external_import(tmp_path):
+    state = _state(tmp_path / "project")
+    history_root = tmp_path / "project" / "data" / "chat_history"
+    external = tmp_path / "external-session"
+    external.mkdir()
+    (external / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+    alias = history_root / "linked-external"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        resolve_history_reference(state, alias.as_posix())
+
+    assert list(history_root.glob("imported-*")) == []
+
+
+def test_missing_history_from_old_project_root_is_not_guessed_at_runtime(tmp_path):
+    project_root = tmp_path / "current"
+    state = _state(project_root)
+    stale = tmp_path / "removed-old-root" / "data" / "chat_history" / "chapter.json"
+
+    with pytest.raises(FileNotFoundError, match="外部聊天历史不存在"):
+        resolve_history_reference(state, stale.as_posix())
+
+
+def test_explicit_legacy_history_migration_can_rebase_old_project_root(tmp_path):
+    project_root = tmp_path / "current"
+    state = _state(project_root)
+    stale = tmp_path / "removed-old-root" / "data" / "chat_history" / "chapter.json"
+
+    resolved = resolve_history_reference(
+        state,
+        stale.as_posix(),
+        recover_legacy_absolute=True,
+    )
+
+    assert resolved == project_root / "data" / "chat_history" / "chapter"
+
+
+def test_missing_unrelated_external_history_has_controlled_error(tmp_path):
+    state = _state(tmp_path / "project")
+    missing = tmp_path / "external-drive" / "missing.json"
+
+    with pytest.raises(FileNotFoundError, match="外部聊天历史不存在"):
+        resolve_history_reference(state, missing.as_posix())
+
+
+def test_resolution_uses_state_root_even_if_cwd_changes(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    state = _state(project_root)
+    unrelated_cwd = tmp_path / "unrelated-cwd"
+    unrelated_cwd.mkdir()
+    monkeypatch.chdir(unrelated_cwd)
+
+    resolved = resolve_history_reference(state, "data/chat_history/session.json")
+
+    assert resolved == project_root / "data" / "chat_history" / "session"
+
+
+@pytest.mark.parametrize("raw", [" session.json", "session.json "])
+def test_history_reference_rejects_surrounding_whitespace(tmp_path, raw):
+    state = _state(tmp_path / "project")
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        resolve_history_reference(state, raw)
+
+
+def test_external_history_reference_rejects_absolute_lexical_alias(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive/session.json"
+    source.parent.mkdir()
+    source.write_text("[]", encoding="utf-8")
+    alias = f"{source.parent.as_posix()}/./{source.name}"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        resolve_history_reference(state, alias)
+
+    assert list((tmp_path / "project/data/chat_history").iterdir()) == []
+
+
+def test_external_history_import_boundary_rejects_alias_before_copy(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive/session.json"
+    source.parent.mkdir()
+    source.write_text("[]", encoding="utf-8")
+    alias = f"{source.parent.as_posix()}/./{source.name}"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        import_external_history(state, alias)
+
+    assert list((tmp_path / "project/data/chat_history").iterdir()) == []
+
+
+def test_external_history_import_boundary_rejects_relative_source(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    state = _state(project_root)
+    source = project_root / "session.json"
+    source.write_text("[]", encoding="utf-8")
+    monkeypatch.chdir(project_root)
+
+    with pytest.raises(ValueError, match="must be absolute"):
+        import_external_history(state, "session.json")
+
+    assert list((project_root / "data/chat_history").iterdir()) == []
+
+
+def test_external_history_import_does_not_expand_user_home_alias(tmp_path):
+    state = _state(tmp_path / "project")
+
+    with pytest.raises(ValueError, match="must be absolute"):
+        import_external_history(state, "~/session.json")
+
+    assert list((tmp_path / "project/data/chat_history").iterdir()) == []
+
+
+def test_external_history_symbolic_link_is_rejected_before_resolution(tmp_path):
+    state = _state(tmp_path / "project")
+    source = tmp_path / "external-drive/session.json"
+    source.parent.mkdir()
+    source.write_text("[]", encoding="utf-8")
+    alias = tmp_path / "external-drive/session-alias.json"
+    try:
+        alias.symlink_to(source)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        resolve_history_reference(state, alias.as_posix())
+    with pytest.raises(PermissionError, match="symbolic links"):
+        import_external_history(state, alias)
+
+    assert list((tmp_path / "project/data/chat_history").iterdir()) == []
+
+
+def test_existing_relative_basename_is_imported_instead_of_silently_ignored(tmp_path):
+    project_root = tmp_path / "project"
+    state = _state(project_root)
+    source = project_root / "session.json"
+    source.write_text('[{"content":"relative source"}]', encoding="utf-8")
+
+    resolved = resolve_history_reference(state, "session.json")
+
+    assert resolved.is_dir()
+    assert "relative source" in (resolved / ACTIVE_HISTORY_FILENAME).read_text(encoding="utf-8")
+    assert source.is_file()
+
+
+@pytest.mark.parametrize(
+    "history_value",
+    [
+        "data/chat_history",
+        "data/chat_history/active.json",
+        "data/chat_history/branches.json",
+        "data/chat_history/session/..",
+        "active.json",
+    ],
+)
+def test_history_collection_root_can_never_be_resolved_as_a_session(tmp_path, history_value):
+    state = _state(tmp_path / "project")
+
+    with pytest.raises(PermissionError, match="history root"):
+        resolve_history_reference(state, history_value)
+
+
+def test_project_history_value_rejects_project_files_outside_history_storage(tmp_path):
+    project_root = tmp_path / "project"
+    state = _state(project_root)
+
+    with pytest.raises(PermissionError, match="history directory"):
+        project_history_value(state, project_root / "config.json")
+
+
+def test_history_directory_cannot_be_configured_as_the_project_root(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    state = SimpleNamespace(
+        history_dir=project_root.as_posix(),
+        project_root_dir=project_root.as_posix(),
+    )
+
+    with pytest.raises(PermissionError, match="outside project root"):
+        resolve_history_reference(state, "session.json")
+
+
+def test_pyqt_v1_snapshot_reaches_react_chat_after_cross_drive_root_move(tmp_path):
+    project_root = tmp_path / "react-project"
+    state = _state(project_root)
+    template_dir = project_root / "data" / "character_templates"
+    template_dir.mkdir(parents=True)
+    state.template_dir_path = template_dir.as_posix()
+    session_file = template_session_file(
+        template_dir.as_posix(),
+        project_root=project_root,
+    )
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "history_file": r"D:\legacy-pyqt\data\chat_history\chapter.json",
+                "scenario_text": "migrated scene",
+                "system_template_text": "system",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    frontend_session = _load_template_session_payload(state)
+    resolved = _chat_history_path(
+        state,
+        {"historyPath": frontend_session["historyPath"]},
+        frontend_session,
+    )
+
+    assert frontend_session["historyPath"] == "data/chat_history/chapter.json"
+    assert resolved == project_root / "data" / "chat_history" / "chapter"

--- a/test/unit/frontend_bridge_core/test_mcp_paths.py
+++ b/test/unit/frontend_bridge_core/test_mcp_paths.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from frontend_bridge_core import mcp
+from frontend_bridge_core.mcp import _open_mcp_config_file, _validate_mcp_server
+from ai.tools.mcp_tool_setup import _exact_mcp_text
+
+
+def test_mcp_stdio_command_preserves_exact_path_text():
+    server = _validate_mcp_server(
+        {
+            "command": "/opt/My Tools/mcp-server",
+            "cwd": "servers/My MCP",
+            "name_prefix": "demo_",
+            "transport": "stdio",
+        }
+    )
+
+    assert server["command"] == "/opt/My Tools/mcp-server"
+    assert server["cwd"] == "servers/My MCP"
+
+
+@pytest.mark.parametrize(
+    ("transport", "field", "value"),
+    [
+        ("stdio", "command", " /opt/mcp-server"),
+        ("stdio", "command", "/opt/mcp-server "),
+        ("sse", "url", " https://mcp.example/sse"),
+        ("streamable_http", "url", "https://mcp.example/api "),
+    ],
+)
+def test_mcp_endpoints_reject_whitespace_aliases(transport, field, value):
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _validate_mcp_server({"transport": transport, field: value})
+
+
+def test_runtime_mcp_text_validator_never_trims_executable_path():
+    assert _exact_mcp_text(
+        "/opt/My Tools/mcp-server",
+        field="MCP stdio command",
+        required=True,
+    ) == "/opt/My Tools/mcp-server"
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _exact_mcp_text(
+            " /opt/mcp-server",
+            field="MCP stdio command",
+            required=True,
+        )
+
+
+def test_mcp_stdio_working_directory_rejects_whitespace_aliases():
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _validate_mcp_server(
+            {
+                "command": "python",
+                "cwd": " servers/demo",
+                "transport": "stdio",
+            }
+        )
+
+
+def test_open_mcp_config_uses_identity_bound_default_application_helper(
+    tmp_path,
+    monkeypatch,
+):
+    config = tmp_path / "mcp.yaml"
+    config.write_text("enabled: true\nservers: []\n", encoding="utf-8")
+    opened = []
+    monkeypatch.setattr(mcp, "_mcp_config_path", lambda _state: config)
+    monkeypatch.setattr(
+        mcp,
+        "open_with_default_application",
+        lambda path: opened.append(path),
+    )
+
+    result = _open_mcp_config_file(object())
+
+    assert opened == [config]
+    assert result == {"path": config.as_posix()}

--- a/test/unit/frontend_bridge_core/test_model_assets.py
+++ b/test/unit/frontend_bridge_core/test_model_assets.py
@@ -103,6 +103,8 @@ def test_existing_relative_configured_local_models_remain_supported(
     tmp_path, monkeypatch, relative_path
 ):
     monkeypatch.chdir(tmp_path)
+    state = _state(model_name=relative_path)
+    state.project_root_dir = tmp_path.as_posix()
     model_dir = tmp_path.joinpath(*relative_path.split("/"))
     model_dir.mkdir(parents=True)
     (model_dir / "config.json").write_text("{}", encoding="utf-8")
@@ -110,12 +112,34 @@ def test_existing_relative_configured_local_models_remain_supported(
     (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
 
     status = model_assets._model_asset_status(
-        _state(model_name=relative_path),
+        state,
         {"assetId": "asr.faster-whisper", "configured": True},
     )
 
     assert status["source"] == "local"
     assert status["cached"] is True
+    assert Path(str(status["path"])) == model_dir.resolve()
+
+
+def test_relative_configured_model_uses_state_root_when_cwd_changes(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    model_dir = project_root / "models" / "whisper"
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.json").write_text("{}", encoding="utf-8")
+    (model_dir / "model.bin").write_bytes(b"model")
+    (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    unrelated_cwd = tmp_path / "unrelated"
+    unrelated_cwd.mkdir()
+    state = _state(model_name="models/whisper")
+    state.project_root_dir = project_root.as_posix()
+    monkeypatch.chdir(unrelated_cwd)
+
+    status = model_assets._model_asset_status(
+        state,
+        {"assetId": "asr.faster-whisper", "configured": True},
+    )
+
+    assert status["source"] == "local"
     assert Path(str(status["path"])) == model_dir.resolve()
 
 
@@ -202,7 +226,36 @@ def test_download_model_asset_uses_configured_huggingface_token(monkeypatch):
 
     assert result == {"assetId": "asr.faster-whisper", "cached": True}
     assert calls[0][1]["token"] == "hf-secret"
+    assert calls[0][1]["root"] == Path(state.project_root_dir)
     assert _get_task(state, str(task["id"]))["progress"] == 0.5
+
+
+def test_model_asset_status_uses_state_root_for_cache_inspection(
+    tmp_path,
+    monkeypatch,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    state = _state()
+    state.project_root_dir = selected.as_posix()
+    observed = []
+
+    def fake_inspect(spec, **kwargs):
+        observed.append((spec, kwargs))
+        return {"assetId": spec.asset_id, "cached": False}
+
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+    monkeypatch.setattr(model_assets, "inspect_model_asset", fake_inspect)
+
+    status = model_assets._model_asset_status(
+        state,
+        {"assetId": "asr.faster-whisper", "variant": "small"},
+    )
+
+    assert status == {"assetId": "asr.faster-whisper", "cached": False}
+    assert observed[0][1]["root"] == selected
 
 
 def test_running_model_asset_task_is_reused_by_task_key():
@@ -259,6 +312,7 @@ def test_request_local_paths_are_rejected_before_path_access(monkeypatch, varian
     [
         "../outside/model",
         "./model/../outside",
+        " small ",
         "file:///tmp/model",
         "bad\x00model",
     ],
@@ -316,22 +370,19 @@ def test_unsafe_windows_configured_paths_are_rejected_before_path_access(
         )
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX permits these path components")
-def test_posix_specific_local_path_components_remain_supported(tmp_path):
+@pytest.mark.skipif(os.name == "nt", reason="Windows cannot create these path components")
+def test_posix_specific_local_path_components_are_rejected_as_non_portable(tmp_path):
     model_dir = tmp_path / "NUL" / "model:version " / "with\\backslash" / "trailing."
     model_dir.mkdir(parents=True)
     (model_dir / "config.json").write_text("{}", encoding="utf-8")
     (model_dir / "model.bin").write_bytes(b"model")
     (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
 
-    status = model_assets._model_asset_status(
-        _state(model_name=str(model_dir)),
-        {"assetId": "asr.faster-whisper", "configured": True},
-    )
-
-    assert status["source"] == "local"
-    assert status["cached"] is True
-    assert Path(str(status["path"])) == model_dir.resolve()
+    with pytest.raises(ValueError, match="non-portable path component"):
+        model_assets._model_asset_status(
+            _state(model_name=str(model_dir)),
+            {"assetId": "asr.faster-whisper", "configured": True},
+        )
 
 
 def test_configured_requests_reject_variant_override():

--- a/test/unit/frontend_bridge_core/test_path_utils.py
+++ b/test/unit/frontend_bridge_core/test_path_utils.py
@@ -1,4 +1,19 @@
-from frontend_bridge_core.path_utils import strip_windows_verbatim_prefix
+import ntpath
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from frontend_bridge_core.path_utils import (
+    common_path_is_within,
+    make_path_reference,
+    normalize_project_relative_path,
+    path_reference_value,
+    relative_path_if_within,
+    resolve_from_root,
+    strip_windows_verbatim_prefix,
+    state_project_root,
+)
 
 
 def test_strip_drops_long_path_prefix():
@@ -13,3 +28,403 @@ def test_strip_keeps_unc_root():
 
 def test_strip_leaves_plain_path_untouched():
     assert strip_windows_verbatim_prefix("D:/tts_bundles/gpt") == "D:/tts_bundles/gpt"
+
+
+def test_strip_preserves_device_and_non_filesystem_namespaces():
+    assert strip_windows_verbatim_prefix(r"\\.\C:\device") == r"\\.\C:\device"
+    assert (
+        strip_windows_verbatim_prefix(r"\\?\GLOBALROOT\Device\HarddiskVolume1")
+        == r"\\?\GLOBALROOT\Device\HarddiskVolume1"
+    )
+
+
+def test_path_reference_rejects_windows_device_namespace(tmp_path):
+    with pytest.raises(ValueError, match="device namespace"):
+        make_path_reference(r"\\.\C:\device", tmp_path)
+    with pytest.raises(ValueError, match="device namespace"):
+        make_path_reference(r"\??\C:\native-device", tmp_path)
+    with pytest.raises(ValueError, match="unsupported Windows verbatim namespace"):
+        make_path_reference(r"\\?\GLOBALROOT\Device\HarddiskVolume1", tmp_path)
+
+
+def test_windows_cross_drive_containment_is_false_instead_of_raising():
+    assert common_path_is_within("C:/Shinsekai", "C:/Shinsekai/data/chat.json", path_module=ntpath)
+    assert not common_path_is_within("C:/Shinsekai", "D:/history/chat.json", path_module=ntpath)
+
+
+def test_windows_unc_containment_respects_share_boundaries():
+    assert common_path_is_within(
+        r"\\server\share\Shinsekai",
+        r"\\server\share\Shinsekai\data\chat.json",
+        path_module=ntpath,
+    )
+    assert not common_path_is_within(
+        r"\\server\share\Shinsekai",
+        r"\\server\other\chat.json",
+        path_module=ntpath,
+    )
+
+
+def test_windows_verbatim_prefix_is_ignored_for_identity_comparison():
+    assert common_path_is_within(
+        r"D:\Shinsekai",
+        r"\\?\D:\Shinsekai\data\chat_history\session.json",
+        path_module=ntpath,
+    )
+    assert common_path_is_within(
+        r"\\server\share\Shinsekai",
+        r"\\?\UNC\server\share\Shinsekai\data\session.json",
+        path_module=ntpath,
+    )
+
+
+def test_windows_verbatim_path_can_be_serialized_relative_to_plain_root():
+    assert relative_path_if_within(
+        r"D:\Shinsekai",
+        r"\\?\D:\Shinsekai\data\chat_history\session.json",
+        path_module=ntpath,
+    ) == "data/chat_history/session.json"
+    assert relative_path_if_within(
+        r"C:\Shinsekai",
+        r"D:\history\session.json",
+        path_module=ntpath,
+    ) is None
+
+
+def test_path_reference_recovers_stale_windows_project_history(tmp_path):
+    reference = make_path_reference(
+        r"D:\old-install\DATA\CHAT_HISTORY\session.json",
+        tmp_path,
+        legacy_project_prefixes=(("data", "chat_history"),),
+    )
+
+    assert reference == {"scope": "project", "path": "data/chat_history/session.json"}
+
+
+def test_path_reference_can_preserve_missing_external_path_after_migration(tmp_path):
+    reference = make_path_reference(
+        r"D:\offline-disk\data\chat_history\session.json",
+        tmp_path,
+        legacy_project_prefixes=(("data", "chat_history"),),
+        recover_legacy_absolute=False,
+    )
+
+    assert reference == {
+        "scope": "external",
+        "path": "D:/offline-disk/data/chat_history/session.json",
+    }
+
+
+def test_path_reference_keeps_application_resources_out_of_project_scope(tmp_path):
+    reference = make_path_reference(
+        r"ASSETS\SYSTEM\WORKFLOW\default.yaml",
+        tmp_path,
+        resource_prefixes=(("assets", "system", "workflow"),),
+    )
+
+    assert reference == {
+        "scope": "resource",
+        "path": "assets/system/workflow/default.yaml",
+    }
+    assert path_reference_value(reference) == "assets/system/workflow/default.yaml"
+
+
+def test_path_reference_does_not_collapse_distinct_same_named_application_resources(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    source = tmp_path / "source"
+    app = tmp_path / "application"
+    relative = "assets/system/workflow/default.yaml"
+    source_asset = source / relative
+    app_asset = app / relative
+    project.mkdir()
+    source_asset.parent.mkdir(parents=True)
+    app_asset.parent.mkdir(parents=True)
+    source_asset.write_text("source", encoding="utf-8")
+    app_asset.write_text("application", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", app.as_posix())
+
+    assert make_path_reference(
+        source_asset,
+        project,
+        resource_prefixes=(("assets", "system", "workflow"),),
+    ) == {"scope": "resource", "path": relative}
+    assert make_path_reference(
+        app_asset,
+        project,
+        resource_prefixes=(("assets", "system", "workflow"),),
+    ) == {"scope": "external", "path": app_asset.as_posix()}
+
+
+def test_path_reference_recovers_stale_install_resource_without_reclassifying_it(
+    tmp_path,
+):
+    reference = make_path_reference(
+        r"D:\old-install\ASSETS\SYSTEM\WORKFLOW\default.yaml",
+        tmp_path,
+        resource_prefixes=(("assets", "system", "workflow"),),
+    )
+
+    assert reference == {
+        "scope": "resource",
+        "path": "assets/system/workflow/default.yaml",
+    }
+
+
+def test_existing_external_resource_suffix_keeps_external_scope(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external/assets/system/workflow/default.yaml"
+    project.mkdir()
+    external.parent.mkdir(parents=True)
+    external.write_text("nodes: []\n", encoding="utf-8")
+
+    reference = make_path_reference(
+        external,
+        project,
+        resource_prefixes=(("assets", "system", "workflow"),),
+    )
+
+    assert reference == {"scope": "external", "path": external.as_posix()}
+
+
+def test_existing_external_legacy_suffix_is_never_reclassified(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external/data/chat_history/session.json"
+    current = project / "data/chat_history/session.json"
+    external.parent.mkdir(parents=True)
+    current.parent.mkdir(parents=True)
+    external.write_text("external", encoding="utf-8")
+    current.write_text("managed", encoding="utf-8")
+
+    reference = make_path_reference(
+        external,
+        project,
+        legacy_project_prefixes=(("data", "chat_history"),),
+    )
+
+    assert reference == {"scope": "external", "path": external.as_posix()}
+
+
+def test_absolute_project_path_is_serialized_relative_without_following_aliases(tmp_path):
+    project = tmp_path / "project"
+    managed = project / "data" / "sprite" / "mio.png"
+    managed.parent.mkdir(parents=True)
+    managed.write_bytes(b"png")
+
+    assert make_path_reference(managed, project) == {
+        "scope": "project",
+        "path": "data/sprite/mio.png",
+    }
+
+
+def test_internal_absolute_alias_escape_is_rejected(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    try:
+        (project / "data" / "alias").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        make_path_reference(project / "data" / "alias" / "asset.png", project)
+
+
+def test_external_alias_back_into_project_keeps_external_scope(tmp_path):
+    project = tmp_path / "project"
+    managed = project / "data" / "sprite" / "mio.png"
+    managed.parent.mkdir(parents=True)
+    managed.write_bytes(b"png")
+    alias = tmp_path / "external-alias.png"
+    try:
+        alias.symlink_to(managed)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    assert make_path_reference(alias, project) == {
+        "scope": "external",
+        "path": alias.as_posix(),
+    }
+
+
+def test_project_relative_normalization_preserves_dotfiles():
+    assert normalize_project_relative_path("data/.history/session.json") == "data/.history/session.json"
+
+
+def test_project_relative_normalization_rejects_windows_drive_relative_paths():
+    assert normalize_project_relative_path("D:session.json") is None
+
+
+def test_project_relative_normalization_rejects_user_home_expansion():
+    assert normalize_project_relative_path("~/outside.txt") is None
+    assert normalize_project_relative_path("~root/outside.txt") is None
+
+
+@pytest.mark.parametrize("raw", [" data/history.json", "data/history.json "])
+def test_project_relative_normalization_rejects_surrounding_whitespace(raw):
+    assert normalize_project_relative_path(raw) is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "data/./history.json",
+        "data/cache/../history.json",
+        "data//history.json",
+        "data/history.json/",
+        "./data/history.json",
+        ".",
+    ],
+)
+def test_project_relative_normalization_rejects_lexical_aliases(raw):
+    assert normalize_project_relative_path(raw) is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "data/CON/history.json",
+        "data/NUL.txt",
+        "data/history.",
+        "data/history ",
+        "data/alternate:stream",
+        "data/question?.json",
+        "data/lone-\ud800.json",
+    ],
+)
+def test_project_relative_normalization_rejects_nonportable_components(raw):
+    assert normalize_project_relative_path(raw) is None
+
+
+def test_project_relative_normalization_only_portabilizes_windows_separators():
+    assert normalize_project_relative_path(r"data\.history\session.json") == (
+        "data/.history/session.json"
+    )
+
+
+def test_path_reference_rejects_lexical_alias_instead_of_retargeting(tmp_path):
+    with pytest.raises(ValueError, match="project path"):
+        make_path_reference("data/cache/../history.json", tmp_path)
+
+    assert path_reference_value(
+        {"scope": "project", "path": "data/cache/../history.json"}
+    ) is None
+
+
+def test_path_reference_rejects_surrounding_whitespace(tmp_path):
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        make_path_reference(" data/history.json", tmp_path)
+
+
+def test_path_reference_rejects_absolute_lexical_alias(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    raw = f"{project.as_posix()}/data/./history.json"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        make_path_reference(raw, project)
+
+    assert path_reference_value(
+        {"scope": "external", "path": raw}
+    ) is None
+
+
+def test_home_path_reference_is_external_instead_of_project_relative(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.setenv("HOME", home.as_posix())
+
+    reference = make_path_reference("~/outside.txt", project)
+
+    assert reference == {
+        "scope": "external",
+        "path": (home / "outside.txt").as_posix(),
+    }
+
+
+def test_non_native_windows_absolute_path_is_never_anchored_to_project(tmp_path):
+    if os.name == "nt":
+        pytest.skip("Windows drive syntax is native on this host")
+
+    with pytest.raises(ValueError, match="non-native absolute"):
+        resolve_from_root(r"D:\external\asset.png", tmp_path)
+
+
+def test_resolve_from_root_rejects_relative_traversal(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        resolve_from_root("../external/asset.png", project)
+
+
+def test_resolve_from_root_normalizes_portable_backslash_separators(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    assert resolve_from_root(r"data\sprite\mika.png", project) == (
+        project / "data/sprite/mika.png"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", " leading.txt", "trailing.txt ", "D:relative.txt", "bad\x00name"],
+)
+def test_resolve_from_root_rejects_ambiguous_or_empty_paths(tmp_path, raw):
+    with pytest.raises(ValueError):
+        resolve_from_root(raw, tmp_path)
+
+
+def test_resolve_from_root_allows_explicit_absolute_external_path(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    external = tmp_path / "external" / "asset.png"
+
+    assert resolve_from_root(external, project) == external.resolve()
+
+
+def test_invalid_authoritative_state_root_never_falls_back_to_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+    state = SimpleNamespace(project_root_dir="invalid\x00root")
+
+    with pytest.raises(ValueError, match="state.project_root_dir"):
+        state_project_root(state)
+
+
+def test_relative_authoritative_state_root_never_depends_on_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state = SimpleNamespace(project_root_dir="relative-project")
+
+    with pytest.raises(ValueError, match="state.project_root_dir"):
+        state_project_root(state)
+
+
+def test_empty_authoritative_state_root_never_falls_back_to_environment(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+    state = SimpleNamespace(project_root_dir="")
+
+    with pytest.raises(ValueError, match="state.project_root_dir"):
+        state_project_root(state)
+
+
+def test_empty_current_environment_root_never_falls_back_to_legacy(
+    tmp_path,
+    monkeypatch,
+):
+    legacy = tmp_path / "legacy"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "")
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", legacy.as_posix())
+    state = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="SHINSEKAI_PROJECT_ROOT"):
+        state_project_root(state)

--- a/test/unit/frontend_bridge_core/test_security.py
+++ b/test/unit/frontend_bridge_core/test_security.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
 from frontend_bridge_core.config import _openai_chat_endpoint
 from frontend_bridge_core.routes.api import FrontendBridgeHandler
 from frontend_bridge_core.security import (
+    download_url,
     host_matches,
     safe_content_disposition,
+    safe_child_path,
+    safe_existing_dir_path,
+    safe_existing_file_path,
     safe_executable,
     safe_filename,
     safe_project_path,
@@ -17,9 +23,28 @@ from frontend_bridge_core.security import (
 )
 
 
+def test_download_url_encodes_path_as_one_query_value():
+    path = "/tmp/项目 & 100% #ready/archive.zip"
+    url = download_url(path)
+
+    assert url.startswith("/api/download?path=")
+    assert parse_qs(urlsplit(url).query, errors="strict") == {"path": [path]}
+    assert " " not in url
+    assert "#" not in url
+    assert "&" not in url.partition("?")[2]
+
+
 def test_validated_http_url_rejects_control_chars_and_special_use_ips():
-    with pytest.raises(ValueError):
-        validated_http_url("https://example.com\r\nX-Test: bad")
+    for value in (
+        "https://example.com\r\nX-Test: bad",
+        " https://example.com/path",
+        "https://example.com/path ",
+        r"https://example.com\@attacker.test/path",
+        "https://user:secret@example.com/path",
+        "https://example.com/path#fragment",
+    ):
+        with pytest.raises(ValueError):
+            validated_http_url(value)
 
     with pytest.raises(ValueError):
         validated_http_url("http://169.254.169.254/latest/meta-data", allow_private_hosts=True)
@@ -61,6 +86,19 @@ def test_validated_http_url_allows_localhost_when_requested():
     assert validated_http_url(url, allow_localhost=True) == url
 
 
+def test_validated_http_url_normalizes_ipv6_loopback_without_changing_ownership():
+    url = "http://[::1]:8080/v1/models"
+
+    assert (
+        validated_http_url(
+            url,
+            allow_localhost=True,
+            allow_private_hosts=True,
+        )
+        == url
+    )
+
+
 def test_host_matches_exact_host():
     assert host_matches("example.com", {"example.com"})
     assert host_matches("example.com", {"example.org", "example.com"})
@@ -87,7 +125,7 @@ def test_safe_executable_allows_simple_command_and_default():
 
 
 def test_safe_executable_rejects_missing_paths_and_shell_metacharacters():
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ValueError, match="absolute"):
         safe_executable("../definitely-missing-python", default="yt-dlp")
 
     with pytest.raises(ValueError):
@@ -95,6 +133,12 @@ def test_safe_executable_rejects_missing_paths_and_shell_metacharacters():
 
     with pytest.raises(ValueError):
         safe_executable("python&&echo", default="yt-dlp")
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        safe_executable(" python", default="yt-dlp")
+
+    with pytest.raises(ValueError, match="absolute"):
+        safe_executable("~/python", default="yt-dlp")
 
 
 def test_safe_search_query_allows_basic_queries():
@@ -117,6 +161,8 @@ def test_safe_search_query_rejects_control_chars_and_newlines():
 def test_safe_filename_applies_default_suffix_when_requested():
     assert safe_filename("report", default_suffix=".txt") == "report.txt"
     assert safe_filename("report.txt", default_suffix=".txt") == "report.txt"
+    assert safe_filename("report.TXT", default_suffix=".txt") == "report.txt"
+    assert safe_filename("a" * 255, default_suffix=".txt") == ("a" * 251) + ".txt"
 
 
 def test_safe_filename_rejects_path_separators():
@@ -129,6 +175,9 @@ def test_safe_filename_rejects_path_separators():
     with pytest.raises(ValueError):
         safe_filename(r"dir\evil")
 
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        safe_filename(" report.txt")
+
 
 def test_safe_project_path_rejects_traversal(tmp_path, monkeypatch):
     root = tmp_path / "project"
@@ -137,6 +186,224 @@ def test_safe_project_path_rejects_traversal(tmp_path, monkeypatch):
 
     with pytest.raises(PermissionError):
         safe_project_path("../secret.txt")
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        safe_project_path(" data/file.txt", root=root)
+
+
+def test_safe_project_path_rejects_ambiguous_windows_drive_relative_path(tmp_path):
+    with pytest.raises(ValueError, match="drive-relative"):
+        safe_project_path("D:session.json", root=tmp_path)
+
+
+def test_safe_child_path_preserves_exact_portable_relative_identity(tmp_path):
+    assert safe_child_path(tmp_path, "assets/app.js") == tmp_path / "assets" / "app.js"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/assets/app.js",
+        r"assets\app.js",
+        "assets/./app.js",
+        "assets/../app.js",
+        "assets//app.js",
+        "assets/app.js/",
+        "D:app.js",
+    ],
+)
+def test_safe_child_path_rejects_aliases_instead_of_retargeting(tmp_path, raw):
+    with pytest.raises(ValueError):
+        safe_child_path(tmp_path, raw)
+
+
+def test_safe_child_path_rejects_existing_link_component(tmp_path):
+    external = tmp_path / "external"
+    root = tmp_path / "root"
+    external.mkdir()
+    root.mkdir()
+    try:
+        (root / "assets").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        safe_child_path(root, "assets/app.js")
+
+
+def test_safe_existing_paths_reject_file_and_directory_aliases(tmp_path):
+    target_file = tmp_path / "target.txt"
+    target_dir = tmp_path / "target-dir"
+    file_alias = tmp_path / "file-alias.txt"
+    dir_alias = tmp_path / "dir-alias"
+    target_file.write_text("private", encoding="utf-8")
+    target_dir.mkdir()
+    try:
+        file_alias.symlink_to(target_file)
+        dir_alias.symlink_to(target_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        safe_existing_file_path(file_alias)
+    with pytest.raises(PermissionError, match="symbolic link"):
+        safe_existing_dir_path(dir_alias)
+
+
+def test_static_path_removes_only_the_http_route_slash(tmp_path):
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+
+    assert handler._resolve_static_path(tmp_path, "/assets/app.js") == (
+        tmp_path / "assets" / "app.js"
+    )
+    with pytest.raises(ValueError):
+        handler._resolve_static_path(tmp_path, "//assets/app.js")
+
+
+def test_static_path_decodes_unicode_once_and_rejects_encoded_aliases(tmp_path):
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+    asset = tmp_path / "assets" / "你好 world.js"
+    literal_percent = tmp_path / "assets" / "100%2Fready.js"
+    asset.parent.mkdir()
+    asset.write_text("unicode", encoding="utf-8")
+    literal_percent.write_text("literal", encoding="utf-8")
+
+    assert handler._resolve_static_path(
+        tmp_path,
+        "/assets/%E4%BD%A0%E5%A5%BD%20world.js",
+    ) == asset
+    assert handler._resolve_static_path(
+        tmp_path,
+        "/assets/100%252Fready.js",
+    ) == literal_percent
+    with pytest.raises(ValueError):
+        handler._resolve_static_path(tmp_path, "/assets/%2e%2e/secret.js")
+    with pytest.raises(ValueError):
+        handler._resolve_static_path(tmp_path, "/assets%5csecret.js")
+    with pytest.raises(ValueError, match="percent"):
+        handler._resolve_static_path(tmp_path, "/assets/bad%escape.js")
+
+
+def _project_path_handler(project_root):
+    handler = FrontendBridgeHandler.__new__(FrontendBridgeHandler)
+    handler.server = SimpleNamespace(
+        state=SimpleNamespace(project_root_dir=project_root.as_posix())
+    )
+    return handler
+
+
+def test_http_project_file_resolver_uses_exact_project_identity(tmp_path):
+    handler = _project_path_handler(tmp_path)
+
+    assert handler._resolve_project_path("data/media/item.png") == (
+        tmp_path / "data/media/item.png"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "./data/media/item.png",
+        "data//media/item.png",
+        "data/./media/item.png",
+        "data/media/../item.png",
+        "data/media/item.png/",
+    ),
+)
+def test_http_project_file_resolver_rejects_lexical_aliases(tmp_path, raw):
+    handler = _project_path_handler(tmp_path)
+
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        handler._resolve_project_path(raw)
+
+
+def test_http_media_resolver_distinguishes_resources_project_and_external_files(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    resource = source / "assets" / "system" / "picture.png"
+    managed = project / "data" / "media" / "item.png"
+    external = tmp_path / "external" / "item.png"
+    resource.parent.mkdir(parents=True)
+    managed.parent.mkdir(parents=True)
+    external.parent.mkdir(parents=True)
+    resource.write_bytes(b"resource")
+    managed.write_bytes(b"managed")
+    external.write_bytes(b"external")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    handler = _project_path_handler(project)
+    handler.server.state.chat_stream = SimpleNamespace(
+        approved_external_media_paths=lambda: [external.as_posix()]
+    )
+
+    assert handler._resolve_media_path("assets/system/picture.png") == resource
+    assert handler._resolve_media_path("data/media/item.png") == managed
+    assert handler._resolve_media_path(external.as_posix()) == external
+    assert handler._resolve_resource_path("assets/system/picture.png") == resource
+
+
+def test_http_resource_resolver_rejects_linked_application_assets(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    source.mkdir()
+    project.mkdir()
+    external.mkdir()
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    try:
+        (source / "assets").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    handler = _project_path_handler(project)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        handler._resolve_resource_path("assets/system/picture.png")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "./assets/system/picture.png",
+        "assets//system/picture.png",
+        "data/./media/item.png",
+        "data/media/../item.png",
+    ),
+)
+def test_http_media_resolver_rejects_lexical_aliases(tmp_path, raw):
+    handler = _project_path_handler(tmp_path)
+
+    with pytest.raises((PermissionError, ValueError)):
+        handler._resolve_media_path(raw)
+
+
+def test_http_project_file_resolver_does_not_guess_legacy_duplicate_segments(
+    tmp_path,
+):
+    handler = _project_path_handler(tmp_path)
+    canonical = tmp_path / "data/backgrounds/demo/image.png"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_bytes(b"image")
+
+    resolved = handler._resolve_project_path(
+        "data/backgrounds/demo/backgrounds/demo/image.png"
+    )
+
+    assert resolved != canonical
+    assert not resolved.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows drive paths are native on Windows")
+def test_safe_project_path_never_reinterprets_windows_absolute_path_as_posix_relative(tmp_path):
+    with pytest.raises(ValueError, match="not native"):
+        safe_project_path(r"D:\history\session.json", root=tmp_path)
 
 
 def test_safe_content_disposition_strips_header_control_chars():
@@ -241,3 +508,46 @@ def test_inject_bridge_token_does_not_duplicate_existing_token():
     result = handler._inject_bridge_token(detail)
 
     assert result["pages"][0]["frontendUrl"] == url
+
+
+def test_inject_bridge_token_matches_query_keys_not_path_or_query_values():
+    handler = _handler_with_auth_token("secret-token")
+    detail = {
+        "pages": [
+            {
+                "frontendUrl": (
+                    "/api/plugins/shinsekai_bridge_token/frontend/page/"
+                    "?pluginId=shinsekai_bridge_token"
+                )
+            }
+        ]
+    }
+
+    result = handler._inject_bridge_token(detail)
+
+    assert result["pages"][0]["frontendUrl"] == (
+        "/api/plugins/shinsekai_bridge_token/frontend/page/"
+        "?pluginId=shinsekai_bridge_token&shinsekai_bridge_token=secret-token"
+    )
+
+
+def test_inject_bridge_token_replaces_stale_duplicates_and_preserves_fragment():
+    handler = _handler_with_auth_token("new token")
+    detail = {
+        "pages": [
+            {
+                "frontendUrl": (
+                    "/api/plugins/demo/frontend/page/"
+                    "?shinsekai_bridge_token=stale&mode=full"
+                    "&shinsekai_bridge_token=older#content"
+                )
+            }
+        ]
+    }
+
+    result = handler._inject_bridge_token(detail)
+
+    assert result["pages"][0]["frontendUrl"] == (
+        "/api/plugins/demo/frontend/page/"
+        "?mode=full&shinsekai_bridge_token=new+token#content"
+    )

--- a/test/unit/frontend_bridge_core/test_template_session.py
+++ b/test/unit/frontend_bridge_core/test_template_session.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from frontend_bridge_core import template_session
+
+
+def _paths(tmp_path):
+    project = tmp_path / "project"
+    templates = project / "data" / "character_templates"
+    templates.mkdir(parents=True)
+    return project, templates
+
+
+def test_template_session_storage_ignores_process_cwd(tmp_path, monkeypatch):
+    project, templates = _paths(tmp_path)
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    template_session.save_template_session(
+        templates,
+        {"history_file": "data/chat_history/session"},
+        project_root=project,
+    )
+
+    path = template_session.template_session_file(
+        templates,
+        project_root=project,
+    )
+    assert path == project / "data" / "config" / "template_tab_last_launch.json"
+    assert not (unrelated / "data").exists()
+    assert template_session.load_template_session(
+        templates,
+        project_root=project,
+    )["history_file"] == "data/chat_history/session"
+
+
+def test_template_session_stored_reference_is_authoritative(tmp_path):
+    project, templates = _paths(tmp_path)
+    path = template_session.template_session_file(
+        templates,
+        project_root=project,
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "history_file": "data/chat_history/must-not-be-used",
+                "path_refs": {
+                    "history_file": {
+                        "scope": "project",
+                        "path": "../outside",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = template_session.load_template_session(
+        templates,
+        project_root=project,
+    )
+
+    assert loaded is not None
+    assert loaded["history_file"] == ""
+
+
+def test_template_session_canonicalizes_known_stored_reference_prefixes(tmp_path):
+    project, templates = _paths(tmp_path)
+    path = template_session.template_session_file(
+        templates,
+        project_root=project,
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "path_refs": {
+                    "history_file": {
+                        "scope": "project",
+                        "path": r"DATA\CHAT_HISTORY\Mio\Session.json",
+                    },
+                    "workflow_path": {
+                        "scope": "resource",
+                        "path": r"ASSETS\SYSTEM\WORKFLOW\Default.yaml",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = template_session.load_template_session(
+        templates,
+        project_root=project,
+    )
+
+    assert loaded is not None
+    assert loaded["history_file"] == "data/chat_history/Mio/Session.json"
+    assert loaded["workflow_path"] == "assets/system/workflow/Default.yaml"
+    assert loaded["path_refs"] == {
+        "history_file": {
+            "scope": "project",
+            "path": "data/chat_history/Mio/Session.json",
+        },
+        "workflow_path": {
+            "scope": "resource",
+            "path": "assets/system/workflow/Default.yaml",
+        },
+    }
+
+
+def test_template_session_migrates_legacy_absolute_paths_once(tmp_path):
+    project, templates = _paths(tmp_path)
+    path = template_session.template_session_file(
+        templates,
+        project_root=project,
+    )
+    path.parent.mkdir(parents=True)
+    stale = (
+        tmp_path
+        / "removed-project"
+        / "data"
+        / "chat_history"
+        / "chapter.json"
+    )
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "history_file": stale.as_posix(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = template_session.load_template_session(
+        templates,
+        project_root=project,
+    )
+
+    assert loaded is not None
+    assert loaded["history_file"] == "data/chat_history/chapter.json"
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["path_contract_version"] == 1
+    assert persisted["path_refs"]["history_file"] == {
+        "scope": "project",
+        "path": "data/chat_history/chapter.json",
+    }
+
+
+def test_versioned_template_session_preserves_missing_external_identity(tmp_path):
+    project, templates = _paths(tmp_path)
+    path = template_session.template_session_file(
+        templates,
+        project_root=project,
+    )
+    path.parent.mkdir(parents=True)
+    external = (
+        tmp_path
+        / "offline-drive"
+        / "data"
+        / "chat_history"
+        / "chapter.json"
+    )
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "path_contract_version": 1,
+                "history_file": external.as_posix(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = template_session.load_template_session(
+        templates,
+        project_root=project,
+    )
+
+    assert loaded is not None
+    assert loaded["history_file"] == external.as_posix()
+    assert loaded["path_refs"]["history_file"] == {
+        "scope": "external",
+        "path": external.as_posix(),
+    }
+
+
+def test_template_session_rejects_linked_config_storage(tmp_path):
+    project, templates = _paths(tmp_path)
+    external = tmp_path / "external"
+    external.mkdir()
+    config = project / "data" / "config"
+    try:
+        config.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        template_session.save_template_session(
+            templates,
+            {"history_file": ""},
+            project_root=project,
+        )
+
+    assert list(external.iterdir()) == []
+
+
+def test_template_session_rejects_replaced_parent_before_write(
+    tmp_path,
+    monkeypatch,
+):
+    project, templates = _paths(tmp_path)
+    config = project / "data" / "config"
+    preserved = project / "data" / "config-preserved"
+    config.mkdir()
+    real_write = template_session.atomic_write_text
+
+    def replace_parent(*args, **kwargs):
+        config.rename(preserved)
+        config.mkdir()
+        (config / "template_tab_last_launch.json").write_text(
+            "peer",
+            encoding="utf-8",
+        )
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(
+        template_session,
+        "atomic_write_text",
+        replace_parent,
+    )
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        template_session.save_template_session(
+            templates,
+            {"history_file": ""},
+            project_root=project,
+        )
+
+    assert (config / "template_tab_last_launch.json").read_text(
+        encoding="utf-8"
+    ) == "peer"
+    assert list(preserved.iterdir()) == []

--- a/test/unit/llm/tools/test_file_tools_paths.py
+++ b/test/unit/llm/tools/test_file_tools_paths.py
@@ -1,0 +1,638 @@
+from __future__ import annotations
+
+import errno
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from sdk.file_transactions import rename_path_without_overwrite
+from core.media.file_operations import (
+    _resolve,
+    append_text_file as file_append,
+    copy_file as file_copy,
+    create_directory as file_mkdir,
+    delete_path as file_delete,
+    extract_archive as file_extract,
+    inspect_path as file_info,
+    list_directory as file_list_dir,
+    move_path as file_move,
+    open_local_path as file_open,
+    read_text_file as file_read,
+    search_file_content as file_search_content,
+    search_files as file_search,
+    write_text_file as file_write,
+)
+
+
+def test_file_open_rejects_symbolic_link_alias(tmp_path, monkeypatch):
+    target = tmp_path / "target.txt"
+    alias = tmp_path / "alias.txt"
+    target.write_text("safe", encoding="utf-8")
+    try:
+        alias.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    calls = []
+    monkeypatch.setattr(
+        "core.media.file_operations.subprocess.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = file_open(alias.as_posix())
+
+    assert "symbolic link" in result["error"]
+    assert calls == []
+
+
+def test_file_delete_reports_size_after_removal(tmp_path):
+    target = tmp_path / "remove.txt"
+    target.write_bytes(b"1234")
+
+    result = file_delete(target.as_posix())
+
+    assert result == {
+        "deleted": target.as_posix(),
+        "type": "file",
+        "size_human": "4.0B",
+    }
+    assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "folder//file.txt",
+        "./file.txt",
+        "folder/../file.txt",
+    ),
+)
+def test_file_tools_reject_relative_lexical_aliases(raw):
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        _resolve(raw)
+
+
+@pytest.mark.parametrize("pattern", ("../*", "../../*", "**/../*", r"..\*"))
+def test_file_search_patterns_cannot_escape_the_selected_directory(
+    tmp_path,
+    pattern,
+):
+    selected = tmp_path / "selected"
+    selected.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private marker", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="escapes"):
+        file_search(pattern, selected.as_posix())
+    with pytest.raises(PermissionError, match="escapes"):
+        file_search_content(
+            "private marker",
+            selected.as_posix(),
+            pattern,
+        )
+
+
+def test_file_search_does_not_return_a_link_outside_the_selected_directory(
+    tmp_path,
+):
+    selected = tmp_path / "selected"
+    selected.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private marker", encoding="utf-8")
+    linked = selected / "linked.txt"
+    try:
+        linked.symlink_to(outside)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    file_result = file_search("*.txt", selected.as_posix())
+    content_result = file_search_content(
+        "private marker",
+        selected.as_posix(),
+        "*.txt",
+    )
+
+    assert file_result["matches"] == []
+    assert content_result["matches"] == []
+
+
+def test_file_search_does_not_mix_a_replaced_nested_directory(
+    tmp_path,
+    monkeypatch,
+):
+    selected = tmp_path / "selected"
+    nested = selected / "nested"
+    preserved = selected / "nested-preserved"
+    nested.mkdir(parents=True)
+    (nested / "original.txt").write_text("original marker", encoding="utf-8")
+    from core.media import file_operations as file_tools
+
+    real_snapshot = file_tools.snapshot_directory_entries_without_links
+    replaced = False
+
+    def replace_nested_after_snapshot(path, **kwargs):
+        nonlocal replaced
+        result = real_snapshot(path, **kwargs)
+        if Path(path) == nested and not replaced:
+            replaced = True
+            nested.rename(preserved)
+            nested.mkdir()
+            (nested / "peer.txt").write_text("peer marker", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(
+        file_tools,
+        "snapshot_directory_entries_without_links",
+        replace_nested_after_snapshot,
+    )
+
+    file_result = file_search("*.txt", selected.as_posix())
+    peer_preserved = tmp_path / "peer-preserved"
+    nested.rename(peer_preserved)
+    preserved.rename(nested)
+    replaced = False
+    content_result = file_search_content(
+        "marker",
+        selected.as_posix(),
+        "*.txt",
+    )
+
+    assert file_result["matches"] == []
+    assert content_result["matches"] == []
+    assert (nested / "peer.txt").read_text(encoding="utf-8") == "peer marker"
+    assert (
+        preserved / "original.txt"
+    ).read_text(encoding="utf-8") == "original marker"
+
+
+def test_file_read_does_not_follow_leaf_symlink(tmp_path):
+    external = tmp_path / "external.txt"
+    link = tmp_path / "linked.txt"
+    external.write_text("private marker", encoding="utf-8")
+    try:
+        link.symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    result = file_read(link.as_posix())
+    info = file_info(link.as_posix())
+
+    assert "error" in result
+    assert info["type"] == "symbolic-link"
+    assert "private marker" not in str(result)
+
+
+def test_file_list_rejects_replaced_directory(tmp_path, monkeypatch):
+    directory = tmp_path / "directory"
+    preserved = tmp_path / "directory-preserved"
+    directory.mkdir()
+    (directory / "original.txt").write_text("original", encoding="utf-8")
+    from core.media import file_operations as file_tools
+
+    real_snapshot = file_tools.snapshot_directory_entries_without_links
+
+    def replace_after_snapshot(*args, **kwargs):
+        result = real_snapshot(*args, **kwargs)
+        directory.rename(preserved)
+        directory.mkdir()
+        (directory / "peer.txt").write_text("peer", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(
+        file_tools,
+        "snapshot_directory_entries_without_links",
+        replace_after_snapshot,
+    )
+
+    result = file_list_dir(directory.as_posix())
+
+    assert "error" in result
+    assert (directory / "peer.txt").read_text(encoding="utf-8") == "peer"
+    assert (preserved / "original.txt").read_text(
+        encoding="utf-8"
+    ) == "original"
+
+
+def test_file_list_default_is_home_not_process_cwd(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    launcher = tmp_path / "launcher"
+    home.mkdir()
+    launcher.mkdir()
+    (home / "home.txt").write_text("home", encoding="utf-8")
+    (launcher / "cwd.txt").write_text("cwd", encoding="utf-8")
+    monkeypatch.chdir(launcher)
+    monkeypatch.setattr(
+        "core.media.file_operations.user_home_directory",
+        lambda: home,
+    )
+
+    result = file_list_dir()
+
+    assert result["path"] == home.as_posix()
+    assert [item["name"] for item in result["items"]] == ["home.txt"]
+
+
+def test_file_delete_rejects_absolute_lexical_alias(tmp_path):
+    target = tmp_path / "keep.txt"
+    target.write_text("keep", encoding="utf-8")
+    alias = f"{tmp_path.as_posix()}/./keep.txt"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        file_delete(alias)
+
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+def test_file_delete_removes_link_instead_of_link_target(tmp_path):
+    target = tmp_path / "target.txt"
+    link = tmp_path / "link.txt"
+    target.write_text("keep", encoding="utf-8")
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    result = file_delete(link.as_posix())
+
+    assert result["type"] == "symbolic-link"
+    assert not link.exists()
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+@pytest.mark.parametrize("operation", ("write", "append", "copy"))
+def test_file_writes_do_not_follow_existing_destination_link(
+    tmp_path,
+    operation,
+):
+    target = tmp_path / "target.txt"
+    link = tmp_path / "link.txt"
+    source = tmp_path / "source.txt"
+    target.write_text("keep", encoding="utf-8")
+    source.write_text("replacement", encoding="utf-8")
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    if operation == "write":
+        result = file_write(link.as_posix(), "replacement")
+    elif operation == "append":
+        result = file_append(link.as_posix(), "replacement")
+    else:
+        result = file_copy(source.as_posix(), link.as_posix())
+
+    assert "symbolic link" in result["error"]
+    assert link.is_symlink()
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+def test_file_move_moves_link_identity_instead_of_target(tmp_path):
+    target = tmp_path / "target.txt"
+    source_link = tmp_path / "source-link.txt"
+    destination = tmp_path / "moved-link.txt"
+    target.write_text("keep", encoding="utf-8")
+    try:
+        source_link.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    result = file_move(source_link.as_posix(), destination.as_posix())
+
+    assert "error" not in result
+    assert not source_link.exists()
+    assert destination.is_symlink()
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+def test_relative_write_target_rejects_linked_home_descendant(tmp_path, monkeypatch):
+    external = tmp_path / "external"
+    external.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setattr("core.media.file_operations.user_home_directory", lambda: tmp_path)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        file_write("alias/escaped.txt", "blocked")
+
+    assert not (external / "escaped.txt").exists()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ("write", "append", "copy", "move", "extract", "mkdir"),
+)
+def test_mutating_file_tools_reject_absolute_intermediate_directory_link(
+    tmp_path,
+    operation,
+):
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    source = tmp_path / "source.txt"
+    archive = tmp_path / "archive.zip"
+    external.mkdir()
+    source.write_text("source", encoding="utf-8")
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("payload.txt", "payload")
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    destination = alias / ("directory" if operation in {"extract", "mkdir"} else "file.txt")
+    with pytest.raises(PermissionError, match="symbolic link"):
+        if operation == "write":
+            file_write(destination.as_posix(), "blocked")
+        elif operation == "append":
+            file_append(destination.as_posix(), "blocked")
+        elif operation == "copy":
+            file_copy(source.as_posix(), destination.as_posix())
+        elif operation == "move":
+            file_move(source.as_posix(), destination.as_posix())
+        elif operation == "extract":
+            file_extract(archive.as_posix(), destination.as_posix())
+        else:
+            file_mkdir(destination.as_posix())
+
+    assert not (external / destination.name).exists()
+    assert source.exists()
+
+
+def test_file_move_treats_destination_as_exact_identity(tmp_path):
+    source = tmp_path / "source.txt"
+    destination = tmp_path / "destination"
+    source.write_text("source", encoding="utf-8")
+    destination.mkdir()
+
+    result = file_move(source.as_posix(), destination.as_posix())
+
+    assert "Destination already exists" in result["error"]
+    assert source.read_text(encoding="utf-8") == "source"
+    assert not (destination / source.name).exists()
+
+
+def _simulate_cross_volume_rename(monkeypatch, source: Path, destination: Path) -> None:
+    real_rename = rename_path_without_overwrite
+
+    def rename_with_cross_volume_error(
+        path: Path,
+        target: Path,
+        *,
+        expected_identity=None,
+    ):
+        if path == source and Path(target) == destination:
+            raise OSError(errno.EXDEV, "cross-device link")
+        return real_rename(
+            path,
+            target,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.media.file_operations.rename_path_without_overwrite",
+        rename_with_cross_volume_error,
+    )
+
+
+def test_file_move_cross_volume_file_publishes_complete_target(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source.txt"
+    destination_dir = tmp_path / "other-volume"
+    destination = destination_dir / "destination.txt"
+    source.write_text("complete", encoding="utf-8")
+    destination_dir.mkdir()
+    _simulate_cross_volume_rename(monkeypatch, source, destination)
+
+    result = file_move(source.as_posix(), destination.as_posix())
+
+    assert "error" not in result
+    assert not source.exists()
+    assert destination.read_text(encoding="utf-8") == "complete"
+    assert not list(tmp_path.glob(".*.move-source-*"))
+    assert not list(destination_dir.glob(".*.move-target-*"))
+
+
+def test_file_move_cross_volume_rejects_source_replaced_after_exdev(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source.txt"
+    preserved = tmp_path / "source-preserved.txt"
+    destination_dir = tmp_path / "other-volume"
+    destination = destination_dir / "destination.txt"
+    source.write_text("original", encoding="utf-8")
+    destination_dir.mkdir()
+    real_rename = rename_path_without_overwrite
+    raced = False
+
+    def replace_then_report_exdev(path, target, *, expected_identity=None):
+        nonlocal raced
+        if path == source and Path(target) == destination and not raced:
+            raced = True
+            source.rename(preserved)
+            source.write_text("peer", encoding="utf-8")
+            raise OSError(errno.EXDEV, "cross-device link")
+        return real_rename(
+            path,
+            target,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        "core.media.file_operations.rename_path_without_overwrite",
+        replace_then_report_exdev,
+    )
+
+    result = file_move(source.as_posix(), destination.as_posix())
+
+    assert "identity changed" in result["error"]
+    assert source.read_text(encoding="utf-8") == "peer"
+    assert preserved.read_text(encoding="utf-8") == "original"
+    assert not destination.exists()
+
+
+def test_file_move_cross_volume_directory_publishes_complete_tree(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    destination_dir = tmp_path / "other-volume"
+    destination = destination_dir / "destination"
+    (source / "nested").mkdir(parents=True)
+    (source / "nested" / "payload.txt").write_text("complete", encoding="utf-8")
+    destination_dir.mkdir()
+    _simulate_cross_volume_rename(monkeypatch, source, destination)
+
+    result = file_move(source.as_posix(), destination.as_posix())
+
+    assert "error" not in result
+    assert not source.exists()
+    assert (destination / "nested" / "payload.txt").read_text(encoding="utf-8") == "complete"
+    assert not list(tmp_path.glob(".*.move-source-*"))
+    assert not list(destination_dir.glob(".*.move-target-*"))
+
+
+def test_file_copy_rejects_source_replaced_after_validation(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source.txt"
+    preserved = tmp_path / "source-preserved.txt"
+    destination = tmp_path / "destination.txt"
+    source.write_text("original", encoding="utf-8")
+    from core.media import file_operations as file_tools
+
+    real_copy = file_tools._copy_file_atomically
+
+    def replace_before_copy(*args, **kwargs):
+        source.rename(preserved)
+        source.write_text("peer", encoding="utf-8")
+        return real_copy(*args, **kwargs)
+
+    monkeypatch.setattr(
+        file_tools,
+        "_copy_file_atomically",
+        replace_before_copy,
+    )
+
+    result = file_copy(source.as_posix(), destination.as_posix())
+
+    assert "identity changed" in result["error"]
+    assert source.read_text(encoding="utf-8") == "peer"
+    assert preserved.read_text(encoding="utf-8") == "original"
+    assert not destination.exists()
+
+
+def test_file_move_cross_volume_copy_failure_restores_source(
+    tmp_path,
+    monkeypatch,
+):
+    source = tmp_path / "source"
+    destination_dir = tmp_path / "other-volume"
+    destination = destination_dir / "destination"
+    source.mkdir()
+    (source / "keep.txt").write_text("keep", encoding="utf-8")
+    destination_dir.mkdir()
+    _simulate_cross_volume_rename(monkeypatch, source, destination)
+
+    def fail_after_partial_copy(_source: Path, staging: Path, **_kwargs):
+        staging.mkdir()
+        (staging / "partial.txt").write_text("partial", encoding="utf-8")
+        raise OSError("copy interrupted")
+
+    monkeypatch.setattr(
+        "core.media.file_operations.copy_directory_without_links",
+        fail_after_partial_copy,
+    )
+
+    result = file_move(source.as_posix(), destination.as_posix())
+
+    assert "copy interrupted" in result["error"]
+    assert (source / "keep.txt").read_text(encoding="utf-8") == "keep"
+    assert not destination.exists()
+    assert not list(tmp_path.glob(".*.move-source-*"))
+    assert not list(destination_dir.glob(".*.move-target-*"))
+
+
+def test_file_extract_rejects_zip_backslash_traversal_without_partial_output(tmp_path):
+    archive = tmp_path / "bad.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("safe.txt", "safe")
+        zf.writestr(r"..\escape.txt", "bad")
+    output = tmp_path / "out"
+
+    result = file_extract(archive.as_posix(), output.as_posix())
+
+    assert "error" in result
+    assert not output.exists()
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_file_extract_rejects_tar_links_without_partial_output(tmp_path):
+    archive = tmp_path / "bad.tar"
+    with tarfile.open(archive, "w") as tf:
+        content = b"safe"
+        regular = tarfile.TarInfo("safe.txt")
+        regular.size = len(content)
+        tf.addfile(regular, io.BytesIO(content))
+        link = tarfile.TarInfo("link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../escape.txt"
+        tf.addfile(link)
+    output = tmp_path / "out"
+
+    result = file_extract(archive.as_posix(), output.as_posix())
+
+    assert "error" in result
+    assert not output.exists()
+
+
+def test_file_extract_backend_failure_preserves_existing_destination(tmp_path, monkeypatch):
+    archive = tmp_path / "demo.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("new.txt", "new")
+    output = tmp_path / "output"
+    output.mkdir()
+    old = output / "old.txt"
+    old.write_text("old", encoding="utf-8")
+
+    def fail_after_partial_write(_archive, staging):
+        (staging / "partial.txt").write_text("partial", encoding="utf-8")
+        raise OSError("read failed")
+
+    monkeypatch.setattr("core.media.file_operations.extract_zip_safely", fail_after_partial_write)
+
+    result = file_extract(archive.as_posix(), output.as_posix())
+
+    assert "read failed" in result["error"]
+    assert old.read_text(encoding="utf-8") == "old"
+    assert not (output / "partial.txt").exists()
+    assert not list(tmp_path.glob(".output.extract-*"))
+
+
+def test_file_extract_rejects_existing_destination_symlink_descendant(tmp_path):
+    archive = tmp_path / "demo.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("new.txt", "new")
+    output = tmp_path / "output"
+    external = tmp_path / "external.txt"
+    output.mkdir()
+    external.write_text("keep", encoding="utf-8")
+    try:
+        (output / "linked.txt").symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    result = file_extract(archive.as_posix(), output.as_posix())
+
+    assert "symbolic link" in result["error"]
+    assert external.read_text(encoding="utf-8") == "keep"
+    assert not (output / "new.txt").exists()
+
+
+def test_file_extract_does_not_follow_destination_symlink(tmp_path):
+    archive = tmp_path / "demo.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("new.txt", "new")
+    external = tmp_path / "external"
+    output_link = tmp_path / "output"
+    external.mkdir()
+    marker = external / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    try:
+        output_link.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    result = file_extract(archive.as_posix(), output_link.as_posix())
+
+    assert "symbolic link" in result["error"]
+    assert output_link.is_symlink()
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert not (external / "new.txt").exists()

--- a/test/unit/llm/tools/test_mcp_config_file_paths.py
+++ b/test/unit/llm/tools/test_mcp_config_file_paths.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.tools.mcp_config_file import (
+    read_mcp_config,
+    require_openable_mcp_config_path,
+    resolve_mcp_config_path,
+    resolve_mcp_stdio_working_directory,
+    write_mcp_config,
+)
+
+
+def test_default_mcp_config_uses_project_root_after_cwd_changes(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+
+    write_mcp_config({"enabled": False, "servers": [{"name": "demo"}]})
+
+    expected = project / "data/config/mcp.yaml"
+    assert expected.is_file()
+    assert read_mcp_config()["enabled"] is False
+    assert not (unrelated / "data").exists()
+
+
+def test_explicit_mcp_project_root_must_be_absolute(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="absolute"):
+        resolve_mcp_config_path(project_root="relative-project")
+
+
+def test_explicit_empty_mcp_config_path_does_not_select_the_default(tmp_path):
+    with pytest.raises(ValueError, match="empty"):
+        resolve_mcp_config_path("", project_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("path", "project_root"),
+    [
+        (" data/config/mcp.yaml", None),
+        (None, " /tmp/project"),
+    ],
+)
+def test_mcp_paths_reject_outer_whitespace(path, project_root):
+    with pytest.raises(ValueError, match="non-portable|project root"):
+        resolve_mcp_config_path(path, project_root=project_root)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "./data/config/mcp.yaml",
+        "data//config/mcp.yaml",
+        "data/other/../config/mcp.yaml",
+    ),
+)
+def test_mcp_paths_reject_lexical_aliases(tmp_path, path):
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        resolve_mcp_config_path(path, project_root=tmp_path)
+
+
+def test_mcp_path_rejects_absolute_lexical_alias(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        resolve_mcp_config_path(
+            f"{project.as_posix()}/./data/config/mcp.yaml",
+            project_root=project,
+        )
+
+
+def test_explicit_external_mcp_config_rejects_linked_parent(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    project.mkdir()
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        resolve_mcp_config_path(
+            alias / "mcp.yaml",
+            project_root=project,
+        )
+
+
+def test_default_mcp_config_rejects_intermediate_symlink_escape(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    (project / "data").mkdir(parents=True)
+    external.mkdir()
+    marker = external / "mcp.yaml"
+    marker.write_text("enabled: false\n", encoding="utf-8")
+    try:
+        (project / "data" / "config").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic links|escapes project root"):
+        write_mcp_config({"enabled": True})
+
+    assert marker.read_text(encoding="utf-8") == "enabled: false\n"
+
+
+def test_default_mcp_config_rejects_internal_symlink_alias(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    alias_target = project / "alternate-config"
+    (project / "data").mkdir(parents=True)
+    alias_target.mkdir()
+    try:
+        (project / "data/config").symlink_to(alias_target, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        write_mcp_config({"enabled": True})
+
+    assert list(alias_target.iterdir()) == []
+
+
+def test_bound_absolute_mcp_path_is_revalidated_before_write(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    config_dir = project / "data/config"
+    external = tmp_path / "external"
+    config_dir.mkdir(parents=True)
+    external.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    bound_path = resolve_mcp_config_path()
+    config_dir.rmdir()
+    try:
+        config_dir.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        write_mcp_config({"enabled": True}, bound_path)
+
+    assert list(external.iterdir()) == []
+
+
+def test_bound_mcp_path_is_revalidated_before_open(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    config_dir = project / "data/config"
+    external = tmp_path / "external"
+    config_dir.mkdir(parents=True)
+    external.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    bound_path = resolve_mcp_config_path()
+    config_dir.rmdir()
+    try:
+        config_dir.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        require_openable_mcp_config_path(bound_path)
+
+
+def test_mcp_stdio_working_directory_is_bound_to_project_root_after_cwd_changes(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    working = project / "servers/demo"
+    unrelated = tmp_path / "unrelated"
+    working.mkdir(parents=True)
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    assert resolve_mcp_stdio_working_directory(
+        "servers/demo",
+        project_root=project,
+    ) == working
+    assert resolve_mcp_stdio_working_directory(
+        project_root=project,
+    ) == project
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "./servers/demo",
+        "servers//demo",
+        "servers/../demo",
+    ),
+)
+def test_mcp_stdio_working_directory_rejects_lexical_aliases(tmp_path, value):
+    project = tmp_path / "project"
+    (project / "servers/demo").mkdir(parents=True)
+
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        resolve_mcp_stdio_working_directory(
+            value,
+            project_root=project,
+        )
+
+
+def test_mcp_stdio_working_directory_rejects_linked_alias(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    try:
+        (project / "server").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(
+        PermissionError,
+        match="symbolic link|escapes project root",
+    ):
+        resolve_mcp_stdio_working_directory(
+            "server",
+            project_root=project,
+        )

--- a/test/unit/llm/tools/test_mcp_launch_paths.py
+++ b/test/unit/llm/tools/test_mcp_launch_paths.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from ai.tools.mcp_tool_setup import _capture_mcp_stdio_launch
+
+
+def test_mcp_stdio_launch_binds_relative_cwd_independently_of_process_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    working = project / "servers/demo"
+    unrelated = tmp_path / "unrelated"
+    working.mkdir(parents=True)
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    launch = _capture_mcp_stdio_launch(
+        {
+            "command": sys.executable,
+            "cwd": "servers/demo",
+            "transport": "stdio",
+        },
+        project_root=project,
+    )
+
+    assert launch.working_directory.path == working
+    assert launch.command.path == Path(sys.executable).resolve()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable fixture")
+def test_mcp_stdio_launch_resolves_bare_command_from_explicit_environment_path(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    binary_dir = tmp_path / "bin"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    binary_dir.mkdir()
+    unrelated.mkdir()
+    executable = binary_dir / "mcp-demo"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.chdir(unrelated)
+    monkeypatch.setenv("PATH", "/does/not/exist")
+
+    launch = _capture_mcp_stdio_launch(
+        {
+            "command": "mcp-demo",
+            "env": {"PATH": binary_dir.as_posix()},
+            "transport": "stdio",
+        },
+        project_root=project,
+    )
+
+    assert launch.command.path == executable
+    assert launch.working_directory.path == project
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable fixture")
+def test_mcp_stdio_launch_resolves_relative_command_against_bound_working_directory(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    working = project / "servers/demo"
+    unrelated = tmp_path / "unrelated"
+    executable = working / "bin/mcp-demo"
+    executable.parent.mkdir(parents=True)
+    unrelated.mkdir()
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.chdir(unrelated)
+
+    launch = _capture_mcp_stdio_launch(
+        {
+            "command": "bin/mcp-demo",
+            "cwd": "servers/demo",
+            "transport": "stdio",
+        },
+        project_root=project,
+    )
+
+    assert launch.command.path == executable
+    assert launch.working_directory.path == working

--- a/test/unit/managers/test_config_manager.py
+++ b/test/unit/managers/test_config_manager.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import config.network_proxy as network_proxy
-from config.config_manager import ConfigManager
+import pytest
+import yaml
+from config.config_manager import (
+    ConfigManager,
+    _migrate_config_asset_paths,
+    _normalize_config_payload_paths,
+)
 from config.schema import AppConfig, ApiConfig, Background, Character, SystemConfig
 from config.sprite_voice import normalize_sprite_voice_types
 
@@ -23,6 +30,710 @@ def _config_manager_with_api(**api_overrides) -> ConfigManager:
         background_list=[Background(name="Default", sprite_prefix="default")],
     )
     return manager
+
+
+def test_config_manager_binds_relative_paths_to_authoritative_project_root(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project_root.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+    monkeypatch.chdir(unrelated)
+    manager = object.__new__(ConfigManager)
+
+    manager._bind_project_paths()
+
+    assert manager._API_CONFIG_PATH == project_root / "data" / "config" / "api.yaml"
+    assert manager._EFFECT_CONFIG_PATH == project_root / "data" / "config" / "effect.yaml"
+
+
+def test_version_metadata_comes_from_application_resources_not_writable_project(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    source = tmp_path / "source"
+    project.mkdir()
+    source.mkdir()
+    (project / "VERSION").write_text("project-spoof", encoding="utf-8")
+    (source / "VERSION").write_text("1.2.3", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source.as_posix())
+    manager = object.__new__(ConfigManager)
+    manager._bind_project_paths()
+
+    assert manager.version == "1.2.3"
+
+
+def test_config_manager_refuses_config_paths_through_external_data_symlink(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    (project / "data").symlink_to(external, target_is_directory=True)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    manager = object.__new__(ConfigManager)
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        manager._bind_project_paths()
+
+
+def test_config_manager_revalidates_storage_when_symlink_appears_after_binding(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    manager = object.__new__(ConfigManager)
+    manager._bind_project_paths()
+    (project / "data").symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        manager._save_single_config(manager._SYSTEM_CONFIG_PATH, {"language": "zh_CN"})
+
+    assert list(external.iterdir()) == []
+
+
+def test_config_write_is_atomic_and_preserves_previous_file_on_dump_failure(
+    tmp_path,
+    monkeypatch,
+):
+    manager = object.__new__(ConfigManager)
+    manager._project_root = tmp_path
+    target = tmp_path / "data/config/system_config.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("previous: true\n", encoding="utf-8")
+
+    def fail_dump(*_args, **_kwargs):
+        raise RuntimeError("serialization failed")
+
+    monkeypatch.setattr("config.config_manager.yaml.dump", fail_dump)
+
+    with pytest.raises(RuntimeError, match="serialization failed"):
+        manager._save_single_config(target, {"replacement": True})
+
+    assert target.read_text(encoding="utf-8") == "previous: true\n"
+    assert list(target.parent.glob(f".{target.name}.*.tmp")) == []
+
+
+def test_config_write_publishes_complete_yaml(tmp_path):
+    manager = object.__new__(ConfigManager)
+    manager._project_root = tmp_path
+    target = tmp_path / "data/config/system_config.yaml"
+
+    manager._save_single_config(target, {"language": "日本語", "items": [1, 2]})
+
+    assert yaml.safe_load(target.read_text(encoding="utf-8")) == {
+        "language": "日本語",
+        "items": [1, 2],
+    }
+
+
+def test_config_write_rejects_lexical_alias_before_creating_file(tmp_path):
+    manager = object.__new__(ConfigManager)
+    manager._project_root = tmp_path
+    alias = f"{tmp_path.as_posix()}/data/./config/system_config.yaml"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        manager._save_single_config(alias, {"language": "zh_CN"})
+
+    assert not (tmp_path / "data").exists()
+
+
+def test_stale_install_asset_paths_migrate_to_portable_project_paths(tmp_path):
+    project = tmp_path / "new-project"
+    old = tmp_path / "removed-install"
+    current_sprite = project / "data/sprite/mika/idle.png"
+    current_sprite.parent.mkdir(parents=True)
+    current_sprite.write_bytes(b"sprite")
+    api = {
+        "gpt_sovits_api_path": (old / "data/tts_bundles/installed/gpt").as_posix(),
+        "asr_extra_configs": {
+            "vosk": {
+                "model_path": (
+                    old / "assets/system/models/vosk-model-small-cn-0.22"
+                ).as_posix()
+            }
+        },
+        "t2i_default_workflow_path": (
+            old / "assets/system/workflow/comfy.json"
+        ).as_posix(),
+    }
+    characters = [
+        {
+            "gpt_model_path": (old / "data/models/mika/model.ckpt").as_posix(),
+            "sprites": [
+                {
+                    "path": (old / "data/sprite/mika/idle.png").as_posix(),
+                    "voice_path": (old / "data/speech/mika/idle.wav").as_posix(),
+                }
+            ],
+        }
+    ]
+    system = {"background_path": (old / "data/backgrounds/room/day.png").as_posix()}
+    backgrounds = [
+        {
+            "sprites": [{"path": (old / "data/backgrounds/room/day.png").as_posix()}],
+            "bgm_list": [(old / "data/bgm/room/day.ogg").as_posix()],
+        }
+    ]
+    effects = [{"audio_list": [(old / "data/effects/rain/rain.wav").as_posix()]}]
+
+    changed = _migrate_config_asset_paths(
+        root=project,
+        api_data=api,
+        characters_data=characters,
+        system_data=system,
+        background_data=backgrounds,
+        effect_data=effects,
+    )
+
+    assert changed == {"api", "characters", "system", "background", "effect"}
+    assert characters[0]["gpt_model_path"] == "data/models/mika/model.ckpt"
+    assert characters[0]["sprites"][0] == {
+        "path": "data/sprite/mika/idle.png",
+        "voice_path": "data/speech/mika/idle.wav",
+    }
+    assert system["background_path"] == "data/backgrounds/room/day.png"
+    assert backgrounds[0]["bgm_list"] == ["data/bgm/room/day.ogg"]
+    assert effects[0]["audio_list"] == ["data/effects/rain/rain.wav"]
+    assert api["gpt_sovits_api_path"] == "data/tts_bundles/installed/gpt"
+    assert api["t2i_default_workflow_path"] == "assets/system/workflow/comfy.json"
+    assert api["asr_extra_configs"]["vosk"]["model_path"] == (
+        "assets/system/models/vosk-model-small-cn-0.22"
+    )
+
+
+def test_stale_install_media_resources_rebase_to_immutable_asset_references(
+    tmp_path,
+):
+    project = tmp_path / "new-project"
+    old = tmp_path / "removed-install"
+    characters = [
+        {
+            "refer_audio_path": (
+                old / "assets/system/sound/reference.wav"
+            ).as_posix(),
+            "sprites": [
+                {
+                    "path": (old / "assets/present_example.png").as_posix(),
+                    "voice_path": (
+                        old / "assets/system/sound/voice.wav"
+                    ).as_posix(),
+                }
+            ],
+        }
+    ]
+    system = {
+        "background_path": (
+            old / "assets/system/picture/background.png"
+        ).as_posix(),
+        "bgm_path": (old / "assets/system/sound/bgm.ogg").as_posix(),
+    }
+    backgrounds = [
+        {
+            "sprites": [
+                {
+                    "path": (
+                        old / "assets/system/picture/room.png"
+                    ).as_posix()
+                }
+            ],
+            "bgm_list": [(old / "assets/system/sound/room.ogg").as_posix()],
+        }
+    ]
+    effects = [
+        {
+            "audio_list": [
+                (old / "assets/system/sound/attention.wav").as_posix()
+            ]
+        }
+    ]
+
+    changed = _migrate_config_asset_paths(
+        root=project,
+        api_data={},
+        characters_data=characters,
+        system_data=system,
+        background_data=backgrounds,
+        effect_data=effects,
+    )
+
+    assert changed == {"characters", "system", "background", "effect"}
+    assert characters[0] == {
+        "refer_audio_path": "assets/system/sound/reference.wav",
+        "sprites": [
+            {
+                "path": "assets/present_example.png",
+                "voice_path": "assets/system/sound/voice.wav",
+            }
+        ],
+    }
+    assert system == {
+        "background_path": "assets/system/picture/background.png",
+        "bgm_path": "assets/system/sound/bgm.ogg",
+    }
+    assert backgrounds[0]["sprites"][0]["path"] == (
+        "assets/system/picture/room.png"
+    )
+    assert backgrounds[0]["bgm_list"] == ["assets/system/sound/room.ogg"]
+    assert effects[0]["audio_list"] == [
+        "assets/system/sound/attention.wav"
+    ]
+
+
+def test_config_path_migration_canonicalizes_known_prefix_case(tmp_path):
+    characters = [
+        {
+            "sprites": [
+                {
+                    "path": r"DATA\SPRITE\Mika\Idle.png",
+                    "voice_path": r"DATA\SPEECH\Mika\Idle.wav",
+                }
+            ]
+        }
+    ]
+    system = {
+        "background_path": r"ASSETS\SYSTEM\PICTURE\Room.png",
+        "bgm_path": r"ASSETS\SYSTEM\SOUND\Theme.ogg",
+    }
+
+    changed = _migrate_config_asset_paths(
+        root=tmp_path,
+        api_data={},
+        characters_data=characters,
+        system_data=system,
+        background_data=[],
+        effect_data=[],
+    )
+
+    assert changed == {"characters", "system"}
+    assert characters[0]["sprites"][0] == {
+        "path": "data/sprite/Mika/Idle.png",
+        "voice_path": "data/speech/Mika/Idle.wav",
+    }
+    assert system == {
+        "background_path": "assets/system/picture/Room.png",
+        "bgm_path": "assets/system/sound/Theme.ogg",
+    }
+
+
+def test_config_path_migration_rejects_outer_whitespace_instead_of_retargeting(
+    tmp_path,
+):
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _migrate_config_asset_paths(
+            root=tmp_path,
+            api_data={"t2i_default_workflow_path": " data/workflows/comfy.json"},
+            characters_data=[],
+            system_data={},
+            background_data=[],
+            effect_data=[],
+        )
+
+
+def test_config_path_migration_canonicalizes_only_the_historical_dot_prefix(
+    tmp_path,
+):
+    api = {
+        "asr_extra_configs": {
+            "vosk": {"model_path": r".\assets\system\models\vosk-model"}
+        }
+    }
+    system = {
+        "music_cover_work_dir": "./data/music_cover",
+        "huggingface_cache_dir": "./data/cache/huggingface",
+        "music_cover_yt_dlp_exe": r".\tools\yt-dlp.exe",
+        "music_cover_ffmpeg_exe": "./tools/ffmpeg",
+    }
+
+    changed = _migrate_config_asset_paths(
+        root=tmp_path,
+        api_data=api,
+        characters_data=[],
+        system_data=system,
+        background_data=[],
+        effect_data=[],
+    )
+
+    assert changed == {"api", "system"}
+    assert api["asr_extra_configs"]["vosk"]["model_path"] == (
+        "assets/system/models/vosk-model"
+    )
+    assert system == {
+        "music_cover_work_dir": "data/music_cover",
+        "huggingface_cache_dir": "data/cache/huggingface",
+        "music_cover_yt_dlp_exe": "tools/yt-dlp.exe",
+        "music_cover_ffmpeg_exe": "tools/ffmpeg",
+    }
+
+
+def test_config_path_migration_collapses_only_known_duplicated_storage_prefixes(
+    tmp_path,
+):
+    characters = [
+        {
+            "sprites": [
+                {
+                    "path": "data/sprite/mika/sprite/mika/idle.png",
+                    "voice_path": "data/speech/mika/speech/mika/idle.wav",
+                }
+            ]
+        }
+    ]
+    backgrounds = [
+        {
+            "sprites": [
+                {
+                    "path": (
+                        "data/backgrounds/room/backgrounds/room/day.png"
+                    )
+                }
+            ],
+            "bgm_list": ["data/bgm/room/bgm/room/day.ogg"],
+        }
+    ]
+    effects = [
+        {
+            "audio_list": [
+                "data/effects/rain/effects/rain/loop.wav",
+            ]
+        }
+    ]
+
+    changed = _migrate_config_asset_paths(
+        root=tmp_path,
+        api_data={},
+        characters_data=characters,
+        system_data={},
+        background_data=backgrounds,
+        effect_data=effects,
+    )
+
+    assert changed == {"characters", "background", "effect"}
+    assert characters[0]["sprites"][0] == {
+        "path": "data/sprite/mika/idle.png",
+        "voice_path": "data/speech/mika/idle.wav",
+    }
+    assert backgrounds[0]["sprites"][0]["path"] == (
+        "data/backgrounds/room/day.png"
+    )
+    assert backgrounds[0]["bgm_list"] == ["data/bgm/room/day.ogg"]
+    assert effects[0]["audio_list"] == ["data/effects/rain/loop.wav"]
+
+
+def test_config_path_migration_does_not_guess_unrelated_repeated_directories(
+    tmp_path,
+):
+    characters = [
+        {
+            "sprites": [
+                {
+                    "path": "data/sprite/mika/archive/mika/idle.png",
+                }
+            ]
+        }
+    ]
+
+    changed = _migrate_config_asset_paths(
+        root=tmp_path,
+        api_data={},
+        characters_data=characters,
+        system_data={},
+        background_data=[],
+        effect_data=[],
+    )
+
+    assert changed == set()
+    assert characters[0]["sprites"][0]["path"] == (
+        "data/sprite/mika/archive/mika/idle.png"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["././data/music_cover", "./data/../music_cover", "./data//music_cover"],
+)
+def test_config_path_migration_rejects_nested_legacy_aliases(tmp_path, value):
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        _migrate_config_asset_paths(
+            root=tmp_path,
+            api_data={},
+            characters_data=[],
+            system_data={"music_cover_work_dir": value},
+            background_data=[],
+            effect_data=[],
+        )
+
+
+def test_config_path_migration_validates_remote_paths_without_rebasing_them(
+    tmp_path,
+):
+    api = {
+        "tts_extra_configs": {
+            "kaggle-gpt-sovits": {
+                "remote_gpt_model_path": "/kaggle/working/model.ckpt",
+                "remote_sovits_model_path": "models/model.pth",
+                "remote_ref_audio_path": "/kaggle/working/ref.wav",
+            }
+        }
+    }
+
+    changed = _migrate_config_asset_paths(
+        root=tmp_path,
+        api_data=api,
+        characters_data=[],
+        system_data={},
+        background_data=[],
+        effect_data=[],
+    )
+
+    assert changed == set()
+    assert api["tts_extra_configs"]["kaggle-gpt-sovits"] == {
+        "remote_gpt_model_path": "/kaggle/working/model.ckpt",
+        "remote_sovits_model_path": "models/model.pth",
+        "remote_ref_audio_path": "/kaggle/working/ref.wav",
+    }
+
+
+def test_config_path_migration_rejects_ambiguous_remote_path_whitespace(tmp_path):
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _migrate_config_asset_paths(
+            root=tmp_path,
+            api_data={
+                "tts_extra_configs": {
+                    "kaggle-gpt-sovits": {
+                        "remote_ref_audio_path": " /kaggle/working/ref.wav",
+                    }
+                }
+            },
+            characters_data=[],
+            system_data={},
+            background_data=[],
+            effect_data=[],
+        )
+
+
+def test_config_path_migration_rejects_remote_lexical_aliases(tmp_path):
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        _migrate_config_asset_paths(
+            root=tmp_path,
+            api_data={
+                "tts_extra_configs": {
+                    "kaggle-gpt-sovits": {
+                        "remote_ref_audio_path": "/kaggle/working/./ref.wav",
+                    }
+                }
+            },
+            characters_data=[],
+            system_data={},
+            background_data=[],
+            effect_data=[],
+        )
+
+
+def test_existing_external_asset_path_is_not_reclassified_as_project_data(tmp_path):
+    project = tmp_path / "project"
+    external = tmp_path / "external/data/models/mika/model.ckpt"
+    external.parent.mkdir(parents=True)
+    external.write_bytes(b"model")
+    characters = [{"gpt_model_path": external.as_posix(), "sprites": []}]
+
+    changed = _migrate_config_asset_paths(
+        root=project,
+        api_data={},
+        characters_data=characters,
+        system_data={},
+        background_data=[],
+        effect_data=[],
+    )
+
+    assert changed == set()
+    assert characters[0]["gpt_model_path"] == external.as_posix()
+
+
+def test_config_save_never_guesses_a_missing_external_path_is_project_data(tmp_path):
+    external = tmp_path / "offline-disk/data/models/mika/model.ckpt"
+    characters = [{"gpt_model_path": external.as_posix(), "sprites": []}]
+
+    _normalize_config_payload_paths("characters", characters, tmp_path / "project")
+
+    assert characters[0]["gpt_model_path"] == external.as_posix()
+
+
+def test_versioned_config_does_not_repeat_stale_absolute_path_recovery(tmp_path):
+    external = tmp_path / "offline-disk/data/models/mika/model.ckpt"
+    characters = [{"gpt_model_path": external.as_posix(), "sprites": []}]
+
+    changed = _migrate_config_asset_paths(
+        root=tmp_path / "project",
+        api_data={},
+        characters_data=characters,
+        system_data={"path_contract_version": 1},
+        background_data=[],
+        effect_data=[],
+        recover_legacy_absolute=False,
+    )
+
+    assert changed == set()
+    assert characters[0]["gpt_model_path"] == external.as_posix()
+
+
+def test_config_load_keeps_missing_relative_assets_repairable_outside_project_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    config_dir = project / "data" / "config"
+    config_dir.mkdir(parents=True)
+    unrelated.mkdir()
+    paths = {
+        "api": config_dir / "api.yaml",
+        "characters": config_dir / "characters.yaml",
+        "system": config_dir / "system_config.yaml",
+        "background": config_dir / "background.yaml",
+        "effect": config_dir / "effect.yaml",
+    }
+    paths["api"].write_text("{}\n", encoding="utf-8")
+    paths["system"].write_text("{}\n", encoding="utf-8")
+    paths["background"].write_text("[]\n", encoding="utf-8")
+    paths["effect"].write_text("[]\n", encoding="utf-8")
+    paths["characters"].write_text(
+        "- name: Offline\n"
+        "  color: '#fff'\n"
+        "  sprite_prefix: offline\n"
+        "  sprites:\n"
+        "    - path: data/sprite/offline/missing.png\n"
+        "      voice_path: data/speech/offline/missing.wav\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(unrelated)
+    manager = object.__new__(ConfigManager)
+    manager._project_root = project
+    manager._API_CONFIG_PATH = paths["api"]
+    manager._CHARACTERS_CONFIG_PATH = paths["characters"]
+    manager._SYSTEM_CONFIG_PATH = paths["system"]
+    manager._BACKGOUND_CONFIG_PATH = paths["background"]
+    manager._EFFECT_CONFIG_PATH = paths["effect"]
+
+    manager._load_all_configs()
+
+    sprite = manager.config.characters[0].sprites[0]
+    sprite_path = sprite.path if hasattr(sprite, "path") else sprite["path"]
+    voice_path = sprite.voice_path if hasattr(sprite, "voice_path") else sprite["voice_path"]
+    assert sprite_path == "data/sprite/offline/missing.png"
+    assert voice_path == "data/speech/offline/missing.wav"
+
+
+def test_config_migration_publishes_version_marker_only_after_other_files(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    config_dir = project / "data/config"
+    old_root = tmp_path / "removed-install"
+    config_dir.mkdir(parents=True)
+    paths = {
+        "api": config_dir / "api.yaml",
+        "characters": config_dir / "characters.yaml",
+        "system": config_dir / "system_config.yaml",
+        "background": config_dir / "background.yaml",
+        "effect": config_dir / "effect.yaml",
+    }
+    payloads = {
+        paths["api"]: {
+            "gpt_sovits_api_path": (
+                old_root / "data/tts_bundles/installed/gpt"
+            ).as_posix(),
+        },
+        paths["characters"]: [
+            {
+                "name": "Offline",
+                "color": "#fff",
+                "sprite_prefix": "offline",
+                "gpt_model_path": (
+                    old_root / "data/models/offline/model.ckpt"
+                ).as_posix(),
+                "sprites": [],
+            }
+        ],
+        paths["system"]: {},
+        paths["background"]: [],
+        paths["effect"]: [],
+    }
+    manager = object.__new__(ConfigManager)
+    manager._project_root = project
+    manager._API_CONFIG_PATH = paths["api"]
+    manager._CHARACTERS_CONFIG_PATH = paths["characters"]
+    manager._SYSTEM_CONFIG_PATH = paths["system"]
+    manager._BACKGOUND_CONFIG_PATH = paths["background"]
+    manager._EFFECT_CONFIG_PATH = paths["effect"]
+    manager._load_yaml = lambda path: payloads[path]
+    attempted: list[str] = []
+
+    def fail_character_write(path, _data):
+        attempted.append(path.name)
+        if path == paths["characters"]:
+            raise OSError("disk full")
+
+    manager._save_single_config = fail_character_write
+
+    with pytest.raises(Exception, match="disk full"):
+        manager._load_all_configs()
+
+    assert attempted == ["api.yaml", "characters.yaml"]
+    assert "system_config.yaml" not in attempted
+
+
+def test_stale_external_data_paths_are_not_guessed_to_be_project_assets(tmp_path):
+    project = tmp_path / "project"
+    old_external = tmp_path / "offline-disk" / "data" / "third-party"
+    api = {
+        "gpt_sovits_api_path": (old_external / "tts-server").as_posix(),
+        "t2i_work_path": (old_external / "ComfyUI").as_posix(),
+    }
+    system = {
+        "chat_ui_theme_path": (old_external / "custom-theme.json").as_posix(),
+    }
+
+    changed = _migrate_config_asset_paths(
+        root=project,
+        api_data=api,
+        characters_data=[],
+        system_data=system,
+        background_data=[],
+        effect_data=[],
+    )
+
+    assert changed == set()
+    assert api["gpt_sovits_api_path"] == (old_external / "tts-server").as_posix()
+    assert api["t2i_work_path"] == (old_external / "ComfyUI").as_posix()
+    assert system["chat_ui_theme_path"] == (old_external / "custom-theme.json").as_posix()
+
+
+def test_character_config_write_serializes_current_project_assets_relatively(tmp_path):
+    project = tmp_path / "project"
+    project_model = project / "data/models/mika/model.ckpt"
+    external_model = tmp_path / "external/model.pth"
+    project_model.parent.mkdir(parents=True)
+    external_model.parent.mkdir(parents=True)
+    project_model.write_bytes(b"gpt")
+    external_model.write_bytes(b"sovits")
+    manager = _config_manager_with_api()
+    manager._project_root = project
+    manager._CHARACTERS_CONFIG_PATH = project / "data/config/characters.yaml"
+    manager.config.characters[0].gpt_model_path = project_model.as_posix()
+    manager.config.characters[0].sovits_model_path = external_model.as_posix()
+    captured = {}
+    manager._save_single_config = lambda _path, data: captured.update(payload=data)
+
+    manager.save_characters_config()
+
+    assert captured["payload"][0]["gpt_model_path"] == "data/models/mika/model.ckpt"
+    assert captured["payload"][0]["sovits_model_path"] == external_model.as_posix()
 
 
 def _save_api_config_for_test(manager: ConfigManager, **overrides) -> str:
@@ -49,6 +760,22 @@ def _save_api_config_for_test(manager: ConfigManager, **overrides) -> str:
     }
     params.update(overrides)
     return manager.save_api_config_new(**params)
+
+
+def test_save_api_config_new_failure_restores_previous_memory_config(monkeypatch):
+    manager = _config_manager_with_api()
+    previous = manager.config.api_config
+
+    def fail_save():
+        raise OSError("disk full")
+
+    monkeypatch.setattr(manager, "save_api_config", fail_save)
+
+    with pytest.raises(OSError, match="disk full"):
+        _save_api_config_for_test(manager, llm_model="changed-model")
+
+    assert manager.config.api_config is previous
+    assert manager.config.api_config.llm_model["Deepseek"] == "deepseek-chat"
 
 
 def test_get_llm_api_config_defaults_known_provider_base_url_when_empty():
@@ -185,6 +912,7 @@ def test_save_api_config_new_clamps_compact_target_below_threshold():
 def test_save_api_config_new_rejects_local_tts_without_server_path(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     manager = _config_manager_with_api()
+    manager._project_root = tmp_path
     saved = {}
     manager._save_single_config = lambda _path, data: saved.update(data)
 
@@ -202,6 +930,7 @@ def test_save_api_config_new_rejects_local_tts_without_server_path(tmp_path, mon
 def test_save_api_config_new_rejects_remote_gpt_sovits_without_server_path(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     manager = _config_manager_with_api()
+    manager._project_root = tmp_path
     saved = {}
     manager._save_single_config = lambda _path, data: saved.update(data)
 
@@ -223,6 +952,7 @@ def test_save_api_config_new_defaults_local_tts_path_to_installed_bundle_root(tm
     bundle_root.mkdir(parents=True)
     (bundle_root / "api_v2.py").write_text("", encoding="utf-8")
     manager = _config_manager_with_api()
+    manager._project_root = tmp_path
     saved = {}
     manager._save_single_config = lambda _path, data: saved.update(data)
     expected_path = bundle_root.resolve().as_posix()
@@ -237,7 +967,75 @@ def test_save_api_config_new_defaults_local_tts_path_to_installed_bundle_root(tm
     assert result == "API配置已保存！"
     assert manager.config.api_config.gpt_sovits_url == "http://127.0.0.1:9880"
     assert manager.config.api_config.gpt_sovits_api_path == expected_path
-    assert saved["gpt_sovits_api_path"] == expected_path
+    assert saved["gpt_sovits_api_path"] == (
+        "data/tts_bundles/installed/gpt_sovits_v2pro/"
+        "GPT-SoVITS-v2pro-20250604"
+    )
+
+
+def test_save_api_config_new_rejects_unusable_comfyui_paths_before_mutation(tmp_path):
+    manager = _config_manager_with_api()
+    manager._project_root = tmp_path
+    previous = manager.config.api_config
+    saved = {}
+    manager._save_single_config = lambda _path, data: saved.update(data)
+
+    result = _save_api_config_for_test(
+        manager,
+        t2i_default_workflow_path="data/workflows/missing.json",
+    )
+
+    assert "ComfyUI 默认工作流必须是已存在的文件" in result
+    assert manager.config.api_config is previous
+    assert saved == {}
+
+
+def test_save_api_config_new_accepts_project_relative_comfyui_paths(tmp_path):
+    workflow = tmp_path / "data" / "workflows" / "sprite.json"
+    work_directory = tmp_path / "data" / "comfyui"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    work_directory.mkdir(parents=True)
+    manager = _config_manager_with_api()
+    manager._project_root = tmp_path
+    saved = {}
+    manager._save_single_config = lambda _path, data: saved.update(data)
+
+    result = _save_api_config_for_test(
+        manager,
+        t2i_work_path="data/comfyui",
+        t2i_default_workflow_path="data/workflows/sprite.json",
+    )
+
+    assert result == "API配置已保存！"
+    assert saved["t2i_work_path"] == "data/comfyui"
+    assert saved["t2i_default_workflow_path"] == "data/workflows/sprite.json"
+
+
+def test_save_api_config_new_rejects_linked_comfyui_work_directory(tmp_path):
+    workflow = tmp_path / "data" / "workflows" / "sprite.json"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("{}", encoding="utf-8")
+    external = tmp_path / "external"
+    external.mkdir()
+    linked_work = tmp_path / "data" / "comfyui"
+    try:
+        linked_work.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    manager = _config_manager_with_api()
+    manager._project_root = tmp_path
+    saved = {}
+    manager._save_single_config = lambda _path, data: saved.update(data)
+
+    result = _save_api_config_for_test(
+        manager,
+        t2i_work_path="data/comfyui",
+        t2i_default_workflow_path="data/workflows/sprite.json",
+    )
+
+    assert "symbolic link" in result
+    assert saved == {}
 
 
 def test_save_system_config_applies_network_proxy_environment(monkeypatch):
@@ -253,7 +1051,10 @@ def test_save_system_config_applies_network_proxy_environment(monkeypatch):
     ):
         monkeypatch.delenv(name, raising=False)
         monkeypatch.setitem(network_proxy._ORIGINAL_PROXY_ENV, name, None)
-    monkeypatch.setattr("config.config_manager.apply_mirror_environment", lambda _config: None)
+    monkeypatch.setattr(
+        "config.config_manager.apply_mirror_environment",
+        lambda _config, **_kwargs: None,
+    )
     manager = _config_manager_with_api()
     saved = {}
     manager._save_single_config = lambda _path, data: saved.update(data)

--- a/test/unit/managers/test_t2i_manager.py
+++ b/test/unit/managers/test_t2i_manager.py
@@ -29,6 +29,11 @@ class TestT2IAdapterFactoryRegistry:
 
 
 class TestT2IManagerWithMock:
+    @pytest.fixture(autouse=True)
+    def _isolated_project_root(self, monkeypatch, tmp_path):
+        self.project_root = tmp_path
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
     def test_init_starts_worker(self, mock_t2i_adapter):
         mgr = T2IManager(t2i_adapter=mock_t2i_adapter)
         assert mgr.worker_thread.is_alive()
@@ -83,8 +88,44 @@ class TestT2IManagerWithMock:
 
     def test_init_creates_cache_dir(self, mock_t2i_adapter):
         mgr = T2IManager(t2i_adapter=mock_t2i_adapter)
+        assert mgr.image_cache_dir == self.project_root / "data/cache/images"
         assert mgr.image_cache_dir.exists()
         mgr.shutdown()
+
+    def test_cache_root_does_not_follow_process_cwd(self, mock_t2i_adapter, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        unrelated = tmp_path / "unrelated"
+        project.mkdir()
+        unrelated.mkdir()
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+        monkeypatch.chdir(unrelated)
+
+        mgr = T2IManager(t2i_adapter=mock_t2i_adapter)
+
+        assert mgr.image_cache_dir == project / "data/cache/images"
+        assert not (unrelated / "data/cache/images").exists()
+        mgr.shutdown()
+
+    def test_relative_cache_path_cannot_escape_project(self, mock_t2i_adapter):
+        with pytest.raises(PermissionError, match="escapes project root"):
+            T2IManager(t2i_adapter=mock_t2i_adapter, image_cache_dir="../outside")
+
+    def test_explicit_empty_cache_path_does_not_fall_back_to_default(
+        self,
+        mock_t2i_adapter,
+    ):
+        with pytest.raises(ValueError, match="path is empty"):
+            T2IManager(t2i_adapter=mock_t2i_adapter, image_cache_dir="")
+
+    def test_explicit_project_root_rejects_outer_whitespace(
+        self,
+        mock_t2i_adapter,
+    ):
+        with pytest.raises(ValueError, match="project root"):
+            T2IManager(
+                t2i_adapter=mock_t2i_adapter,
+                project_root=f" {self.project_root}",
+            )
 
     def test_queue_generation_processes_via_t2i(self, mock_t2i_adapter):
         """queue_generation puts a task; the worker calls t2i() to handle it."""

--- a/test/unit/managers/test_tts_manager.py
+++ b/test/unit/managers/test_tts_manager.py
@@ -1,6 +1,7 @@
 """Unit tests for TTSManager — factory, queue behavior, adapter switching."""
 
 import time
+import os
 from pathlib import Path
 
 import pytest
@@ -166,7 +167,6 @@ class TestTTSManagerWithMock:
         mgr.audio_cache_dir = tmp_path
 
         final_audio = tmp_path / "0.wav"
-        part_audio = tmp_path / "0.wav.part"
         final_audio.write_bytes(b"old audio")
         ref_audio = tmp_path / "ref.wav"
         ref_audio.write_text("fake ref")
@@ -181,8 +181,11 @@ class TestTTSManagerWithMock:
 
             assert result == str(final_audio)
             assert final_audio.read_bytes() == b"fake audio data"
-            assert not part_audio.exists()
-            assert mock_tts_adapter.call_history[-1]["file_path"] == str(part_audio)
+            staging = Path(mock_tts_adapter.call_history[-1]["file_path"])
+            assert staging.parent == tmp_path
+            assert staging.name.startswith(".0.wav.")
+            assert staging.name.endswith(".part")
+            assert not staging.exists()
         finally:
             mgr.shutdown()
 
@@ -192,6 +195,81 @@ class TestTTSManagerWithMock:
         result = mgr.generate_tts(text="Hello", ref_audio_path=None)
         assert result == ""
         mgr.shutdown()
+
+    def test_generate_tts_rejects_reference_audio_alias_before_adapter_call(
+        self,
+        mock_tts_adapter,
+        tmp_path,
+        monkeypatch,
+    ):
+        project = tmp_path / "project"
+        reference = project / "data" / "speech" / "ref.wav"
+        reference.parent.mkdir(parents=True)
+        reference.write_bytes(b"wav")
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+        mgr = TTSManager()
+        mgr.set_tts_adapter(mock_tts_adapter)
+        try:
+            result = mgr.generate_tts(
+                text="Hello",
+                ref_audio_path="data/speech/./ref.wav",
+            )
+        finally:
+            mgr.shutdown()
+
+        assert result == ""
+        assert mock_tts_adapter.call_history == []
+
+    def test_generate_tts_rejects_symlinked_reference_before_adapter_call(
+        self,
+        mock_tts_adapter,
+        tmp_path,
+    ):
+        project = tmp_path / "project"
+        external = tmp_path / "external.wav"
+        reference = project / "data" / "speech" / "ref.wav"
+        reference.parent.mkdir(parents=True)
+        external.write_bytes(b"wav")
+        try:
+            reference.symlink_to(external)
+        except (NotImplementedError, OSError):
+            pytest.skip("file symlinks are unavailable")
+        mgr = TTSManager(project_root=project)
+        mgr.set_tts_adapter(mock_tts_adapter)
+        try:
+            result = mgr.generate_tts(
+                text="Hello",
+                ref_audio_path="data/speech/ref.wav",
+            )
+        finally:
+            mgr.shutdown()
+
+        assert result == ""
+        assert mock_tts_adapter.call_history == []
+
+    def test_generate_tts_resolves_relative_reference_against_manager_root(
+        self,
+        mock_tts_adapter,
+        tmp_path,
+    ):
+        project = tmp_path / "project"
+        reference = project / "data" / "speech" / "ref.wav"
+        reference.parent.mkdir(parents=True)
+        reference.write_bytes(b"wav")
+        mgr = TTSManager(project_root=project)
+        mgr.set_tts_adapter(mock_tts_adapter)
+        try:
+            result = mgr.generate_tts(
+                text="Hello",
+                ref_audio_path="data/speech/ref.wav",
+            )
+        finally:
+            mgr.shutdown()
+
+        assert result
+        assert mock_tts_adapter.call_history[0]["kwargs"]["ref_audio_path"] == (
+            reference.as_posix()
+        )
 
     def test_generate_tts_retries_empty_audio_result(self):
         adapter = EmptyThenSuccessTTSAdapter()
@@ -210,9 +288,73 @@ class TestTTSManagerWithMock:
         mgr.audio_cache_dir = tmp_path
         result = mgr.generate_tts(text="Hello", ref_audio_path="ref.wav")
         assert result == ""
-        assert not (tmp_path / "0.wav.part").exists()
+        assert not list(tmp_path.glob(".0.wav.*.part"))
         assert len(adapter.call_history) == 2
         mgr.shutdown()
+
+    def test_generate_tts_rejects_cache_directory_replaced_during_adapter_call(
+        self,
+        tmp_path,
+    ):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        preserved_cache = tmp_path / "preserved-cache"
+        reference = tmp_path / "ref.wav"
+        reference.write_bytes(b"reference")
+
+        class ReplacingCacheAdapter(MockTTSAdapter):
+            def generate_speech(self, text, file_path=None, **kwargs):
+                self.call_history.append(
+                    {"text": text, "file_path": file_path, "kwargs": kwargs}
+                )
+                cache.rename(preserved_cache)
+                cache.mkdir()
+                (cache / "0.wav").write_bytes(b"peer")
+                staging = Path(file_path)
+                staging.write_bytes(b"generated")
+                return str(staging)
+
+        mgr = TTSManager()
+        mgr.audio_cache_dir = cache
+        mgr.set_tts_adapter(ReplacingCacheAdapter())
+        try:
+            with pytest.raises(PermissionError, match="parent identity changed"):
+                mgr.generate_tts(text="Hello", ref_audio_path=reference)
+        finally:
+            mgr.shutdown()
+
+        assert (cache / "0.wav").read_bytes() == b"peer"
+        assert list(preserved_cache.iterdir()) == []
+        assert not list(cache.glob(".*.part"))
+
+    def test_generate_tts_rejects_cache_destination_symlink(
+        self,
+        mock_tts_adapter,
+        tmp_path,
+    ):
+        mgr = TTSManager()
+        mgr.set_tts_adapter(mock_tts_adapter)
+        mgr.audio_cache_dir = tmp_path
+        external = tmp_path / "external.wav"
+        final_audio = tmp_path / "0.wav"
+        reference = tmp_path / "ref.wav"
+        external.write_bytes(b"private")
+        reference.write_bytes(b"reference")
+        try:
+            final_audio.symlink_to(external)
+        except (OSError, NotImplementedError):
+            mgr.shutdown()
+            pytest.skip("symbolic links are unavailable")
+
+        try:
+            with pytest.raises(PermissionError, match="symbolic link"):
+                mgr.generate_tts(text="Hello", ref_audio_path=reference)
+        finally:
+            mgr.shutdown()
+
+        assert final_audio.is_symlink()
+        assert external.read_bytes() == b"private"
+        assert not list(tmp_path.glob(".0.wav.*.part"))
 
     def test_set_language(self, mock_tts_adapter):
         mgr = TTSManager()
@@ -245,6 +387,119 @@ class TestTTSManagerWithMock:
         mgr = TTSManager()
         assert mgr.audio_cache_dir.exists()
         mgr.shutdown()
+
+    def test_cache_directory_uses_project_root_after_cwd_changes(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        unrelated = tmp_path / "unrelated"
+        project.mkdir()
+        unrelated.mkdir()
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+        monkeypatch.chdir(unrelated)
+
+        mgr = TTSManager()
+        try:
+            assert mgr.audio_cache_dir == project / "data/cache/audio"
+            assert mgr.audio_cache_dir.is_dir()
+            assert not (unrelated / "data").exists()
+        finally:
+            mgr.shutdown()
+
+    def test_audio_validation_uses_the_manager_project_root(self, tmp_path, monkeypatch):
+        manager_project = tmp_path / "manager-project"
+        ambient_project = tmp_path / "ambient-project"
+        ambient_project.mkdir()
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient_project.as_posix())
+
+        mgr = TTSManager(project_root=manager_project)
+        try:
+            audio = manager_project / "data/cache/audio/probe.wav"
+            audio.write_bytes(b"audio")
+
+            assert mgr._is_valid_audio_file("data/cache/audio/probe.wav")
+            assert not (ambient_project / "data/cache/audio/probe.wav").exists()
+        finally:
+            mgr.shutdown()
+
+    def test_legacy_loader_uses_manager_root_and_native_bundled_python(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        project = tmp_path / "project"
+        work_root = project / "engines" / "gpt-sovits"
+        runtime_python = (
+            work_root / "runtime/python.exe"
+            if os.name == "nt"
+            else work_root / "runtime/bin/python3"
+        )
+        runtime_python.parent.mkdir(parents=True)
+        runtime_python.write_bytes(b"python")
+        runtime_python.chmod(runtime_python.stat().st_mode | 0o100)
+        api_path = work_root / "api_v2.py"
+        api_path.write_text("", encoding="utf-8")
+        calls = []
+        monkeypatch.setenv("PYTHONHOME", "/stale/python")
+        monkeypatch.setenv("PYTHONPATH", "/stale/project")
+        monkeypatch.setattr(
+            "ai.tts.tts_manager.subprocess.Popen",
+            lambda command, **kwargs: calls.append((command, kwargs)),
+        )
+        mgr = TTSManager(project_root=project)
+        try:
+            mgr.load_tts_model("engines/gpt-sovits")
+        finally:
+            mgr.shutdown()
+
+        assert len(calls) == 1
+        command, kwargs = calls[0]
+        assert command == [str(runtime_python), str(api_path)]
+        assert kwargs["cwd"] == str(work_root)
+        assert kwargs["env"]["PYTHONNOUSERSITE"] == "1"
+        assert "PYTHONHOME" not in kwargs["env"]
+        assert "PYTHONPATH" not in kwargs["env"]
+
+    def test_legacy_loader_rejects_linked_startup_script(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        project = tmp_path / "project"
+        work_root = project / "engines" / "gpt-sovits"
+        runtime_python = (
+            work_root / "runtime/python.exe"
+            if os.name == "nt"
+            else work_root / "runtime/bin/python3"
+        )
+        runtime_python.parent.mkdir(parents=True)
+        runtime_python.write_bytes(b"python")
+        runtime_python.chmod(runtime_python.stat().st_mode | 0o100)
+        external_script = tmp_path / "api_v2.py"
+        external_script.write_text("", encoding="utf-8")
+        try:
+            (work_root / "api_v2.py").symlink_to(external_script)
+        except (NotImplementedError, OSError):
+            pytest.skip("file symlinks are unavailable")
+        calls = []
+        monkeypatch.setattr(
+            "ai.tts.tts_manager.subprocess.Popen",
+            lambda command, **kwargs: calls.append((command, kwargs)),
+        )
+        mgr = TTSManager(project_root=project)
+        try:
+            with pytest.raises(PermissionError, match="symbolic link"):
+                mgr.load_tts_model("engines/gpt-sovits")
+        finally:
+            mgr.shutdown()
+
+        assert calls == []
+
+    def test_legacy_loader_has_no_machine_specific_default(self, tmp_path):
+        mgr = TTSManager(project_root=tmp_path)
+        try:
+            with pytest.raises(ValueError, match="work path is required"):
+                mgr.load_tts_model()
+        finally:
+            mgr.shutdown()
 
     def test_queue_speech_with_mock(self, mock_tts_adapter, tmp_path):
         """queue_speech calls generate_tts which queues work; mock generate_tts."""

--- a/test/unit/plugin_system/test_host_bindings.py
+++ b/test/unit/plugin_system/test_host_bindings.py
@@ -78,11 +78,20 @@ def test_plugin_host_applies_application_runtime_bindings(monkeypatch, tmp_path)
     }
 
     monkeypatch.setattr(service, "_loaded", False)
+    monkeypatch.setattr(service, "_loaded_project_root", None)
     monkeypatch.setattr(service, "_plugin_manager", None)
     monkeypatch.setattr(service, "_MANIFEST", tmp_path / "missing.yaml")
-    monkeypatch.setattr(service, "PluginManager", lambda: manager)
-    monkeypatch.setattr(service, "ensure_plugins_namespace_on_syspath", lambda: None)
-    monkeypatch.setattr(service, "ensure_plugin_site_packages_on_syspath", lambda: None)
+    monkeypatch.setattr(service, "PluginManager", lambda **_kwargs: manager)
+    monkeypatch.setattr(
+        service,
+        "ensure_plugins_namespace_on_syspath",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        service,
+        "ensure_plugin_site_packages_on_syspath",
+        lambda **_kwargs: None,
+    )
     monkeypatch.setattr("sdk.tool_registry.apply_registered_tools", lambda value: calls.setdefault("sdk_tools", value))
 
     bindings = PluginRuntimeBindings(

--- a/test/unit/plugin_system/test_package_install.py
+++ b/test/unit/plugin_system/test_package_install.py
@@ -17,6 +17,7 @@ from plugin_system.install.package import (
     PluginPackageNetworkError,
     PluginPackageNonFallbackError,
     install_registry_package_under_plugins,
+    registry_package_target,
 )
 from plugin_system.registry.catalog import RegistryPluginRecord
 
@@ -69,6 +70,26 @@ class _FakeResponse:
         body = self._body
         self._body = b""
         return body
+
+
+def test_private_package_cleanup_preserves_a_replacement_directory(tmp_path):
+    private = tmp_path / "private"
+    preserved = tmp_path / "preserved"
+    private.mkdir()
+    (private / "owned.txt").write_text("owned", encoding="utf-8")
+    identity = private.lstat()
+    private.rename(preserved)
+    private.mkdir()
+    replacement = private / "replacement.txt"
+    replacement.write_text("replacement", encoding="utf-8")
+
+    package_download._cleanup_private_tree(
+        private,
+        expected_identity=identity,
+    )
+
+    assert replacement.read_text(encoding="utf-8") == "replacement"
+    assert (preserved / "owned.txt").read_text(encoding="utf-8") == "owned"
 
 
 def test_registry_package_install_verifies_checksum_size_and_extracts(tmp_path, monkeypatch):
@@ -228,6 +249,30 @@ def test_registry_package_install_skips_download_when_target_exists_without_over
     assert (target / "plugin.py").read_text(encoding="utf-8") == "old\n"
 
 
+def test_registry_package_no_overwrite_rechecks_target_after_download(tmp_path, monkeypatch):
+    body = _zip_bytes({"demo-plugin/plugin.py": "stale downloader\n"})
+    sha = hashlib.sha256(body).hexdigest()
+    target = tmp_path / "demo-plugin"
+
+    def publish_peer_then_respond(*_args, **_kwargs):
+        target.mkdir()
+        (target / "plugin.py").write_text("peer install\n", encoding="utf-8")
+        return _FakeResponse(body)
+
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+    monkeypatch.setattr(package_download, "urlopen", publish_peer_then_respond)
+
+    result = install_registry_package_under_plugins(
+        _record(sha256=sha, size=len(body)),
+        plugins_parent=tmp_path,
+        overwrite=False,
+    )
+
+    assert result == target.resolve(strict=False)
+    assert (target / "plugin.py").read_text(encoding="utf-8") == "peer install\n"
+    assert not list(tmp_path.glob(".demo-plugin.backup-*"))
+
+
 def test_registry_package_install_rolls_back_old_directory_when_overwrite_replace_fails(
     tmp_path,
     monkeypatch,
@@ -241,10 +286,14 @@ def test_registry_package_install_rolls_back_old_directory_when_overwrite_replac
     monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
     monkeypatch.setattr(package_download, "urlopen", lambda *_args, **_kwargs: _FakeResponse(body))
 
-    def fail_move(_source, _target):
+    def fail_publish(_source, _target, **_kwargs):
         raise OSError("simulated replace failure")
 
-    monkeypatch.setattr(package_download.shutil, "move", fail_move)
+    monkeypatch.setattr(
+        package_download,
+        "replace_directory_transactionally",
+        fail_publish,
+    )
 
     with pytest.raises(OSError, match="simulated replace failure"):
         install_registry_package_under_plugins(
@@ -296,3 +345,267 @@ def test_registry_download_persists_and_reads_install_metadata(tmp_path, monkeyp
     raw = json.loads(state_path.read_text(encoding="utf-8"))
     assert raw["repos"] == ["owner/demo"]
     assert "plugins.demo.plugin:DemoPlugin" in raw["entry_install"]
+
+    assert registry_download.load_plugin_install_metadata(
+        " demo.plugin:DemoPlugin"
+    ) == {}
+    with pytest.raises(ValueError, match="exact portable"):
+        registry_download.mark_repo_downloaded(
+            "owner/other",
+            manifest_entry=" demo.plugin:DemoPlugin",
+        )
+
+
+def test_registry_download_state_uses_project_root_when_cwd_changes(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project_root.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+    monkeypatch.chdir(unrelated)
+
+    registry_download.mark_repo_downloaded("owner/demo")
+
+    state_path = project_root / "data" / "config" / "plugin_registry_downloads.json"
+    assert state_path.is_file()
+    assert not (unrelated / "data").exists()
+
+
+def test_registry_download_state_prefers_explicit_root_over_ambient_root(
+    tmp_path,
+    monkeypatch,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+
+    registry_download.mark_repo_downloaded(
+        "owner/demo",
+        manifest_entry="plugins.demo:Plugin",
+        root=selected,
+    )
+
+    assert registry_download.load_downloaded_repos(root=selected) == {
+        "owner/demo"
+    }
+    assert (
+        selected / "data/config/plugin_registry_downloads.json"
+    ).is_file()
+    assert not (
+        ambient / "data/config/plugin_registry_downloads.json"
+    ).exists()
+
+
+def test_registry_package_default_target_uses_project_root_not_cwd(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+
+    target = registry_package_target(_record())
+
+    assert target == project / "plugins/demo-plugin"
+
+
+def test_registry_package_explicit_parent_must_be_absolute(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="absolute"):
+        registry_package_target(_record(), plugins_parent=Path("relative-plugins"))
+
+
+def test_registry_package_explicit_parent_does_not_expand_user_home_alias():
+    with pytest.raises(ValueError, match="absolute"):
+        registry_package_target(_record(), plugins_parent=Path("~/plugins"))
+
+
+def test_registry_package_rejects_symlink_parent(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    linked = tmp_path / "plugins"
+    linked.symlink_to(real, target_is_directory=True)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        registry_package_target(_record(), plugins_parent=linked)
+
+
+def test_registry_package_rejects_intermediate_alias_inside_project(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    alias = project / "alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        registry_package_target(
+            _record(),
+            plugins_parent=alias / "plugins",
+        )
+
+
+def test_registry_package_rejects_intermediate_alias_outside_project(tmp_path):
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        registry_package_target(
+            _record(),
+            plugins_parent=alias / "plugins",
+        )
+
+
+def test_registry_package_replace_rejects_existing_file_without_touching_it(tmp_path):
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    (extracted / "plugin.py").write_text("new", encoding="utf-8")
+    target = tmp_path / "plugins/demo-plugin"
+    target.parent.mkdir()
+    target.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(PluginPackageNonFallbackError, match="not a directory"):
+        package_download._replace_directory(extracted, target)
+
+    assert target.read_text(encoding="utf-8") == "keep"
+    assert (extracted / "plugin.py").is_file()
+
+
+def test_registry_package_target_uses_portable_windows_device_name_on_all_platforms(tmp_path):
+    target = registry_package_target(_record(name="CON"), plugins_parent=tmp_path)
+
+    assert target.name == "CON_plugin"
+
+
+def test_registry_package_target_rejects_case_only_portable_collision(tmp_path):
+    (tmp_path / "Demo-Plugin").mkdir()
+
+    with pytest.raises(PluginPackageNonFallbackError, match="portable filesystem") as error:
+        registry_package_target(_record(name="demo-plugin"), plugins_parent=tmp_path)
+
+    assert error.value.code == "package_name_collision"
+
+
+def test_source_plugin_target_rejects_unicode_normalization_collision(tmp_path):
+    (tmp_path / "Caf\N{LATIN SMALL LETTER E WITH ACUTE}").mkdir()
+
+    with pytest.raises(FileExistsError, match="portable filesystem"):
+        registry_download.portable_plugin_target(tmp_path, "Cafe\N{COMBINING ACUTE ACCENT}")
+
+
+def test_registry_package_install_rejects_symlink_target_without_touching_external_data(
+    tmp_path,
+    monkeypatch,
+):
+    plugins = tmp_path / "plugins"
+    external = tmp_path / "external"
+    plugins.mkdir()
+    external.mkdir()
+    marker = external / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    try:
+        (plugins / "demo-plugin").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PLUGIN_PACKAGE_HOSTS", "packages.example")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        install_registry_package_under_plugins(
+            _record(sha256="0" * 64, size=1),
+            plugins_parent=plugins,
+            overwrite=True,
+        )
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_github_source_download_extracts_through_staging_directory(tmp_path, monkeypatch):
+    body = _zip_bytes({"demo-main/plugin.py": "plugin"})
+    plugins = tmp_path / "plugins"
+    monkeypatch.setattr(registry_download, "urlopen", lambda *_args, **_kwargs: _FakeResponse(body))
+
+    target = registry_download.download_github_repo_sources(
+        "owner/demo",
+        plugins_parent=plugins,
+        folder_name="Demo",
+    )
+
+    assert target == (plugins / "Demo").resolve()
+    assert (target / "plugin.py").read_text(encoding="utf-8") == "plugin"
+    assert not list(plugins.glob(".Demo.install-*"))
+
+
+def test_github_source_download_rejects_parent_lexical_alias_before_network(
+    tmp_path,
+    monkeypatch,
+):
+    called = False
+
+    def fail_network(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network must not run")
+
+    monkeypatch.setattr(registry_download, "urlopen", fail_network)
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        registry_download.download_github_repo_sources(
+            "owner/demo",
+            plugins_parent=f"{tmp_path.as_posix()}/./plugins",
+            folder_name="Demo",
+        )
+
+    assert called is False
+
+
+def test_github_source_download_rejects_user_home_parent_before_network(monkeypatch):
+    called = False
+
+    def fail_network(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network must not run")
+
+    monkeypatch.setattr(registry_download, "urlopen", fail_network)
+
+    with pytest.raises(ValueError, match="absolute"):
+        registry_download.download_github_repo_sources(
+            "owner/demo",
+            plugins_parent="~/plugins",
+            folder_name="Demo",
+        )
+
+    assert called is False
+
+
+def test_github_source_download_rejects_backslash_traversal_before_publish(tmp_path, monkeypatch):
+    body = _zip_bytes(
+        {
+            "demo-main/plugin.py": "plugin",
+            r"demo-main\..\outside.py": "bad",
+        }
+    )
+    plugins = tmp_path / "plugins"
+    monkeypatch.setattr(registry_download, "urlopen", lambda *_args, **_kwargs: _FakeResponse(body))
+
+    with pytest.raises(ValueError, match="archive"):
+        registry_download.download_github_repo_sources(
+            "owner/demo",
+            plugins_parent=plugins,
+            folder_name="Demo",
+        )
+
+    assert not (plugins / "Demo").exists()
+    assert not (tmp_path / "outside.py").exists()

--- a/test/unit/plugin_system/test_plugin_manifest_paths.py
+++ b/test/unit/plugin_system/test_plugin_manifest_paths.py
@@ -1,0 +1,159 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from plugin_system.host.service import (
+    _plugin_manifest_path,
+    append_plugin_manifest_entry_if_missing,
+    managed_plugin_package_directory,
+    read_plugin_manifest_items,
+    remove_plugin_manifest_entry,
+    set_plugin_manifest_enabled,
+    write_plugin_manifest_items,
+)
+
+
+def test_plugin_manifest_path_rejects_outer_whitespace(tmp_path):
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        _plugin_manifest_path(Path(f" {tmp_path}/plugins.yaml"))
+
+
+def test_plugin_manifest_path_rejects_absolute_lexical_alias(tmp_path):
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        _plugin_manifest_path(
+            f"{tmp_path.as_posix()}/./plugins.yaml",
+        )
+
+
+def test_plugin_manifest_path_rejects_symlinked_external_parent(tmp_path):
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _plugin_manifest_path(alias / "plugins.yaml")
+
+
+def test_plugin_manifest_mutations_reject_whitespace_aliases(tmp_path):
+    manifest = tmp_path / "plugins.yaml"
+    write_plugin_manifest_items([{"entry": "plugins.demo:Plugin"}], manifest)
+
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        set_plugin_manifest_enabled(" plugins.demo:Plugin", False, manifest)
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        remove_plugin_manifest_entry("plugins.demo:Plugin ", manifest)
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        append_plugin_manifest_entry_if_missing(" demo.plugin:Plugin", path=manifest)
+
+    assert read_plugin_manifest_items(manifest) == [
+        {"entry": "plugins.demo:Plugin"}
+    ]
+
+
+def test_plugin_manifest_writer_rejects_invalid_entry_identity(tmp_path):
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        write_plugin_manifest_items(
+            [{"entry": " plugins.demo:Plugin"}],
+            tmp_path / "plugins.yaml",
+        )
+
+
+def test_concurrent_manifest_appends_do_not_lose_entries(tmp_path):
+    manifest = tmp_path / "plugins.yaml"
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(
+            executor.map(
+                lambda index: append_plugin_manifest_entry_if_missing(
+                    f"demo_{index}.plugin:Plugin",
+                    path=manifest,
+                ),
+                range(20),
+            )
+        )
+
+    assert results.count("added") == 20
+    assert {item["entry"] for item in read_plugin_manifest_items(manifest)} == {
+        f"plugins.demo_{index}.plugin:Plugin" for index in range(20)
+    }
+
+
+def test_manifest_publish_failure_preserves_previous_yaml(tmp_path, monkeypatch):
+    manifest = tmp_path / "plugins.yaml"
+    write_plugin_manifest_items([{"entry": "plugins.old:Plugin"}], manifest)
+    previous = manifest.read_text(encoding="utf-8")
+
+    def fail_replace(_source, _target, **_kwargs):
+        raise OSError("publish failed")
+
+    monkeypatch.setattr(
+        "core.file_transactions.replace_file_transactionally",
+        fail_replace,
+    )
+
+    with pytest.raises(OSError, match="publish failed"):
+        write_plugin_manifest_items([{"entry": "plugins.new:Plugin"}], manifest)
+
+    assert manifest.read_text(encoding="utf-8") == previous
+
+
+def test_default_manifest_rejects_intermediate_symlink_escape(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    data = project / "data"
+    external = tmp_path / "external-config"
+    data.mkdir(parents=True)
+    external.mkdir()
+    try:
+        (data / "config").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.delenv("EASYAI_PROJECT_ROOT", raising=False)
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        write_plugin_manifest_items([{"entry": "plugins.demo:Plugin"}])
+
+    assert not (external / "plugins.yaml").exists()
+
+
+def test_explicit_manifest_root_overrides_ambient_project_root(
+    tmp_path,
+    monkeypatch,
+):
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+
+    write_plugin_manifest_items(
+        [{"entry": "plugins.demo:Plugin"}],
+        root=selected,
+    )
+
+    assert read_plugin_manifest_items(root=selected) == [
+        {"entry": "plugins.demo:Plugin"}
+    ]
+    assert (selected / "data/config/plugins.yaml").is_file()
+    assert not (ambient / "data/config/plugins.yaml").exists()
+
+
+def test_strict_plugin_package_directory_rejects_exact_child_alias(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    plugins = project / "plugins"
+    external = tmp_path / "external-plugin"
+    plugins.mkdir(parents=True)
+    external.mkdir()
+    try:
+        (plugins / "demo").symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        managed_plugin_package_directory("plugins.demo.plugin:DemoPlugin")

--- a/test/unit/plugin_system/test_requirements.py
+++ b/test/unit/plugin_system/test_requirements.py
@@ -6,10 +6,154 @@ from pathlib import Path
 import pytest
 
 
+def test_frozen_plugin_paths_keep_app_runtime_and_project_data_separate(tmp_path, monkeypatch):
+    from plugin_system.requirements import install as installer
+
+    app_root = tmp_path / "app"
+    project_root = tmp_path / "project"
+    app_root.mkdir()
+    (project_root / "plugins").mkdir(parents=True)
+    monkeypatch.setattr(installer.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", app_root.as_posix())
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+    monkeypatch.setattr(installer.sys, "path", list(installer.sys.path))
+
+    installer.ensure_plugins_namespace_on_syspath()
+
+    assert installer.frozen_release_root() == app_root.resolve()
+    assert installer.plugin_pip_target_directory() == (
+        project_root / "data" / "plugin_site_packages"
+    )
+    assert installer.sys.path[0] == project_root.as_posix()
+
+
+def test_frozen_plugin_target_prefers_explicit_root_over_ambient_root(
+    tmp_path,
+    monkeypatch,
+):
+    from plugin_system.requirements import install as installer
+
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    ambient.mkdir()
+    selected.mkdir()
+    monkeypatch.setattr(installer.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+
+    assert installer.plugin_pip_target_directory(root=selected) == (
+        selected / "data/plugin_site_packages"
+    )
+
+
+def test_frozen_plugin_pip_uses_the_native_runtime_layout(tmp_path, monkeypatch):
+    from plugin_system.requirements import install as installer
+
+    app_root = tmp_path / "app"
+    runtime_python = (
+        app_root / "runtime/python.exe"
+        if os.name == "nt"
+        else app_root / "runtime/bin/python3"
+    )
+    runtime_python.parent.mkdir(parents=True)
+    runtime_python.write_bytes(b"python")
+    runtime_python.chmod(runtime_python.stat().st_mode | 0o100)
+    monkeypatch.setattr(installer.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", app_root.as_posix())
+
+    assert installer.pip_python_executable() == runtime_python
+
+
+def test_frozen_plugin_target_rejects_project_directory_alias(tmp_path, monkeypatch):
+    from plugin_system.requirements import install as installer
+
+    project_root = tmp_path / "project"
+    external_target = tmp_path / "external-plugin-site-packages"
+    (project_root / "data").mkdir(parents=True)
+    external_target.mkdir()
+    try:
+        (project_root / "data" / "plugin_site_packages").symlink_to(
+            external_target,
+            target_is_directory=True,
+        )
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    monkeypatch.setattr(installer.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        installer.plugin_pip_target_directory()
+
+
+def test_plugin_site_packages_rejects_alias_at_syspath_boundary(tmp_path, monkeypatch):
+    from plugin_system.requirements import install as installer
+
+    external_target = tmp_path / "external-plugin-site-packages"
+    external_target.mkdir()
+    alias = tmp_path / "plugin-site-packages"
+    try:
+        alias.symlink_to(external_target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    original_path = list(installer.sys.path)
+    monkeypatch.setattr(installer.sys, "path", original_path.copy())
+    monkeypatch.setattr(installer, "plugin_pip_target_directory", lambda: alias)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        installer.ensure_plugin_site_packages_on_syspath()
+
+    assert installer.sys.path == original_path
+
+
+def test_plugin_pip_command_rejects_alias_at_subprocess_boundary(tmp_path):
+    from plugin_system.requirements import install as installer
+
+    external_target = tmp_path / "external-plugin-site-packages"
+    external_target.mkdir()
+    alias = tmp_path / "plugin-site-packages"
+    try:
+        alias.symlink_to(external_target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        installer._pip_base_install_cmd(Path("python"), alias)
+
+
+def test_plugins_namespace_rejects_external_directory_alias(tmp_path, monkeypatch):
+    from plugin_system.requirements import install as installer
+
+    project_root = tmp_path / "project"
+    external_plugins = tmp_path / "external-plugins"
+    project_root.mkdir()
+    external_plugins.mkdir()
+    try:
+        (project_root / "plugins").symlink_to(external_plugins, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    original_path = list(installer.sys.path)
+    monkeypatch.setattr(installer.sys, "path", original_path.copy())
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project_root.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        installer.ensure_plugins_namespace_on_syspath()
+
+    assert installer.sys.path == original_path
+
+
 def _prepare_installer(monkeypatch, tmp_path):
     from plugin_system.requirements import install as installer
 
-    monkeypatch.setattr(installer, "pip_python_executable", lambda: Path("python"))
+    python_executable = tmp_path / "python"
+    python_executable.write_bytes(b"python")
+    python_executable.chmod(python_executable.stat().st_mode | 0o100)
+    monkeypatch.setattr(
+        installer,
+        "pip_python_executable",
+        lambda: python_executable,
+    )
     monkeypatch.setattr(installer, "plugin_pip_target_directory", lambda: None)
     monkeypatch.setattr(installer.sys, "platform", "linux")
 
@@ -48,6 +192,58 @@ def _write_requirements(plugin_root: Path, text: str) -> Path:
     req = plugin_root / "requirements.txt"
     req.write_text(text, encoding="utf-8")
     return req
+
+
+def test_installer_resolves_relative_plugin_root_from_project_not_cwd(
+    monkeypatch,
+    tmp_path,
+):
+    installer, _unused = _prepare_installer(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    plugin_root = project / "plugins/demo"
+    unrelated = tmp_path / "launcher"
+    plugin_root.mkdir(parents=True)
+    unrelated.mkdir()
+    _write_requirements(plugin_root, "missing-package>=2\n")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    calls = _capture_pip_invocation(monkeypatch, installer)
+
+    result = installer.install_plugin_requirements_txt(Path("plugins/demo"))
+
+    assert result == ("pip_ok", "")
+    assert calls[0]["cwd"] == plugin_root
+
+
+def test_installer_rejects_symlinked_plugin_root(monkeypatch, tmp_path):
+    from plugin_system.requirements import install as installer
+
+    project = tmp_path / "project"
+    external = tmp_path / "external-plugin"
+    alias = project / "plugins/demo"
+    alias.parent.mkdir(parents=True)
+    external.mkdir()
+    (external / "requirements.txt").write_text("requests\n", encoding="utf-8")
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        installer.install_plugin_requirements_txt(alias)
+
+
+def test_installer_rejects_requirements_filename_traversal(monkeypatch, tmp_path):
+    installer, plugin_root = _prepare_installer(monkeypatch, tmp_path)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("must-not-run\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="portable path component"):
+        installer.install_plugin_requirements_txt(
+            plugin_root,
+            requirements_file="../outside.txt",
+        )
 
 
 def test_finish_install_result_refreshes_plugin_target_on_success(monkeypatch):
@@ -531,17 +727,61 @@ def test_write_temp_requirements_removes_file_when_write_fails(monkeypatch, tmp_
         fd = os.open(str(created), os.O_CREAT | os.O_TRUNC | os.O_RDWR)
         return fd, str(created)
 
-    original_write_text = Path.write_text
+    real_fdopen = os.fdopen
 
-    def fail_write_text(self, *args, **kwargs):
-        if self == created:
+    class FailingWriter:
+        def __init__(self, handle):
+            self.handle = handle
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.handle.close()
+
+        def write(self, _text):
             raise OSError("disk full")
-        return original_write_text(self, *args, **kwargs)
+
+    def fail_fdopen(fd, *args, **kwargs):
+        return FailingWriter(real_fdopen(fd, *args, **kwargs))
 
     monkeypatch.setattr(installer.tempfile, "mkstemp", fake_mkstemp)
-    monkeypatch.setattr(Path, "write_text", fail_write_text)
+    monkeypatch.setattr(installer.os, "fdopen", fail_fdopen)
 
     with pytest.raises(OSError, match="disk full"):
         installer._write_temp_requirements("easyai_missing_req_", ["missing-package>=2"])
 
     assert not created.exists()
+
+
+def test_write_temp_requirements_pins_a_platform_temp_alias(
+    monkeypatch,
+    tmp_path,
+):
+    from plugin_system.requirements import install as installer
+
+    external = tmp_path / "platform-temp"
+    alias = tmp_path / "platform-temp-alias"
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    created_through_alias = alias / "easyai_missing_req.txt"
+
+    def fake_mkstemp(prefix, suffix):
+        fd = os.open(
+            str(created_through_alias),
+            os.O_CREAT | os.O_EXCL | os.O_RDWR,
+        )
+        return fd, str(created_through_alias)
+
+    monkeypatch.setattr(installer.tempfile, "mkstemp", fake_mkstemp)
+
+    result, identity = installer._write_temp_requirements(
+        "easyai_missing_req_",
+        ["missing-package>=2"],
+    )
+
+    assert result == external / created_through_alias.name
+    installer.remove_file_without_links(result, expected_identity=identity)

--- a/test/unit/scripts/test_launcher_path_contract.py
+++ b/test/unit/scripts/test_launcher_path_contract.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WINDOWS_LAUNCHERS = (
+    "start-react.bat",
+    "start.bat",
+    "start-tauri.bat",
+)
+WINDOWS_SOURCE_LAUNCHERS = (
+    "start-react.bat",
+    "start.bat",
+)
+WINDOWS_COMMAND_LAUNCHERS = (*WINDOWS_LAUNCHERS, "install.bat")
+UNIX_LAUNCHERS = (
+    "start-react.sh",
+    "start-react.command",
+    "start.command",
+    "install.command",
+    "scripts/start.command",
+    "scripts/install.command",
+    "scripts/start.sh",
+    "scripts/install.sh",
+)
+
+
+def _text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_repository_root_contains_no_literal_windows_separator_artifacts():
+    offenders = sorted(entry.name for entry in REPO_ROOT.iterdir() if "\\" in entry.name)
+    assert offenders == []
+
+
+def test_windows_launchers_anchor_to_their_own_directory_and_allow_unicode_paths():
+    for launcher in WINDOWS_LAUNCHERS:
+        content = _text(launcher)
+        assert 'set "PROJECT_ROOT=%~dp0"' in content
+        assert 'cd /d "%~dp0"' not in content
+        assert r"[^\x20-\x7E]" not in content
+        assert "Path contains non-ASCII" not in content
+        assert "only English letters" not in content
+
+
+def test_windows_source_launchers_do_not_require_a_local_drive_working_directory():
+    for launcher in WINDOWS_SOURCE_LAUNCHERS:
+        content = _text(launcher)
+        expected_entry = "webui_react.py"
+        assert f'"%PROJECT_ROOT%{expected_entry}"' in content
+        assert 'if exist "%PROJECT_ROOT%runtime\\python.exe"' in content
+        assert f"%PYTHON_CMD% {expected_entry}" not in content
+        assert "%PYTHON_CMD%" not in content
+        assert ":run_python" in content
+        assert ":run_conda" in content
+        assert ":resolve_conda_python" in content
+        assert (
+            '"%CONDA_CMD%" run --cwd "%PROJECT_ROOT%" -n "%CONDA_ENV_NAME%" '
+            '"%SHINSEKAI_CONDA_PYTHON%"'
+        ) in content
+        assert '"%CONDA_CMD%" run -n "%CONDA_ENV_NAME%" python' not in content
+        assert "__SHINSEKAI_CONDA_PREFIX__=" in content
+        assert '--cwd "%SystemRoot%\\System32"' in content
+        assert "if defined CONDA_PREFIX if /i" in content
+        assert ":paths_are_non_reparse" in content
+        assert "[IO.FileAttributes]::ReparsePoint" in content
+        assert "while($null -ne $item)" in content
+        assert "$driveAbsolute=" in content
+        assert "$uncAbsolute=" in content
+        assert "CONDA_EXE must be an absolute" in content
+        assert "CONDA_PREFIX must be an absolute" in content
+        assert 'set "PYTHON_EXE=python"' not in content
+        assert 'set "CONDA_CMD=conda"' not in content
+
+    installer = _text("install.bat")
+    assert '"%PROJECT_ROOT%requirements.txt"' in installer
+    assert "%PYTHON_CMD%" not in installer
+    assert ":install_with_python" in installer
+    assert ":install_with_conda" in installer
+    assert ":resolve_conda_python" in installer
+    assert (
+        '"%CONDA_CMD%" run --cwd "%PROJECT_ROOT%" -n "%CONDA_ENV_NAME%" '
+        '"%SHINSEKAI_CONDA_PYTHON%"'
+    ) in installer
+    assert '"%CONDA_CMD%" run -n "%CONDA_ENV_NAME%" python' not in installer
+    assert ":paths_are_non_reparse" in installer
+    assert "[IO.FileAttributes]::ReparsePoint" in installer
+    assert "if defined CONDA_PREFIX if /i" in installer
+    assert "while($null -ne $item)" in installer
+    assert "$driveAbsolute=" in installer
+    assert "$uncAbsolute=" in installer
+    assert "CONDA_EXE must be an absolute" in installer
+    assert "CONDA_PREFIX must be an absolute" in installer
+    assert 'set "PYTHON_EXE=python"' not in installer
+    assert 'set "CONDA_CMD=conda"' not in installer
+    tauri = _text("start-tauri.bat")
+    assert 'pushd "%PROJECT_ROOT%frontend"' in tauri
+    assert 'set "EXE_PATH=%PROJECT_ROOT%frontend\\src-tauri\\target\\release\\shinsekai.exe"' in tauri
+    assert ":paths_are_non_reparse" in tauri
+    assert "[IO.FileAttributes]::ReparsePoint" in tauri
+    assert "while($null -ne $item)" in tauri
+    assert "$driveAbsolute=" in tauri
+    assert "$uncAbsolute=" in tauri
+    assert "if defined USERPROFILE if exist" in tauri
+    assert "USERPROFILE or the rustup cargo path is not an absolute" in tauri
+
+
+def test_windows_launchers_bind_path_commands_to_checked_absolute_executables():
+    for launcher in WINDOWS_COMMAND_LAUNCHERS:
+        content = _text(launcher)
+        assert ":resolve_command" in content
+        assert r"%PROJECT_ROOT%scripts\resolve-command.ps1" in content
+        assert (
+            r"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+            in content
+        )
+        assert "\npowershell.exe " not in content
+        assert "\nwhere " not in content
+        assert "where.exe" not in content
+        assert 'set "SHINSEKAI_RESOLVED_COMMAND=%%I"' in content
+        assert (
+            'call :paths_are_non_reparse "%SHINSEKAI_RESOLVED_COMMAND%"'
+            in content
+        )
+
+    tauri = _text("start-tauri.bat")
+    assert 'set "PNPM_CMD=%SHINSEKAI_RESOLVED_COMMAND%"' in tauri
+    assert 'set "CARGO_CMD=%SHINSEKAI_RESOLVED_COMMAND%"' in tauri
+    assert 'set "CARGO=%CARGO_CMD%"' in tauri
+    assert 'call "%PNPM_CMD%" tauri build --no-bundle' in tauri
+    assert "call pnpm " not in tauri
+
+    resolver = _text("scripts/resolve-command.ps1")
+    assert '$env:PATH.Split(";")' in resolver
+    assert "Test-PortableComponent" in resolver
+    assert "Test-ExactAbsolutePath" in resolver
+    assert "Test-NoReparseComponents" in resolver
+    assert (
+        r"CON|PRN|AUX|NUL|CLOCK\$|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³]"
+        in resolver
+    )
+    assert "[Text.Encoding]::UTF8.GetByteCount($Value) -gt 255" in resolver
+    assert "$codePoint -ge 0xD800 -and $codePoint -le 0xDFFF" in resolver
+    assert r'\A\.[A-Za-z0-9]+\z' in resolver
+    assert "Test-PortableComponent $candidateName" in resolver
+    assert "$Name.Length -gt 128" not in resolver
+    assert '.Split("/", 3)' not in resolver
+    assert "[Console]::Out.WriteLine($item.FullName)" in resolver
+    assert "Get-Command" not in resolver
+
+
+def test_non_pyqt_windows_launchers_reject_nonportable_conda_environment_names():
+    for launcher in ("start-react.bat", "start.bat", "install.bat"):
+        content = _text(launcher)
+        assert "$value.EndsWith('.')" in content
+        assert (
+            r"CON|PRN|AUX|NUL|CLOCK\$|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³]"
+            in content
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "accepted"),
+    [
+        ("shinsekai", True),
+        ("project-env_2", True),
+        ("COM10", True),
+        ("CON", False),
+        ("con.txt", False),
+        ("LPT1.env", False),
+        ("environment.", False),
+        ("bad/name", False),
+    ],
+)
+def test_posix_path_contract_validates_portable_conda_environment_names(
+    name,
+    accepted,
+):
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; shinsekai_portable_environment_name "$2"',
+            "path-contract-test",
+            str(REPO_ROOT / "scripts" / "shell-path-contract.sh"),
+            name,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert (result.returncode == 0) is accepted
+
+
+def test_tauri_launcher_starts_only_the_declared_application_binary():
+    content = _text("start-tauri.bat")
+
+    assert r"frontend\src-tauri\target\release\shinsekai.exe" in content
+    assert r'target\release\*.exe' not in content
+    assert "dir /b /s" not in content
+
+
+def test_installers_do_not_persist_install_location_specific_qt_paths():
+    content = _text("install.bat")
+
+    assert "setx PATH" not in content
+    assert r"PyQt5\Qt5\qml" not in content
+    assert "QML_PATH" not in content
+
+
+def test_unix_installer_anchors_relative_resources_to_repository_root():
+    content = _text("scripts/install.sh")
+
+    assert 'PROJECT_ROOT="$(CDPATH= cd -P -- "$SCRIPT_DIR/.." && pwd)"' in content
+    assert 'cd "$PROJECT_ROOT"' in content
+    assert '"$PROJECT_ROOT/requirements.txt"' in content
+
+
+def test_unix_launchers_follow_script_symlinks_and_never_depend_on_calling_cwd():
+    for launcher in UNIX_LAUNCHERS:
+        content = _text(launcher)
+        assert "set -euo pipefail" in content
+        assert "resolve_script_directory()" in content
+        assert 'source_path="${BASH_SOURCE[0]}"' in content
+        assert 'while [[ -L "$source_path" ]]' in content
+        assert "local link_hops=0" in content
+        assert "((link_hops > 64))" in content
+        assert "too many symbolic-link hops" in content
+        assert 'source_path="$(/usr/bin/readlink "$source_path")"' in content
+        assert '/usr/bin/dirname "$source_path"' in content
+        assert 'source_path="$(readlink ' not in content
+        assert 'cd "$PROJECT_ROOT"' in content
+        assert "$PWD/" not in content
+        assert "${PWD" not in content
+
+
+def test_unix_launchers_validate_project_identity_before_running():
+    react_launchers = ("start-react.sh", "scripts/start.sh", "scripts/install.sh")
+
+    for launcher in react_launchers:
+        content = _text(launcher)
+        assert '"webui_react.py"' in content
+        assert '"requirements.txt"' in content
+        assert "CONDA_EXE must be an absolute executable path" in content
+        assert "CONDA_PREFIX must be an absolute path" in content
+        assert "HOME must be an absolute path when set" in content
+        assert '${HOME:-}' in content
+
+
+def test_unix_launchers_use_the_shared_link_free_path_contract():
+    launchers = (
+        "start-react.sh",
+        "scripts/start.sh",
+        "scripts/install.sh",
+    )
+    for launcher in launchers:
+        content = _text(launcher)
+        assert 'PATH_CONTRACT="$PROJECT_ROOT/scripts/shell-path-contract.sh"' in content
+        assert 'source "$PATH_CONTRACT"' in content
+        assert "shinsekai_project_file_is_real" in content
+
+    assert "shinsekai_find_embedded_python" in _text("start-react.sh")
+    assert "shinsekai_find_embedded_python" in _text("scripts/start.sh")
+    assert "shinsekai_find_embedded_python" in _text("scripts/install.sh")
+    assert "shinsekai_absolute_path_has_no_links" in _text(
+        "scripts/shell-path-contract.sh"
+    )
+    assert "shinsekai_resolve_executable" in _text(
+        "scripts/shell-path-contract.sh"
+    )
+    for launcher in ("start-react.sh", "scripts/start.sh", "scripts/install.sh"):
+        content = _text(launcher)
+        assert (
+            'SYSTEM_PYTHON="$(shinsekai_resolve_executable python3)"'
+            in content
+        )
+        assert "PYTHON_CMD=(python3)" not in content
+        assert "command -v conda" not in content
+        assert "shinsekai_resolve_conda_python" in content
+        assert 'run --cwd / -n "$CONDA_ENV_NAME" "$CONDA_PYTHON"' in content
+        assert 'run -n "$CONDA_ENV_NAME" python' not in content
+    shell_contract = _text("scripts/shell-path-contract.sh")
+    assert 'IFS=":" read -r -a search_directories' in shell_contract
+    assert "command -v --" not in shell_contract
+    assert "__SHINSEKAI_CONDA_PREFIX__=" in shell_contract
+
+
+def test_macos_command_wrappers_delegate_with_absolute_repository_paths():
+    expected = {
+        "start-react.command": "start-react.sh",
+        "start.command": "scripts/start.sh",
+        "install.command": "scripts/install.sh",
+        "scripts/start.command": "scripts/start.sh",
+        "scripts/install.command": "scripts/install.sh",
+    }
+    for launcher, delegated_script in expected.items():
+        content = _text(launcher)
+        assert f'DELEGATED_SCRIPT="$PROJECT_ROOT/{delegated_script}"' in content
+        assert 'exec /bin/bash "$DELEGATED_SCRIPT" "$@"' in content
+        assert '-L "$DELEGATED_SCRIPT"' in content
+        assert f"exec bash {delegated_script}" not in content
+
+
+def test_react_unix_launcher_resolves_a_symlink_from_an_unrelated_cwd(tmp_path):
+    link_dir = tmp_path / "链接 launchers"
+    unrelated = tmp_path / "unrelated cwd"
+    link_dir.mkdir()
+    unrelated.mkdir()
+    launcher = link_dir / "start react"
+    try:
+        launcher.symlink_to(REPO_ROOT / "start-react.sh")
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    environment = os.environ.copy()
+    environment["CONDA_DEFAULT_ENV"] = "path-contract-test"
+    environment["SHINSEKAI_CONDA_ENV"] = "path-contract-test"
+    environment["CONDA_PREFIX"] = sys.prefix
+    environment.pop("HOME", None)
+    completed = subprocess.run(
+        ["bash", str(launcher), "--help"],
+        cwd=unrelated,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Run the built Shinsekai React settings UI" in completed.stdout
+
+
+def test_react_unix_launcher_rejects_relative_conda_prefix_before_launch(tmp_path):
+    environment = os.environ.copy()
+    environment["CONDA_DEFAULT_ENV"] = "path-contract-test"
+    environment["SHINSEKAI_CONDA_ENV"] = "path-contract-test"
+    environment["CONDA_PREFIX"] = "relative-env"
+    environment.pop("CONDA_EXE", None)
+
+    completed = subprocess.run(
+        ["bash", str(REPO_ROOT / "start-react.sh"), "--help"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode != 0
+    assert "CONDA_PREFIX must be an absolute path" in completed.stderr
+
+
+def _run_shell_contract(project_root: Path, body: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'set -euo pipefail; PROJECT_ROOT="$1"; source "$2"; shift 2; ' + body,
+            "path-contract-test",
+            str(project_root),
+            str(REPO_ROOT / "scripts" / "shell-path-contract.sh"),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_shell_path_contract_creates_only_real_project_directories(tmp_path):
+    project_root = tmp_path / "project with spaces"
+    project_root.mkdir()
+
+    completed = _run_shell_contract(
+        project_root,
+        'shinsekai_ensure_project_directory "data/config"',
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert (project_root / "data" / "config").is_dir()
+    assert not (project_root / "data").is_symlink()
+
+
+def test_shell_executable_resolution_rejects_relative_path_entries(tmp_path):
+    project_root = tmp_path / "project"
+    relative_bin = project_root / "relative-bin"
+    project_root.mkdir()
+    relative_bin.mkdir()
+    executable = relative_bin / "path-tool"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    relative = _run_shell_contract(
+        project_root,
+        'cd "$PROJECT_ROOT"; PATH=relative-bin; shinsekai_resolve_executable path-tool',
+    )
+    absolute = _run_shell_contract(
+        project_root,
+        'shinsekai_resolve_executable "$PROJECT_ROOT/relative-bin/path-tool"',
+    )
+
+    assert relative.returncode != 0
+    assert absolute.returncode == 0
+    assert absolute.stdout.strip() == str(executable)
+
+
+def test_shell_executable_resolution_skips_relative_path_entries(tmp_path):
+    project_root = tmp_path / "project"
+    relative_bin = project_root / "relative-bin"
+    absolute_bin = tmp_path / "absolute-bin"
+    project_root.mkdir()
+    relative_bin.mkdir()
+    absolute_bin.mkdir()
+    relative_executable = relative_bin / "path-tool"
+    absolute_executable = absolute_bin / "path-tool"
+    for executable in (relative_executable, absolute_executable):
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o755)
+
+    completed = _run_shell_contract(
+        project_root,
+        (
+            'cd "$PROJECT_ROOT"; '
+            f'PATH="relative-bin:{absolute_bin}"; '
+            "shinsekai_resolve_executable path-tool"
+        ),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == str(absolute_executable)
+
+
+def test_shell_executable_resolution_resolves_a_leaf_symlink(tmp_path):
+    project_root = tmp_path / "project"
+    bin_dir = tmp_path / "bin"
+    real_dir = tmp_path / "runtime" / "bin"
+    project_root.mkdir()
+    bin_dir.mkdir()
+    real_dir.mkdir(parents=True)
+    executable = real_dir / "path-tool"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    alias = bin_dir / "path-tool"
+    try:
+        alias.symlink_to(Path("..") / "runtime" / "bin" / "path-tool")
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    completed = _run_shell_contract(
+        project_root,
+        f'PATH="{bin_dir}"; shinsekai_resolve_executable path-tool',
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == str(executable)
+
+
+def test_shell_executable_resolution_skips_a_linked_path_directory(tmp_path):
+    project_root = tmp_path / "project"
+    linked_target = tmp_path / "linked-target"
+    safe_bin = tmp_path / "safe-bin"
+    linked_bin = tmp_path / "linked-bin"
+    project_root.mkdir()
+    linked_target.mkdir()
+    safe_bin.mkdir()
+    for directory in (linked_target, safe_bin):
+        executable = directory / "path-tool"
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o755)
+    try:
+        linked_bin.symlink_to(linked_target, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    completed = _run_shell_contract(
+        project_root,
+        (
+            f'PATH="{linked_bin}:{safe_bin}"; '
+            "shinsekai_resolve_executable path-tool"
+        ),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == str(safe_bin / "path-tool")
+
+
+def test_shell_executable_resolution_rejects_a_linked_parent_for_direct_path(
+    tmp_path,
+):
+    project_root = tmp_path / "project"
+    real_bin = tmp_path / "real-bin"
+    linked_bin = tmp_path / "linked-bin"
+    project_root.mkdir()
+    real_bin.mkdir()
+    executable = real_bin / "path-tool"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    try:
+        linked_bin.symlink_to(real_bin, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    completed = _run_shell_contract(
+        project_root,
+        f'shinsekai_resolve_executable "{linked_bin}/path-tool"',
+    )
+
+    assert completed.returncode != 0
+
+
+def test_shell_path_contract_rejects_linked_project_directory_without_external_write(tmp_path):
+    project_root = tmp_path / "project"
+    external = tmp_path / "external"
+    project_root.mkdir()
+    external.mkdir()
+    try:
+        (project_root / "data").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    completed = _run_shell_contract(
+        project_root,
+        'shinsekai_ensure_project_directory "data/config"',
+    )
+
+    assert completed.returncode != 0
+    assert not (external / "config").exists()
+
+
+def test_shell_path_contract_rejects_linked_project_file(tmp_path):
+    project_root = tmp_path / "project"
+    external = tmp_path / "external.py"
+    project_root.mkdir()
+    external.write_text("print('external')", encoding="utf-8")
+    try:
+        (project_root / "webui_react.py").symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    completed = _run_shell_contract(
+        project_root,
+        'shinsekai_project_file_is_real "webui_react.py"',
+    )
+
+    assert completed.returncode != 0

--- a/test/unit/scripts/test_presubmit.py
+++ b/test/unit/scripts/test_presubmit.py
@@ -1,6 +1,29 @@
 import subprocess
+from pathlib import Path
 
 from scripts import presubmit
+
+
+def test_commit_message_file_is_anchored_to_repository_root(
+    tmp_path,
+    monkeypatch,
+):
+    repository = tmp_path / "repository"
+    message_file = repository / ".git" / "COMMIT_EDITMSG"
+    message_file.parent.mkdir(parents=True)
+    message_file.write_text(
+        "fix: validate repository-relative commit message paths\n",
+        encoding="utf-8",
+    )
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.setattr(presubmit, "ROOT", repository)
+    monkeypatch.chdir(unrelated)
+
+    assert (
+        presubmit.validate_commit_message_file(Path(".git/COMMIT_EDITMSG"))
+        == 0
+    )
 
 
 def test_pre_push_commit_range_excludes_commits_reachable_from_any_remote(monkeypatch):

--- a/test/unit/scripts/test_release_cherry_pick_command.py
+++ b/test/unit/scripts/test_release_cherry_pick_command.py
@@ -123,6 +123,22 @@ def test_run_rejects_unsupported_subcommand(monkeypatch):
         module.run(["git", "remote", "-v"])
 
 
+def test_run_binds_git_commands_to_the_script_repository(monkeypatch, tmp_path):
+    module = load_module(monkeypatch)
+    observed = {}
+
+    def fake_run(command, **kwargs):
+        observed.update(kwargs)
+        return module.subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    module.run(["git", "rev-parse", "HEAD"])
+
+    assert observed["cwd"] == str(module.REPOSITORY_ROOT)
+
+
 def test_cherry_pick_command_keeps_regular_commit_simple(monkeypatch):
     module = load_module(monkeypatch)
 

--- a/test/unit/scripts/test_windows_installer_contract.py
+++ b/test/unit/scripts/test_windows_installer_contract.py
@@ -419,6 +419,13 @@ def test_windows_ci_renders_custom_nsis_and_runs_project_root_tests() -> None:
     assert "[IO.File]::WriteAllBytes($partialPath, $downloadBytes)" in migration_script
     assert '"legacy-msi-updated="' in migration_script
     assert '"$DestinationPath.partial.$PID"' in migration_script
+    assert "function Test-WindowsAbsolutePath" in migration_script
+    assert "function Resolve-RepositoryInputPath" in migration_script
+    assert "IsPathRooted" not in migration_script
+    assert "rooted but not a fully qualified Windows path" in migration_script
+    assert "escapes the repository root" in migration_script
+    assert "GITHUB_OUTPUT must be an absolute path" in migration_script
+    assert "[IO.Path]::GetPathRoot($normalized)" in migration_script
     partial_hash = migration_script.index(
         "Get-FileHash -LiteralPath $partialPath -Algorithm SHA256"
     )

--- a/test/unit/sdk/test_frontend_config_contributions.py
+++ b/test/unit/sdk/test_frontend_config_contributions.py
@@ -39,6 +39,81 @@ def test_plugin_host_context_exposes_huggingface_cache_dir(tmp_path: Path) -> No
     assert host.huggingface_cache_dir == cache_dir.resolve(strict=False)
 
 
+def test_plugin_host_context_exposes_absolute_project_data_root(tmp_path: Path) -> None:
+    data_root = tmp_path / "project" / "data"
+
+    host = PluginHostContext.from_config_manager(
+        None,
+        project_data_dir=data_root,
+    )
+
+    assert host.project_data_dir == data_root.resolve(strict=False)
+    assert host.huggingface_cache_dir == data_root / "cache" / "huggingface"
+
+
+def test_plugin_host_context_rejects_relative_project_data_root(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="absolute"):
+        PluginHostContext.from_config_manager(None, project_data_dir=Path("relative/data"))
+
+
+def test_plugin_host_context_rejects_user_home_project_data_alias() -> None:
+    with pytest.raises(ValueError, match="absolute"):
+        PluginHostContext.from_config_manager(None, project_data_dir="~/data")
+
+
+def test_plugin_host_context_rejects_explicit_empty_project_data_root() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        PluginHostContext.from_config_manager(None, project_data_dir="")
+
+
+def test_plugin_host_context_rejects_lexical_project_data_root_alias(tmp_path: Path) -> None:
+    data_root = tmp_path / "project/data"
+    data_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        PluginHostContext.from_config_manager(
+            None,
+            project_data_dir=f"{tmp_path.as_posix()}/project/./data",
+        )
+
+
+def test_plugin_host_context_rejects_symlinked_project_data_root(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    data_link = project / "data"
+    try:
+        data_link.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic links"):
+        PluginHostContext.from_config_manager(None, project_data_dir=data_link)
+
+
+def test_plugin_host_context_rejects_relative_cache_escape(tmp_path: Path) -> None:
+    data_root = tmp_path / "project" / "data"
+    cm = SimpleNamespace(
+        config=SimpleNamespace(
+            api_config=SimpleNamespace(llm_provider="", tts_provider=""),
+            system_config=SimpleNamespace(
+                base_font_size_px=56,
+                huggingface_cache_dir="../../external-cache",
+                live_room_id="",
+                theme_color="#d4788e",
+                ui_language="zh_CN",
+                voice_language="ja",
+            ),
+        )
+    )
+
+    with pytest.raises(PermissionError, match="escapes project root"):
+        PluginHostContext.from_config_manager(cm, project_data_dir=data_root)
+
+
 def test_frontend_config_contribution_gets_plugin_context() -> None:
     registry = PluginCapabilityRegistry()
     registry.set_settings_ui_plugin_context("demo.plugin", "1.2.3")

--- a/test/unit/sdk/test_output_contracts.py
+++ b/test/unit/sdk/test_output_contracts.py
@@ -31,6 +31,32 @@ def test_register_dag_yaml_is_workflow_contribution() -> None:
     assert registry.dag_yaml_paths == ["plugins/demo/workflow.yaml"]
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        " plugins/demo/workflow.yaml",
+        "plugins/demo/workflow.yaml ",
+        "bad\npath.yaml",
+        "./plugins/demo/workflow.yaml",
+        "plugins//demo/workflow.yaml",
+        "plugins/../demo/workflow.yaml",
+    ],
+)
+def test_register_dag_yaml_rejects_ambiguous_path_text(path: str) -> None:
+    registry = PluginCapabilityRegistry()
+
+    with pytest.raises((PermissionError, ValueError)):
+        registry.register_dag_yaml(path)
+
+
+def test_register_dag_yaml_derives_name_from_portable_separators() -> None:
+    registry = PluginCapabilityRegistry()
+
+    registry.register_dag_yaml(r"plugins\demo\workflow.yaml")
+
+    assert registry.workflow_contributions[0].name == "workflow"
+
+
 def test_register_workflow_with_output_contract() -> None:
     registry = PluginCapabilityRegistry()
     contribution = WorkflowContribution(

--- a/test/unit/sdk/test_sdk_chat_ui_theme_extra.py
+++ b/test/unit/sdk/test_sdk_chat_ui_theme_extra.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+import stat
 import zipfile
 from pathlib import Path
 
 import pytest
 
+import sdk.chat_ui_theme as chat_ui_theme
 from sdk.chat_ui_theme import (
     MANIFEST_NAME,
     _main,
@@ -107,6 +109,8 @@ def _write_theme(root: Path, manifest: dict | None = None) -> Path:
 def test_slugify_and_validate_manifest_normalizes_rich_theme() -> None:
     assert slugify_theme_id(" Demo Theme! ") == "demo-theme"
     assert slugify_theme_id("!!!") == "theme"
+    assert slugify_theme_id("CON") == "theme-con"
+    assert slugify_theme_id("LPT1") == "theme-lpt1"
 
     result = validate_manifest(_valid_manifest())
 
@@ -123,6 +127,17 @@ def test_slugify_and_validate_manifest_normalizes_rich_theme() -> None:
     assert result.normalized["tokens"]["logs"]["levels"]["warn"]["color"] == "#ffee88"
     assert result.normalized["tokens"]["logs"]["panel"]["frameSlice"] == 24
     assert result.normalized["tokens"]["typewriter"]["sound"] == "assets/type.wav"
+
+
+def test_validate_manifest_rejects_theme_id_outer_whitespace_without_retargeting() -> None:
+    manifest = _valid_manifest()
+    manifest["id"] = " demo-theme "
+
+    result = validate_manifest(manifest)
+
+    assert result.ok is False
+    assert result.normalized["id"] == " demo-theme "
+    assert any("首尾" in error for error in result.errors)
 
 
 @pytest.mark.parametrize(
@@ -153,6 +168,28 @@ def test_validate_manifest_rejects_invalid_shapes(manifest) -> None:
 
     assert result.ok is False
     assert result.errors
+
+
+@pytest.mark.parametrize(
+    "asset_ref",
+    [
+        " assets/preview.png",
+        "assets/preview.png ",
+        "assets/bad\nname.png",
+        "./assets/preview.png",
+        "assets//preview.png",
+        "assets/../preview.png",
+        "assets/preview.png/",
+    ],
+)
+def test_validate_manifest_rejects_nonportable_asset_reference_text(asset_ref: str) -> None:
+    manifest = _valid_manifest()
+    manifest["preview"] = asset_ref
+
+    result = validate_manifest(manifest)
+
+    assert result.ok is False
+    assert any("preview" in error for error in result.errors)
 
 
 @pytest.mark.parametrize(
@@ -223,13 +260,119 @@ def test_pack_theme_extracts_safely_and_locates_manifest_root(tmp_path: Path) ->
     assert locate_manifest_root(tmp_path / "dist") is None
 
 
-def test_safe_extract_rejects_zip_slip_entries(tmp_path: Path) -> None:
+def test_theme_sdk_rejects_source_and_output_path_aliases(tmp_path: Path) -> None:
+    theme_dir = _write_theme(tmp_path)
+    source_alias = f"{tmp_path.as_posix()}/./theme"
+    output_alias = f"{tmp_path.as_posix()}/dist/../theme.zip"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        validate_theme_dir(source_alias)
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        pack_theme(theme_dir, output_alias)
+
+    assert not (tmp_path / "theme.zip").exists()
+
+
+def test_theme_sdk_rejects_extraction_target_alias_before_writing(tmp_path: Path) -> None:
+    zip_path = tmp_path / "theme.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("theme.json", "{}")
+    output_alias = f"{tmp_path.as_posix()}/./out"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        safe_extract(zip_path, output_alias)
+
+    assert not (tmp_path / "out").exists()
+
+
+def test_theme_sdk_rejects_linked_external_output_parent(tmp_path: Path) -> None:
+    theme_dir = _write_theme(tmp_path)
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        pack_theme(theme_dir, alias / "theme.zip")
+
+    assert list(external.iterdir()) == []
+
+
+def test_theme_sdk_rejects_linked_external_extraction_parent(tmp_path: Path) -> None:
+    zip_path = tmp_path / "theme.zip"
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    external.mkdir()
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("theme.json", "{}")
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        safe_extract(zip_path, alias / "theme")
+
+    assert list(external.iterdir()) == []
+
+
+@pytest.mark.parametrize("member", ["../escape.txt", r"..\escape.txt"])
+def test_safe_extract_rejects_zip_slip_entries(tmp_path: Path, member: str) -> None:
     zip_path = tmp_path / "bad.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:
-        zf.writestr("../escape.txt", "bad")
+        zf.writestr(member, "bad")
 
     with pytest.raises(ValueError, match="路径穿越"):
         safe_extract(zip_path, tmp_path / "out")
+
+
+def test_safe_extract_rejects_link_entries_before_writing(tmp_path: Path) -> None:
+    zip_path = tmp_path / "link.zip"
+    link = zipfile.ZipInfo("assets/link")
+    link.create_system = 3
+    link.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("theme.json", "{}")
+        zf.writestr(link, "../../outside")
+
+    output = tmp_path / "out"
+    with pytest.raises(ValueError, match="非便携路径"):
+        safe_extract(zip_path, output)
+
+    assert not output.exists()
+
+
+def test_safe_extract_rejects_symlinked_archive_path(tmp_path: Path) -> None:
+    archive = tmp_path / "theme.zip"
+    alias = tmp_path / "theme-alias.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("theme.json", "{}")
+    try:
+        alias.symlink_to(archive)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        safe_extract(alias, tmp_path / "out")
+
+    assert not (tmp_path / "out").exists()
+
+
+def test_locate_manifest_root_rejects_symlinked_nested_theme(tmp_path: Path) -> None:
+    extracted = tmp_path / "extracted"
+    external = tmp_path / "external-theme"
+    extracted.mkdir()
+    external.mkdir()
+    (external / MANIFEST_NAME).write_text("{}", encoding="utf-8")
+    try:
+        (extracted / "theme").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+
+    assert locate_manifest_root(extracted) is None
 
 
 def test_pack_theme_rejects_invalid_manifest(tmp_path: Path) -> None:
@@ -240,6 +383,69 @@ def test_pack_theme_rejects_invalid_manifest(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="主题校验失败"):
         pack_theme(theme_dir, tmp_path / "bad.zip")
+
+
+def test_theme_validation_and_pack_reject_symlinked_resources(tmp_path: Path) -> None:
+    theme_dir = _write_theme(tmp_path)
+    external = tmp_path / "external.txt"
+    external.write_text("secret", encoding="utf-8")
+    try:
+        (theme_dir / "linked.txt").symlink_to(external)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    result = validate_theme_dir(theme_dir)
+    assert result.ok is False
+    assert any("符号链接" in error for error in result.errors)
+    with pytest.raises(ValueError, match="主题校验失败"):
+        pack_theme(theme_dir, tmp_path / "linked.zip")
+
+
+def test_pack_theme_rejects_output_inside_source_tree(tmp_path: Path) -> None:
+    theme_dir = _write_theme(tmp_path)
+    output = theme_dir / "theme.zip"
+
+    with pytest.raises(ValueError, match="主题目录内部"):
+        pack_theme(theme_dir, output)
+
+    assert not output.exists()
+
+
+def test_pack_theme_preserves_previous_output_when_source_changes_after_validation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    theme_dir = _write_theme(tmp_path)
+    candidate = theme_dir / "assets" / "preview.png"
+    external = tmp_path / "external.png"
+    external.write_bytes(b"secret")
+    output = tmp_path / "theme.zip"
+    output.write_bytes(b"previous package")
+    try:
+        probe = tmp_path / "probe"
+        probe.symlink_to(external)
+        probe.unlink()
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    real_validate = chat_ui_theme.validate_theme_dir
+
+    def validate_then_replace(path):
+        result = real_validate(path)
+        candidate.unlink()
+        candidate.symlink_to(external)
+        return result
+
+    monkeypatch.setattr(
+        chat_ui_theme,
+        "validate_theme_dir",
+        validate_then_replace,
+    )
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        pack_theme(theme_dir, output)
+
+    assert output.read_bytes() == b"previous package"
 
 
 def test_cli_validate_and_pack_return_codes(tmp_path: Path, capsys) -> None:

--- a/test/unit/sdk/test_sdk_cli_path_identity.py
+++ b/test/unit/sdk/test_sdk_cli_path_identity.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sdk.cli.__main__ import _resolve_create_root, main
+from sdk.cli.registry_ops import exact_registry_entry, normalize_repo_slug, run_git_commit
+from sdk.cli.scaffold import validate_package_name, write_plugin_project
+
+
+def test_plugin_package_name_is_not_silently_trimmed():
+    assert validate_package_name("demo_plugin") == "demo_plugin"
+    with pytest.raises(ValueError, match="snake_case"):
+        validate_package_name(" demo_plugin")
+
+
+def test_registry_entry_is_not_silently_trimmed():
+    assert exact_registry_entry("plugins.demo.plugin:DemoPlugin") == (
+        "plugins.demo.plugin:DemoPlugin"
+    )
+    with pytest.raises(ValueError, match="surrounding whitespace"):
+        exact_registry_entry(" plugins.demo.plugin:DemoPlugin")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        " owner/demo",
+        "owner/demo ",
+        "/owner/demo",
+        "owner/demo/",
+        "owner//demo",
+        "owner/./demo",
+        "owner/team/demo",
+    ),
+)
+def test_registry_repo_slug_is_not_silently_canonicalized(raw):
+    with pytest.raises(ValueError, match="exact owner/name"):
+        normalize_repo_slug(raw)
+
+
+def test_registry_repo_slug_preserves_exact_display_identity():
+    assert normalize_repo_slug("Owner/Demo_Plugin") == "Owner/Demo_Plugin"
+
+
+def test_registry_commit_uses_one_portable_relative_path_identity(tmp_path, monkeypatch):
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_run(command, *, cwd, check):
+        assert check is True
+        calls.append((command, cwd))
+
+    monkeypatch.setattr("sdk.cli.registry_ops.subprocess.run", fake_run)
+
+    run_git_commit(
+        tmp_path,
+        "registry: update",
+        file_path=r"nested\plugins.json",
+    )
+
+    git_path = calls[0][0][0]
+    assert calls == [
+        (
+            [git_path, "add", "--", "nested/plugins.json"],
+            str(tmp_path),
+        ),
+        (
+            [git_path, "commit", "-m", "registry: update"],
+            str(tmp_path),
+        ),
+    ]
+    assert Path(git_path).is_absolute()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "../plugins.json",
+        "nested/../plugins.json",
+        "./plugins.json",
+        "nested//plugins.json",
+    ),
+)
+def test_registry_commit_rejects_aliased_relative_file_path(
+    tmp_path,
+    monkeypatch,
+    raw,
+):
+    calls = []
+    monkeypatch.setattr(
+        "sdk.cli.registry_ops.subprocess.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        run_git_commit(tmp_path, "registry: update", file_path=raw)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("raw", ("./plugins", "plugins//nested", "plugins/../other"))
+def test_plugin_scaffold_root_rejects_lexical_aliases(tmp_path, monkeypatch, raw):
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        _resolve_create_root(raw)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_plugin_scaffold_writer_rejects_relative_root(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="absolute"):
+        write_plugin_project(
+            root=Path("relative-root"),
+            package="demo_plugin",
+            plugin_id="com.example.demo_plugin",
+            display_name="Demo",
+            include_settings_ui=False,
+        )
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_plugin_scaffold_writer_rejects_symlinked_root(tmp_path):
+    external = tmp_path / "external"
+    alias = tmp_path / "alias"
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        write_plugin_project(
+            root=alias,
+            package="demo_plugin",
+            plugin_id="com.example.demo_plugin",
+            display_name="Demo",
+            include_settings_ui=False,
+        )
+
+    assert list(external.iterdir()) == []
+
+
+def test_registry_file_must_remain_inside_selected_clone(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    registry = tmp_path / "registry"
+    outside = tmp_path / "outside.json"
+    project.mkdir()
+    registry.mkdir()
+    outside.write_text("[]\n", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="outside project root"):
+        main(
+            [
+                "registry-append",
+                "--registry",
+                registry.as_posix(),
+                "--file",
+                outside.as_posix(),
+                "--name",
+                "Demo",
+                "--author",
+                "Tester",
+                "--repo",
+                "owner/demo",
+                "--description",
+                "demo",
+                "--entry",
+                "demo.plugin:DemoPlugin",
+            ]
+        )
+
+    assert outside.read_text(encoding="utf-8") == "[]\n"
+
+
+def test_registry_root_must_not_be_a_symlinked_clone(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    registry = tmp_path / "registry"
+    alias = tmp_path / "registry-alias"
+    project.mkdir()
+    registry.mkdir()
+    (registry / "plugins.json").write_text("[]\n", encoding="utf-8")
+    try:
+        alias.symlink_to(registry, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        main(
+            [
+                "registry-append",
+                "--registry",
+                alias.as_posix(),
+                "--name",
+                "Demo",
+                "--author",
+                "Tester",
+                "--repo",
+                "owner/demo",
+                "--description",
+                "demo",
+                "--entry",
+                "demo.plugin:DemoPlugin",
+            ]
+        )
+
+    assert (registry / "plugins.json").read_text(encoding="utf-8") == "[]\n"

--- a/test/unit/sdk/test_sdk_logging_utilities.py
+++ b/test/unit/sdk/test_sdk_logging_utilities.py
@@ -112,14 +112,24 @@ def test_timing_tracker_tracks_local_cross_thread_and_reports(monkeypatch, capsy
 def test_logging_configuration_helpers_cover_common_paths(monkeypatch, tmp_path):
     assert logging_config._safe_name(" Shinsekai/App ") == "Shinsekai-App"
     assert logging_config._safe_name("!!!") == "app"
+    assert logging_config._safe_name("CON.txt") == "app-CON.txt"
+    assert logging_config._safe_name("logger.") == "logger"
+    assert logging_config._safe_name("a" * 300) == "a" * 255
 
-    (tmp_path / "VERSION").write_text("1.2.3\n", encoding="utf-8")
-    assert logging_config._read_version(tmp_path) == "1.2.3"
+    source_root = tmp_path / "source"
+    project_root = tmp_path / "project"
+    source_root.mkdir()
+    project_root.mkdir()
+    (source_root / "VERSION").write_text("1.2.3\n", encoding="utf-8")
+    (project_root / "VERSION").write_text("spoofed-project-version\n", encoding="utf-8")
+    monkeypatch.setenv("SHINSEKAI_SOURCE_ROOT", source_root.as_posix())
+    monkeypatch.setenv("SHINSEKAI_APP_ROOT", source_root.as_posix())
+    assert logging_config._read_version(project_root) == "1.2.3"
 
     real_import = __import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "core.paths":
+        if name == "sdk.path_contract":
             raise ImportError("resource path unavailable")
         return real_import(name, globals, locals, fromlist, level)
 
@@ -170,6 +180,60 @@ def test_configure_logging_handles_null_handler_existing_listener_and_file_error
 
         assert first_path is None
         assert second_path is None
+    finally:
+        logging_config.shutdown_logging()
+
+
+def test_path_safe_log_rotation_preserves_regular_file_identities(tmp_path):
+    path = tmp_path / "session.jsonl"
+    handler = logging_config._PathSafeRotatingFileHandler(
+        path,
+        maxBytes=8,
+        backupCount=2,
+        encoding="utf-8",
+    )
+    try:
+        handler.emit(logging.LogRecord("test", logging.INFO, "", 0, "first line", (), None))
+        handler.emit(logging.LogRecord("test", logging.INFO, "", 0, "second line", (), None))
+    finally:
+        handler.close()
+
+    assert path.is_file()
+    assert (tmp_path / "session.jsonl.1").is_file()
+    assert not path.is_symlink()
+    assert not (tmp_path / "session.jsonl.1").is_symlink()
+
+
+def test_configure_logging_rejects_lexical_path_aliases(tmp_path):
+    logging_config.shutdown_logging()
+    project = tmp_path / "project"
+    project.mkdir()
+
+    try:
+        with pytest.raises(ValueError, match="lexical path aliases"):
+            logging_config.configure_logging(
+                "test",
+                project_root=f"{tmp_path.as_posix()}/./project",
+                console=False,
+                file=False,
+                install_exception_hooks=False,
+            )
+        with pytest.raises(ValueError, match="exact relative components"):
+            logging_config.configure_logging(
+                "test",
+                project_root=project,
+                log_dir="logs//test",
+                console=False,
+                install_exception_hooks=False,
+            )
+        with pytest.raises(ValueError, match="output path is empty"):
+            logging_config.configure_logging(
+                "test",
+                project_root=project,
+                log_dir="",
+                console=False,
+                install_exception_hooks=False,
+            )
     finally:
         logging_config.shutdown_logging()
 

--- a/test/unit/sdk/test_sdk_plugin_manager_lifecycle.py
+++ b/test/unit/sdk/test_sdk_plugin_manager_lifecycle.py
@@ -270,6 +270,123 @@ def test_plugin_manager_isolates_plugin_failures(tmp_path: Path, caplog) -> None
     assert "shutdown failed for demo.broken-shutdown" in caplog.text
 
 
+def test_plugin_manager_rejects_escaping_plugin_id_without_blocking_good_plugins(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    class EscapingPlugin(_BasePlugin):
+        @property
+        def plugin_id(self) -> str:
+            return ".."
+
+        def initialize(
+            self,
+            register: PluginCapabilityRegistry,
+            plugin_root: Path,
+            host: PluginHostContext,
+        ) -> None:
+            _ = register, host
+            (plugin_root / "escaped.txt").write_text("bad", encoding="utf-8")
+
+    class GoodPlugin(_BasePlugin):
+        @property
+        def plugin_id(self) -> str:
+            return "demo.safe"
+
+        def initialize(
+            self,
+            register: PluginCapabilityRegistry,
+            plugin_root: Path,
+            host: PluginHostContext,
+        ) -> None:
+            _ = plugin_root, host
+            register.register_llm_adapter("safe", object)  # type: ignore[arg-type]
+
+    plugin_root = tmp_path / "plugins"
+    manager = PluginManager(plugin_data_root=plugin_root)
+    manager.register_plugin_class(EscapingPlugin)
+    manager.register_plugin_class(GoodPlugin)
+
+    with caplog.at_level(logging.ERROR):
+        target: dict[str, object] = {}
+        manager.apply_llm_providers(target)
+
+    assert target == {"safe": object}
+    assert not (tmp_path / "escaped.txt").exists()
+    assert "initialize failed for .." in caplog.text
+
+
+def test_plugin_manager_rejects_lexical_plugin_data_root_alias(tmp_path: Path) -> None:
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        PluginManager(plugin_data_root=f"{tmp_path.as_posix()}/./plugins")
+
+
+def test_plugin_manager_rejects_symlinked_external_data_root(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    alias = tmp_path / "plugin-data-alias"
+    project.mkdir()
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        PluginManager(plugin_data_root=alias)
+
+
+def test_plugin_manager_revalidates_data_root_before_initialization(tmp_path: Path) -> None:
+    external = tmp_path / "external"
+    alias = tmp_path / "plugin-data"
+    external.mkdir()
+    manager = PluginManager(plugin_data_root=alias)
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        manager.load_own_config_all()
+
+    assert list(external.iterdir()) == []
+
+
+def test_plugin_manager_rejects_case_only_storage_collision(tmp_path: Path, caplog) -> None:
+    initialized: list[str] = []
+
+    class UpperPlugin(_BasePlugin):
+        @property
+        def plugin_id(self) -> str:
+            return "Demo.Plugin"
+
+        def initialize(self, register, plugin_root, host) -> None:
+            _ = register, plugin_root, host
+            initialized.append(self.plugin_id)
+
+    class LowerPlugin(_BasePlugin):
+        @property
+        def plugin_id(self) -> str:
+            return "demo.plugin"
+
+        def initialize(self, register, plugin_root, host) -> None:
+            _ = register, plugin_root, host
+            initialized.append(self.plugin_id)
+
+    manager = PluginManager(plugin_data_root=tmp_path / "plugins")
+    manager.register_plugin_class(UpperPlugin)
+    manager.register_plugin_class(LowerPlugin)
+
+    with caplog.at_level(logging.ERROR):
+        manager.load_own_config_all()
+
+    assert len(initialized) == 1
+    assert "initialize failed for" in caplog.text
+
+
 def test_apply_llm_tools_logs_registrar_failures(tmp_path: Path, caplog) -> None:
     class ToolPlugin(_BasePlugin):
         def initialize(
@@ -318,6 +435,57 @@ def test_load_manifest_file_accepts_json_and_yaml(tmp_path: Path) -> None:
     assert list(manager.iter_plugin_ids()) == []
 
 
+def test_load_manifest_file_resolves_relative_path_from_project_not_cwd(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project = tmp_path / "project"
+    unrelated = tmp_path / "launcher"
+    manifest = project / "data/config/plugins.yaml"
+    manifest.parent.mkdir(parents=True)
+    unrelated.mkdir()
+    manifest.write_text(
+        "- entry: sdk.plugin:PluginBase\n  enabled: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+    manager = PluginManager(plugin_data_root=project / "data/plugins")
+
+    manager.load_manifest_file(Path("data/config/plugins.yaml"))
+
+    assert list(manager.iter_plugin_ids()) == []
+
+
+def test_plugin_manager_prefers_explicit_root_over_ambient_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    ambient = tmp_path / "ambient"
+    selected = tmp_path / "selected"
+    launcher = tmp_path / "launcher"
+    manifest = selected / "data/config/plugins.yaml"
+    ambient.mkdir()
+    launcher.mkdir()
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "- entry: sdk.plugin:PluginBase\n  enabled: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", ambient.as_posix())
+    monkeypatch.chdir(launcher)
+    manager = PluginManager(
+        plugin_data_root=selected / "data/plugins",
+        root=selected,
+    )
+
+    manager.load_manifest_file(Path("data/config/plugins.yaml"))
+
+    assert manager._project_root == selected
+    assert manager._plugin_data_root == selected / "data/plugins"
+    assert list(manager.iter_plugin_ids()) == []
+
+
 @pytest.mark.parametrize(
     ("content", "message"),
     [
@@ -354,3 +522,45 @@ def test_discovery_registry_validates_entries_and_deduplicates(caplog) -> None:
         registry.register_class(object)  # type: ignore[arg-type]
     with pytest.raises(ValueError):
         registry.register_entry("   ")
+    with pytest.raises(ValueError, match="non-portable"):
+        registry.register_entry(" missing.module:Plugin")
+
+
+def test_plugin_capability_registry_rejects_identity_aliases() -> None:
+    registry = PluginCapabilityRegistry()
+
+    with pytest.raises(ValueError, match="portable path component"):
+        registry.set_settings_ui_plugin_context(" demo.plugin", "1.0")
+    with pytest.raises(ValueError, match="portable path component"):
+        registry.register_frontend_page(
+            FrontendPageContribution(
+                page_id=" page ",
+                title="Page",
+                entry="plugin/index.html",
+                plugin_id="demo.plugin",
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "entry",
+    (
+        "./plugin/index.html",
+        "plugin//index.html",
+        "plugin/../index.html",
+    ),
+)
+def test_plugin_capability_registry_rejects_frontend_entry_path_aliases(
+    entry: str,
+) -> None:
+    registry = PluginCapabilityRegistry()
+
+    with pytest.raises((PermissionError, ValueError)):
+        registry.register_frontend_page(
+            FrontendPageContribution(
+                page_id="page",
+                title="Page",
+                entry=entry,
+                plugin_id="demo.plugin",
+            )
+        )

--- a/test/unit/tools/test_background_import.py
+++ b/test/unit/tools/test_background_import.py
@@ -7,6 +7,8 @@ import yaml
 from config.schema import Background
 from tools import file_util
 
+_OPEN_EXPORT_FOLDER = file_util._open_export_folder
+
 
 @pytest.fixture(autouse=True)
 def _prevent_export_folder_open(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -71,6 +73,28 @@ def test_export_background_accepts_open_folder_false(tmp_path, monkeypatch):
     file_util.export_background([Background(name="Room", sprite_prefix="scene")], str(output), open_folder=False)
 
     assert output.is_file()
+
+
+def test_open_export_folder_does_not_follow_a_late_directory_alias(tmp_path, monkeypatch):
+    external = tmp_path / "external"
+    external.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    opened: list[list[str]] = []
+    monkeypatch.setattr(file_util.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        file_util.subprocess,
+        "Popen",
+        lambda args: opened.append(list(args)),
+    )
+
+    _OPEN_EXPORT_FOLDER(alias / "background.bg")
+
+    assert opened == []
 
 
 def test_import_background_accepts_legacy_export_with_absolute_asset_paths(tmp_path, monkeypatch):
@@ -138,3 +162,72 @@ def test_import_background_rejects_unsafe_zip_members(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError):
         file_util.import_background(str(package), [])
+
+
+def test_background_import_uses_explicit_project_root_after_cwd_drift(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    package = tmp_path / "scene.bg"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "background.yaml",
+            yaml.safe_dump(
+                [{"name": "Scene", "sprite_prefix": "scene", "sprites": [{"path": "room.png"}]}],
+                allow_unicode=True,
+            ),
+        )
+        zf.writestr("sprites/scene/room.png", "png")
+    monkeypatch.chdir(unrelated)
+
+    result = file_util.import_background(str(package), [], project_root=project.resolve())
+
+    assert _sprite_path(result[0].sprites[0]) == "data/backgrounds/scene/room.png"
+    assert (project / "data/backgrounds/scene/room.png").is_file()
+    assert not (unrelated / "data").exists()
+
+
+def test_failed_background_validation_rolls_back_copied_assets(tmp_path):
+    project = tmp_path / "project"
+    package = tmp_path / "invalid.bg"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "background.yaml",
+            yaml.safe_dump(
+                [{"name": "Invalid", "sprite_prefix": "invalid", "sprites": "not-a-list"}],
+                allow_unicode=True,
+            ),
+        )
+        zf.writestr("sprites/invalid/room.png", "png")
+
+    with pytest.raises(Exception):
+        file_util.import_background(str(package), [], project_root=project.resolve())
+
+    assert not (project / "data/backgrounds/invalid").exists()
+
+
+def test_background_import_transaction_rolls_back_after_config_save_failure(tmp_path):
+    project = tmp_path / "project"
+    package = tmp_path / "scene.bg"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "background.yaml",
+            yaml.safe_dump(
+                [{"name": "Scene", "sprite_prefix": "scene", "sprites": [{"path": "room.png"}]}],
+                allow_unicode=True,
+            ),
+        )
+        zf.writestr("sprites/scene/room.png", "png")
+
+    with pytest.raises(OSError, match="disk full"):
+        with file_util.package_import_transaction() as transaction_paths:
+            imported = file_util.import_background(
+                str(package),
+                [],
+                project_root=project.resolve(),
+                transaction_paths=transaction_paths,
+            )
+            assert imported
+            raise OSError("disk full")
+
+    assert not (project / "data/backgrounds/scene").exists()

--- a/test/unit/tools/test_character_import.py
+++ b/test/unit/tools/test_character_import.py
@@ -25,6 +25,25 @@ def _prevent_export_folder_open(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(file_util, "_open_export_folder", fail_open_folder)
 
 
+def test_unique_package_name_preserves_suffix_within_byte_limit():
+    original = ("界" * 83) + "ab.png"
+    used_names = {file_util.portable_name_key(original)}
+
+    candidate = file_util._unique_file_name(original, used_names)
+
+    assert candidate == ("界" * 83) + "_1.png"
+    assert len(candidate.encode("utf-8")) == 255
+
+
+def test_sprite_prefix_conflict_reserves_bytes_for_counter():
+    original = "界" * 85
+
+    candidate = file_util._resolve_sprite_prefix_conflict(original, {original})
+
+    assert candidate.endswith("1")
+    assert len(candidate.encode("utf-8")) <= 255
+
+
 def _make_export_zip(root: Path, char_data: dict, *,
                      sprites: dict[str, str] | None = None,
                      speeches: dict[str, str] | None = None) -> Path:
@@ -51,6 +70,54 @@ def _make_export_zip(root: Path, char_data: dict, *,
             if f.is_file():
                 zf.write(f, f.relative_to(export))
     return zip_path
+
+
+def test_default_package_paths_ignore_process_cwd(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    project.mkdir()
+    unrelated.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.chdir(unrelated)
+
+    paths = file_util._package_paths(None)
+
+    assert paths.project_root == project.resolve()
+    assert paths.sprite == project / "data" / "sprite"
+    assert paths.characters_config == project / "data" / "config" / "characters.yaml"
+
+
+def test_default_package_paths_reject_lexical_alias_before_path_conversion(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(file_util, "SPRITE_DIR", "data//sprite")
+
+    with pytest.raises(ValueError, match="exact relative components"):
+        file_util._package_paths(None)
+
+
+def test_default_package_paths_reject_a_linked_parent_in_external_storage(
+    tmp_path,
+    monkeypatch,
+):
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    alias = tmp_path / "external-alias"
+    project.mkdir()
+    external.mkdir()
+    try:
+        alias.symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+    monkeypatch.setattr(file_util, "SPRITE_DIR", alias / "sprite")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        file_util._package_paths(None)
 
 
 @contextlib.contextmanager
@@ -534,10 +601,101 @@ class TestRoundTrip:
 
             c = result[0]
             assert c.name == "Alice"
-            assert c.sprite_prefix == "alice"
+            # Existing on-disk storage is occupied even when a stale config
+            # entry is missing; importing must not merge into or overwrite it.
+            assert c.sprite_prefix == "alice1"
             assert c.sprite_scale == 1.5
             assert len(c.sprites) == 2
+            assert (file_util.SPRITE_DIR / "alice1" / "smile.png").is_file()
+            assert (file_util.SPEECH_DIR / "alice1" / "greet.wav").is_file()
             assert (file_util.SPRITE_DIR / "alice" / "smile.png").is_file()
             assert (file_util.SPEECH_DIR / "alice" / "greet.wav").is_file()
             vp = c.sprites[0].get("voice_path")
             assert vp and Path(vp).is_file()
+
+
+def test_explicit_project_root_is_stable_when_cwd_changes(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    package_root = tmp_path / "package"
+    package_root.mkdir()
+    package = _make_export_zip(
+        package_root,
+        BASIC_CHAR,
+        sprites={"smile.png": "png", "angry.png": "png"},
+        speeches={"greet.wav": "wav"},
+    )
+    monkeypatch.chdir(unrelated)
+
+    result = file_util.import_character(str(package), project_root=project.resolve())
+
+    assert result[0].sprites[0]["path"] == "data/sprite/alice/smile.png"
+    assert (project / result[0].sprites[0]["path"]).is_file()
+    assert (project / "data/config/characters.yaml").is_file()
+    assert not (unrelated / "data").exists()
+
+
+def test_failed_character_validation_rolls_back_copied_directories(tmp_path):
+    invalid = dict(BASIC_CHAR)
+    invalid["sprites"] = [
+        {
+            "path": "smile.png",
+            "voice_path": "greet.wav",
+            "voice_type": "invalid",
+        }
+    ]
+    package_root = tmp_path / "package"
+    package_root.mkdir()
+    package = _make_export_zip(
+        package_root,
+        invalid,
+        sprites={"smile.png": "png"},
+        speeches={"greet.wav": "wav"},
+    )
+    project = tmp_path / "project"
+
+    with pytest.raises(ValueError, match="voice_type"):
+        file_util.import_character(str(package), project_root=project.resolve())
+
+    assert not (project / "data/sprite/alice").exists()
+    assert not (project / "data/speech/alice").exists()
+    assert not (project / "data/config/characters.yaml").exists()
+
+
+def test_empty_sprite_prefix_keeps_models_in_an_owned_subdirectory(tmp_path):
+    character = dict(BASIC_CHAR)
+    character["sprite_prefix"] = ""
+    character["sprites"] = []
+    character["gpt_model_path"] = "models/model.bin"
+    package = tmp_path / "model.char"
+    with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("character.yaml", yaml.safe_dump([character], allow_unicode=True))
+        zf.writestr("models/model.bin", b"model")
+    project = tmp_path / "project"
+
+    result = file_util.import_character(str(package), project_root=project.resolve())
+
+    stored = str(result[0].gpt_model_path)
+    assert stored == "data/models/character-models/model.bin"
+    assert (project / stored).read_bytes() == b"model"
+    assert not (project / "data/models/model.bin").exists()
+
+
+def test_failed_export_does_not_replace_existing_package(tmp_path, monkeypatch):
+    from config.character_config import CharacterConfig
+
+    output = tmp_path / "existing.char"
+    output.write_bytes(b"known-good-package")
+    config = CharacterConfig.parse_dic(char_data=BASIC_CHAR)
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("simulated archive failure")
+
+    monkeypatch.setattr(file_util, "write_directory_to_zip_without_links", fail_write)
+
+    with pytest.raises(OSError, match="archive failure"):
+        file_util.export_character([config], str(output), open_folder=False)
+
+    assert output.read_bytes() == b"known-good-package"
+    assert not list(tmp_path.glob(".existing.char.*.tmp"))

--- a/test/unit/tools/test_comfyui_workflow2api.py
+++ b/test/unit/tools/test_comfyui_workflow2api.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 
-from tools.comfyui_workflow2api import convert_workflow, main
+import pytest
+
+from tools.comfyui_workflow2api import convert_workflow, load_json, main
 
 
 def test_api_prompt_passthrough_detects_nodes() -> None:
@@ -153,3 +155,37 @@ def test_cli_writes_converted_workflow(tmp_path) -> None:
             "inputs": {"text": "prompt"},
         }
     }
+
+
+def test_comfyui_converter_rejects_input_alias_before_read(tmp_path) -> None:
+    source = tmp_path / "workflow.json"
+    source.write_text("{}", encoding="utf-8")
+    alias = f"{tmp_path.as_posix()}/./workflow.json"
+
+    with pytest.raises(ValueError, match="lexical path aliases"):
+        load_json(alias)
+
+
+def test_comfyui_converter_rejects_symlinked_input_before_read(tmp_path) -> None:
+    source = tmp_path / "workflow.json"
+    source.write_text("{}", encoding="utf-8")
+    alias = tmp_path / "workflow-alias.json"
+    try:
+        alias.symlink_to(source)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        load_json(alias)
+
+
+def test_comfyui_converter_rejects_output_alias_before_write(tmp_path) -> None:
+    source = tmp_path / "workflow.json"
+    source.write_text(
+        '{"1":{"class_type":"SaveImage","inputs":{}}}',
+        encoding="utf-8",
+    )
+    output_alias = f"{tmp_path.as_posix()}/./workflow.api.json"
+
+    assert main([source.as_posix(), "-o", output_alias]) == 1
+    assert not (tmp_path / "workflow.api.json").exists()

--- a/test/unit/tools/test_dag_graph.py
+++ b/test/unit/tools/test_dag_graph.py
@@ -363,6 +363,77 @@ class TestDagSerialization:
         assert "A" in content
         assert "EchoNode" in content
 
+    @pytest.mark.parametrize("alias", ("./graph.yaml", "nested//graph.yaml", "nested/../graph.yaml"))
+    def test_to_yaml_rejects_lexical_output_aliases(self, tmp_path, alias, monkeypatch):
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+        builder = DagBuilder()
+
+        with pytest.raises((PermissionError, ValueError), match="exact|alias|escapes"):
+            builder.to_yaml(alias)
+
+        assert not (tmp_path / "graph.yaml").exists()
+        assert not (tmp_path / "nested" / "graph.yaml").exists()
+
+    def test_to_yaml_rejects_explicit_empty_output(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+        builder = DagBuilder()
+
+        with pytest.raises(ValueError, match="empty"):
+            builder.to_yaml("")
+
+    def test_load_yaml_rejects_an_existing_file_alias(self, tmp_path):
+        yaml_path = tmp_path / "workflow.yaml"
+        yaml_path.write_text("nodes: []\nedges: []\n", encoding="utf-8")
+        alias = f"{tmp_path.as_posix()}/./workflow.yaml"
+        builder = DagBuilder()
+
+        with pytest.raises(ValueError, match="alias"):
+            builder.load_yaml(alias)
+
+    def test_load_yaml_rejects_symlinked_workflow(self, tmp_path):
+        workflow = tmp_path / "workflow.yaml"
+        alias = tmp_path / "workflow-alias.yaml"
+        workflow.write_text("nodes: []\nedges: []\n", encoding="utf-8")
+        try:
+            alias.symlink_to(workflow)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks are unavailable")
+
+        with pytest.raises(PermissionError, match="symbolic link"):
+            DagBuilder().load_yaml(alias.as_posix())
+
+    def test_load_yaml_resolves_relative_file_from_project_not_cwd(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        project = tmp_path / "project"
+        unrelated = tmp_path / "launcher"
+        workflow = project / "workflows/workflow.yaml"
+        workflow.parent.mkdir(parents=True)
+        unrelated.mkdir()
+        workflow.write_text("nodes: []\nedges: []\n", encoding="utf-8")
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+        monkeypatch.chdir(unrelated)
+        builder = DagBuilder()
+
+        builder.load_yaml("workflows/workflow.yaml")
+
+        assert builder._nodes == {}
+        assert builder._edges == []
+
+    def test_load_yaml_reports_missing_declared_path(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", tmp_path.as_posix())
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            DagBuilder().load_yaml("workflows/missing.yaml")
+
+        assert exc_info.value.filename == (tmp_path / "workflows/missing.yaml").as_posix()
+
     def test_from_yaml_round_trip(self, tmp_path):
         """Export to YAML, re-import, verify nodes exist."""
         a = EchoNode("src")

--- a/test/unit/tools/test_generate_sprites_paths.py
+++ b/test/unit/tools/test_generate_sprites_paths.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.generate_sprites import (
+    _existing_input_image,
+    _output_parent_identity,
+    _publish_generated_image,
+    _writable_output_directory,
+    _writable_output_file,
+)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "./reference.png",
+        "images//reference.png",
+        "images/../reference.png",
+    ),
+)
+def test_sprite_generator_rejects_input_aliases_before_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+) -> None:
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+    (tmp_path / "reference.png").write_bytes(b"not-an-image")
+    (tmp_path / "images").mkdir()
+    (tmp_path / "images" / "reference.png").write_bytes(b"not-an-image")
+
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        _existing_input_image(raw)
+
+
+def test_sprite_generator_rejects_symlinked_input_before_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    target = external / "reference.png"
+    target.write_bytes(b"not-an-image")
+    alias = project / "reference.png"
+    try:
+        alias.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("file symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _existing_input_image("reference.png")
+
+
+@pytest.mark.parametrize(
+    "resolver,raw",
+    (
+        (_writable_output_file, "./sprite.png"),
+        (_writable_output_file, "images//sprite.png"),
+        (_writable_output_directory, "images/../sprites"),
+    ),
+)
+def test_sprite_generator_rejects_output_aliases_before_creating_anything(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    resolver,
+    raw: str,
+) -> None:
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+
+    with pytest.raises((PermissionError, ValueError), match="exact|escapes"):
+        resolver(raw)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_sprite_generator_rejects_replaced_output_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+    output = _writable_output_file("generated/sprite.png")
+    expected_parent_identity = _output_parent_identity(output)
+    preserved = tmp_path / "generated-preserved"
+    output.parent.rename(preserved)
+    output.parent.mkdir()
+    peer = output.parent / output.name
+    peer.write_bytes(b"peer")
+
+    with pytest.raises(PermissionError, match="identity changed"):
+        _publish_generated_image(
+            output,
+            b"generated",
+            expected_parent_identity=expected_parent_identity,
+        )
+
+    assert peer.read_bytes() == b"peer"
+    assert not (preserved / output.name).exists()

--- a/test/unit/tools/test_generate_voice_lines.py
+++ b/test/unit/tools/test_generate_voice_lines.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools import generate_voice_lines as module
+
+
+class RecordingTTS:
+    def __init__(self) -> None:
+        self.generated: list[dict[str, object]] = []
+
+    def switch_model(self, _gpt_model_path: str, _sovits_model_path: str) -> None:
+        pass
+
+    def generate_tts(self, _word: str, **kwargs: object) -> None:
+        self.generated.append(kwargs)
+
+
+def _character(sprite_prefix: str, sprite_count: int = 2) -> dict[str, object]:
+    return {
+        "name": "Alice",
+        "sprite_prefix": sprite_prefix,
+        "gpt_model_path": "gpt.ckpt",
+        "sovits_model_path": "sovits.pth",
+        "refer_audio_path": "reference.wav",
+        "prompt_text": "reference",
+        "prompt_lang": "en",
+        "sprites": [{} for _ in range(sprite_count)],
+    }
+
+
+def test_generate_voice_lines_generates_each_word_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tts = RecordingTTS()
+    character = _character("alice")
+    saved: list[bool] = []
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setattr(module, "characters", [character])
+    monkeypatch.setattr(module, "tts_manager", tts)
+    monkeypatch.setattr(
+        module,
+        "save_characters_to_file",
+        lambda: saved.append(True),
+    )
+
+    module.generate_voice_lines("Alice", ["first", "second"])
+
+    assert len(tts.generated) == 2
+    assert [
+        Path(str(call["file_path"])).relative_to(tmp_path).as_posix()
+        for call in tts.generated
+    ] == [
+        "data/speech/alice/alice_voice_00.wav",
+        "data/speech/alice/alice_voice_01.wav",
+    ]
+    assert [
+        sprite["voice_path"] for sprite in character["sprites"]  # type: ignore[index]
+    ] == [
+        "data/speech/alice/alice_voice_00.wav",
+        "data/speech/alice/alice_voice_01.wav",
+    ]
+    assert saved == [True]
+
+
+def test_generate_voice_lines_rejects_unsafe_sprite_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setattr(module, "characters", [_character("../outside")])
+    monkeypatch.setattr(module, "tts_manager", RecordingTTS())
+
+    with pytest.raises(ValueError, match="sprite_prefix"):
+        module.generate_voice_lines("Alice", ["first"])
+
+    assert not (tmp_path / "data").exists()

--- a/test/unit/tools/test_sprite_batch_tool_paths.py
+++ b/test/unit/tools/test_sprite_batch_tool_paths.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.crop_sprite import batch_crop_upper_half
+from tools.remove_bg import batch_remove_background
+
+
+@pytest.mark.parametrize(
+    "operation",
+    (
+        lambda: batch_crop_upper_half(0.5, "./images", "output"),
+        lambda: batch_remove_background("./images", "output"),
+    ),
+)
+def test_batch_sprite_tools_reject_input_aliases_before_creating_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation,
+) -> None:
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+    (tmp_path / "images").mkdir()
+
+    with pytest.raises(ValueError, match="exact"):
+        operation()
+
+    assert not (tmp_path / "output").exists()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    (
+        lambda: batch_crop_upper_half(0.5, "images", "output"),
+        lambda: batch_remove_background("images", "output"),
+    ),
+)
+def test_batch_sprite_tools_reject_symlinked_input_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation,
+) -> None:
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    project.mkdir()
+    external.mkdir()
+    try:
+        (project / "images").symlink_to(external, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", project.as_posix())
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        operation()
+
+    assert not (project / "output").exists()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    (
+        lambda: batch_crop_upper_half(0.5, "images", "./output"),
+        lambda: batch_remove_background("images", "output//nested"),
+    ),
+)
+def test_batch_sprite_tools_reject_output_aliases_before_creating_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation,
+) -> None:
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(tmp_path))
+    (tmp_path / "images").mkdir()
+
+    with pytest.raises(ValueError, match="exact"):
+        operation()
+
+    assert not (tmp_path / "output").exists()

--- a/test/unit/ui_helpers/test_webui_react.py
+++ b/test/unit/ui_helpers/test_webui_react.py
@@ -3,7 +3,12 @@ import time
 
 import pytest
 
-from webui_react import FrontendMigrationNeeded, _ensure_frontend_dist
+from webui_react import (
+    FrontendMigrationNeeded,
+    _ensure_frontend_dist,
+    _resolve_frontend_dist,
+    _resolve_project_root,
+)
 
 
 def test_existing_stale_dist_is_served_when_build_environment_is_missing(tmp_path, capsys):
@@ -39,3 +44,106 @@ def test_missing_dist_requests_migration_when_build_environment_is_missing(tmp_p
             build_if_missing=True,
             build_if_stale=True,
         )
+
+
+def test_relative_frontend_dist_cannot_escape_repository_root(tmp_path):
+    with pytest.raises(ValueError, match="escapes repository root"):
+        _resolve_frontend_dist(tmp_path / "repo", "../outside")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_frontend_dist_cannot_be_a_linked_directory(tmp_path):
+    repo_root = tmp_path / "repo"
+    external_dist = tmp_path / "external-dist"
+    (repo_root / "frontend").mkdir(parents=True)
+    external_dist.mkdir()
+    (repo_root / "frontend" / "dist").symlink_to(
+        external_dist,
+        target_is_directory=True,
+    )
+
+    with pytest.raises(ValueError, match="linked component"):
+        _resolve_frontend_dist(repo_root, "frontend/dist")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_frontend_dist_cannot_use_a_linked_index(tmp_path):
+    frontend_dir = tmp_path / "frontend"
+    dist = frontend_dir / "dist"
+    external_index = tmp_path / "external-index.html"
+    dist.mkdir(parents=True)
+    external_index.write_text("external", encoding="utf-8")
+    (dist / "index.html").symlink_to(external_index)
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _ensure_frontend_dist(
+            tmp_path,
+            dist,
+            build_if_missing=True,
+            build_if_stale=True,
+        )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_frontend_build_cannot_use_a_linked_source_file(tmp_path):
+    frontend_dir = tmp_path / "frontend"
+    dist = frontend_dir / "dist"
+    external_package = tmp_path / "package.json"
+    dist.mkdir(parents=True)
+    external_package.write_text('{"scripts":{"build":"true"}}', encoding="utf-8")
+    (frontend_dir / "package.json").symlink_to(external_package)
+    (dist / "index.html").write_text("built", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        _ensure_frontend_dist(
+            tmp_path,
+            dist,
+            build_if_missing=True,
+            build_if_stale=True,
+        )
+
+
+def test_explicit_project_root_must_be_absolute(tmp_path, monkeypatch):
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    with pytest.raises(ValueError, match="--project-root must be an absolute path"):
+        _resolve_project_root(tmp_path / "repo", "relative-project")
+
+    selected = tmp_path / "selected"
+    assert _resolve_project_root(tmp_path / "repo", str(selected)) == selected.resolve()
+
+
+def test_project_root_distinguishes_absent_from_explicit_empty(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    monkeypatch.delenv("SHINSEKAI_PROJECT_ROOT", raising=False)
+    monkeypatch.delenv("EASYAI_PROJECT_ROOT", raising=False)
+
+    assert _resolve_project_root(repo_root, None) == repo_root.resolve()
+    with pytest.raises(ValueError, match="--project-root must not be empty"):
+        _resolve_project_root(repo_root, "")
+
+
+def test_project_root_uses_current_environment_before_legacy(tmp_path, monkeypatch):
+    current = tmp_path / "current"
+    legacy = tmp_path / "legacy"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", str(current))
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(legacy))
+
+    assert _resolve_project_root(tmp_path / "repo", None) == current.resolve()
+
+    monkeypatch.delenv("SHINSEKAI_PROJECT_ROOT")
+    assert _resolve_project_root(tmp_path / "repo", None) == legacy.resolve()
+
+
+def test_project_root_rejects_present_empty_environment_without_legacy_fallback(
+    tmp_path,
+    monkeypatch,
+):
+    legacy = tmp_path / "legacy"
+    monkeypatch.setenv("SHINSEKAI_PROJECT_ROOT", "")
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(legacy))
+
+    with pytest.raises(ValueError, match="SHINSEKAI_PROJECT_ROOT must not be empty"):
+        _resolve_project_root(tmp_path / "repo", None)

--- a/test/unit/ui_helpers/test_webui_react_migration.py
+++ b/test/unit/ui_helpers/test_webui_react_migration.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import SimpleNamespace
 
 import pytest
 
@@ -26,12 +27,86 @@ def test_build_frontend_requests_migration_when_pnpm_is_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    from core import process_launch
+
     frontend = _frontend_root(tmp_path)
     (frontend / "node_modules").mkdir()
-    monkeypatch.setattr(webui_react.shutil, "which", lambda name: None)
+
+    def missing_pnpm(*_args, **_kwargs):
+        raise FileNotFoundError("pnpm")
+
+    monkeypatch.setattr(
+        process_launch,
+        "capture_command_executable",
+        missing_pnpm,
+    )
 
     with pytest.raises(webui_react.FrontendMigrationNeeded, match="pnpm"):
         webui_react._build_frontend(tmp_path, frontend / "dist", "not found")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_build_frontend_rejects_linked_dependency_root(
+    tmp_path: Path,
+) -> None:
+    frontend = _frontend_root(tmp_path)
+    external_modules = tmp_path / "external-modules"
+    external_modules.mkdir()
+    (frontend / "node_modules").symlink_to(
+        external_modules,
+        target_is_directory=True,
+    )
+
+    with pytest.raises(PermissionError, match="symbolic link"):
+        webui_react._build_frontend(tmp_path, frontend / "dist", "not found")
+
+
+def test_build_frontend_rejects_source_changed_during_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from core import process_launch
+
+    frontend = _frontend_root(tmp_path)
+    package = frontend / "package.json"
+    package.write_text('{"name":"before"}', encoding="utf-8")
+    (frontend / "node_modules").mkdir()
+
+    def python_executable(*_args, **_kwargs):
+        return process_launch.capture_launch_file(
+            sys.executable,
+            field="test Python executable",
+            executable=True,
+        )
+
+    monkeypatch.setattr(
+        process_launch,
+        "capture_command_executable",
+        python_executable,
+    )
+
+    def change_source_during_build(*_args, **_kwargs):
+        package.write_text(
+            '{"name":"replacement-is-longer"}',
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(
+        webui_react.subprocess,
+        "run",
+        change_source_during_build,
+    )
+
+    with pytest.raises(
+        webui_react.FrontendMigrationNeeded,
+        match="changed while",
+    ):
+        webui_react._build_frontend(
+            tmp_path,
+            frontend / "dist",
+            "not found",
+        )
 
 
 def test_main_opens_migration_dialog_for_missing_frontend_environment(
@@ -66,36 +141,3 @@ def test_main_can_force_show_migration_helper(monkeypatch: pytest.MonkeyPatch) -
     webui_react.main()
 
     assert shown == ["Opening the Shinsekai Frontend migration helper for testing."]
-
-
-def test_show_migration_dialog_opens_preserved_tools_helper(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    calls: list[str] = []
-
-    class FakeApplication:
-        @classmethod
-        def instance(cls):
-            return None
-
-        def __init__(self, _args) -> None:
-            calls.append("app")
-
-    class FakeDialog:
-        def __init__(self) -> None:
-            calls.append("dialog")
-
-        def exec(self) -> int:
-            calls.append("exec")
-            return 0
-
-    helper_module = ModuleType("tools.migrate_helper.dialog")
-    helper_module.MigrationRoleDialog = FakeDialog  # type: ignore[attr-defined]
-    qtwidgets_module = ModuleType("PySide6.QtWidgets")
-    qtwidgets_module.QApplication = FakeApplication  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "tools.migrate_helper.dialog", helper_module)
-    monkeypatch.setitem(sys.modules, "PySide6.QtWidgets", qtwidgets_module)
-
-    webui_react._show_frontend_migration_dialog("migration required")
-
-    assert calls == ["app", "dialog", "exec"]


### PR DESCRIPTION
## What changed

Adds regression coverage under `test/` for path resolution, storage safety,
process launching, runtime assets, bridge requests, plugins, SDK APIs, and
tools.

## Why

The migration changes shared invariants across many subsystems and needs
explicit coverage for valid paths, rejected paths, and race-resistant file
operations.

## Impact

Future changes receive broader regression protection for cross-platform and
security-sensitive path behavior.

## Root cause

Existing tests covered individual call sites but did not enforce one common
path contract across the migrated architecture.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `test/`.
