### PR TITLE
fix(tools): enforce migration-safe path contracts

### DIFF
--- a/tools/comfyui_workflow2api.py
+++ b/tools/comfyui_workflow2api.py
@@ -17,6 +17,19 @@ from pathlib import Path
 from typing import Any
 from urllib.request import urlopen
 
+if __package__ in {None, ""}:
+    _source_root = Path(__file__).resolve().parent.parent
+    if str(_source_root) not in sys.path:
+        sys.path.insert(0, str(_source_root))
+
+from core.file_transactions import atomic_write_text, read_text_without_links
+from core.paths import (
+    project_root,
+    require_directory_without_links,
+    resolve_project_output_path,
+    resolve_runtime_asset_read_path,
+)
+
 
 class WorkflowConversionError(ValueError):
     """Raised when a workflow cannot be converted into an API prompt."""
@@ -69,8 +82,10 @@ _BUILTIN_WIDGET_INPUTS: dict[str, list[tuple[str, str]]] = {
 
 
 def load_json(path: str | Path) -> Any:
-    with Path(path).open("r", encoding="utf-8") as handle:
-        return json.load(handle)
+    source = resolve_runtime_asset_read_path(path, root=project_root())
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    return json.loads(read_text_without_links(source))
 
 
 def is_api_prompt(data: Any) -> bool:
@@ -395,8 +410,13 @@ def main(argv: list[str] | None = None) -> int:
         result = convert_workflow(load_json(args.workflow), object_info=object_info)
         text = json.dumps(result.prompt, ensure_ascii=False, indent=args.indent)
         if args.output:
-            Path(args.output).parent.mkdir(parents=True, exist_ok=True)
-            Path(args.output).write_text(text + "\n", encoding="utf-8")
+            output = resolve_project_output_path(args.output, root=project_root())
+            output.parent.mkdir(parents=True, exist_ok=True)
+            require_directory_without_links(
+                output.parent,
+                field="ComfyUI workflow output directory",
+            )
+            atomic_write_text(output, text + "\n")
         else:
             print(text)
         if args.summary:

--- a/tools/crop_sprite.py
+++ b/tools/crop_sprite.py
@@ -1,8 +1,30 @@
 import os
 import sys
 import argparse
+import stat
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    _source_root = Path(__file__).resolve().parent.parent
+    if str(_source_root) not in sys.path:
+        sys.path.insert(0, str(_source_root))
+
 from PIL import Image
-import glob
+
+from core.file_transactions import (
+    atomic_binary_writer,
+    file_snapshot_is_stable,
+    open_binary_read_without_links,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from core.paths import (
+    managed_child_path,
+    project_root,
+    require_directory_without_links,
+    resolve_project_output_path,
+    resolve_runtime_asset_read_path,
+)
 
 # ./runtime/python.exe ./tools/crop_sprite.py -x 0.6 -d "C:\输入目录" -o "输出目录"
 def batch_crop_upper_half(factor, directory, output_dir=None):
@@ -18,26 +40,43 @@ def batch_crop_upper_half(factor, directory, output_dir=None):
     if not 0 < factor <= 1:
         return("错误：因子必须在0到1之间")
     
-    # 检查目录是否存在
-    if not os.path.exists(directory):
-        return(f"错误：目录 '{directory}' 不存在")
-        return False
+    root = project_root()
+    input_path = resolve_runtime_asset_read_path(os.fspath(directory), root=root)
+    if not input_path.is_dir():
+        return f"错误：目录 '{input_path}' 不存在"
+    input_path, input_identity, input_entries = (
+        snapshot_directory_entries_without_links(
+            input_path,
+            field="sprite crop input directory",
+        )
+    )
     
     # 设置输出目录
     if output_dir is None or output_dir == '':
-        output_dir = os.path.join(directory, f"cropped_upper_{factor}")
+        output_dir = input_path / f"cropped_upper_{factor}"
     
     # 创建输出目录
-    os.makedirs(output_dir, exist_ok=True)
+    output_path = resolve_project_output_path(os.fspath(output_dir), root=root)
+    output_path.mkdir(parents=True, exist_ok=True)
+    output_path = require_directory_without_links(
+        output_path,
+        field="cropped sprite output directory",
+    )
+    output_identity = output_path.lstat()
     
     # 支持的图片格式
-    supported_formats = ['*.jpg', '*.jpeg', '*.png', '*.bmp', '*.tiff', '*.webp']
+    supported_suffixes = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff', '.webp'}
     
     # 获取所有图片文件
-    image_files = []
-    for format in supported_formats:
-        image_files.extend(glob.glob(os.path.join(directory, format)))
-        image_files.extend(glob.glob(os.path.join(directory, format.upper())))
+    image_files = sorted(
+        [
+            (child, metadata)
+            for child, metadata in input_entries
+            if stat.S_ISREG(metadata.st_mode)
+            and child.suffix.lower() in supported_suffixes
+        ],
+        key=lambda item: (item[0].name.casefold(), item[0].name),
+    )
     
     if not image_files:
         print(f"在目录 '{directory}' 中未找到支持的图片文件")
@@ -49,10 +88,24 @@ def batch_crop_upper_half(factor, directory, output_dir=None):
     processed_count = 0
     error_count = 0
     
-    for image_path in image_files:
+    for image_path, image_identity in image_files:
         try:
             # 打开图片
-            with Image.open(image_path) as img:
+            with (
+                open_binary_read_without_links(
+                    image_path,
+                    expected_identity=image_identity,
+                    expected_parent_identity=input_identity,
+                ) as image_file,
+                Image.open(image_file) as img,
+            ):
+                before = os.fstat(image_file.fileno())
+                img.load()
+                after = os.fstat(image_file.fileno())
+                if not file_snapshot_is_stable(before, after):
+                    raise PermissionError(
+                        f"input image changed while it was being read: {image_path}"
+                    )
                 # 获取图片尺寸
                 width, height = img.size
                 
@@ -66,27 +119,46 @@ def batch_crop_upper_half(factor, directory, output_dir=None):
                 cropped_img = img.crop(crop_box)
                 
                 # 生成输出文件名
-                filename = os.path.basename(image_path)
-                name, ext = os.path.splitext(filename)
-                output_filename = f"{name}{ext}"
-                output_path = os.path.join(output_dir, output_filename)
+                filename = image_path.name
+                output_file = managed_child_path(
+                    output_path,
+                    filename,
+                    field="cropped sprite filename",
+                )
                 
                 # 保存图片
-                cropped_img.save(output_path)
+                image_format = (
+                    Image.registered_extensions().get(output_file.suffix.lower())
+                    or img.format
+                    or "PNG"
+                )
+                with atomic_binary_writer(
+                    output_file,
+                    expected_parent_identity=output_identity,
+                ) as output:
+                    cropped_img.save(output, format=image_format)
                 
                 processed_count += 1
-                print(f"✓ 已处理: {filename} -> {output_filename}")
+                print(f"✓ 已处理: {filename} -> {filename}")
                 
         except Exception as e:
             error_count += 1
-            print(f"✗ 处理失败: {os.path.basename(image_path)} - 错误: {str(e)}")
-    
+            print(f"✗ 处理失败: {image_path.name} - 错误: {str(e)}")
+
+    require_directory_identity(
+        input_path,
+        input_identity,
+        field="sprite crop input directory",
+    )
+    require_directory_identity(
+        output_path,
+        output_identity,
+        field="cropped sprite output directory",
+    )
     print(f"\n处理完成！")
     print(f"成功处理: {processed_count} 个文件")
     print(f"处理失败: {error_count} 个文件")
-    return f"成功裁剪，输出目录: {output_dir}"
-    
-    return True
+    return f"成功裁剪，输出目录: {output_path}"
 
 def main():
     parser = argparse.ArgumentParser(description='批量截取图片的上半部分')

--- a/tools/diarization.py
+++ b/tools/diarization.py
@@ -1,10 +1,32 @@
 import os
-import numpy as np
+import sys
+from io import BytesIO
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    _source_root = Path(__file__).resolve().parent.parent
+    if str(_source_root) not in sys.path:
+        sys.path.insert(0, str(_source_root))
+
 from pydub import AudioSegment
 from pyannote.audio import Pipeline
 import torchaudio
 
 from config.config_manager import ConfigManager
+from core.file_transactions import (
+    atomic_binary_writer,
+    capture_directory_identity,
+    read_bytes_without_links,
+)
+from core.process_launch import capture_launch_file, require_launch_file
+from core.paths import (
+    managed_child_path,
+    project_root,
+    require_directory_without_links,
+    resolve_project_output_path,
+    resolve_runtime_asset_read_path,
+    safe_path_component_with_suffix,
+)
 
 config = ConfigManager()
 
@@ -19,10 +41,28 @@ def diarize_and_stitch_by_speaker(input_audio_path, output_dir):
         output_dir (str): 输出拼接后音频文件的目录。
     """
     
-    # 检查输出目录
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-        print(f"创建输出目录: {output_dir}")
+    root = project_root()
+    source = resolve_runtime_asset_read_path(
+        os.fspath(input_audio_path),
+        root=root,
+    )
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    source_snapshot = capture_launch_file(
+        source,
+        field="diarization input audio",
+    )
+    output_path = resolve_project_output_path(os.fspath(output_dir), root=root)
+    output_path.mkdir(parents=True, exist_ok=True)
+    output_path = require_directory_without_links(
+        output_path,
+        field="diarization output directory",
+    )
+    output_path, output_identity = capture_directory_identity(
+        output_path,
+        field="diarization output directory",
+    )
+    print(f"输出目录: {output_path}")
 
     # 1. 初始化说话人识别 Pipeline
     try:
@@ -38,21 +78,33 @@ def diarize_and_stitch_by_speaker(input_audio_path, output_dir):
         print(f"加载 pyannote 模型失败，请检查您的 HUGGING_FACE_TOKEN 和网络连接。\n错误信息: {e}")
         return
 
-    # 2. 执行说话人识别
-    print(f"正在处理音频文件: {input_audio_path}")
+    # 2. 从同一个经过校验的文件描述符加载音频，后续识别与切片都使用
+    # 这一份内存数据，避免路径在多个库各自打开之间被替换。
+    print(f"正在处理音频文件: {source}")
     try:
-        diarization = pipeline(input_audio_path)
+        source_payload = read_bytes_without_links(
+            source_snapshot.path,
+            expected_identity=source_snapshot.identity,
+            expected_parent_identity=source_snapshot.parent.identity,
+        )
+        waveform, sample_rate = torchaudio.load(BytesIO(source_payload))
+        full_audio = AudioSegment.from_file(
+            BytesIO(source_payload),
+            format=source.suffix.removeprefix(".") or None,
+        )
+        require_launch_file(source_snapshot)
+        diarization = pipeline(
+            {
+                "waveform": waveform,
+                "sample_rate": sample_rate,
+            }
+        )
     except Exception as e:
         print(f"说话人识别失败: {e}")
         return
 
     # 3. 按说话人分组片段
     speaker_segments = {}
-    
-    # torchaudio 读取音频用于片段提取
-    waveform, sample_rate = torchaudio.load(input_audio_path)
-    # 将 waveform 转换为 numpy 数组以便处理
-    waveform_np = waveform.squeeze().numpy() 
 
     # 遍历识别结果
     for segment, _, speaker in diarization.itertracks(yield_labelling=True):
@@ -71,18 +123,8 @@ def diarize_and_stitch_by_speaker(input_audio_path, output_dir):
             # 初始化一个空的 AudioSegment，代表该说话人拼接后的总音频
             speaker_segments[speaker] = AudioSegment.empty()
 
-        try:
-            # 使用 pydub 加载整个音频（确保格式兼容，如wav, mp3）
-            full_audio = AudioSegment.from_file(input_audio_path)
-            # 切割出该片段
-            segment_audio = full_audio[start_ms:end_ms]
-            
-            # 拼接片段
-            speaker_segments[speaker] += segment_audio
-        
-        except Exception as e:
-            print(f"处理说话人 {speaker} 的片段时出错: {e}")
-            continue
+        # 切割并拼接这一说话人的片段。
+        speaker_segments[speaker] += full_audio[start_ms:end_ms]
 
     # 4. 导出结果
     print("\n--- 导出结果 ---")
@@ -91,11 +133,24 @@ def diarize_and_stitch_by_speaker(input_audio_path, output_dir):
         return
 
     for speaker, stitched_audio in speaker_segments.items():
-        output_filename = os.path.join(output_dir, f"{speaker}_stitched.wav")
+        output_filename = safe_path_component_with_suffix(
+            str(speaker),
+            "_stitched.wav",
+            field="speaker output filename",
+        )
+        output_file = managed_child_path(
+            output_path,
+            output_filename,
+            field="speaker output filename",
+        )
         
         # 导出为 WAV 格式
-        stitched_audio.export(output_filename, format="wav")
-        print(f"成功导出 {speaker} 的音频到: {output_filename}")
+        with atomic_binary_writer(
+            output_file,
+            expected_parent_identity=output_identity,
+        ) as output:
+            stitched_audio.export(output, format="wav")
+        print(f"成功导出 {speaker} 的音频到: {output_file}")
 
 # --- 运行示例 ---
 if __name__ == "__main__":
@@ -107,7 +162,10 @@ if __name__ == "__main__":
 
     if HUGGING_FACE_TOKEN == "YOUR_HUGGING_FACE_TOKEN_HERE":
         print("!!! 请在代码顶部设置您的 HUGGING_FACE_TOKEN 才能运行 !!!")
-    elif not os.path.exists(INPUT_FILE):
+    elif not resolve_runtime_asset_read_path(
+        INPUT_FILE,
+        root=project_root(),
+    ).is_file():
         print(f"!!! 错误: 找不到输入文件 '{INPUT_FILE}'。请将您的音频文件放置于此或修改 INPUT_FILE 变量。")
     else:
         diarize_and_stitch_by_speaker(INPUT_FILE, OUTPUT_FOLDER)

--- a/tools/file_util.py
+++ b/tools/file_util.py
@@ -1,19 +1,58 @@
 import os
-import shutil
+import threading
 import zipfile
 import yaml
 import json
 import re
+import stat
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from config.character_config import CharacterConfig
 from config.schema import Background
 from config.config_manager import ConfigManager
+from core.archive_paths import (
+    extract_zip_safely,
+    write_directory_to_zip_without_links,
+    write_zip_files_without_links,
+)
+from core.file_transactions import (
+    atomic_binary_writer,
+    atomic_write_text,
+    copy_directory_without_links,
+    copy_file_exclusive,
+    create_private_temporary_directory,
+    file_snapshot_is_stable,
+    open_binary_read_without_links,
+    portable_name_key,
+    read_text_without_links,
+    remove_directory_without_links,
+    remove_link_without_following,
+    snapshot_directory_entries_without_links,
+)
+from core.paths import (
+    _metadata_is_link_or_reparse_point,
+    managed_child_path,
+    managed_project_storage,
+    path_is_link_or_reparse_point,
+    portable_project_path,
+    project_root as runtime_project_root,
+    resolve_managed_project_path,
+    resolve_project_output_path,
+    resolve_project_path,
+    resolve_runtime_asset_read_path,
+    require_directory_without_links,
+    require_symlink_free_absolute_path,
+    safe_path_component,
+    safe_path_component_with_suffix,
+)
+from core.process_launch import open_with_default_application
 from typing import List
 import platform
 import subprocess
 
 # 定义项目的基础数据路径
-BASE_DATA_PATH = Path('./data')
+BASE_DATA_PATH = Path('data')
 SPRITE_DIR = BASE_DATA_PATH / 'sprite'
 SPEECH_DIR = BASE_DATA_PATH / 'speech'
 MODEL_DIR = BASE_DATA_PATH / 'models'
@@ -25,28 +64,288 @@ BGM_UPLOAD_DIR = BASE_DATA_PATH / 'bgm'
 EFFECT_UPLOAD_DIR = BASE_DATA_PATH / 'effects'
 
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_PACKAGE_IO_LOCK = threading.RLock()
+
+
+@dataclass(frozen=True)
+class _PackagePaths:
+    project_root: Path | None
+    sprite: Path
+    speech: Path
+    models: Path
+    config: Path
+    characters_config: Path
+    backgrounds: Path
+    bgm: Path
+    effects: Path
+
+
+def _package_paths(project_root: str | os.PathLike | None) -> _PackagePaths:
+    """Resolve package storage once, independent of later cwd changes.
+
+    Direct callers without an explicit root still use the legacy configurable
+    globals, but relative globals are anchored to the authoritative project
+    root instead of the process working directory.  Absolute test/integration
+    overrides retain their explicit meaning.
+    """
+
+    if project_root is None:
+        root = runtime_project_root()
+
+        def anchored(value: str | os.PathLike, *, file_path: bool = False) -> Path:
+            path = Path(value).expanduser()
+            if not path.is_absolute():
+                resolver = resolve_managed_project_path if file_path else managed_project_storage
+                return resolver(value, root=root)
+            try:
+                path.relative_to(root)
+            except ValueError:
+                return require_symlink_free_absolute_path(
+                    path,
+                    field="package storage path",
+                )
+            return resolve_managed_project_path(value, root=root)
+
+        return _PackagePaths(
+            project_root=root,
+            sprite=anchored(SPRITE_DIR),
+            speech=anchored(SPEECH_DIR),
+            models=anchored(MODEL_DIR),
+            config=anchored(CONFIG_DIR),
+            characters_config=anchored(CHARACTERS_CONFIG_PATH, file_path=True),
+            backgrounds=anchored(BACKGROUND_UPLOAD_DIR),
+            bgm=anchored(BGM_UPLOAD_DIR),
+            effects=anchored(EFFECT_UPLOAD_DIR),
+        )
+
+    root = resolve_project_path(".", root=project_root)
+    config = managed_project_storage("data/config", root=root)
+    paths = _PackagePaths(
+        project_root=root,
+        sprite=managed_project_storage("data/sprite", root=root),
+        speech=managed_project_storage("data/speech", root=root),
+        models=managed_project_storage("data/models", root=root),
+        config=config,
+        characters_config=resolve_managed_project_path(
+            "data/config/characters.yaml",
+            root=root,
+        ),
+        backgrounds=managed_project_storage("data/backgrounds", root=root),
+        bgm=managed_project_storage("data/bgm", root=root),
+        effects=managed_project_storage("data/effects", root=root),
+    )
+    return paths
+
+
+def _resolve_io_path(
+    value: str | os.PathLike,
+    paths: _PackagePaths,
+    *,
+    writable: bool = False,
+) -> Path:
+    if paths.project_root is not None:
+        if writable:
+            return resolve_project_output_path(value, root=paths.project_root)
+        return resolve_runtime_asset_read_path(value, root=paths.project_root)
+    return Path(value).expanduser()
+
+
+def _stored_path(value: Path, paths: _PackagePaths) -> str:
+    if paths.project_root is not None:
+        return portable_project_path(value, root=paths.project_root)
+    return value.as_posix()
+
+
+def _package_storage_child(
+    paths: _PackagePaths,
+    storage: Path,
+    component: str,
+    *,
+    field: str,
+) -> Path:
+    """Resolve one storage child and recheck project-owned ancestors."""
+
+    name = safe_path_component(component, field=field)
+    unresolved = storage / name
+    if paths.project_root is not None:
+        try:
+            unresolved.relative_to(paths.project_root)
+        except ValueError:
+            pass
+        else:
+            return resolve_managed_project_path(
+                unresolved,
+                root=paths.project_root,
+            )
+    return managed_child_path(storage, name, field=field)
+
+
+_OwnedDirectory = tuple[Path, os.stat_result]
+
+
+def _new_package_temp_dir(kind: str) -> _OwnedDirectory:
+    return create_private_temporary_directory(prefix=f"shinsekai-{kind}-")
+
+
+def _existing_storage_names(*roots: Path) -> set[str]:
+    names: set[str] = set()
+    for root in roots:
+        try:
+            _root, _identity, entries = (
+                snapshot_directory_entries_without_links(
+                    root,
+                    field="package storage directory",
+                )
+            )
+            names.update(child.name for child, _metadata in entries)
+        except (FileNotFoundError, NotADirectoryError):
+            continue
+    return names
+
+
+def _write_yaml_atomic(path: Path, data: object) -> None:
+    atomic_write_text(
+        path,
+        yaml.dump(data, allow_unicode=True, sort_keys=False),
+    )
+
+
+@contextmanager
+def _atomic_package_output(output: Path):
+    """Publish a complete archive without clobbering a valid older export."""
+
+    with atomic_binary_writer(output) as staging:
+        yield staging
+
+
+def _record_import_directory(path: Path, created: list[_OwnedDirectory]) -> Path:
+    exact = require_directory_without_links(
+        path,
+        field="package import directory",
+    )
+    created.append((exact, exact.lstat()))
+    return exact
+
+
+def _reserve_import_directory(
+    path: Path,
+    created: list[_OwnedDirectory],
+    *,
+    expected_parent_identity: os.stat_result | None = None,
+) -> None:
+    """Reserve a previously conflict-checked directory without following links."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    parent = require_directory_without_links(
+        path.parent,
+        field="package import parent directory",
+    )
+    parent_identity = parent.lstat()
+    if (
+        expected_parent_identity is not None
+        and not os.path.samestat(
+            expected_parent_identity,
+            parent_identity,
+        )
+    ):
+        raise PermissionError(
+            f"package import parent identity changed: {parent}"
+        )
+    if os.path.lexists(path):
+        raise FileExistsError(f"import target already exists: {path}")
+    path.mkdir()
+    created_path = _record_import_directory(path, created)
+    if not os.path.samestat(parent_identity, parent.lstat()):
+        created_identity = created[-1][1]
+        remove_directory_without_links(
+            created_path,
+            expected_identity=created_identity,
+        )
+        created.pop()
+        raise PermissionError(
+            f"package import parent identity changed: {parent}"
+        )
+
+
+def _rollback_import_directories(created: list[_OwnedDirectory]) -> None:
+    for path, expected_identity in reversed(created):
+        try:
+            metadata = path.lstat()
+            if not os.path.samestat(expected_identity, metadata):
+                continue
+            if _metadata_is_link_or_reparse_point(metadata):
+                remove_link_without_following(path, expected_identity=metadata)
+            elif stat.S_ISDIR(metadata.st_mode):
+                remove_directory_without_links(path, expected_identity=metadata)
+        except (FileNotFoundError, OSError, ValueError):
+            pass
+
+
+def _cleanup_private_directory(path: Path, expected_identity: os.stat_result) -> None:
+    try:
+        remove_directory_without_links(path, expected_identity=expected_identity)
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+
+
+@contextmanager
+def package_import_transaction():
+    """Keep imported resources rollbackable until their YAML save succeeds.
+
+    Package extraction and configuration persistence are one logical mutation.
+    Callers pass the yielded list to ``import_background`` / ``import_effect``;
+    any exception before leaving the context removes only directories created
+    by those imports.  The process-local package lock also spans the YAML save,
+    closing the former race between conflict selection and persistence.
+    """
+
+    created_directories: list[_OwnedDirectory] = []
+    with _PACKAGE_IO_LOCK:
+        try:
+            yield created_directories
+        except BaseException:
+            _rollback_import_directories(created_directories)
+            raise
+
+
+def _unique_file_name(original: str, used_names: set[str]) -> str:
+    name = safe_path_component(original, field="package filename")
+    candidate = name
+    counter = 1
+    while portable_name_key(candidate) in used_names:
+        source = Path(name)
+        candidate = safe_path_component_with_suffix(
+            source.stem,
+            f"_{counter}{source.suffix}",
+            field="package filename",
+        )
+        counter += 1
+    used_names.add(portable_name_key(candidate))
+    return candidate
 
 
 def _open_export_folder(output_path: str | os.PathLike) -> None:
-    folder_path = Path(output_path).parent.resolve()
-
+    folder_path = Path(output_path).parent
     try:
-        system = platform.system()
-        if system == 'Windows':
-            os.startfile(folder_path)  # type: ignore[attr-defined]
-        elif system == 'Darwin':  # macOS
-            subprocess.Popen(['open', str(folder_path)])
-        elif system == 'Linux':
-            subprocess.Popen(['xdg-open', str(folder_path)])
+        folder_path = require_directory_without_links(
+            folder_path,
+            field="export directory",
+        )
+        open_with_default_application(
+            folder_path,
+            system_name=platform.system(),
+            popen_factory=subprocess.Popen,
+            startfile_factory=getattr(os, "startfile", None),
+        )
     except Exception as e:
         print(f"Failed to open export folder {folder_path}: {e}")
 
 
 def _safe_package_relpath(path: str | os.PathLike | None, field_name: str) -> Path:
     """Interpret package paths written on Windows or POSIX as safe relative paths."""
-    raw = str(path or "").replace("\\", "/").strip()
-    while raw.startswith("./"):
-        raw = raw[2:]
+    raw = str(path or "").replace("\\", "/")
+    if raw != raw.strip():
+        raise ValueError(f"{field_name} contains surrounding whitespace: {path!r}")
     if not raw:
         raise ValueError(f"{field_name} must not be empty")
     if "\x00" in raw or raw.startswith("/") or _WINDOWS_DRIVE_RE.match(raw):
@@ -54,6 +353,8 @@ def _safe_package_relpath(path: str | os.PathLike | None, field_name: str) -> Pa
     if any(part in ("", ".", "..") for part in raw.split("/")):
         raise ValueError(f"{field_name} contains an unsafe path component: {path!r}")
     rel = PurePosixPath(raw)
+    for component in rel.parts:
+        safe_path_component(component, field=field_name)
     return Path(*rel.parts)
 
 
@@ -65,7 +366,9 @@ def _safe_package_basename_or_legacy_absolute(
     path: str | os.PathLike | None, field_name: str
 ) -> str:
     """Return a safe package filename, accepting old host-absolute YAML paths."""
-    raw = str(path or "").replace("\\", "/").strip()
+    raw = str(path or "").replace("\\", "/")
+    if raw != raw.strip():
+        raise ValueError(f"{field_name} contains surrounding whitespace: {path!r}")
     if not raw:
         raise ValueError(f"{field_name} must not be empty")
     if "\x00" in raw:
@@ -86,7 +389,7 @@ def _safe_package_basename_or_legacy_absolute(
 
 
 def _safe_package_name(value: str | os.PathLike | None, field_name: str) -> str:
-    raw = str(value or "").replace("\\", "/").strip()
+    raw = str(value or "").replace("\\", "/")
     if not raw:
         return ""
     if (
@@ -96,15 +399,35 @@ def _safe_package_name(value: str | os.PathLike | None, field_name: str) -> str:
         or _WINDOWS_DRIVE_RE.match(raw)
     ):
         raise ValueError(f"{field_name} must be a plain package name: {value!r}")
-    return raw
+    return safe_path_component(raw, field=field_name)
 
 
 def _safe_extract_zip(zf: zipfile.ZipFile, target_dir: Path) -> None:
-    for info in zf.infolist():
-        member = str(info.filename or "").replace("\\", "/").rstrip("/")
-        if member:
-            _safe_package_relpath(member, "zip member")
-    zf.extractall(target_dir)
+    extract_zip_safely(zf, target_dir)
+
+
+def _extract_package_zip(package_path: Path, target_dir: Path) -> None:
+    try:
+        package_identity = package_path.lstat()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"文件未找到: {package_path}") from None
+    if (
+        _metadata_is_link_or_reparse_point(package_identity)
+        or not stat.S_ISREG(package_identity.st_mode)
+    ):
+        raise FileNotFoundError(f"文件未找到: {package_path}")
+    with open_binary_read_without_links(
+        package_path,
+        expected_identity=package_identity,
+    ) as package_file:
+        before = os.fstat(package_file.fileno())
+        with zipfile.ZipFile(package_file, "r") as archive:
+            _safe_extract_zip(archive, target_dir)
+        after = os.fstat(package_file.fileno())
+    if not file_snapshot_is_stable(before, after):
+        raise PermissionError(
+            f"package changed while it was extracted: {package_path}"
+        )
 
 
 def _sanitize_background_package_paths(bg_data: dict) -> None:
@@ -123,7 +446,13 @@ def _sanitize_background_package_paths(bg_data: dict) -> None:
             for path in bgm_list
         ]
 
-def export_character(character_configs: list[CharacterConfig], output_path: str, open_folder: bool = True):
+def export_character(
+    character_configs: list[CharacterConfig],
+    output_path: str,
+    open_folder: bool = True,
+    *,
+    project_root: str | os.PathLike | None = None,
+):
     """
     将人物配置及其依赖文件打包成一个 .cha 文件。
     
@@ -132,12 +461,15 @@ def export_character(character_configs: list[CharacterConfig], output_path: str,
         output_path (str): 导出的 .cha 文件路径。
         open_folder (bool): 导出后是否打开输出目录。
     """
-    temp_dir = Path(f'./temp_export_{os.getpid()}')
-    temp_dir.mkdir(exist_ok=True)
+    paths = _package_paths(project_root)
+    output = _resolve_io_path(output_path, paths, writable=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir, temp_dir_identity = _new_package_temp_dir("character-export")
     
     try:
         manifest_data = {'original_paths': {}}
         character_data_list = []
+        used_model_names: set[str] = set()
 
         for config in character_configs:
             # 准备要写入YAML的配置数据
@@ -164,28 +496,41 @@ def export_character(character_configs: list[CharacterConfig], output_path: str,
             }
 
             for key, abs_path in model_paths.items():
-                if abs_path and os.path.exists(abs_path):
-                    file_path = Path(abs_path)
-                    new_relative_path = Path('models') / file_path.name
+                file_path = _resolve_io_path(abs_path, paths) if abs_path else None
+                if file_path is not None and file_path.is_file():
+                    archive_name = _unique_file_name(file_path.name, used_model_names)
+                    new_relative_path = Path('models') / archive_name
 
                     # 将模型的原始绝对路径记录到清单中
-                    manifest_data['original_paths'][file_path.name] = str(file_path)
+                    manifest_data['original_paths'][archive_name] = str(file_path)
 
                     # 将模型文件复制到临时目录
-                    destination_path = temp_dir / new_relative_path
-                    destination_path.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(file_path, destination_path)
+                    destination_path = copy_file_exclusive(
+                        file_path,
+                        temp_dir / new_relative_path.parent,
+                        archive_name,
+                        field="model filename",
+                    )
 
                     # 更新YAML数据中的路径为相对路径
-                    char_data[key] = str(new_relative_path)
+                    char_data[key] = new_relative_path.as_posix()
                 else:
                     char_data[key] = None
 
             # 处理立绘文件
             if config.sprite_prefix:
-                sprite_source_dir = SPRITE_DIR / config.sprite_prefix
+                sprite_prefix = _safe_package_name(config.sprite_prefix, "sprite_prefix")
+                sprite_source_dir = _package_storage_child(
+                    paths,
+                    paths.sprite,
+                    sprite_prefix,
+                    field="sprite_prefix",
+                )
                 if sprite_source_dir.is_dir():
-                    shutil.copytree(sprite_source_dir, temp_dir / 'sprites' / config.sprite_prefix, dirs_exist_ok=True)
+                    copy_directory_without_links(
+                        sprite_source_dir,
+                        temp_dir / 'sprites' / sprite_prefix,
+                    )
 
             # 重写 sprite/voice path 为仅文件名（导入时按文件名匹配重建路径）
             sprites = char_data.get('sprites') or []
@@ -217,35 +562,44 @@ def export_character(character_configs: list[CharacterConfig], output_path: str,
 
             # 复制语音文件
             if config.sprite_prefix:
-                voice_src_dir = SPEECH_DIR / config.sprite_prefix
+                sprite_prefix = _safe_package_name(config.sprite_prefix, "sprite_prefix")
+                voice_src_dir = _package_storage_child(
+                    paths,
+                    paths.speech,
+                    sprite_prefix,
+                    field="sprite_prefix",
+                )
                 if voice_src_dir.is_dir():
-                    shutil.copytree(voice_src_dir, temp_dir / 'speech' / config.sprite_prefix, dirs_exist_ok=True)
+                    copy_directory_without_links(
+                        voice_src_dir,
+                        temp_dir / 'speech' / sprite_prefix,
+                    )
 
             character_data_list.append(char_data)
 
         # 将配置数据和清单写入临时文件
-        with open(temp_dir / 'character.yaml', 'w', encoding='utf-8') as f:
-            yaml.dump(character_data_list, f, allow_unicode=True, sort_keys=False)
-        
-        with open(temp_dir / 'manifest.json', 'w', encoding='utf-8') as f:
-            json.dump(manifest_data, f, indent=4)
+        atomic_write_text(
+            temp_dir / "character.yaml",
+            yaml.dump(character_data_list, allow_unicode=True, sort_keys=False),
+        )
+        atomic_write_text(
+            temp_dir / "manifest.json",
+            json.dumps(manifest_data, indent=4),
+        )
             
         # 打包成 .cha 文件
-        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for file_path in temp_dir.rglob('*'):
-                if file_path.is_file():
-                    # 计算文件在zip中的相对路径
-                    arcname = file_path.relative_to(temp_dir)
-                    zf.write(file_path, arcname)
+        with _atomic_package_output(output) as staging_output:
+            with zipfile.ZipFile(staging_output, 'w', zipfile.ZIP_DEFLATED) as zf:
+                write_directory_to_zip_without_links(zf, temp_dir)
         
         if open_folder:
-            _open_export_folder(output_path)
+            _open_export_folder(output)
 
-        print(f"人物成功导出到: {output_path}")
+        print(f"人物成功导出到: {output}")
 
     finally:
         # 清理临时目录
-        shutil.rmtree(temp_dir)
+        _cleanup_private_directory(temp_dir, temp_dir_identity)
 
 def _resolve_name_conflict(name: str, existing_names: set) -> str:
     """
@@ -280,18 +634,42 @@ def _resolve_sprite_prefix_conflict(sprite_prefix: str, existing_prefixes: set) 
     Returns:
         str: 解决冲突后的sprite_prefix
     """
-    if sprite_prefix not in existing_prefixes:
+    folded_prefixes = {portable_name_key(str(value)) for value in existing_prefixes}
+    if portable_name_key(sprite_prefix) not in folded_prefixes:
         return sprite_prefix
     
     counter = 1
-    new_prefix = f"{sprite_prefix}{counter}"
-    while new_prefix in existing_prefixes:
+    new_prefix = safe_path_component_with_suffix(
+        sprite_prefix,
+        str(counter),
+        field="sprite_prefix",
+    )
+    while portable_name_key(new_prefix) in folded_prefixes:
         counter += 1
-        new_prefix = f"{sprite_prefix}{counter}"
+        new_prefix = safe_path_component_with_suffix(
+            sprite_prefix,
+            str(counter),
+            field="sprite_prefix",
+        )
     
     return new_prefix
 
-def import_character(input_path: str) -> list[CharacterConfig]:
+def import_character(
+    input_path: str,
+    *,
+    project_root: str | os.PathLike | None = None,
+) -> list[CharacterConfig]:
+    """Import a character package under one process-local mutation lock."""
+
+    with _PACKAGE_IO_LOCK:
+        return _import_character_unlocked(input_path, project_root=project_root)
+
+
+def _import_character_unlocked(
+    input_path: str,
+    *,
+    project_root: str | os.PathLike | None = None,
+) -> list[CharacterConfig]:
     """
     从 .cha 文件导入人物配置及其依赖文件，并将配置追加入 characters.yaml。
     检测名称和sprite_prefix冲突，自动添加后缀解决冲突。
@@ -302,22 +680,25 @@ def import_character(input_path: str) -> list[CharacterConfig]:
     Returns:
         list[CharacterConfig]: 导入的 CharacterConfig 对象列表。
     """
-    if not os.path.exists(input_path):
-        raise FileNotFoundError(f"文件未找到: {input_path}")
-        
-    temp_dir = Path(f'./temp_import_{os.getpid()}')
-    temp_dir.mkdir(exist_ok=True)
+    paths = _package_paths(project_root)
+    package_path = _resolve_io_path(input_path, paths)
+    if not package_path.is_file():
+        raise FileNotFoundError(f"文件未找到: {package_path}")
+
+    temp_dir, temp_dir_identity = _new_package_temp_dir("character-import")
     
     imported_configs = []
+    created_directories: list[_OwnedDirectory] = []
+    committed = False
 
     try:
         # 解压 .cha 文件到临时目录
-        with zipfile.ZipFile(input_path, 'r') as zf:
-            _safe_extract_zip(zf, temp_dir)
+        _extract_package_zip(package_path, temp_dir)
 
         # 读取YAML配置文件
-        with open(temp_dir / 'character.yaml', 'r', encoding='utf-8') as f:
-            yaml_data = yaml.safe_load(f)
+        yaml_data = yaml.safe_load(
+            read_text_without_links(temp_dir / 'character.yaml')
+        )
 
         if not yaml_data:
             raise ValueError("YAML配置文件为空或格式错误。")
@@ -326,12 +707,16 @@ def import_character(input_path: str) -> list[CharacterConfig]:
         existing_names = set()
         existing_sprite_prefixes = set()
         
-        if CHARACTERS_CONFIG_PATH.exists():
-            with open(CHARACTERS_CONFIG_PATH, 'r', encoding='utf-8') as f:
-                existing_configs = yaml.safe_load(f) or []
-                for config in existing_configs:
-                    existing_names.add(config.get('name', ''))
-                    existing_sprite_prefixes.add(config.get('sprite_prefix', ''))
+        if paths.characters_config.exists():
+            existing_configs = yaml.safe_load(
+                read_text_without_links(paths.characters_config)
+            ) or []
+            for config in existing_configs:
+                existing_names.add(config.get('name', ''))
+                existing_sprite_prefixes.add(config.get('sprite_prefix', ''))
+        existing_sprite_prefixes.update(
+            _existing_storage_names(paths.sprite, paths.speech, paths.models)
+        )
         
         # 记录本次导入中已使用的名称和sprite_prefix，避免内部冲突
         imported_names = set(existing_names)
@@ -358,14 +743,35 @@ def import_character(input_path: str) -> list[CharacterConfig]:
                 print(f"检测到冲突，已将 '{original_name}' ({original_sprite_prefix}) 重命名为 '{new_name}' ({new_sprite_prefix})")
             
             sprites = char_data.get('sprites') or []
-            dest_sprite_dir = SPRITE_DIR / new_sprite_prefix
-            dest_speech_dir = SPEECH_DIR / new_sprite_prefix
+            dest_sprite_dir = (
+                _package_storage_child(
+                    paths,
+                    paths.sprite,
+                    new_sprite_prefix,
+                    field="sprite_prefix",
+                )
+                if new_sprite_prefix
+                else paths.sprite
+            )
+            dest_speech_dir = (
+                _package_storage_child(
+                    paths,
+                    paths.speech,
+                    new_sprite_prefix,
+                    field="sprite_prefix",
+                )
+                if new_sprite_prefix
+                else paths.speech
+            )
 
             # 恢复立绘文件（使用新的sprite_prefix）
             if new_sprite_prefix:
                 source_sprite_dir = temp_dir / 'sprites' / original_sprite_prefix
                 if source_sprite_dir.is_dir():
-                    shutil.copytree(source_sprite_dir, dest_sprite_dir, dirs_exist_ok=True)
+                    _record_import_directory(
+                        copy_directory_without_links(source_sprite_dir, dest_sprite_dir),
+                        created_directories,
+                    )
 
             # 修复 sprite path：指向导入机器上的实际路径；无 prefix 时至少去掉宿主机路径。
             for s in sprites:
@@ -375,10 +781,7 @@ def import_character(input_path: str) -> list[CharacterConfig]:
                     )
                     if new_sprite_prefix:
                         new_path = dest_sprite_dir / filename
-                        try:
-                            s['path'] = str(new_path.relative_to(Path.cwd()))
-                        except ValueError:
-                            s['path'] = new_path.as_posix()
+                        s['path'] = _stored_path(new_path, paths)
                     else:
                         s['path'] = filename
 
@@ -386,12 +789,10 @@ def import_character(input_path: str) -> list[CharacterConfig]:
                 # 恢复语音文件（使用新的sprite_prefix）
                 source_speech_dir = temp_dir / 'speech' / original_sprite_prefix
                 if source_speech_dir.is_dir():
-                    shutil.copytree(source_speech_dir, dest_speech_dir, dirs_exist_ok=True)
-
-                # 恢复语音文件
-                source_speech_dir = temp_dir / 'speech' / original_sprite_prefix
-                if source_speech_dir.is_dir():
-                    shutil.copytree(source_speech_dir, SPEECH_DIR / new_sprite_prefix, dirs_exist_ok=True)
+                    _record_import_directory(
+                        copy_directory_without_links(source_speech_dir, dest_speech_dir),
+                        created_directories,
+                    )
 
             # 修复 voice_path：指向 SPEECH_DIR；无 prefix 时至少去掉宿主机路径。
             for s in sprites:
@@ -401,10 +802,7 @@ def import_character(input_path: str) -> list[CharacterConfig]:
                     )
                     if new_sprite_prefix:
                         new_vp = dest_speech_dir / filename
-                        try:
-                            s['voice_path'] = str(new_vp.relative_to(Path.cwd()))
-                        except ValueError:
-                            s['voice_path'] = new_vp.as_posix()
+                        s['voice_path'] = _stored_path(new_vp, paths)
                     else:
                         s['voice_path'] = filename
                     voice_type = str(s.get('voice_type') or '').strip().lower()
@@ -422,15 +820,33 @@ def import_character(input_path: str) -> list[CharacterConfig]:
                 'refer_audio_path': char_data.get('refer_audio_path')
             }
             
+            dest_model_dir: Path | None = None
             for key, path in model_paths.items():
                 if path:  # 确保路径不为空
                     source_model_path = temp_dir / _safe_package_relpath(path, key)
-                    dest_model_dir = MODEL_DIR / new_sprite_prefix
-                    dest_model_dir.mkdir(parents=True, exist_ok=True)
-                    dest_model_path = dest_model_dir / _safe_package_basename(path, key)
-                    if source_model_path.exists():  # 确保源文件存在
-                        shutil.copy2(source_model_path, dest_model_path)
-                        char_data[key] = dest_model_path.as_posix()  # 更新为相对路径
+                    if source_model_path.is_file():  # 确保源文件存在
+                        if dest_model_dir is None:
+                            model_storage_prefix = new_sprite_prefix
+                            if not model_storage_prefix:
+                                model_storage_prefix = _resolve_sprite_prefix_conflict(
+                                    "character-models",
+                                    imported_sprite_prefixes,
+                                )
+                                imported_sprite_prefixes.add(model_storage_prefix)
+                            dest_model_dir = _package_storage_child(
+                                paths,
+                                paths.models,
+                                model_storage_prefix,
+                                field="model storage prefix",
+                            )
+                            _reserve_import_directory(dest_model_dir, created_directories)
+                        dest_model_path = copy_file_exclusive(
+                            source_model_path,
+                            dest_model_dir,
+                            _safe_package_basename(path, key),
+                            field=key,
+                        )
+                        char_data[key] = _stored_path(dest_model_path, paths)
                     else:
                         char_data[key] = None
 
@@ -438,46 +854,52 @@ def import_character(input_path: str) -> list[CharacterConfig]:
             imported_configs.append(CharacterConfig.parse_dic(char_data=char_data))
         
         # 将配置追加到 characters.yaml
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        paths.config.mkdir(parents=True, exist_ok=True)
         
         existing_data = []
-        if CHARACTERS_CONFIG_PATH.exists():
-            with open(CHARACTERS_CONFIG_PATH, 'r', encoding='utf-8') as f:
-                existing_data = yaml.safe_load(f) or []
+        if paths.characters_config.exists():
+            existing_data = yaml.safe_load(
+                read_text_without_links(paths.characters_config)
+            ) or []
 
         # 将导入的配置转换为字典格式并追加
         new_data_list = [config.__dict__ for config in imported_configs]
         existing_data.extend(new_data_list)
         
-        with open(CHARACTERS_CONFIG_PATH, 'w', encoding='utf-8') as f:
-            yaml.dump(existing_data, f, allow_unicode=True, sort_keys=False)
+        _write_yaml_atomic(paths.characters_config, existing_data)
+        committed = True
 
-        print(f"人物成功从 {input_path} 导入，并已将配置追加到 {CHARACTERS_CONFIG_PATH}。")
+        print(f"人物成功从 {package_path} 导入，并已将配置追加到 {paths.characters_config}。")
         return imported_configs
 
     finally:
+        if not committed:
+            _rollback_import_directories(created_directories)
         # 清理临时目录
-        shutil.rmtree(temp_dir)
+        _cleanup_private_directory(temp_dir, temp_dir_identity)
 
 # ---------------------------------------------
 
 
 def export_background(
     background_configs: List[Background],
-    output_path: str = './output/background.bg',
+    output_path: str = 'output/background.bg',
     open_folder: bool = True,
+    *,
+    project_root: str | os.PathLike | None = None,
 ):
     """
     将背景配置及其依赖文件（图片和音乐）打包成一个 .bg 文件。
     
     Args:
         background_configs (List[Background]): 要导出的 Background 对象列表。
-        output_path (str): 导出的 .bg 文件路径 (默认路径为 ./output/background.bg)。
+        output_path (str): 导出的 .bg 文件路径 (默认路径为 output/background.bg)。
         open_folder (bool): 导出后是否打开输出目录。
     """
-    Path('./output').mkdir(exist_ok=True) # 确保输出目录存在
-    temp_dir = Path(f'./temp_export_bg_{os.getpid()}')
-    temp_dir.mkdir(exist_ok=True)
+    paths = _package_paths(project_root)
+    output = _resolve_io_path(output_path, paths, writable=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir, temp_dir_identity = _new_package_temp_dir("background-export")
     
     try:
         background_data_list = []
@@ -491,42 +913,82 @@ def export_background(
             
             # 处理背景图片文件 (sprites)
             if config.sprite_prefix:
+                sprite_prefix = _safe_package_name(
+                    config.sprite_prefix, "background sprite_prefix"
+                )
                 # 复制图片文件
-                sprite_source_dir = Path(BACKGROUND_UPLOAD_DIR) / config.sprite_prefix
+                sprite_source_dir = _package_storage_child(
+                    paths,
+                    paths.backgrounds,
+                    sprite_prefix,
+                    field="background sprite_prefix",
+                )
                 if sprite_source_dir.is_dir():
-                    shutil.copytree(sprite_source_dir, temp_dir / 'sprites' / config.sprite_prefix, dirs_exist_ok=True)
+                    copy_directory_without_links(
+                        sprite_source_dir,
+                        temp_dir / 'sprites' / sprite_prefix,
+                    )
                 
                 # 复制背景音乐文件 (bgm_list)
-                bgm_source_dir = Path(BGM_UPLOAD_DIR) / config.sprite_prefix
+                bgm_source_dir = _package_storage_child(
+                    paths,
+                    paths.bgm,
+                    sprite_prefix,
+                    field="background sprite_prefix",
+                )
                 if bgm_source_dir.is_dir():
-                    shutil.copytree(bgm_source_dir, temp_dir / 'bgm' / config.sprite_prefix, dirs_exist_ok=True)
+                    copy_directory_without_links(
+                        bgm_source_dir,
+                        temp_dir / 'bgm' / sprite_prefix,
+                    )
                     
             _sanitize_background_package_paths(bg_data)
             
             background_data_list.append(bg_data)
 
         # 将配置数据写入临时文件
-        with open(temp_dir / 'background.yaml', 'w', encoding='utf-8') as f:
-            yaml.dump(background_data_list, f, allow_unicode=True, sort_keys=False)
+        atomic_write_text(
+            temp_dir / "background.yaml",
+            yaml.dump(background_data_list, allow_unicode=True, sort_keys=False),
+        )
         
         # 打包成 .bg 文件
-        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for file_path in temp_dir.rglob('*'):
-                if file_path.is_file():
-                    # 计算文件在zip中的相对路径
-                    arcname = file_path.relative_to(temp_dir)
-                    zf.write(file_path, arcname)
+        with _atomic_package_output(output) as staging_output:
+            with zipfile.ZipFile(staging_output, 'w', zipfile.ZIP_DEFLATED) as zf:
+                write_directory_to_zip_without_links(zf, temp_dir)
         
         if open_folder:
-            _open_export_folder(output_path)
+            _open_export_folder(output)
 
-        print(f"背景包成功导出到: {output_path}")
+        print(f"背景包成功导出到: {output}")
 
     finally:
         # 清理临时目录
-        shutil.rmtree(temp_dir)
+        _cleanup_private_directory(temp_dir, temp_dir_identity)
 
-def import_background(input_path: str, existing_configs: List[Background]) -> List[Background]:
+def import_background(
+    input_path: str,
+    existing_configs: List[Background],
+    *,
+    project_root: str | os.PathLike | None = None,
+    transaction_paths: list[_OwnedDirectory] | None = None,
+) -> List[Background]:
+    with _PACKAGE_IO_LOCK:
+        return _import_background_unlocked(
+            input_path,
+            existing_configs,
+            project_root=project_root,
+            transaction_paths=transaction_paths,
+        )
+
+
+def _import_background_unlocked(
+    input_path: str,
+    existing_configs: List[Background],
+    *,
+    project_root: str | os.PathLike | None = None,
+    transaction_paths: list[_OwnedDirectory] | None = None,
+) -> List[Background]:
     """
     从 .bg 文件导入背景配置及其依赖文件，并将配置合并到现有列表中。
     检测名称和sprite_prefix冲突，自动添加后缀解决冲突。
@@ -538,22 +1000,25 @@ def import_background(input_path: str, existing_configs: List[Background]) -> Li
     Returns:
         List[Background]: 导入的 Background 对象列表。
     """
-    if not os.path.exists(input_path):
-        raise FileNotFoundError(f"文件未找到: {input_path}")
-        
-    temp_dir = Path(f'./temp_import_bg_{os.getpid()}')
-    temp_dir.mkdir(exist_ok=True)
+    paths = _package_paths(project_root)
+    package_path = _resolve_io_path(input_path, paths)
+    if not package_path.is_file():
+        raise FileNotFoundError(f"文件未找到: {package_path}")
+
+    temp_dir, temp_dir_identity = _new_package_temp_dir("background-import")
     
     imported_configs = []
+    created_directories: list[_OwnedDirectory] = []
+    committed = False
 
     try:
         # 解压 .bg 文件到临时目录
-        with zipfile.ZipFile(input_path, 'r') as zf:
-            _safe_extract_zip(zf, temp_dir)
+        _extract_package_zip(package_path, temp_dir)
 
         # 读取YAML配置文件
-        with open(temp_dir / 'background.yaml', 'r', encoding='utf-8') as f:
-            yaml_data = yaml.safe_load(f)
+        yaml_data = yaml.safe_load(
+            read_text_without_links(temp_dir / 'background.yaml')
+        )
 
         if not yaml_data:
             raise ValueError("背景配置 YAML 文件为空或格式错误。")
@@ -561,6 +1026,9 @@ def import_background(input_path: str, existing_configs: List[Background]) -> Li
         # 读取现有配置，用于检测冲突
         existing_names = {config.name for config in existing_configs}
         existing_sprite_prefixes = {config.sprite_prefix for config in existing_configs}
+        existing_sprite_prefixes.update(
+            _existing_storage_names(paths.backgrounds, paths.bgm)
+        )
         
         # 记录本次导入中已使用的名称和sprite_prefix，避免内部冲突
         imported_names = set(existing_names)
@@ -590,15 +1058,31 @@ def import_background(input_path: str, existing_configs: List[Background]) -> Li
             if new_sprite_prefix:
                 # 恢复图片
                 source_sprite_dir = temp_dir / 'sprites' / original_sprite_prefix
-                dest_sprite_dir = Path(BACKGROUND_UPLOAD_DIR) / new_sprite_prefix
+                dest_sprite_dir = _package_storage_child(
+                    paths,
+                    paths.backgrounds,
+                    new_sprite_prefix,
+                    field="background sprite_prefix",
+                )
                 if source_sprite_dir.is_dir():
-                    shutil.copytree(source_sprite_dir, dest_sprite_dir, dirs_exist_ok=True)
+                    _record_import_directory(
+                        copy_directory_without_links(source_sprite_dir, dest_sprite_dir),
+                        created_directories,
+                    )
 
                 # 恢复音乐文件
                 source_bgm_dir = temp_dir / 'bgm' / original_sprite_prefix
-                dest_bgm_dir = Path(BGM_UPLOAD_DIR) / new_sprite_prefix
+                dest_bgm_dir = _package_storage_child(
+                    paths,
+                    paths.bgm,
+                    new_sprite_prefix,
+                    field="background sprite_prefix",
+                )
                 if source_bgm_dir.is_dir():
-                    shutil.copytree(source_bgm_dir, dest_bgm_dir, dirs_exist_ok=True)
+                    _record_import_directory(
+                        copy_directory_without_links(source_bgm_dir, dest_bgm_dir),
+                        created_directories,
+                    )
             # 更新 sprites 中的路径
             if 'sprites' in bg_data:
                 for sprite_entry in bg_data['sprites']:
@@ -608,16 +1092,16 @@ def import_background(input_path: str, existing_configs: List[Background]) -> Li
                         filename = _safe_package_basename_or_legacy_absolute(
                             sprite_entry['path'], "background sprite path"
                         )
-                        new_path = Path(BACKGROUND_UPLOAD_DIR) / new_sprite_prefix / filename
-                        sprite_entry['path'] = new_path.as_posix()
+                        new_path = paths.backgrounds / new_sprite_prefix / filename
+                        sprite_entry['path'] = _stored_path(new_path, paths)
 
             # 更新 bgm_list 中的路径
             if 'bgm_list' in bg_data:
                 new_bgm_list = []
                 for path in bg_data['bgm_list']:
                     filename = _safe_package_basename_or_legacy_absolute(path, "background bgm path")
-                    new_path = Path(BGM_UPLOAD_DIR) / new_sprite_prefix / filename
-                    new_bgm_list.append(new_path.as_posix())
+                    new_path = paths.bgm / new_sprite_prefix / filename
+                    new_bgm_list.append(_stored_path(new_path, paths))
                 bg_data['bgm_list'] = new_bgm_list
                 
             # 将更新后的数据创建为 Background 对象
@@ -625,69 +1109,137 @@ def import_background(input_path: str, existing_configs: List[Background]) -> Li
             imported_configs.append(Background.model_validate(bg_data))
         
         # 导入后，调用方需要将这些 imported_configs 合并到 ConfigManager 的配置中并保存。
-        print(f"背景包成功从 {input_path} 导入。")
+        if transaction_paths is not None:
+            transaction_paths.extend(created_directories)
+        committed = True
+        print(f"背景包成功从 {package_path} 导入。")
         return imported_configs
 
     finally:
+        if not committed:
+            _rollback_import_directories(created_directories)
         # 清理临时目录
-        shutil.rmtree(temp_dir)
+        _cleanup_private_directory(temp_dir, temp_dir_identity)
 
 
 def export_effect(
     effect_configs: list,
-    output_path: str = './output/effect.ef',
+    output_path: str = 'output/effect.ef',
     open_folder: bool = True,
+    *,
+    project_root: str | os.PathLike | None = None,
 ):
     """Export effects as a .ef package file."""
-    Path('./output').mkdir(exist_ok=True)
-    temp_dir = Path(f'./temp_export_ef_{os.getpid()}')
-    temp_dir.mkdir(exist_ok=True)
+    paths = _package_paths(project_root)
+    output = _resolve_io_path(output_path, paths, writable=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir, temp_dir_identity = _new_package_temp_dir("effect-export")
 
     try:
         effect_data_list = []
+        packaged_audio: list[tuple[Path, str]] = []
+        used_audio_names: set[str] = set()
         for config in effect_configs:
             ef_data = config.model_dump(exclude_none=True, mode='json')
+            _safe_package_name(ef_data.get("name", ""), "effect name")
+            normalized_audio = []
+            for audio_path in (config.audio_list or []):
+                audio_file = _resolve_io_path(audio_path, paths)
+                if not audio_file.is_file():
+                    continue
+                original_name = _safe_package_basename_or_legacy_absolute(
+                    audio_path, "effect audio path"
+                )
+                archive_name = original_name
+                counter = 1
+                while portable_name_key(archive_name) in used_audio_names:
+                    source_name = Path(original_name)
+                    archive_name = safe_path_component_with_suffix(
+                        source_name.stem,
+                        f"_{counter}{source_name.suffix}",
+                        field="effect audio filename",
+                    )
+                    counter += 1
+                used_audio_names.add(portable_name_key(archive_name))
+                normalized_audio.append(archive_name)
+                packaged_audio.append((audio_file, archive_name))
+            ef_data["audio_list"] = normalized_audio
             effect_data_list.append(ef_data)
 
         yaml_path = temp_dir / 'effect.yaml'
-        with open(yaml_path, 'w', encoding='utf-8') as f:
-            yaml.dump(effect_data_list, f, allow_unicode=True, default_flow_style=False)
+        atomic_write_text(
+            yaml_path,
+            yaml.dump(
+                effect_data_list,
+                allow_unicode=True,
+                default_flow_style=False,
+            ),
+        )
 
-        output = Path(output_path)
-        with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
-            zf.write(yaml_path, 'effect.yaml')
-            for config in effect_configs:
-                for audio_path in (config.audio_list or []):
-                    audio_file = Path(audio_path)
-                    if audio_file.exists():
-                        arcname = f"audio/{audio_file.name}"
-                        zf.write(audio_file, arcname)
+        with _atomic_package_output(output) as staging_output:
+            with zipfile.ZipFile(staging_output, 'w', zipfile.ZIP_DEFLATED) as zf:
+                write_zip_files_without_links(
+                    zf,
+                    [
+                        (yaml_path, "effect.yaml"),
+                        *[
+                            (audio_file, f"audio/{archive_name}")
+                            for audio_file, archive_name in packaged_audio
+                        ],
+                    ],
+                )
 
         if open_folder:
-            os.startfile(output.parent)
+            _open_export_folder(output)
 
         print(f"特效导出完成：{output}")
     finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        _cleanup_private_directory(temp_dir, temp_dir_identity)
 
 
-def import_effect(input_path: str, existing_configs: list) -> list:
+def import_effect(
+    input_path: str,
+    existing_configs: list,
+    *,
+    effect_upload_dir: str | os.PathLike | None = None,
+    project_root: str | os.PathLike | None = None,
+    transaction_paths: list[_OwnedDirectory] | None = None,
+) -> list:
+    with _PACKAGE_IO_LOCK:
+        return _import_effect_unlocked(
+            input_path,
+            existing_configs,
+            effect_upload_dir=effect_upload_dir,
+            project_root=project_root,
+            transaction_paths=transaction_paths,
+        )
+
+
+def _import_effect_unlocked(
+    input_path: str,
+    existing_configs: list,
+    *,
+    effect_upload_dir: str | os.PathLike | None = None,
+    project_root: str | os.PathLike | None = None,
+    transaction_paths: list[_OwnedDirectory] | None = None,
+) -> list:
     """Import effects from a .ef package file."""
-    if not os.path.exists(input_path):
-        raise FileNotFoundError(f"文件未找到: {input_path}")
+    paths = _package_paths(project_root)
+    package_path = _resolve_io_path(input_path, paths)
+    if not package_path.is_file():
+        raise FileNotFoundError(f"文件未找到: {package_path}")
 
-    temp_dir = Path(f'./temp_import_ef_{os.getpid()}')
-    temp_dir.mkdir(exist_ok=True)
+    temp_dir, temp_dir_identity = _new_package_temp_dir("effect-import")
 
     imported_configs = []
+    created_directories: list[_OwnedDirectory] = []
+    committed = False
 
     try:
-        with zipfile.ZipFile(input_path, 'r') as zf:
-            _safe_extract_zip(zf, temp_dir)
+        _extract_package_zip(package_path, temp_dir)
 
         yaml_path = temp_dir / 'effect.yaml'
-        with open(yaml_path, 'r', encoding='utf-8') as f:
-            yaml_data = yaml.safe_load(f)
+        yaml_data = yaml.safe_load(read_text_without_links(yaml_path))
 
         if not yaml_data:
             raise ValueError("特效配置 YAML 文件为空或格式错误。")
@@ -696,9 +1248,36 @@ def import_effect(input_path: str, existing_configs: list) -> list:
 
         from config.schema import Effect as EffectModel
 
-        existing_names = {e.name.lower() for e in existing_configs}
-
         audio_source_dir = temp_dir / 'audio'
+
+        managed_effect_root = (
+            _resolve_io_path(effect_upload_dir, paths, writable=True)
+            if effect_upload_dir is not None
+            else paths.effects
+        )
+        if paths.project_root is not None:
+            expected_effect_root = paths.effects
+            if managed_effect_root != expected_effect_root:
+                raise PermissionError("effect upload directory must be project data/effects")
+        managed_effect_root.mkdir(parents=True, exist_ok=True)
+        managed_effect_root = require_directory_without_links(
+            managed_effect_root,
+            field="effect storage directory",
+        )
+        (
+            _managed_effect_root,
+            managed_effect_root_identity,
+            managed_effect_entries,
+        ) = snapshot_directory_entries_without_links(
+            managed_effect_root,
+            field="effect storage directory",
+        )
+
+        existing_names = {portable_name_key(str(e.name)) for e in existing_configs}
+        existing_names.update(
+            portable_name_key(child.name)
+            for child, _metadata in managed_effect_entries
+        )
 
         for item in yaml_data:
             if not isinstance(item, dict):
@@ -708,42 +1287,56 @@ def import_effect(input_path: str, existing_configs: list) -> list:
                 raise ValueError("effect name must not be empty")
             name = original_name
             counter = 1
-            while name.lower() in existing_names:
-                name = f"{original_name}_{counter}"
+            while portable_name_key(name) in existing_names:
+                name = safe_path_component_with_suffix(
+                    original_name,
+                    f"_{counter}",
+                    field="effect name",
+                )
                 counter += 1
             item['name'] = name
-            existing_names.add(name.lower())
+            existing_names.add(portable_name_key(name))
 
             # Create managed directory and copy audio files
-            ef_dir = EFFECT_UPLOAD_DIR / name
-            ef_dir.mkdir(parents=True, exist_ok=True)
+            ef_dir = managed_child_path(
+                managed_effect_root,
+                name,
+                field="effect name",
+            )
+            _reserve_import_directory(
+                ef_dir,
+                created_directories,
+                expected_parent_identity=managed_effect_root_identity,
+            )
 
             new_audio_list = []
             old_audio_list = item.get('audio_list') or []
             for audio_path in old_audio_list:
-                audio_filename = Path(str(audio_path)).name
+                audio_filename = _safe_package_basename_or_legacy_absolute(
+                    audio_path, "effect audio path"
+                )
                 src = audio_source_dir / audio_filename
-                if src.exists():
-                    dest = ef_dir / audio_filename
-                    counter2 = 1
-                    while dest.exists():
-                        stem = Path(audio_filename).stem
-                        suffix = Path(audio_filename).suffix
-                        dest = ef_dir / f"{stem}_{counter2}{suffix}"
-                        counter2 += 1
-                    shutil.copy2(src, dest)
-                    new_audio_list.append(dest.as_posix())
-                else:
-                    # File not in archive, keep original path
-                    new_audio_list.append(str(audio_path))
+                if src.is_file():
+                    dest = copy_file_exclusive(
+                        src,
+                        ef_dir,
+                        audio_filename,
+                        field="effect audio filename",
+                    )
+                    new_audio_list.append(_stored_path(dest, paths))
 
             item['audio_list'] = new_audio_list
 
             effect = EffectModel.model_validate(item)
             imported_configs.append(effect)
 
-        print(f"特效包成功从 {input_path} 导入。")
+        if transaction_paths is not None:
+            transaction_paths.extend(created_directories)
+        committed = True
+        print(f"特效包成功从 {package_path} 导入。")
         return imported_configs
 
     finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        if not committed:
+            _rollback_import_directories(created_directories)
+        _cleanup_private_directory(temp_dir, temp_dir_identity)

--- a/tools/generate_sprites.py
+++ b/tools/generate_sprites.py
@@ -2,23 +2,88 @@ from google import genai
 from google.genai import types
 from PIL import Image
 from io import BytesIO
+import os
 import sys
 from typing import Union, List, Dict, Any
 import json
 from pathlib import Path
-from PIL import Image
 # 获取当前脚本的绝对路径
 current_script = Path(__file__).resolve()
-project_root = current_script.parent.parent
-if str(project_root) not in sys.path:
-    sys.path.append(str(project_root))
+source_root = current_script.parent.parent
+if str(source_root) not in sys.path:
+    sys.path.append(str(source_root))
 
 from config.config_manager import ConfigManager
+from core.file_transactions import (
+    atomic_binary_writer,
+    capture_directory_identity,
+    file_snapshot_is_stable,
+    open_binary_read_without_links,
+)
+from core.paths import (
+    project_root as runtime_project_root,
+    require_directory_without_links,
+    resolve_project_output_path,
+    resolve_runtime_asset_read_path,
+)
 
 config = ConfigManager()
 IMAGE_MODEL = 'gemini-2.5-flash-image'
 PROMPT_GENERATION_MODEL = "gemini-2.5-flash" 
 # 或者 "gemini-2.5-flash"
+
+
+def _existing_input_image(value: Union[str, Path]) -> Path:
+    path = resolve_runtime_asset_read_path(
+        os.fspath(value),
+        root=runtime_project_root(),
+    )
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path
+
+
+def _writable_output_file(value: Union[str, Path]) -> Path:
+    path = resolve_project_output_path(os.fspath(value), root=runtime_project_root())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    require_directory_without_links(
+        path.parent,
+        field="generated image output directory",
+    )
+    return path
+
+
+def _writable_output_directory(value: Union[str, Path]) -> Path:
+    path = resolve_project_output_path(os.fspath(value), root=runtime_project_root())
+    path.mkdir(parents=True, exist_ok=True)
+    return require_directory_without_links(
+        path,
+        field="generated sprite output directory",
+    )
+
+
+def _output_parent_identity(path: Path) -> os.stat_result:
+    parent, identity = capture_directory_identity(
+        path.parent,
+        field="generated image output directory",
+    )
+    if path.parent != parent:
+        raise PermissionError("generated image output directory changed identity")
+    return identity
+
+
+def _publish_generated_image(
+    output_path: Path,
+    payload: bytes,
+    *,
+    expected_parent_identity: os.stat_result,
+) -> None:
+    with atomic_binary_writer(
+        output_path,
+        expected_parent_identity=expected_parent_identity,
+    ) as output:
+        output.write(payload)
+
 
 class ImageGenerator:
     def __init__(self):
@@ -122,10 +187,24 @@ class ImageGenerator:
             prompt: 用于指导模型如何使用参考图片生成立绘的文本描述（例如：“Keep the character’s face and outfit from the reference image, but change the background to a sci-fi city.”）。
             output_file: 图片保存路径和文件名。
         """
+        image_path = _existing_input_image(image_path)
+        output_path = _writable_output_file(output_file)
+        output_parent_identity = _output_parent_identity(output_path)
         try:
             # 1. 加载参考图片
             print(f"-> 正在加载参考图片: {image_path}")
-            ref_image = Image.open(image_path)
+            with (
+                open_binary_read_without_links(image_path) as source,
+                Image.open(source) as opened_image,
+            ):
+                before = os.fstat(source.fileno())
+                opened_image.load()
+                ref_image = opened_image.copy()
+                after = os.fstat(source.fileno())
+                if not file_snapshot_is_stable(before, after):
+                    raise PermissionError(
+                        f"reference image changed while it was read: {image_path}"
+                    )
 
             # 2. 构造 contents 列表：同时包含文本和图片
             # 传入的 contents 列表中可以包含多个 Part，其中一个是图片，一个是文本
@@ -158,14 +237,22 @@ class ImageGenerator:
                     image_bytes = generated_image_part.inline_data.data
                     
                     # 将字节数据写入文件
-                    output_path = Path(output_file)
-                    output_path.parent.mkdir(parents=True, exist_ok=True) # 确保目录存在
-                    
                     # 使用 BytesIO 和 PIL Image 来保存，确保格式正确
                     output_image = Image.open(BytesIO(image_bytes))
-                    output_image.save(output_path)
+                    image_format = (
+                        Image.registered_extensions().get(output_path.suffix.lower())
+                        or output_image.format
+                        or "PNG"
+                    )
+                    with BytesIO() as encoded:
+                        output_image.save(encoded, format=image_format)
+                        _publish_generated_image(
+                            output_path,
+                            encoded.getvalue(),
+                            expected_parent_identity=output_parent_identity,
+                        )
 
-                    print(f"-> 成功生成并保存图片至: {output_path.resolve()}")
+                    print(f"-> 成功生成并保存图片至: {output_path}")
                     return output_path
                 else:
                     print("-> 警告：模型未在响应中返回图片。")
@@ -195,6 +282,8 @@ class ImageGenerator:
                         父目录必须存在。
         """
         print(f"-> 正在为 prompt: '{prompt[:50]}...' 生成图片...")
+        output_path = _writable_output_file(output_file)
+        output_parent_identity = _output_parent_identity(output_path)
         try:
             # 调用模型生成图片
             result = self.client.models.generate_images(
@@ -212,12 +301,13 @@ class ImageGenerator:
                 image_bytes = result.generated_images[0].image.image_bytes
 
                 # 将字节数据写入文件
-                output_path = Path(output_file)
-                output_path.parent.mkdir(parents=True, exist_ok=True) # 确保目录存在
-                with open(output_path, "wb") as f:
-                    f.write(image_bytes)
+                _publish_generated_image(
+                    output_path,
+                    image_bytes,
+                    expected_parent_identity=output_parent_identity,
+                )
 
-                print(f"-> 成功生成并保存图片至: {output_path.resolve()}")
+                print(f"-> 成功生成并保存图片至: {output_path}")
                 return output_path
             else:
                 print("-> 警告：模型未返回任何图片。")
@@ -242,9 +332,9 @@ class ImageGenerator:
             prompt_list: 包含所有立绘描述的列表。
             output_dir: 批量图片保存的目录。
         """
-        output_path = Path(output_dir)
-        output_path.mkdir(parents=True, exist_ok=True)
-        print(f"--- 开始批量生成立绘到目录: {output_path.resolve()} ---")
+        image_path = _existing_input_image(image_path)
+        output_path = _writable_output_directory(output_dir)
+        print(f"--- 开始批量生成立绘到目录: {output_path} ---")
 
         generated_files = []
         for i, prompt in enumerate(prompt_list):

--- a/tools/generate_voice_lines.py
+++ b/tools/generate_voice_lines.py
@@ -2,24 +2,29 @@ import time
 import yaml
 import sys
 
-import os
 from pathlib import Path
 # 获取当前脚本的绝对路径
 current_script = Path(__file__).resolve()
 
-# 获取项目根目录（main.py所在的目录）
-project_root = current_script.parent.parent
+# 获取源码根目录（main.py所在的目录）
+source_root = current_script.parent.parent
 
 # 将项目根目录添加到Python模块搜索路径
-if str(project_root) not in sys.path:
-    sys.path.append(str(project_root))
+if str(source_root) not in sys.path:
+    sys.path.append(str(source_root))
 
+from sdk.file_transactions import atomic_write_text, read_text_without_links
+from sdk.path_contract import (
+    activate_project_root,
+    managed_project_directory,
+    portable_project_path,
+    project_root as runtime_project_root,
+    require_directory_without_links,
+    resolve_managed_project_path,
+    safe_path_component,
+    safe_path_component_with_suffix,
+)
 from ai.tts.tts_manager import TTSManager
-UPLOAD_DIR = "./data/sprite"
-VOICE_DIR = "./data/speech"
-API_CONFIG_PATH = "./data/config/api.yaml"
-CHARACTER_CONFIG_PATH = "./data/config/characters.yaml"
-TEMPLATE_DIR_PATH = "./data/character_templates"
 
 api_config = None
 tts_manager = None
@@ -29,10 +34,16 @@ characters=[]
 def load_characters_from_file():
     global characters
     try:
-        with open(CHARACTER_CONFIG_PATH, 'r', encoding='utf-8') as f:
-            loaded_characters = yaml.safe_load(f) or []
-            characters.clear()
-            characters.extend(loaded_characters)
+        root = runtime_project_root()
+        config_path = resolve_managed_project_path(
+            "data/config/characters.yaml",
+            root=root,
+        )
+        loaded_characters = yaml.safe_load(
+            read_text_without_links(config_path)
+        ) or []
+        characters.clear()
+        characters.extend(loaded_characters)
         return "人物设定已加载！", [[c.get("name", ""), c.get("color", ""), c.get("prompt_lang", "")] for c in characters]
     except Exception as e:
         return f"加载失败: {str(e)}", [[c.get("name", ""), c.get("color", ""), c.get("prompt_lang", "")] for c in characters]
@@ -43,22 +54,44 @@ def generate_voice_lines(character_name, words, index=None):
     global tts_manager
 
     character = next((c for c in characters if c["name"] == character_name), None)
+    if character is None:
+        raise KeyError(f"character not found: {character_name}")
 
+    root = runtime_project_root()
     tts_manager.switch_model(character["gpt_model_path"], character["sovits_model_path"])
-    voice_char_dir = os.path.join(VOICE_DIR, character["sprite_prefix"])
-    Path(voice_char_dir).mkdir(parents=True, exist_ok=True)
-    
+    sprite_prefix = safe_path_component(
+        str(character.get("sprite_prefix") or ""),
+        field="sprite_prefix",
+    )
+    voice_char_dir = managed_project_directory(
+        "data/speech",
+        sprite_prefix,
+        root=root,
+    )
+    voice_char_dir.mkdir(parents=True, exist_ok=True)
+    voice_char_dir = require_directory_without_links(
+        voice_char_dir,
+        field="voice output directory",
+    )
+
     def generate_tts_for_index(word, i):
-        voice_filename = f"{character['sprite_prefix']}_voice_{i:02d}.wav"
-        voice_path = os.path.join(voice_char_dir, voice_filename)
-        character['sprites'][i]["voice_path"] = voice_path
+        voice_filename = safe_path_component_with_suffix(
+            f"{sprite_prefix}_voice",
+            f"_{i:02d}.wav",
+            field="voice filename",
+        )
+        voice_path = voice_char_dir / voice_filename
+        character['sprites'][i]["voice_path"] = portable_project_path(
+            voice_path,
+            root=root,
+        )
         tts_manager.generate_tts(
             word,
             text_processor=None,
             ref_audio_path=character['refer_audio_path'],
             prompt_text=character['prompt_text'],
             prompt_lang=character['prompt_lang'],
-            file_path=voice_path
+            file_path=voice_path.as_posix()
         )
         print(f"生成语音文件: {voice_path}")
 
@@ -67,39 +100,41 @@ def generate_voice_lines(character_name, words, index=None):
     else:
         for i, word in enumerate(words):
             generate_tts_for_index(word, i)
-        
-        # 保存语音文件
-        voice_filename = f"{character['sprite_prefix']}_voice_{i:02d}.wav"
-        voice_path = os.path.join(voice_char_dir, voice_filename)
-        character['sprites'][i]["voice_path"] = voice_path
-        tts_manager.generate_tts(
-            word,
-            text_processor=None,
-                ref_audio_path=character['refer_audio_path'],
-                prompt_text=character['prompt_text'],
-                prompt_lang=character['prompt_lang'],
-                file_path=voice_path
-            )
-        print(f"生成语音文件: {voice_path}")
     save_characters_to_file()
 
 def save_characters_to_file():
     global characters
     try:
-        # 保存到当前目录下的characters.yaml文件
-        file_path = CHARACTER_CONFIG_PATH
-        with open(file_path, 'w', encoding='utf-8') as f:
-            yaml.dump(characters, f, allow_unicode=True)
+        root = runtime_project_root()
+        file_path = resolve_managed_project_path(
+            "data/config/characters.yaml",
+            root=root,
+        )
+        atomic_write_text(
+            file_path,
+            yaml.safe_dump(
+                characters,
+                allow_unicode=True,
+                default_flow_style=False,
+                sort_keys=False,
+            ),
+        )
         return f"人物设定已保存到 {file_path}！"
     except Exception as e:
         return f"保存失败: {str(e)}"
 
 def main():
+    root = activate_project_root(source_root)
+
     # 加载配置文件
     load_characters_from_file()
 
     global api_config
-    api_config = yaml.safe_load(open(API_CONFIG_PATH, 'r', encoding='utf-8'))
+    api_config_path = resolve_managed_project_path(
+        "data/config/api.yaml",
+        root=root,
+    )
+    api_config = yaml.safe_load(read_text_without_links(api_config_path))
 
     global tts_manager
     tts_manager = TTSManager(tts_server_url=api_config.get("gpt_sovits_url",""))

--- a/tools/remove_bg.py
+++ b/tools/remove_bg.py
@@ -1,43 +1,160 @@
-def ai_remove_background(input_path, output_path):
+import os
+import stat
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    _source_root = Path(__file__).resolve().parent.parent
+    if str(_source_root) not in sys.path:
+        sys.path.insert(0, str(_source_root))
+
+from core.file_transactions import (
+    atomic_binary_writer,
+    capture_directory_identity,
+    file_snapshot_is_stable,
+    open_binary_read_without_links,
+    require_directory_identity,
+    snapshot_directory_entries_without_links,
+)
+from core.process_launch import capture_launch_file
+from core.paths import (
+    managed_child_path,
+    project_root,
+    require_directory_without_links,
+    resolve_project_output_path,
+    resolve_runtime_asset_read_path,
+)
+
+
+def ai_remove_background(
+    input_path,
+    output_path,
+    *,
+    expected_source_identity: os.stat_result | None = None,
+    expected_source_parent_identity: os.stat_result | None = None,
+    expected_destination_parent_identity: os.stat_result | None = None,
+):
     """
     Use rembg with the isnet-anime model (optimised for anime-style sprites).
     """
+    root = project_root()
+    source = resolve_runtime_asset_read_path(os.fspath(input_path), root=root)
+    target = resolve_project_output_path(os.fspath(output_path), root=root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    source_snapshot = capture_launch_file(
+        source,
+        field="background removal input image",
+    )
+    if (
+        expected_source_identity is not None
+        and not file_snapshot_is_stable(
+            expected_source_identity,
+            source_snapshot.identity,
+        )
+    ):
+        raise PermissionError(
+            f"background removal input image identity changed: {source}"
+        )
+    if (
+        expected_source_parent_identity is not None
+        and not os.path.samestat(
+            expected_source_parent_identity,
+            source_snapshot.parent.identity,
+        )
+    ):
+        raise PermissionError(
+            f"background removal input directory identity changed: {source.parent}"
+        )
+    target_parent, target_parent_identity = capture_directory_identity(
+        target.parent,
+        field="background removal output directory",
+    )
+    if target.parent != target_parent:
+        raise PermissionError("background removal output directory changed identity")
+    if (
+        expected_destination_parent_identity is not None
+        and not os.path.samestat(
+            expected_destination_parent_identity,
+            target_parent_identity,
+        )
+    ):
+        raise PermissionError(
+            f"background removal output directory identity changed: {target.parent}"
+        )
     try:
         from rembg import remove, new_session
         from PIL import Image
-        input_img = Image.open(input_path)
-        session = new_session("isnet-anime")
-        output_img = remove(input_img, session=session)
+        with (
+            open_binary_read_without_links(
+                source,
+                expected_identity=source_snapshot.identity,
+                expected_parent_identity=source_snapshot.parent.identity,
+            ) as input_file,
+            Image.open(input_file) as input_img,
+        ):
+            before = os.fstat(input_file.fileno())
+            input_img.load()
+            after = os.fstat(input_file.fileno())
+            if not file_snapshot_is_stable(before, after):
+                raise PermissionError(
+                    f"input image changed while it was being read: {source}"
+                )
+            session = new_session("isnet-anime")
+            output_img = remove(input_img, session=session)
 
-        output_img.save(output_path, "PNG")
-        print(f"AI 自动移除背景完成，图片已保存到 {output_path}")
+        with atomic_binary_writer(
+            target,
+            expected_parent_identity=target_parent_identity,
+        ) as output:
+            output_img.save(output, "PNG")
+        print(f"AI 自动移除背景完成，图片已保存到 {target}")
 
     except ModuleNotFoundError as me:
         print(f"请先pip install 相关的依赖 {me}")
+        raise
 
     except Exception as e:
         print(f"处理出错：{e}, ")
+        raise
 
 
 def batch_remove_background(input_dir, output_dir=None):
     """
     Batch-process images in a directory, removing backgrounds.
     """
-    import os
-    import glob
+    root = project_root()
+    input_path = resolve_runtime_asset_read_path(os.fspath(input_dir), root=root)
+    if not input_path.is_dir():
+        raise NotADirectoryError(input_path)
+    input_path, input_identity, input_entries = (
+        snapshot_directory_entries_without_links(
+            input_path,
+            field="background removal input directory",
+        )
+    )
 
     if output_dir is None or output_dir == "":
-        output_dir = os.path.join(input_dir, "removed_backgrounds")
+        output_dir = input_path / "removed_backgrounds"
 
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    output_path = resolve_project_output_path(os.fspath(output_dir), root=root)
+    output_path.mkdir(parents=True, exist_ok=True)
+    output_path = require_directory_without_links(
+        output_path,
+        field="background removal output directory",
+    )
+    output_identity = output_path.lstat()
 
-    supported_formats = ["*.jpg", "*.jpeg", "*.png", "*.bmp", "*.tiff", "*.webp"]
+    supported_suffixes = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".webp"}
 
-    image_files = []
-    for fmt in supported_formats:
-        image_files.extend(glob.glob(os.path.join(input_dir, fmt)))
-        image_files.extend(glob.glob(os.path.join(input_dir, fmt.upper())))
+    image_files = sorted(
+        [
+            (child, metadata)
+            for child, metadata in input_entries
+            if stat.S_ISREG(metadata.st_mode)
+            and child.suffix.lower() in supported_suffixes
+        ],
+        key=lambda item: (item[0].name.casefold(), item[0].name),
+    )
 
     if not image_files:
         print(f"在目录 '{input_dir}' 中未找到支持的图片文件")
@@ -48,18 +165,36 @@ def batch_remove_background(input_dir, output_dir=None):
     processed_count = 0
     error_count = 0
 
-    for image_path in image_files:
+    for image_path, image_identity in image_files:
+        filename = image_path.name
         try:
-            filename = os.path.basename(image_path)
-            name, ext = os.path.splitext(filename)
-            output_filename = f"{name}{ext}"
-            output_path = os.path.join(output_dir, output_filename)
-            ai_remove_background(image_path, output_path)
+            output_file = managed_child_path(
+                output_path,
+                filename,
+                field="background-removed sprite filename",
+            )
+            ai_remove_background(
+                image_path,
+                output_file,
+                expected_source_identity=image_identity,
+                expected_source_parent_identity=input_identity,
+                expected_destination_parent_identity=output_identity,
+            )
             processed_count += 1
-            print(f"✓ 已处理: {filename} -> {output_filename}")
+            print(f"✓ 已处理: {filename} -> {filename}")
         except Exception as e:
             error_count += 1
             print(f"✗ 处理失败: {filename}，错误: {e}")
 
+    require_directory_identity(
+        input_path,
+        input_identity,
+        field="background removal input directory",
+    )
+    require_directory_identity(
+        output_path,
+        output_identity,
+        field="background removal output directory",
+    )
     print(f"批量处理完成，成功处理: {processed_count}，失败: {error_count}")
-    return f"成功处理: {processed_count}，失败: {error_count}，输出到目录： {output_dir}"
+    return f"成功处理: {processed_count}，失败: {error_count}，输出到目录： {output_path}"


### PR DESCRIPTION
## What changed

Applies strict input, output, subprocess, model, sprite, voice, and file path
handling to command-line utilities under `tools/`.

## Why

CLI tools often receive user-controlled paths and run outside the repository
working directory, so they need the same validation as the application.

## Impact

Tooling resolves resources and output locations predictably while rejecting
ambiguous or unsafe paths before launching subprocesses or writing files.

## Root cause

Utilities constructed paths independently and relied on caller working
directories, which diverged from packaged runtime behavior.

## Validation

This is one of 14 directory-scoped slices of the coordinated migration. The
combined rebased change passed the path-contract Node test, 74 targeted
frontend tests, and 8 targeted Python tests. The branch contains one commit
directly on the latest `upstream/main` and only changes `tools/`.
