### PR TITLE
feat(config): add centralized fail-closed story system feature flag

### DIFF
--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -21,6 +21,7 @@ from config.tts_provider_config import (
     uses_shared_tts_server_config,
 )
 from config.llm_defaults import LLM_BASE_URLS
+from config.feature_flags import FeatureFlagConfigManager
 from config.mirror_env import apply_mirror_environment
 from config.network_proxy import apply_network_proxy_environment
 from config.sprite_voice import normalize_sprite_voice_types
@@ -102,6 +103,11 @@ class ConfigManager:
             if self._config is None:
                  raise RuntimeError("配置加载失败，无法访问配置数据。")
         return self._config
+
+    @property
+    def feature_flags(self) -> FeatureFlagConfigManager:
+        """Return the centralized flag view for the current system config."""
+        return FeatureFlagConfigManager(self.config.system_config)
 
     # --- 内部加载/合并逻辑 ---
     def _load_yaml(self, file_path: Path) -> Dict[str, Any]:

--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -95,6 +95,15 @@ class FeatureFlagConfigManager:
             self._system_config, config_field
         ):
             configured = getattr(self._system_config, config_field)
+            load_diagnostic = getattr(
+                self._system_config, f"{config_field}_diagnostic", None
+            )
+            if isinstance(load_diagnostic, str) and load_diagnostic.strip():
+                return FeatureFlagResolution(
+                    enabled=False,
+                    source=f"config:{config_field}",
+                    diagnostic=load_diagnostic,
+                )
             if isinstance(configured, bool):
                 return FeatureFlagResolution(
                     enabled=configured,
@@ -149,6 +158,22 @@ class FeatureFlagConfigManager:
             return FeatureFlag(str(flag))
         except ValueError as error:
             raise KeyError(f"unregistered feature flag {flag!r}") from error
+
+    @classmethod
+    def coerce_persisted_value(cls, value: Any) -> tuple[bool, str | None]:
+        """Coerce a persisted flag value without raising.
+
+        Invalid values fail closed (``False``) and return a diagnostic. ``None``
+        uses the registry default and is not treated as a load error.
+        """
+        if value is None:
+            return False, None
+        if isinstance(value, bool):
+            return value, None
+        parsed = cls._parse_bool(value)
+        if parsed is None:
+            return False, f"invalid boolean value {value!r}; failed closed"
+        return parsed, None
 
     @staticmethod
     def _parse_bool(value: Any) -> bool | None:

--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -1,0 +1,160 @@
+"""Centralized, fail-closed feature flag resolution for Shinsekai."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+import os
+from types import MappingProxyType
+from typing import Any
+
+
+class FeatureFlag(str, Enum):
+    """Registered host feature flags.
+
+    Story capabilities intentionally share one master switch while the staged
+    implementation is experimental. New story sub-flags must not be added in
+    individual modules.
+    """
+
+    STORY_SYSTEM = "story_system"
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureFlagResolution:
+    enabled: bool
+    source: str
+    diagnostic: str | None = None
+
+
+class FeatureDisabledError(RuntimeError):
+    def __init__(self, flag: FeatureFlag, resolution: FeatureFlagResolution) -> None:
+        self.flag = flag
+        self.resolution = resolution
+        super().__init__(f"feature {flag.value!r} is disabled ({resolution.source})")
+
+
+class FeatureFlagConfigManager:
+    """Resolve registered flags from overrides, environment, and app config.
+
+    Precedence is explicit process override, environment variable, persisted
+    ``SystemConfig``, then the registry default. Invalid values fail closed and
+    retain a diagnostic so callers never have to interpret raw configuration.
+    """
+
+    _CONFIG_FIELDS: Mapping[FeatureFlag, str] = MappingProxyType(
+        {FeatureFlag.STORY_SYSTEM: "story_system_enabled"}
+    )
+    _ENVIRONMENT_FIELDS: Mapping[FeatureFlag, str] = MappingProxyType(
+        {FeatureFlag.STORY_SYSTEM: "SHINSEKAI_STORY_SYSTEM_ENABLED"}
+    )
+    _DEFAULTS: Mapping[FeatureFlag, bool] = MappingProxyType(
+        {FeatureFlag.STORY_SYSTEM: False}
+    )
+
+    def __init__(
+        self,
+        system_config: object | None = None,
+        *,
+        environ: Mapping[str, str] | None = None,
+        overrides: Mapping[FeatureFlag | str, bool] | None = None,
+    ) -> None:
+        self._system_config = system_config
+        self._environ = os.environ if environ is None else environ
+        self._overrides = self._normalize_overrides(overrides or {})
+
+    def is_enabled(self, flag: FeatureFlag | str) -> bool:
+        return self.resolve(flag).enabled
+
+    def resolve(self, flag: FeatureFlag | str) -> FeatureFlagResolution:
+        registered = self._registered(flag)
+        if registered in self._overrides:
+            return FeatureFlagResolution(
+                enabled=self._overrides[registered],
+                source="override",
+            )
+
+        environment_name = self._ENVIRONMENT_FIELDS[registered]
+        raw_environment = self._environ.get(environment_name)
+        if raw_environment is not None:
+            parsed = self._parse_bool(raw_environment)
+            if parsed is None:
+                return FeatureFlagResolution(
+                    enabled=False,
+                    source=f"environment:{environment_name}",
+                    diagnostic=f"invalid boolean value {raw_environment!r}; failed closed",
+                )
+            return FeatureFlagResolution(
+                enabled=parsed,
+                source=f"environment:{environment_name}",
+            )
+
+        config_field = self._CONFIG_FIELDS[registered]
+        if self._system_config is not None and hasattr(
+            self._system_config, config_field
+        ):
+            configured = getattr(self._system_config, config_field)
+            if isinstance(configured, bool):
+                return FeatureFlagResolution(
+                    enabled=configured,
+                    source=f"config:{config_field}",
+                )
+            return FeatureFlagResolution(
+                enabled=False,
+                source=f"config:{config_field}",
+                diagnostic=f"non-boolean config value {configured!r}; failed closed",
+            )
+
+        return FeatureFlagResolution(
+            enabled=self._DEFAULTS[registered],
+            source="default",
+        )
+
+    def require(self, flag: FeatureFlag | str) -> None:
+        registered = self._registered(flag)
+        resolution = self.resolve(registered)
+        if not resolution.enabled:
+            raise FeatureDisabledError(registered, resolution)
+
+    def snapshot(self) -> Mapping[FeatureFlag, FeatureFlagResolution]:
+        return MappingProxyType({flag: self.resolve(flag) for flag in FeatureFlag})
+
+    @classmethod
+    def environment_name(cls, flag: FeatureFlag | str) -> str:
+        return cls._ENVIRONMENT_FIELDS[cls._registered(flag)]
+
+    @classmethod
+    def config_field(cls, flag: FeatureFlag | str) -> str:
+        return cls._CONFIG_FIELDS[cls._registered(flag)]
+
+    @classmethod
+    def _normalize_overrides(
+        cls,
+        overrides: Mapping[FeatureFlag | str, bool],
+    ) -> Mapping[FeatureFlag, bool]:
+        normalized: dict[FeatureFlag, bool] = {}
+        for flag, value in overrides.items():
+            registered = cls._registered(flag)
+            if not isinstance(value, bool):
+                raise TypeError(f"override for {registered.value!r} must be a boolean")
+            normalized[registered] = value
+        return MappingProxyType(normalized)
+
+    @staticmethod
+    def _registered(flag: FeatureFlag | str) -> FeatureFlag:
+        if isinstance(flag, FeatureFlag):
+            return flag
+        try:
+            return FeatureFlag(str(flag))
+        except ValueError as error:
+            raise KeyError(f"unregistered feature flag {flag!r}") from error
+
+    @staticmethod
+    def _parse_bool(value: Any) -> bool | None:
+        normalized = str(value).strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        return None

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,6 +1,9 @@
+from collections.abc import Mapping
+
 from pydantic import BaseModel, Field, HttpUrl, FilePath, BeforeValidator, field_validator, model_validator
 from pydantic_core import PydanticUseDefault
 from typing import List, Dict, Optional, Union, Any, Annotated, TypeVar
+from config.feature_flags import FeatureFlagConfigManager
 from config.network_proxy import normalize_proxy_url
 
 # ----------------- 解决 YAML None 问题的工具 -----------------
@@ -213,6 +216,11 @@ class SystemConfig(BaseModel):
         default=False,
         description="Experimental master switch for every structured story capability.",
     )
+    story_system_enabled_diagnostic: Optional[str] = Field(
+        default=None,
+        exclude=True,
+        description="Load-time fail-closed diagnostic for story_system_enabled; never persisted.",
+    )
 
     # 音乐翻唱流水线（YouTube/B站下载 → UVR 分离 → RVC 转换 → pydub 合成）
     mirror_auto_detect_china: DefaultIfNone[bool] = Field(
@@ -255,6 +263,24 @@ class SystemConfig(BaseModel):
         default="",
         description="SOCKS5 proxy URL, exported as ALL_PROXY/all_proxy.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _fail_closed_story_system_enabled(cls, data: Any) -> Any:
+        """Invalid persisted story_system_enabled must not abort SystemConfig load."""
+        if not isinstance(data, Mapping):
+            return data
+        updated = dict(data)
+        updated.pop("story_system_enabled_diagnostic", None)
+        if "story_system_enabled" not in updated:
+            return updated
+        enabled, diagnostic = FeatureFlagConfigManager.coerce_persisted_value(
+            updated.get("story_system_enabled")
+        )
+        updated["story_system_enabled"] = enabled
+        if diagnostic:
+            updated["story_system_enabled_diagnostic"] = diagnostic
+        return updated
 
     @field_validator("chat_ui_runtime_mode", mode="before")
     @classmethod

--- a/config/schema.py
+++ b/config/schema.py
@@ -209,6 +209,10 @@ class SystemConfig(BaseModel):
         default=False,
         description="实验性功能：启用 React Chat UI 的对话分支流程图/树功能",
     )
+    story_system_enabled: DefaultIfNone[bool] = Field(
+        default=False,
+        description="Experimental master switch for every structured story capability.",
+    )
 
     # 音乐翻唱流水线（YouTube/B站下载 → UVR 分离 → RVC 转换 → pydub 合成）
     mirror_auto_detect_china: DefaultIfNone[bool] = Field(

--- a/test/unit/application/test_audio_playback_controller.py
+++ b/test/unit/application/test_audio_playback_controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -42,6 +43,16 @@ def _start_playback(controller: VoicePlaybackController, **kwargs):
     thread = threading.Thread(target=run)
     thread.start()
     return thread, result
+
+
+def _wait_for_post_tts_play(ui_updates, timeout: float = 1.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        call_args = ui_updates.post_tts_play.call_args
+        if call_args is not None:
+            return call_args.kwargs
+        time.sleep(0.01)
+    raise AssertionError("post_tts_play was not called")
 
 
 def test_controller_blocks_until_matching_backend_finished_signal() -> None:
@@ -160,7 +171,7 @@ def test_frontend_backend_emits_ids_and_waits_for_external_signal() -> None:
     thread, result = _start_playback(controller)
 
     assert thread.is_alive()
-    play_kwargs = ui_updates.post_tts_play.call_args.kwargs
+    play_kwargs = _wait_for_post_tts_play(ui_updates)
     playback_id = play_kwargs["playback_id"]
     assert play_kwargs["volume"] == 1.0
     assert controller.handle_signal(playback_id, "started") is True
@@ -177,7 +188,7 @@ def test_controller_rejects_terminal_signal_from_a_different_renderer() -> None:
     )
     controller = VoicePlaybackController(FrontendVoicePlaybackBackend(ui_updates))
     thread, result = _start_playback(controller)
-    playback_id = ui_updates.post_tts_play.call_args.kwargs["playback_id"]
+    playback_id = _wait_for_post_tts_play(ui_updates)["playback_id"]
 
     assert controller.handle_signal(
         playback_id,

--- a/test/unit/config/test_feature_flags.py
+++ b/test/unit/config/test_feature_flags.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from config.feature_flags import (
+    FeatureDisabledError,
+    FeatureFlag,
+    FeatureFlagConfigManager,
+)
+
+
+def test_story_system_is_disabled_by_default() -> None:
+    manager = FeatureFlagConfigManager(environ={})
+
+    resolution = manager.resolve(FeatureFlag.STORY_SYSTEM)
+
+    assert resolution.enabled is False
+    assert resolution.source == "default"
+
+
+def test_persisted_story_flag_is_resolved_centrally() -> None:
+    manager = FeatureFlagConfigManager(
+        SimpleNamespace(story_system_enabled=True),
+        environ={},
+    )
+
+    assert manager.is_enabled(FeatureFlag.STORY_SYSTEM)
+    assert manager.resolve(FeatureFlag.STORY_SYSTEM).source == (
+        "config:story_system_enabled"
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1", True), ("true", True), ("ON", True), ("0", False), ("no", False)],
+)
+def test_environment_override_has_deterministic_boolean_parsing(
+    value: str,
+    expected: bool,
+) -> None:
+    manager = FeatureFlagConfigManager(
+        SimpleNamespace(story_system_enabled=not expected),
+        environ={"SHINSEKAI_STORY_SYSTEM_ENABLED": value},
+    )
+
+    assert manager.is_enabled(FeatureFlag.STORY_SYSTEM) is expected
+
+
+def test_invalid_environment_value_fails_closed_with_diagnostic() -> None:
+    manager = FeatureFlagConfigManager(
+        SimpleNamespace(story_system_enabled=True),
+        environ={"SHINSEKAI_STORY_SYSTEM_ENABLED": "sometimes"},
+    )
+
+    resolution = manager.resolve(FeatureFlag.STORY_SYSTEM)
+
+    assert resolution.enabled is False
+    assert resolution.diagnostic == "invalid boolean value 'sometimes'; failed closed"
+
+
+def test_explicit_override_has_highest_precedence() -> None:
+    manager = FeatureFlagConfigManager(
+        SimpleNamespace(story_system_enabled=False),
+        environ={"SHINSEKAI_STORY_SYSTEM_ENABLED": "false"},
+        overrides={FeatureFlag.STORY_SYSTEM: True},
+    )
+
+    assert manager.is_enabled(FeatureFlag.STORY_SYSTEM)
+    assert manager.resolve(FeatureFlag.STORY_SYSTEM).source == "override"
+
+
+def test_require_raises_a_typed_error_when_disabled() -> None:
+    manager = FeatureFlagConfigManager(environ={})
+
+    with pytest.raises(FeatureDisabledError) as exc_info:
+        manager.require(FeatureFlag.STORY_SYSTEM)
+
+    assert exc_info.value.flag == FeatureFlag.STORY_SYSTEM
+
+
+def test_unknown_flags_are_rejected() -> None:
+    manager = FeatureFlagConfigManager(environ={})
+
+    with pytest.raises(KeyError):
+        manager.is_enabled("story_runtime_enabled")

--- a/test/unit/config/test_feature_flags.py
+++ b/test/unit/config/test_feature_flags.py
@@ -9,6 +9,7 @@ from config.feature_flags import (
     FeatureFlag,
     FeatureFlagConfigManager,
 )
+from config.schema import SystemConfig
 
 
 def test_story_system_is_disabled_by_default() -> None:
@@ -58,6 +59,18 @@ def test_invalid_environment_value_fails_closed_with_diagnostic() -> None:
 
     assert resolution.enabled is False
     assert resolution.diagnostic == "invalid boolean value 'sometimes'; failed closed"
+
+
+def test_invalid_persisted_config_value_fails_closed_with_diagnostic() -> None:
+    system_config = SystemConfig.model_validate({"story_system_enabled": "maybe"})
+    manager = FeatureFlagConfigManager(system_config, environ={})
+
+    resolution = manager.resolve(FeatureFlag.STORY_SYSTEM)
+
+    assert system_config.story_system_enabled is False
+    assert resolution.enabled is False
+    assert resolution.source == "config:story_system_enabled"
+    assert resolution.diagnostic == "invalid boolean value 'maybe'; failed closed"
 
 
 def test_explicit_override_has_highest_precedence() -> None:

--- a/test/unit/config/test_schema.py
+++ b/test/unit/config/test_schema.py
@@ -97,6 +97,47 @@ class TestSystemConfig:
 
     def test_story_system_is_disabled_by_default(self):
         assert SystemConfig().story_system_enabled is False
+        assert SystemConfig().story_system_enabled_diagnostic is None
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("OFF", False),
+            (1, True),
+            (0, False),
+        ],
+    )
+    def test_story_system_accepts_boolean_like_persisted_values(self, raw, expected):
+        config = SystemConfig.model_validate({"story_system_enabled": raw})
+
+        assert config.story_system_enabled is expected
+        assert config.story_system_enabled_diagnostic is None
+
+    def test_invalid_persisted_story_system_flag_fails_closed_without_aborting(self):
+        config = SystemConfig.model_validate({"story_system_enabled": "maybe"})
+
+        assert config.story_system_enabled is False
+        assert (
+            config.story_system_enabled_diagnostic
+            == "invalid boolean value 'maybe'; failed closed"
+        )
+        dumped = config.model_dump(by_alias=True)
+        assert dumped["story_system_enabled"] is False
+        assert "story_system_enabled_diagnostic" not in dumped
+
+    def test_injected_story_system_diagnostic_is_not_trusted(self):
+        config = SystemConfig.model_validate(
+            {
+                "story_system_enabled": True,
+                "story_system_enabled_diagnostic": "spoofed",
+            }
+        )
+
+        assert config.story_system_enabled is True
+        assert config.story_system_enabled_diagnostic is None
 
     @pytest.mark.parametrize("configured_mode", ["native", "react", "unexpected", None])
     def test_chat_ui_runtime_mode_is_forced_to_react(self, configured_mode):

--- a/test/unit/config/test_schema.py
+++ b/test/unit/config/test_schema.py
@@ -95,6 +95,9 @@ class TestSystemConfig:
     def test_react_chat_ui_is_enabled_by_default(self):
         assert SystemConfig().chat_ui_runtime_mode == "react"
 
+    def test_story_system_is_disabled_by_default(self):
+        assert SystemConfig().story_system_enabled is False
+
     @pytest.mark.parametrize("configured_mode", ["native", "react", "unexpected", None])
     def test_chat_ui_runtime_mode_is_forced_to_react(self, configured_mode):
         assert SystemConfig(chat_ui_runtime_mode=configured_mode).chat_ui_runtime_mode == "react"

--- a/test/unit/managers/test_config_manager.py
+++ b/test/unit/managers/test_config_manager.py
@@ -4,6 +4,7 @@ import os
 
 import config.network_proxy as network_proxy
 from config.config_manager import ConfigManager
+from config.feature_flags import FeatureFlag
 from config.schema import AppConfig, ApiConfig, Background, Character, SystemConfig
 from config.sprite_voice import normalize_sprite_voice_types
 
@@ -49,6 +50,13 @@ def _save_api_config_for_test(manager: ConfigManager, **overrides) -> str:
     }
     params.update(overrides)
     return manager.save_api_config_new(**params)
+
+
+def test_config_manager_exposes_centralized_feature_flags():
+    manager = _config_manager_with_api()
+    manager.config.system_config.story_system_enabled = True
+
+    assert manager.feature_flags.is_enabled(FeatureFlag.STORY_SYSTEM)
 
 
 def test_get_llm_api_config_defaults_known_provider_base_url_when_empty():

--- a/test/unit/managers/test_config_manager.py
+++ b/test/unit/managers/test_config_manager.py
@@ -59,6 +59,19 @@ def test_config_manager_exposes_centralized_feature_flags():
     assert manager.feature_flags.is_enabled(FeatureFlag.STORY_SYSTEM)
 
 
+def test_invalid_persisted_story_flag_does_not_abort_config_load():
+    manager = _config_manager_with_api()
+    manager.config.system_config = SystemConfig.model_validate(
+        {"story_system_enabled": "maybe"}
+    )
+
+    resolution = manager.feature_flags.resolve(FeatureFlag.STORY_SYSTEM)
+
+    assert manager.config.system_config.story_system_enabled is False
+    assert resolution.enabled is False
+    assert resolution.diagnostic == "invalid boolean value 'maybe'; failed closed"
+
+
 def test_get_llm_api_config_defaults_known_provider_base_url_when_empty():
     manager = _config_manager_with_api(
         llm_provider="Deepseek",


### PR DESCRIPTION
﻿## Summary

- add a centralized, typed `FeatureFlagConfigManager`
- register one fail-closed `story_system` master flag for every remaining story phase
- support deterministic precedence across explicit overrides, environment, persisted config, and defaults
- expose the manager through `ConfigManager.feature_flags` while keeping the flag disabled by default

## Compatibility

- no existing chat or runtime path is connected to the flag in this foundation PR
- invalid environment/config values fail closed and retain a diagnostic
- later story services must call this manager instead of reading raw booleans or adding per-module flags

## Stack

- based on `main` (merged #310, including the review-comment fixes)

## Verification

- `python -m pytest test/unit/config/test_feature_flags.py test/unit/config/test_schema.py test/unit/managers/test_config_manager.py test/unit/architecture/test_import_boundaries.py -q` (52 passed)
- `python -m black --check config/feature_flags.py test/unit/config/test_feature_flags.py`
- `python -m compileall -q config`
- `git diff --check`

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次核对的重点轻轻收拢，方便你快速查看。

此 PR 在 `config/` 中新增集中式 `story_system` 开关并将其接入 `SystemConfig` 与 `ConfigManager`，默认关闭；但持久化的非布尔值会在开关解析之前中止配置加载，而非按失败关闭处理。

### New Features

- 新增 `FeatureFlagConfigManager`，按显式覆盖、环境变量、持久化配置、默认值的优先级解析 `FeatureFlag.STORY_SYSTEM`。
- 新增 `SystemConfig.story_system_enabled` 和 `ConfigManager.feature_flags`。

### Tests

- 新增默认关闭、优先级、环境布尔解析及禁用异常的单元测试。

<details>
<summary>Original summary in English</summary>

This PR adds a centralized `story_system` flag in `config/`, wired through `SystemConfig` and `ConfigManager` with a disabled default; however, a non-boolean persisted value aborts configuration loading before flag resolution instead of failing closed.

### New Features

- Adds `FeatureFlagConfigManager`, resolving `FeatureFlag.STORY_SYSTEM` by explicit override, environment, persisted configuration, then default.
- Adds `SystemConfig.story_system_enabled` and `ConfigManager.feature_flags`.

### Tests

- Adds unit coverage for the disabled default, precedence, environment boolean parsing, and the disabled-feature exception.

</details>

<!-- astrbot-review:end:summary -->