### PR TITLE
feat(story): add feature-gated session persistence and chat options

### DIFF
--- a/application/chat/runtime_process.py
+++ b/application/chat/runtime_process.py
@@ -38,7 +38,9 @@ from core.sprite.chat_branch_storage import (
     chat_history_active_path,
     chat_history_download_path,
     chat_history_session_dir,
+    load_branch_state,
     remove_chat_history_storage,
+    save_branch_state,
 )
 from core.sprite.chat_history_text import history_payload_to_plain_text, parse_assistant_dialog_content
 from ai.tools.chat_ui_tools import sanitize_user_display_name
@@ -61,8 +63,13 @@ from application.chat.templates import (
 )
 from application.runtime.dependencies import runtime_dependency_error_from_text
 from application.runtime.state import BridgeState
-from application.story.coordinator import story_snapshot_patch
-from config.feature_flags import FeatureFlag
+from application.story.coordinator import (
+    bound_story_session,
+    clear_story_session,
+    discard_story_session_storage,
+    publish_story_transition,
+    story_snapshot_patch,
+)
 from core.story import SelectChoice
 from core.sprite.sprite_cli import CHAT_LAUNCH_CONFIG_ENV
 from sdk.path_utils import reject_control_chars
@@ -552,6 +559,7 @@ def _close_chat(
                 delete_session(session_id)
         if str(state.chat_session.get("sessionId") or "").strip() == session_id:
             state.chat_session = {**state.chat_session, "sessionId": ""}
+    clear_story_session(state)
     return closed_snapshot
 
 
@@ -923,6 +931,134 @@ def _chat_history_download_file(state: BridgeState, capability: str) -> Path:
     return history_file
 
 
+def _story_choice_label(session: Any, choice_id: str) -> str:
+    snapshot = session.chat_snapshot()
+    for option in snapshot.get("options") or []:
+        if not isinstance(option, dict):
+            continue
+        if str(option.get("id") or "") != choice_id:
+            continue
+        label = str(option.get("label") or "").strip()
+        if label:
+            return label
+    return choice_id
+
+
+def _persist_story_choice_messages(
+    state: BridgeState,
+    label: str,
+    user_name: str,
+) -> None:
+    history_raw = str(state.chat_session.get("historyPath") or "").strip()
+    if not history_raw or is_unc_history_path(history_raw):
+        return
+    history_path = _resolve_history_file(state, history_raw)
+    if is_unc_history_path(history_path):
+        return
+    active = chat_history_active_path(history_path)
+    messages: list[Any] = []
+    if active.is_file():
+        loaded = _read_history_file(active)
+        if isinstance(loaded, list):
+            messages = loaded
+    messages.append({"role": "user", "content": label})
+    active.parent.mkdir(parents=True, exist_ok=True)
+    with active.open("w", encoding="utf-8") as file:
+        json.dump(messages, file, ensure_ascii=False, indent=4)
+    branch_state = load_branch_state(history_path)
+    if branch_state is None:
+        return
+    branches = branch_state.get("branches")
+    if not isinstance(branches, dict):
+        return
+    active_id = str(branch_state.get("active") or "main")
+    branch = branches.get(active_id)
+    if not isinstance(branch, dict):
+        return
+    history = list(branch.get("history") or [])
+    history.append(f"<b>{user_name}</b>：{label}")
+    branch["messages"] = list(messages)
+    branch["history"] = history
+    save_branch_state(history_path, branch_state)
+
+
+def _record_story_choice_history(state: BridgeState, label: str) -> list[dict[str, Any]]:
+    entries = [dict(item) for item in _chat_history_entries(state)]
+    user_name = _chat_user_display_name_from_snapshot(state)
+    user_index = sum(1 for item in entries if str(item.get("role") or "") == "user")
+    entries.append(
+        {
+            "id": f"history-{len(entries)}",
+            "revertUserIndex": user_index,
+            "role": "user",
+            "text": f"{user_name}: {label}",
+        }
+    )
+    _persist_story_choice_messages(state, label, user_name)
+    return entries
+
+
+def _allocate_aligned_story_branch_id(state: BridgeState, session: Any) -> str:
+    max_counter = 1
+    history_raw = str(state.chat_session.get("historyPath") or "").strip()
+    if history_raw and not is_unc_history_path(history_raw):
+        history_path = _resolve_history_file(state, history_raw)
+        if not is_unc_history_path(history_path):
+            branch_state = load_branch_state(history_path)
+            if branch_state is not None:
+                try:
+                    max_counter = max(max_counter, int(branch_state.get("counter") or 1))
+                except (TypeError, ValueError):
+                    pass
+    for branch_id in session.branches:
+        suffix = str(branch_id)[7:] if str(branch_id).startswith("branch-") else ""
+        if suffix.isdigit():
+            max_counter = max(max_counter, int(suffix))
+    candidate = max_counter + 1
+    while f"branch-{candidate}" in session.branches:
+        candidate += 1
+    return f"branch-{candidate}"
+
+
+def _sync_story_session_branch_command(
+    state: BridgeState,
+    command: str,
+    body: dict[str, Any],
+) -> None:
+    session = bound_story_session(state)
+    if session is None:
+        return
+    if command == "fork-history":
+        payload = body.get("payload")
+        raw_index = payload.get("userIndex") if isinstance(payload, dict) else payload
+        user_index = int(raw_index)
+        generation = session.checkpoint_generation_before_user_index(user_index)
+        branch_id = _allocate_aligned_story_branch_id(state, session)
+        session.fork(branch_id, generation=generation)
+        if isinstance(payload, dict):
+            body["payload"] = {**payload, "branchId": branch_id}
+        else:
+            body["payload"] = {"userIndex": user_index, "branchId": branch_id}
+        return
+    if command == "switch-branch":
+        branch_id = str(body.get("payload") or "").strip()
+        if branch_id in session.branches:
+            session.switch_branch(branch_id)
+        return
+    if command == "revert-history":
+        generation = session.checkpoint_generation_before_user_index(int(body.get("payload")))
+        session.restore_generation(generation)
+
+
+def _discard_bound_story_session(state: BridgeState) -> None:
+    history_raw = str(state.chat_session.get("historyPath") or "").strip()
+    if history_raw and not is_unc_history_path(history_raw):
+        history_path = _resolve_history_file(state, history_raw)
+        if not is_unc_history_path(history_path):
+            discard_story_session_storage(history_path)
+    clear_story_session(state)
+
+
 def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, Any]:
     command = str(body.get("type") or "").strip()
     history_raw = str(state.chat_session.get("historyPath") or "").strip()
@@ -1006,6 +1142,7 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
         )
 
     if command == "clear-history":
+        _discard_bound_story_session(state)
         if session_id and chat_stream is not None:
             return _forward_runtime_command(
                 "idle",
@@ -1094,13 +1231,8 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
     if command == "submit-option" and isinstance(body.get("payload"), dict):
         payload = body["payload"]
         if payload.get("kind") == "story-choice":
-            flags = getattr(state.config_manager, "feature_flags", None)
-            story_session = getattr(state, "story_session", None)
-            if (
-                flags is None
-                or not flags.is_enabled(FeatureFlag.STORY_SYSTEM)
-                or story_session is None
-            ):
+            story_session = bound_story_session(state)
+            if story_session is None:
                 raise ValueError("Option selection must be a string.")
             choice_id = reject_control_chars(
                 str(payload.get("choiceId") or "").strip(),
@@ -1117,6 +1249,10 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
             if not choice_id or not expected_node_id:
                 raise ValueError("Story choice is invalid.")
             command_id = str(body.get("cmdId") or uuid.uuid4().hex)
+            history_entries = _record_story_choice_history(
+                state,
+                _story_choice_label(story_session, choice_id),
+            )
             ack = story_session.execute(
                 SelectChoice(
                     command_id=command_id,
@@ -1124,12 +1260,16 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
                     choice_id=choice_id,
                     expected_node_id=expected_node_id,
                 ),
-                history_entries=_chat_history_entries(state),
+                history_entries=history_entries,
             )
             patch = story_session.chat_snapshot()
             patch["storyAck"] = ack.to_payload()
-            if session_id and chat_stream is not None:
-                chat_stream.update_session_snapshot(session_id, patch)
+            publish_story_transition(
+                state,
+                patch,
+                history_entries=history_entries,
+                presentation_events=ack.presentation_events,
+            )
             return _chat_snapshot(state, "idle", extra=patch)
         if payload.get("kind") != "tool-confirmation":
             raise ValueError("Option selection must be a string.")
@@ -1239,6 +1379,7 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
             int(body.get("payload"))
         except (TypeError, ValueError) as exc:
             raise ValueError("回溯索引无效。") from exc
+        _sync_story_session_branch_command(state, command, body)
         return _forward_runtime_command("idle")
     if command == "fork-history":
         if not _chat_experimental_features(state)["forkHistory"]:
@@ -1249,6 +1390,7 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
             int(raw_index)
         except (TypeError, ValueError) as exc:
             raise ValueError("分支索引无效。") from exc
+        _sync_story_session_branch_command(state, command, body)
         return _forward_runtime_command("generating", "正在创建对话分支。")
     if command == "switch-branch":
         if not _chat_experimental_features(state)["conversationTree"]:
@@ -1256,6 +1398,7 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
         branch_id = str(body.get("payload") or "").strip()
         if not branch_id:
             raise ValueError("分支 id 不能为空。")
+        _sync_story_session_branch_command(state, command, body)
         return _forward_runtime_command("idle", "已切换对话分支。")
     if command == "rename-branch":
         if not _chat_experimental_features(state)["conversationTree"]:

--- a/application/chat/runtime_process.py
+++ b/application/chat/runtime_process.py
@@ -61,6 +61,9 @@ from application.chat.templates import (
 )
 from application.runtime.dependencies import runtime_dependency_error_from_text
 from application.runtime.state import BridgeState
+from application.story.coordinator import story_snapshot_patch
+from config.feature_flags import FeatureFlag
+from core.story import SelectChoice
 from core.sprite.sprite_cli import CHAT_LAUNCH_CONFIG_ENV
 from sdk.path_utils import reject_control_chars
 
@@ -774,6 +777,7 @@ def _chat_snapshot(
         "chatRuntimeClosing": _chat_runtime_closing(state),
         "turnOptions": _chat_turn_options(state),
     }
+    story_patch = story_snapshot_patch(state)
     mobile_access_info = get_mobile_access_info(state)
     if mobile_access_info is not None:
         runtime_state["mobileAccess"] = mobile_access_info.to_payload()
@@ -807,6 +811,8 @@ def _chat_snapshot(
                 next_snapshot["wsUrl"] = mobile_access_info.websocket_url
             if extra:
                 next_snapshot.update(extra)
+            if story_patch:
+                next_snapshot.update(story_patch)
             return next_snapshot
     bg_path, character_name, sprites = _chat_session_media(state)
     history_path = str(state.chat_session.get("historyPath") or "")
@@ -828,6 +834,7 @@ def _chat_snapshot(
         "userDisplayName": user_display_name,
         "voiceLanguage": voice_language,
         **runtime_state,
+        **story_patch,
         **(extra or {}),
     }
 
@@ -1086,6 +1093,44 @@ def _handle_chat_command(state: BridgeState, body: dict[str, Any]) -> dict[str, 
 
     if command == "submit-option" and isinstance(body.get("payload"), dict):
         payload = body["payload"]
+        if payload.get("kind") == "story-choice":
+            flags = getattr(state.config_manager, "feature_flags", None)
+            story_session = getattr(state, "story_session", None)
+            if (
+                flags is None
+                or not flags.is_enabled(FeatureFlag.STORY_SYSTEM)
+                or story_session is None
+            ):
+                raise ValueError("Option selection must be a string.")
+            choice_id = reject_control_chars(
+                str(payload.get("choiceId") or "").strip(),
+                field="choiceId",
+            )
+            expected_node_id = reject_control_chars(
+                str(payload.get("expectedNodeId") or "").strip(),
+                field="expectedNodeId",
+            )
+            try:
+                expected_revision = int(payload.get("expectedRevision"))
+            except (TypeError, ValueError) as exc:
+                raise ValueError("Story choice revision is invalid.") from exc
+            if not choice_id or not expected_node_id:
+                raise ValueError("Story choice is invalid.")
+            command_id = str(body.get("cmdId") or uuid.uuid4().hex)
+            ack = story_session.execute(
+                SelectChoice(
+                    command_id=command_id,
+                    expected_revision=expected_revision,
+                    choice_id=choice_id,
+                    expected_node_id=expected_node_id,
+                ),
+                history_entries=_chat_history_entries(state),
+            )
+            patch = story_session.chat_snapshot()
+            patch["storyAck"] = ack.to_payload()
+            if session_id and chat_stream is not None:
+                chat_stream.update_session_snapshot(session_id, patch)
+            return _chat_snapshot(state, "idle", extra=patch)
         if payload.get("kind") != "tool-confirmation":
             raise ValueError("Option selection must be a string.")
         confirmation_id = reject_control_chars(

--- a/application/runtime/event_sink.py
+++ b/application/runtime/event_sink.py
@@ -256,8 +256,34 @@ def fold_event_into_snapshot(snapshot: Dict[str, Any], event: Dict[str, Any]) ->
 
     if event_type == "options.show":
         _clear_transient_notification_state(next_snapshot)
-        next_snapshot["options"] = [str(item) for item in (event.get("options") or [])]
+        next_snapshot["options"] = [
+            dict(item) if isinstance(item, dict) else str(item)
+            for item in (event.get("options") or [])
+        ]
         next_snapshot["toolConfirmation"] = None
+        return next_snapshot
+
+    if event_type == "story.state.replace":
+        story = event.get("story")
+        if isinstance(story, dict):
+            next_snapshot["story"] = dict(story)
+            next_snapshot["options"] = [
+                dict(item)
+                for item in story.get("options", [])
+                if isinstance(item, dict)
+            ]
+        return next_snapshot
+
+    if event_type in {"story.node.entered", "story.node.unlocked", "story.cast.replace", "story.ending.reached"}:
+        story = dict(next_snapshot.get("story") or {})
+        payload = event.get("payload")
+        if isinstance(payload, dict):
+            story["lastEvent"] = {
+                "type": event_type,
+                "payload": dict(payload),
+                "revision": event.get("revision"),
+            }
+        next_snapshot["story"] = story
         return next_snapshot
 
     if event_type == "options.clear":

--- a/application/runtime/state.py
+++ b/application/runtime/state.py
@@ -52,6 +52,7 @@ class BridgeState:
     plugin_load_error: str = ""
     plugin_load_started_at: float = 0.0
     plugin_load_completed_at: float = 0.0
+    story_session: Any = None
     # Keep this field last so positional construction by older integrations remains compatible.
     project_root_dir: str = field(default_factory=_default_project_root_dir)
 

--- a/application/story/__init__.py
+++ b/application/story/__init__.py
@@ -7,11 +7,30 @@ from .idempotency import (
     story_command_payload_hash,
 )
 from .project_loader import StoryProjectLoader, load_story_project
+from .coordinator import start_or_recover_story_session, story_snapshot_patch
+from .persistence import (
+    GlobalStoryProgress,
+    JsonGlobalStoryProgressStore,
+    JsonStorySessionRepository,
+    StoryPersistenceError,
+    StoryProgramMismatchError,
+)
+from .session import StoryBranch, StorySession, StorySessionAck
 
 __all__ = [
     "StoryCommandConflictError",
     "StoryCommandIdempotencyIndex",
     "StoryCommandRecord",
+    "StoryBranch",
+    "StorySession",
+    "StorySessionAck",
+    "GlobalStoryProgress",
+    "JsonGlobalStoryProgressStore",
+    "JsonStorySessionRepository",
+    "StoryPersistenceError",
+    "StoryProgramMismatchError",
+    "start_or_recover_story_session",
+    "story_snapshot_patch",
     "StoryProjectLoader",
     "load_story_project",
     "story_command_payload_hash",

--- a/application/story/coordinator.py
+++ b/application/story/coordinator.py
@@ -7,7 +7,10 @@ from typing import Any
 
 from application.chat.history_paths import resolve_history_path_for_project
 from config.feature_flags import FeatureFlag
-from core.sprite.chat_branch_storage import chat_history_session_dir
+from core.sprite.chat_branch_storage import (
+    STORY_SESSION_FILENAME,
+    chat_history_session_dir,
+)
 from core.story import StoryCompiler, StoryRuntime
 from sdk.path_utils import safe_existing_path
 
@@ -59,16 +62,109 @@ def start_or_recover_story_session(
             repository=repository,
             global_store=global_store,
         )
+    session.owner_history_path = str(Path(history_path).resolve(strict=False))
     state.story_session = session
     return session
 
 
-def story_snapshot_patch(state: Any) -> dict[str, Any]:
+def bound_story_session(state: Any) -> StorySession | None:
     config_manager = getattr(state, "config_manager", None)
     flags = getattr(config_manager, "feature_flags", None)
     session = getattr(state, "story_session", None)
     if flags is None or session is None:
-        return {}
+        return None
     if not flags.is_enabled(FeatureFlag.STORY_SYSTEM):
+        return None
+    owner = str(getattr(session, "owner_history_path", "") or "").strip()
+    if not owner:
+        return session
+    current = str(getattr(state, "chat_session", {}).get("historyPath") or "").strip()
+    if not current:
+        return None
+    try:
+        if Path(owner).resolve(strict=False) != Path(current).resolve(strict=False):
+            return None
+    except OSError:
+        return None
+    return session
+
+
+def story_snapshot_patch(state: Any) -> dict[str, Any]:
+    session = bound_story_session(state)
+    if session is None:
         return {}
     return session.chat_snapshot()
+
+
+def clear_story_session(state: Any) -> None:
+    setattr(state, "story_session", None)
+
+
+def discard_story_session_storage(history_path: str | Path) -> None:
+    path = chat_history_session_dir(history_path) / STORY_SESSION_FILENAME
+    path.unlink(missing_ok=True)
+
+
+def release_unbound_story_session(state: Any, history_path: str | Path) -> None:
+    session = getattr(state, "story_session", None)
+    if session is None:
+        return
+    owner = str(getattr(session, "owner_history_path", "") or "").strip()
+    if not owner:
+        return
+    try:
+        if Path(owner).resolve(strict=False) != Path(history_path).resolve(strict=False):
+            clear_story_session(state)
+    except OSError:
+        clear_story_session(state)
+
+
+def publish_story_transition(
+    state: Any,
+    patch: dict[str, Any],
+    *,
+    history_entries: list[dict[str, Any]] | None = None,
+    presentation_events: tuple[Any, ...] = (),
+) -> None:
+    session_id = str(getattr(state, "chat_session", {}).get("sessionId") or "").strip()
+    chat_stream = getattr(state, "chat_stream", None)
+    if not session_id or chat_stream is None:
+        return
+    events: list[dict[str, Any]] = []
+    if history_entries is not None:
+        events.append(
+            {
+                "type": "history.replace",
+                "entries": [dict(item) for item in history_entries],
+            }
+        )
+    story = patch.get("story")
+    if isinstance(story, dict):
+        events.append({"type": "story.state.replace", "story": dict(story)})
+    options = patch.get("options")
+    if isinstance(options, list):
+        events.append({"type": "options.show", "options": list(options)})
+    for item in presentation_events:
+        if isinstance(item, dict):
+            events.append(dict(item))
+    publish = getattr(chat_stream, "publish_event", None)
+    published_any = False
+    if callable(publish):
+        for event in events:
+            if publish(session_id, event):
+                published_any = True
+    update = getattr(chat_stream, "update_session_snapshot", None)
+    if not callable(update):
+        return
+    snapshot_patch = dict(patch)
+    if history_entries is not None:
+        snapshot_patch["historyEntries"] = [dict(item) for item in history_entries]
+    if not published_any:
+        get_snapshot = getattr(chat_stream, "get_snapshot", None)
+        current = get_snapshot(session_id) if callable(get_snapshot) else None
+        try:
+            current_seq = int((current or {}).get("eventSeq") or 0)
+        except (TypeError, ValueError):
+            current_seq = 0
+        snapshot_patch["eventSeq"] = current_seq + max(1, len(events) or 1)
+    update(session_id, snapshot_patch)

--- a/application/story/coordinator.py
+++ b/application/story/coordinator.py
@@ -1,0 +1,74 @@
+"""Feature-gated composition of a compiled story with an active chat session."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from application.chat.history_paths import resolve_history_path_for_project
+from config.feature_flags import FeatureFlag
+from core.sprite.chat_branch_storage import chat_history_session_dir
+from core.story import StoryCompiler, StoryRuntime
+from sdk.path_utils import safe_existing_path
+
+from .persistence import JsonGlobalStoryProgressStore, JsonStorySessionRepository
+from .project_loader import load_story_project
+from .session import StorySession
+
+
+def start_or_recover_story_session(
+    state: Any,
+    story_path: str | Path,
+    *,
+    command_id: str,
+) -> StorySession:
+    """Attach one story to the current chat without changing legacy storage."""
+    flags = state.config_manager.feature_flags
+    flags.require(FeatureFlag.STORY_SYSTEM)
+    root = Path(state.project_root_dir).resolve(strict=False)
+    resolved_story_path = safe_existing_path(
+        story_path,
+        roots=(root,),
+        field="story path",
+    )
+    history_path = resolve_history_path_for_project(
+        state,
+        state.chat_session.get("historyPath"),
+    )
+    if str(history_path).startswith("\\\\"):
+        raise ValueError("story sessions do not support UNC history storage")
+
+    program = StoryCompiler().compile(load_story_project(resolved_story_path))
+    runtime = StoryRuntime(program)
+    repository = JsonStorySessionRepository(chat_history_session_dir(history_path))
+    global_store = JsonGlobalStoryProgressStore(
+        Path(state.history_dir).resolve(strict=False) / ".story-global"
+    )
+    if repository.load() is None:
+        session = StorySession.create(
+            runtime,
+            flags,
+            command_id=command_id,
+            repository=repository,
+            global_store=global_store,
+        )
+    else:
+        session = StorySession.recover(
+            runtime,
+            flags,
+            repository=repository,
+            global_store=global_store,
+        )
+    state.story_session = session
+    return session
+
+
+def story_snapshot_patch(state: Any) -> dict[str, Any]:
+    config_manager = getattr(state, "config_manager", None)
+    flags = getattr(config_manager, "feature_flags", None)
+    session = getattr(state, "story_session", None)
+    if flags is None or session is None:
+        return {}
+    if not flags.is_enabled(FeatureFlag.STORY_SYSTEM):
+        return {}
+    return session.chat_snapshot()

--- a/application/story/idempotency.py
+++ b/application/story/idempotency.py
@@ -52,6 +52,56 @@ class StoryCommandIdempotencyIndex:
     def records(self) -> Mapping[str, StoryCommandRecord]:
         return MappingProxyType(dict(self._records))
 
+    def to_payload(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "commandId": record.command_id,
+                "payloadHash": record.payload_hash,
+                "accepted": record.accepted,
+                "resultingRevision": record.resulting_revision,
+                "eventIds": list(record.event_ids),
+                "ack": dict(record.ack),
+            }
+            for command_id in self._order
+            if (record := self._records.get(command_id)) is not None
+        ]
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Any,
+        *,
+        max_entries: int = 256,
+    ) -> StoryCommandIdempotencyIndex:
+        if not isinstance(payload, list):
+            raise ValueError("idempotency payload must be a list")
+        index = cls(max_entries=max_entries)
+        for raw in payload[-max_entries:]:
+            if not isinstance(raw, Mapping):
+                raise ValueError("idempotency record must be an object")
+            command_id = str(raw.get("commandId") or "")
+            payload_hash = str(raw.get("payloadHash") or "")
+            event_ids = raw.get("eventIds")
+            ack = raw.get("ack")
+            if (
+                not command_id
+                or len(payload_hash) != 64
+                or not isinstance(event_ids, list)
+                or not isinstance(ack, Mapping)
+            ):
+                raise ValueError("invalid idempotency record")
+            record = StoryCommandRecord(
+                command_id=command_id,
+                payload_hash=payload_hash,
+                accepted=bool(raw.get("accepted")),
+                resulting_revision=int(raw.get("resultingRevision") or 0),
+                event_ids=tuple(str(item) for item in event_ids),
+                ack=ack,
+            )
+            index._records[command_id] = record
+            index._order.append(command_id)
+        return index
+
     def lookup(self, command: Any) -> StoryCommandRecord | None:
         command_id = self._command_id(command)
         existing = self._records.get(command_id)

--- a/application/story/persistence.py
+++ b/application/story/persistence.py
@@ -1,0 +1,502 @@
+"""Versioned and atomic persistence primitives for story sessions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import json
+import os
+from pathlib import Path
+import re
+import tempfile
+from types import MappingProxyType
+from typing import Any
+
+from core.story import (
+    CanonFact,
+    CastState,
+    EffectSpec,
+    SemanticSignalState,
+    StoryEvent,
+    StoryEventReplayer,
+    StoryEventType,
+    StoryProgram,
+    StoryState,
+    VariableScope,
+    VariableType,
+    freeze_mapping,
+    freeze_value,
+)
+from core.story.state import variable_value_is_valid
+
+
+STORY_SESSION_STORAGE_VERSION = 2
+STORY_SESSION_FILENAME = "story-v2.json"
+
+
+class StoryPersistenceError(ValueError):
+    pass
+
+
+class StoryProgramMismatchError(StoryPersistenceError):
+    pass
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (set, frozenset)):
+        return sorted((_json_value(item) for item in value), key=str)
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def story_event_to_payload(event: StoryEvent) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "revision": event.revision,
+        "type": event.type.value,
+        "payload": _json_value(event.payload),
+        "causeCommandId": event.cause_command_id,
+    }
+
+
+def story_event_from_payload(raw: Mapping[str, Any]) -> StoryEvent:
+    try:
+        event_type = StoryEventType(str(raw["type"]))
+        event_id = str(raw["id"])
+        revision = int(raw["revision"])
+        command_id = str(raw["causeCommandId"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise StoryPersistenceError("invalid story event payload") from error
+    payload = raw.get("payload")
+    if (
+        not event_id
+        or revision < 1
+        or not command_id
+        or not isinstance(payload, Mapping)
+    ):
+        raise StoryPersistenceError("invalid story event fields")
+    return StoryEvent(
+        id=event_id,
+        revision=revision,
+        type=event_type,
+        payload=freeze_mapping(payload),
+        cause_command_id=command_id,
+    )
+
+
+def story_state_to_payload(state: StoryState) -> dict[str, Any]:
+    semantic = state.semantic_signal_state
+    cast = state.cast_state
+    return {
+        "schemaVersion": state.schema_version,
+        "storyId": state.story_id,
+        "storyVersion": state.story_version,
+        "programSourceHash": state.program_source_hash,
+        "revision": state.revision,
+        "currentNodeId": state.current_node_id,
+        "variables": _json_value(state.variables),
+        "completedNodeIds": sorted(state.completed_node_ids),
+        "failedNodeIds": sorted(state.failed_node_ids),
+        "unlockedNodeIds": sorted(state.unlocked_node_ids),
+        "canon": [
+            {
+                "id": fact.id,
+                "text": fact.text,
+                "sourceEventId": fact.source_event_id,
+            }
+            for fact in state.canon
+        ],
+        "semanticSignalState": {
+            "sequence": semantic.sequence,
+            "usage": dict(semantic.usage),
+            "turnId": semantic.turn_id,
+            "sceneId": semantic.scene_id,
+            "chapterId": semantic.chapter_id,
+            "recentFingerprints": [list(item) for item in semantic.recent_fingerprints],
+            "acceptedCauseGroups": list(semantic.accepted_cause_groups),
+        },
+        "castState": {
+            "registeredStoryCharacterIds": sorted(cast.registered_story_character_ids),
+            "activeCharacterIds": list(cast.active_character_ids),
+            "offstageCharacterIds": sorted(cast.offstage_character_ids),
+            "storyScopedCharacterIds": sorted(cast.story_scoped_character_ids),
+            "adHocCharacterIds": sorted(cast.ad_hoc_character_ids),
+            "roleBindings": dict(cast.role_bindings),
+            "resolvedForNodeId": cast.resolved_for_node_id,
+            "castRevision": cast.cast_revision,
+        },
+        "eventCursor": state.event_cursor,
+    }
+
+
+def story_state_from_payload(
+    raw: Mapping[str, Any],
+    *,
+    program: StoryProgram,
+) -> StoryState:
+    if (
+        str(raw.get("storyId") or "") != program.story_id
+        or int(raw.get("storyVersion") or -1) != program.story_version
+        or str(raw.get("programSourceHash") or "") != program.source_hash
+    ):
+        raise StoryProgramMismatchError(
+            "saved story state does not match the compiled StoryProgram"
+        )
+    variables_raw = _mapping(raw.get("variables"), "variables")
+    branch_definitions = {
+        definition.id: definition
+        for definition in program.variables
+        if definition.scope == VariableScope.BRANCH
+    }
+    variables: dict[str, Any] = {}
+    if set(variables_raw) != set(branch_definitions):
+        raise StoryPersistenceError("saved branch variables do not match schema")
+    for variable_id, definition in branch_definitions.items():
+        value = _persisted_variable_value(definition.type, variables_raw[variable_id])
+        if not variable_value_is_valid(definition, value):
+            raise StoryPersistenceError(
+                f"saved value is invalid for branch variable {variable_id!r}"
+            )
+        variables[variable_id] = value
+
+    semantic_raw = _mapping(
+        raw.get("semanticSignalState", {}),
+        "semanticSignalState",
+    )
+    cast_raw = _mapping(raw.get("castState", {}), "castState")
+    fingerprints = tuple(
+        (str(item[0]), int(item[1]))
+        for item in _sequence(
+            semantic_raw.get("recentFingerprints", ()),
+            "recentFingerprints",
+        )
+        if isinstance(item, Sequence)
+        and not isinstance(item, (str, bytes, bytearray))
+        and len(item) == 2
+    )
+    canon = tuple(
+        CanonFact(
+            id=str(item.get("id") or ""),
+            text=str(item.get("text") or ""),
+            source_event_id=str(item.get("sourceEventId") or ""),
+        )
+        for item in _mapping_sequence(raw.get("canon", ()), "canon")
+    )
+    state = StoryState(
+        schema_version=int(raw.get("schemaVersion") or 1),
+        story_id=program.story_id,
+        story_version=program.story_version,
+        program_source_hash=program.source_hash,
+        revision=int(raw.get("revision") or 0),
+        current_node_id=str(raw.get("currentNodeId") or ""),
+        variables=freeze_mapping(variables),
+        completed_node_ids=frozenset(
+            str(item)
+            for item in _sequence(raw.get("completedNodeIds", ()), "completedNodeIds")
+        ),
+        failed_node_ids=frozenset(
+            str(item)
+            for item in _sequence(raw.get("failedNodeIds", ()), "failedNodeIds")
+        ),
+        unlocked_node_ids=frozenset(
+            str(item)
+            for item in _sequence(raw.get("unlockedNodeIds", ()), "unlockedNodeIds")
+        ),
+        canon=canon,
+        semantic_signal_state=SemanticSignalState(
+            sequence=int(semantic_raw.get("sequence") or 0),
+            usage=freeze_mapping(
+                _mapping(semantic_raw.get("usage", {}), "semantic usage")
+            ),
+            turn_id=_optional_text(semantic_raw.get("turnId")),
+            scene_id=_optional_text(semantic_raw.get("sceneId")),
+            chapter_id=_optional_text(semantic_raw.get("chapterId")),
+            recent_fingerprints=fingerprints,
+            accepted_cause_groups=tuple(
+                str(item)
+                for item in _sequence(
+                    semantic_raw.get("acceptedCauseGroups", ()),
+                    "acceptedCauseGroups",
+                )
+            ),
+        ),
+        cast_state=CastState(
+            registered_story_character_ids=frozenset(
+                str(item)
+                for item in _sequence(
+                    cast_raw.get("registeredStoryCharacterIds", ()),
+                    "registeredStoryCharacterIds",
+                )
+            ),
+            active_character_ids=tuple(
+                str(item)
+                for item in _sequence(
+                    cast_raw.get("activeCharacterIds", ()),
+                    "activeCharacterIds",
+                )
+            ),
+            offstage_character_ids=frozenset(
+                str(item)
+                for item in _sequence(
+                    cast_raw.get("offstageCharacterIds", ()),
+                    "offstageCharacterIds",
+                )
+            ),
+            story_scoped_character_ids=frozenset(
+                str(item)
+                for item in _sequence(
+                    cast_raw.get("storyScopedCharacterIds", ()),
+                    "storyScopedCharacterIds",
+                )
+            ),
+            ad_hoc_character_ids=frozenset(
+                str(item)
+                for item in _sequence(
+                    cast_raw.get("adHocCharacterIds", ()),
+                    "adHocCharacterIds",
+                )
+            ),
+            role_bindings=freeze_mapping(
+                _mapping(cast_raw.get("roleBindings", {}), "roleBindings")
+            ),
+            resolved_for_node_id=_optional_text(cast_raw.get("resolvedForNodeId")),
+            cast_revision=int(cast_raw.get("castRevision") or 0),
+        ),
+        event_cursor=int(raw.get("eventCursor") or 0),
+    )
+    StoryEventReplayer().replay(state, (), program=program)
+    return state
+
+
+@dataclass(slots=True)
+class GlobalStoryProgress:
+    story_id: str
+    story_version: int
+    program_source_hash: str
+    variables: dict[str, Any]
+    unlocked_ending_ids: set[str] = field(default_factory=set)
+    applied_outbox_ids: set[str] = field(default_factory=set)
+    revision: int = 0
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "storyId": self.story_id,
+            "storyVersion": self.story_version,
+            "programSourceHash": self.program_source_hash,
+            "variables": _json_value(self.variables),
+            "unlockedEndingIds": sorted(self.unlocked_ending_ids),
+            "appliedOutboxIds": sorted(self.applied_outbox_ids),
+            "revision": self.revision,
+        }
+
+
+@dataclass(slots=True)
+class GlobalEffectOutboxEntry:
+    id: str
+    source_branch_id: str
+    source_command_id: str
+    effects: tuple[EffectSpec, ...]
+    ending_ids: tuple[str, ...] = ()
+    applied: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sourceBranchId": self.source_branch_id,
+            "sourceCommandId": self.source_command_id,
+            "effects": [
+                {"op": effect.op, "args": _json_value(effect.args)}
+                for effect in self.effects
+            ],
+            "endingIds": list(self.ending_ids),
+            "applied": self.applied,
+        }
+
+    @classmethod
+    def from_payload(cls, raw: Mapping[str, Any]) -> GlobalEffectOutboxEntry:
+        effects = tuple(
+            EffectSpec(
+                op=str(item.get("op") or ""),
+                args=tuple(_sequence(item.get("args", ()), "effect args")),
+            )
+            for item in _mapping_sequence(raw.get("effects", ()), "effects")
+        )
+        return cls(
+            id=str(raw.get("id") or ""),
+            source_branch_id=str(raw.get("sourceBranchId") or ""),
+            source_command_id=str(raw.get("sourceCommandId") or ""),
+            effects=effects,
+            ending_ids=tuple(
+                str(item) for item in _sequence(raw.get("endingIds", ()), "endingIds")
+            ),
+            applied=bool(raw.get("applied", False)),
+        )
+
+
+class JsonStorySessionRepository:
+    """Store one v2 story document beside, but separate from, legacy history."""
+
+    def __init__(self, session_root: str | Path) -> None:
+        self.session_root = Path(session_root).resolve(strict=False)
+        self.path = self.session_root / STORY_SESSION_FILENAME
+
+    def load(self) -> dict[str, Any] | None:
+        if not self.path.is_file():
+            return None
+        try:
+            with self.path.open(encoding="utf-8") as file:
+                payload = json.load(file)
+        except (OSError, json.JSONDecodeError) as error:
+            raise StoryPersistenceError(
+                "story session document is unreadable"
+            ) from error
+        if not isinstance(payload, dict):
+            raise StoryPersistenceError("story session document must be an object")
+        if int(payload.get("version") or 0) != STORY_SESSION_STORAGE_VERSION:
+            raise StoryPersistenceError("unsupported story session storage version")
+        return payload
+
+    def save(self, payload: Mapping[str, Any]) -> None:
+        document = dict(payload)
+        document["version"] = STORY_SESSION_STORAGE_VERSION
+        self.session_root.mkdir(parents=True, exist_ok=True)
+        _atomic_write_json(self.path, document)
+
+
+class JsonGlobalStoryProgressStore:
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root).resolve(strict=False)
+
+    def load(self, program: StoryProgram) -> GlobalStoryProgress:
+        path = self._path(program.story_id)
+        if not path.is_file():
+            variables = {
+                definition.id: freeze_value(definition.initial)
+                for definition in program.variables
+                if definition.scope == VariableScope.GLOBAL
+            }
+            return GlobalStoryProgress(
+                story_id=program.story_id,
+                story_version=program.story_version,
+                program_source_hash=program.source_hash,
+                variables=variables,
+            )
+        try:
+            with path.open(encoding="utf-8") as file:
+                raw = json.load(file)
+        except (OSError, json.JSONDecodeError) as error:
+            raise StoryPersistenceError(
+                "global story progress is unreadable"
+            ) from error
+        if not isinstance(raw, Mapping):
+            raise StoryPersistenceError("global story progress must be an object")
+        if (
+            str(raw.get("storyId") or "") != program.story_id
+            or int(raw.get("storyVersion") or -1) != program.story_version
+            or str(raw.get("programSourceHash") or "") != program.source_hash
+        ):
+            raise StoryProgramMismatchError(
+                "global story progress belongs to another StoryProgram"
+            )
+        variables = dict(_mapping(raw.get("variables", {}), "global variables"))
+        definitions = {
+            definition.id: definition
+            for definition in program.variables
+            if definition.scope == VariableScope.GLOBAL
+        }
+        if set(variables) != set(definitions):
+            raise StoryPersistenceError("saved global variables do not match schema")
+        for variable_id, definition in definitions.items():
+            variables[variable_id] = _persisted_variable_value(
+                definition.type,
+                variables[variable_id],
+            )
+            if not variable_value_is_valid(definition, variables[variable_id]):
+                raise StoryPersistenceError(
+                    f"saved value is invalid for global variable {variable_id!r}"
+                )
+        return GlobalStoryProgress(
+            story_id=program.story_id,
+            story_version=program.story_version,
+            program_source_hash=program.source_hash,
+            variables=variables,
+            unlocked_ending_ids=set(
+                str(item)
+                for item in _sequence(
+                    raw.get("unlockedEndingIds", ()),
+                    "unlockedEndingIds",
+                )
+            ),
+            applied_outbox_ids=set(
+                str(item)
+                for item in _sequence(
+                    raw.get("appliedOutboxIds", ()),
+                    "appliedOutboxIds",
+                )
+            ),
+            revision=int(raw.get("revision") or 0),
+        )
+
+    def save(self, progress: GlobalStoryProgress) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        _atomic_write_json(self._path(progress.story_id), progress.to_payload())
+
+    def _path(self, story_id: str) -> Path:
+        slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", story_id).strip(".-")[:100]
+        if not slug:
+            raise StoryPersistenceError("story id cannot map to an empty filename")
+        return self.root / f"{slug}.json"
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as file:
+            temporary_path = Path(file.name)
+            json.dump(_json_value(payload), file, ensure_ascii=False, indent=2)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise StoryPersistenceError(f"{label} must be an object")
+    return value
+
+
+def _sequence(value: Any, label: str) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise StoryPersistenceError(f"{label} must be a list")
+    return value
+
+
+def _mapping_sequence(value: Any, label: str) -> tuple[Mapping[str, Any], ...]:
+    sequence = _sequence(value, label)
+    if not all(isinstance(item, Mapping) for item in sequence):
+        raise StoryPersistenceError(f"{label} must contain objects")
+    return tuple(item for item in sequence if isinstance(item, Mapping))
+
+
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _persisted_variable_value(variable_type: Any, value: Any) -> Any:
+    if variable_type in {VariableType.STRING_SET, VariableType.NODE_SET}:
+        return frozenset(str(item) for item in _sequence(value, "set variable"))
+    return freeze_value(value)

--- a/application/story/persistence.py
+++ b/application/story/persistence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -11,6 +12,8 @@ import re
 import tempfile
 from types import MappingProxyType
 from typing import Any
+
+from core.sprite.chat_branch_storage import STORY_SESSION_FILENAME
 
 from core.story import (
     CanonFact,
@@ -31,7 +34,16 @@ from core.story.state import variable_value_is_valid
 
 
 STORY_SESSION_STORAGE_VERSION = 2
-STORY_SESSION_FILENAME = "story-v2.json"
+_GLOBAL_PROGRESS_SLUG_LIMIT = 100
+_GLOBAL_PROGRESS_HASH_LENGTH = 16
+_VARIABLE_EVENT_TYPES = frozenset(
+    {
+        StoryEventType.VARIABLE_CHANGED,
+        StoryEventType.METRIC_CHANGED,
+        StoryEventType.SET_VALUE_ADDED,
+        StoryEventType.SET_VALUE_REMOVED,
+    }
+)
 
 
 class StoryPersistenceError(ValueError):
@@ -82,7 +94,7 @@ def story_event_from_payload(raw: Mapping[str, Any]) -> StoryEvent:
         id=event_id,
         revision=revision,
         type=event_type,
-        payload=freeze_mapping(payload),
+        payload=_restore_event_payload(event_type, payload),
         cause_command_id=command_id,
     )
 
@@ -445,10 +457,7 @@ class JsonGlobalStoryProgressStore:
         _atomic_write_json(self._path(progress.story_id), progress.to_payload())
 
     def _path(self, story_id: str) -> Path:
-        slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", story_id).strip(".-")[:100]
-        if not slug:
-            raise StoryPersistenceError("story id cannot map to an empty filename")
-        return self.root / f"{slug}.json"
+        return self.root / global_progress_filename(story_id)
 
 
 def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
@@ -500,3 +509,34 @@ def _persisted_variable_value(variable_type: Any, value: Any) -> Any:
     if variable_type in {VariableType.STRING_SET, VariableType.NODE_SET}:
         return frozenset(str(item) for item in _sequence(value, "set variable"))
     return freeze_value(value)
+
+
+def _restore_event_variable_value(value: Any) -> Any:
+    if isinstance(value, (list, tuple)) and not isinstance(value, (str, bytes, bytearray)):
+        return frozenset(str(item) for item in value)
+    return freeze_value(value)
+
+
+def _restore_event_payload(
+    event_type: StoryEventType,
+    payload: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    restored = dict(payload)
+    if event_type in _VARIABLE_EVENT_TYPES:
+        for key in ("previous", "current"):
+            if key in restored:
+                restored[key] = _restore_event_variable_value(restored[key])
+    return freeze_mapping(restored)
+
+
+def global_progress_filename(story_id: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", story_id).strip(".-")
+    if not slug:
+        raise StoryPersistenceError("story id cannot map to an empty filename")
+    if len(slug) > _GLOBAL_PROGRESS_SLUG_LIMIT:
+        digest = hashlib.sha256(story_id.encode("utf-8")).hexdigest()[
+            :_GLOBAL_PROGRESS_HASH_LENGTH
+        ]
+        prefix_len = _GLOBAL_PROGRESS_SLUG_LIMIT - _GLOBAL_PROGRESS_HASH_LENGTH - 1
+        slug = f"{slug[:prefix_len]}-{digest}"
+    return f"{slug}.json"

--- a/application/story/protocol.py
+++ b/application/story/protocol.py
@@ -1,0 +1,135 @@
+"""Presentation-safe story projections for chat snapshots and realtime events."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from core.story import ConditionEvaluator, StoryEvent, StoryProgram, StoryState
+
+from .persistence import GlobalStoryProgress
+
+
+def story_state_view(
+    program: StoryProgram,
+    state: StoryState,
+    global_progress: GlobalStoryProgress,
+) -> dict[str, Any]:
+    """Project only player-visible story data into the chat protocol."""
+    node = program.nodes_by_id[state.current_node_id]
+    variables = {**global_progress.variables, **state.variables}
+    evaluator = ConditionEvaluator()
+    options = []
+    for choice in node.choices:
+        enabled = evaluator.evaluate(
+            choice.when,
+            variables=variables,
+            completed_node_ids=state.completed_node_ids,
+        )
+        options.append(
+            {
+                "id": choice.id,
+                "label": choice.label,
+                "enabled": enabled,
+                "lockedReason": None if enabled else "condition-not-satisfied",
+                "source": "story",
+                "expectedNodeId": node.id,
+                "expectedRevision": state.revision,
+            }
+        )
+    visible_variables = []
+    for definition in program.variables:
+        if not definition.visible:
+            continue
+        value = variables[definition.id]
+        visible_variables.append(
+            {
+                "id": definition.id,
+                "type": definition.type.value,
+                "value": _protocol_value(value),
+                "minimum": definition.minimum,
+                "maximum": definition.maximum,
+            }
+        )
+    ending = None
+    if node.type == "ending":
+        ending = {"id": node.id, "title": node.title}
+    return {
+        "storyId": program.story_id,
+        "storyVersion": program.story_version,
+        "revision": state.revision,
+        "currentNodeId": node.id,
+        "currentNodeTitle": node.title,
+        "activeCast": [
+            {
+                "id": character_id,
+                "roles": list(program.character_registry.by_id[character_id].roles),
+            }
+            for character_id in state.cast_state.active_character_ids
+        ],
+        "objectives": [],
+        "visibleVariables": visible_variables,
+        "unlockedNotifications": [
+            {"id": node_id, "kind": "node"}
+            for node_id in sorted(state.unlocked_node_ids)
+        ],
+        "ending": ending,
+        "options": options,
+        "castRevision": state.cast_state.cast_revision,
+    }
+
+
+def story_event_messages(events: tuple[StoryEvent, ...]) -> list[dict[str, Any]]:
+    event_names = {
+        "NodeEntered": "story.node.entered",
+        "NodeUnlocked": "story.node.unlocked",
+        "CastResolved": "story.cast.replace",
+        "EndingReached": "story.ending.reached",
+    }
+    messages = []
+    for event in events:
+        event_type = event_names.get(event.type.value)
+        if event_type is None:
+            continue
+        messages.append(
+            {
+                "type": event_type,
+                "eventId": event.id,
+                "revision": event.revision,
+                "payload": _protocol_value(event.payload),
+            }
+        )
+    return messages
+
+
+def story_chat_snapshot(view: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "story": dict(view),
+        "options": [dict(item) for item in view.get("options", ())],
+        "stats": [
+            {
+                "icon": "gauge",
+                "label": str(item["id"]),
+                "value": int(item["value"]),
+                **(
+                    {"max": int(item["maximum"])}
+                    if isinstance(item.get("maximum"), int)
+                    else {}
+                ),
+            }
+            for item in view.get("visibleVariables", ())
+            if isinstance(item, Mapping)
+            and isinstance(item.get("value"), int)
+            and not isinstance(item.get("value"), bool)
+        ],
+    }
+
+
+def _protocol_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _protocol_value(item) for key, item in value.items()}
+    if isinstance(value, (set, frozenset)):
+        return sorted(_protocol_value(item) for item in value)
+    if isinstance(value, (list, tuple)):
+        return [_protocol_value(item) for item in value]
+    return value

--- a/application/story/session.py
+++ b/application/story/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+import threading
 from types import MappingProxyType
 from typing import Any
 
@@ -190,6 +191,8 @@ class StorySession:
         self.active_branch_id = "main"
         self.branches: dict[str, StoryBranch] = {}
         self.outbox: list[GlobalEffectOutboxEntry] = []
+        self.owner_history_path = ""
+        self._lock = threading.RLock()
 
     @classmethod
     def create(
@@ -294,124 +297,151 @@ class StorySession:
         *,
         history_entries: Sequence[Mapping[str, Any]] | None = None,
     ) -> StorySessionAck:
-        self._require_enabled()
-        branch = self.active_branch
-        duplicate = branch.idempotency.lookup(command)
-        if duplicate is not None:
-            return StorySessionAck.from_payload(duplicate.ack, duplicate=True)
-        result = self.runtime.execute(
-            branch.state,
-            command,
-            global_variables=self.global_progress.variables,
-        )
-        if history_entries is not None:
-            branch.history_entries = _history_entries(history_entries)
-        return self._commit_result(
-            branch,
-            command,
-            result.events,
-            result.global_effects,
-            state=result.state,
-        )
+        with self._lock:
+            self._require_enabled()
+            branch = self.active_branch
+            duplicate = branch.idempotency.lookup(command)
+            if duplicate is not None:
+                return StorySessionAck.from_payload(duplicate.ack, duplicate=True)
+            result = self.runtime.execute(
+                branch.state,
+                command,
+                global_variables=self.global_progress.variables,
+            )
+            if history_entries is not None:
+                branch.history_entries = _history_entries(history_entries)
+            return self._commit_result(
+                branch,
+                command,
+                result.events,
+                result.global_effects,
+                state=result.state,
+            )
+
+    def checkpoint_generation_before_user_index(self, user_index: int) -> int:
+        with self._lock:
+            self._require_enabled()
+            branch = self.active_branch
+            prefix = len(branch.history_entries)
+            seen = 0
+            for index, entry in enumerate(branch.history_entries):
+                if str(entry.get("role") or "") != "user":
+                    continue
+                if seen == user_index:
+                    prefix = index
+                    break
+                seen += 1
+            for checkpoint in reversed(branch.checkpoints):
+                if checkpoint.message_count <= prefix:
+                    return checkpoint.generation
+            if not branch.checkpoints:
+                raise KeyError("story branch has no checkpoint")
+            return branch.checkpoints[0].generation
 
     def fork(self, branch_id: str, *, generation: int | None = None) -> StoryBranch:
-        self._require_enabled()
-        branch_id = _branch_id(branch_id)
-        if branch_id in self.branches:
-            raise ValueError(f"story branch {branch_id!r} already exists")
-        source = self.active_branch
-        checkpoint = self._checkpoint(
-            source,
-            source.generation if generation is None else generation,
-        )
-        forked = StoryBranch(
-            id=branch_id,
-            parent_id=source.id,
-            generation=checkpoint.generation,
-            state=checkpoint.state,
-            head_event_id=checkpoint.head_event_id,
-            events=list(source.events[: checkpoint.event_count]),
-            checkpoints=[
-                item
-                for item in source.checkpoints
-                if item.generation <= checkpoint.generation
-            ],
-            idempotency=StoryCommandIdempotencyIndex.from_payload(
-                list(checkpoint.idempotency_payload)
-            ),
-            history_entries=checkpoint.history_entries,
-        )
-        self.branches[branch_id] = forked
-        self.active_branch_id = branch_id
-        self._save()
-        return forked
+        with self._lock:
+            self._require_enabled()
+            branch_id = _branch_id(branch_id)
+            if branch_id in self.branches:
+                raise ValueError(f"story branch {branch_id!r} already exists")
+            source = self.active_branch
+            checkpoint = self._checkpoint(
+                source,
+                source.generation if generation is None else generation,
+            )
+            forked = StoryBranch(
+                id=branch_id,
+                parent_id=source.id,
+                generation=checkpoint.generation,
+                state=checkpoint.state,
+                head_event_id=checkpoint.head_event_id,
+                events=list(source.events[: checkpoint.event_count]),
+                checkpoints=[
+                    item
+                    for item in source.checkpoints
+                    if item.generation <= checkpoint.generation
+                ],
+                idempotency=StoryCommandIdempotencyIndex.from_payload(
+                    list(checkpoint.idempotency_payload)
+                ),
+                history_entries=checkpoint.history_entries,
+            )
+            self.branches[branch_id] = forked
+            self.active_branch_id = branch_id
+            self._save()
+            return forked
 
     def restore_generation(self, generation: int) -> StoryBranch:
-        self._require_enabled()
-        branch = self.active_branch
-        checkpoint = self._checkpoint(branch, generation)
-        branch.generation = checkpoint.generation
-        branch.state = checkpoint.state
-        branch.head_event_id = checkpoint.head_event_id
-        del branch.events[checkpoint.event_count :]
-        branch.checkpoints = [
-            item for item in branch.checkpoints if item.generation <= generation
-        ]
-        branch.idempotency = StoryCommandIdempotencyIndex.from_payload(
-            list(checkpoint.idempotency_payload)
-        )
-        branch.history_entries = checkpoint.history_entries
-        self._save()
-        return branch
+        with self._lock:
+            self._require_enabled()
+            branch = self.active_branch
+            checkpoint = self._checkpoint(branch, generation)
+            branch.generation = checkpoint.generation
+            branch.state = checkpoint.state
+            branch.head_event_id = checkpoint.head_event_id
+            del branch.events[checkpoint.event_count :]
+            branch.checkpoints = [
+                item for item in branch.checkpoints if item.generation <= generation
+            ]
+            branch.idempotency = StoryCommandIdempotencyIndex.from_payload(
+                list(checkpoint.idempotency_payload)
+            )
+            branch.history_entries = checkpoint.history_entries
+            self._save()
+            return branch
 
     def switch_branch(self, branch_id: str) -> StoryBranch:
-        self._require_enabled()
-        if branch_id not in self.branches:
-            raise KeyError(f"story branch {branch_id!r} does not exist")
-        self.active_branch_id = branch_id
-        self._save()
-        return self.active_branch
+        with self._lock:
+            self._require_enabled()
+            if branch_id not in self.branches:
+                raise KeyError(f"story branch {branch_id!r} does not exist")
+            self.active_branch_id = branch_id
+            self._save()
+            return self.active_branch
 
     def chat_snapshot(self) -> dict[str, Any]:
-        self._require_enabled()
-        view = story_state_view(
-            self.runtime.program,
-            self.active_branch.state,
-            self.global_progress,
-        )
-        return story_chat_snapshot(view)
+        with self._lock:
+            self._require_enabled()
+            view = story_state_view(
+                self.runtime.program,
+                self.active_branch.state,
+                self.global_progress,
+            )
+            return story_chat_snapshot(view)
 
     def to_payload(self) -> dict[str, Any]:
-        self._require_enabled()
-        return {
-            "activeBranchId": self.active_branch_id,
-            "storyId": self.runtime.program.story_id,
-            "storyVersion": self.runtime.program.story_version,
-            "programSourceHash": self.runtime.program.source_hash,
-            "branches": {
-                branch_id: branch.to_payload()
-                for branch_id, branch in sorted(self.branches.items())
-            },
-            "globalEffectOutbox": [item.to_payload() for item in self.outbox],
-        }
+        with self._lock:
+            self._require_enabled()
+            return {
+                "activeBranchId": self.active_branch_id,
+                "storyId": self.runtime.program.story_id,
+                "storyVersion": self.runtime.program.story_version,
+                "programSourceHash": self.runtime.program.source_hash,
+                "branches": {
+                    branch_id: branch.to_payload()
+                    for branch_id, branch in sorted(self.branches.items())
+                },
+                "globalEffectOutbox": [item.to_payload() for item in self.outbox],
+            }
 
     def flush_global_outbox(self) -> None:
-        self._require_enabled()
-        changed = False
-        for entry in self.outbox:
-            if entry.applied:
-                continue
-            if entry.id not in self.global_progress.applied_outbox_ids:
-                self._apply_global_entry(entry)
-                if self.global_store is not None:
-                    self.global_store.save(self.global_progress)
-                self.failure_injector("after_global_apply")
-            entry.applied = True
-            changed = True
-            self._save()
-        if changed:
-            self.outbox = [item for item in self.outbox if not item.applied][-256:]
-            self._save()
+        with self._lock:
+            self._require_enabled()
+            changed = False
+            for entry in self.outbox:
+                if entry.applied:
+                    continue
+                if entry.id not in self.global_progress.applied_outbox_ids:
+                    self._apply_global_entry(entry)
+                    if self.global_store is not None:
+                        self.global_store.save(self.global_progress)
+                    self.failure_injector("after_global_apply")
+                entry.applied = True
+                changed = True
+                self._save()
+            if changed:
+                self.outbox = [item for item in self.outbox if not item.applied][-256:]
+                self._save()
 
     def _commit_result(
         self,

--- a/application/story/session.py
+++ b/application/story/session.py
@@ -1,0 +1,686 @@
+"""Feature-gated story session orchestration, branching, and crash recovery."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+
+from config.feature_flags import FeatureFlag, FeatureFlagConfigManager
+from core.story import (
+    EffectSpec,
+    RuntimeCommand,
+    StartStory,
+    StoryEvent,
+    StoryEventReplayer,
+    StoryEventType,
+    StoryProgram,
+    StoryRuntime,
+    StoryState,
+    VariableScope,
+    VariableType,
+    freeze_value,
+)
+from core.story.state import variable_value_is_valid
+
+from .idempotency import StoryCommandIdempotencyIndex
+from .persistence import (
+    GlobalEffectOutboxEntry,
+    GlobalStoryProgress,
+    JsonGlobalStoryProgressStore,
+    JsonStorySessionRepository,
+    StoryPersistenceError,
+    StoryProgramMismatchError,
+    story_event_from_payload,
+    story_event_to_payload,
+    story_state_from_payload,
+    story_state_to_payload,
+)
+from .protocol import story_chat_snapshot, story_event_messages, story_state_view
+
+
+FailureInjector = Callable[[str], None]
+
+
+@dataclass(frozen=True, slots=True)
+class CausalStoryEvent:
+    id: str
+    parent_event_id: str | None
+    event: StoryEvent
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "parentEventId": self.parent_event_id,
+            "event": story_event_to_payload(self.event),
+        }
+
+
+@dataclass(slots=True)
+class StoryCheckpoint:
+    generation: int
+    message_count: int
+    state: StoryState
+    head_event_id: str | None
+    event_count: int
+    history_entries: tuple[Mapping[str, Any], ...] = ()
+    idempotency_payload: tuple[Mapping[str, Any], ...] = ()
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "generation": self.generation,
+            "messageCount": self.message_count,
+            "state": story_state_to_payload(self.state),
+            "headEventId": self.head_event_id,
+            "eventCount": self.event_count,
+            "historyEntries": [dict(item) for item in self.history_entries],
+            "idempotency": [dict(item) for item in self.idempotency_payload],
+        }
+
+
+@dataclass(slots=True)
+class StoryBranch:
+    id: str
+    parent_id: str | None
+    generation: int
+    state: StoryState
+    head_event_id: str | None
+    events: list[CausalStoryEvent] = field(default_factory=list)
+    checkpoints: list[StoryCheckpoint] = field(default_factory=list)
+    idempotency: StoryCommandIdempotencyIndex = field(
+        default_factory=StoryCommandIdempotencyIndex
+    )
+    history_entries: tuple[Mapping[str, Any], ...] = ()
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "parentId": self.parent_id,
+            "generation": self.generation,
+            "state": story_state_to_payload(self.state),
+            "headEventId": self.head_event_id,
+            "events": [item.to_payload() for item in self.events],
+            "checkpoints": [item.to_payload() for item in self.checkpoints],
+            "idempotency": self.idempotency.to_payload(),
+            "historyEntries": [dict(item) for item in self.history_entries],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StorySessionAck:
+    command_id: str
+    branch_id: str
+    generation: int
+    revision: int
+    event_ids: tuple[str, ...]
+    head_event_id: str | None
+    duplicate: bool
+    story: Mapping[str, Any]
+    presentation_events: tuple[Mapping[str, Any], ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "commandId": self.command_id,
+            "branchId": self.branch_id,
+            "generation": self.generation,
+            "revision": self.revision,
+            "eventIds": list(self.event_ids),
+            "headEventId": self.head_event_id,
+            "duplicate": self.duplicate,
+            "story": dict(self.story),
+            "presentationEvents": [dict(item) for item in self.presentation_events],
+        }
+
+    @classmethod
+    def from_payload(
+        cls,
+        raw: Mapping[str, Any],
+        *,
+        duplicate: bool,
+    ) -> StorySessionAck:
+        story = raw.get("story")
+        events = raw.get("presentationEvents")
+        event_ids = raw.get("eventIds")
+        if (
+            not isinstance(story, Mapping)
+            or not isinstance(events, Sequence)
+            or isinstance(events, (str, bytes, bytearray))
+            or not isinstance(event_ids, Sequence)
+            or isinstance(event_ids, (str, bytes, bytearray))
+        ):
+            raise StoryPersistenceError("stored command ack is invalid")
+        return cls(
+            command_id=str(raw.get("commandId") or ""),
+            branch_id=str(raw.get("branchId") or ""),
+            generation=int(raw.get("generation") or 0),
+            revision=int(raw.get("revision") or 0),
+            event_ids=tuple(str(item) for item in event_ids),
+            head_event_id=_optional_text(raw.get("headEventId")),
+            duplicate=duplicate,
+            story=MappingProxyType(dict(story)),
+            presentation_events=tuple(
+                MappingProxyType(dict(item))
+                for item in events
+                if isinstance(item, Mapping)
+            ),
+        )
+
+
+class StorySession:
+    """Own the branch-local runtime while global progress remains monotonic."""
+
+    def __init__(
+        self,
+        runtime: StoryRuntime,
+        flags: FeatureFlagConfigManager,
+        *,
+        global_progress: GlobalStoryProgress,
+        repository: JsonStorySessionRepository | None = None,
+        global_store: JsonGlobalStoryProgressStore | None = None,
+        failure_injector: FailureInjector | None = None,
+    ) -> None:
+        flags.require(FeatureFlag.STORY_SYSTEM)
+        self.runtime = runtime
+        self.flags = flags
+        self.global_progress = global_progress
+        self.repository = repository
+        self.global_store = global_store
+        self.failure_injector = failure_injector or (lambda _point: None)
+        self.active_branch_id = "main"
+        self.branches: dict[str, StoryBranch] = {}
+        self.outbox: list[GlobalEffectOutboxEntry] = []
+
+    @classmethod
+    def create(
+        cls,
+        runtime: StoryRuntime,
+        flags: FeatureFlagConfigManager,
+        *,
+        command_id: str,
+        repository: JsonStorySessionRepository | None = None,
+        global_store: JsonGlobalStoryProgressStore | None = None,
+        history_entries: Sequence[Mapping[str, Any]] = (),
+        failure_injector: FailureInjector | None = None,
+    ) -> StorySession:
+        flags.require(FeatureFlag.STORY_SYSTEM)
+        progress = (
+            global_store.load(runtime.program)
+            if global_store is not None
+            else _initial_global_progress(runtime.program)
+        )
+        session = cls(
+            runtime,
+            flags,
+            global_progress=progress,
+            repository=repository,
+            global_store=global_store,
+            failure_injector=failure_injector,
+        )
+        command = StartStory(command_id)
+        result = runtime.start(command, global_variables=progress.variables)
+        branch = StoryBranch(
+            id="main",
+            parent_id=None,
+            generation=0,
+            state=result.state,
+            head_event_id=None,
+            history_entries=_history_entries(history_entries),
+        )
+        session.branches[branch.id] = branch
+        session._commit_result(branch, command, result.events, result.global_effects)
+        return session
+
+    @classmethod
+    def recover(
+        cls,
+        runtime: StoryRuntime,
+        flags: FeatureFlagConfigManager,
+        *,
+        repository: JsonStorySessionRepository,
+        global_store: JsonGlobalStoryProgressStore,
+        failure_injector: FailureInjector | None = None,
+    ) -> StorySession:
+        flags.require(FeatureFlag.STORY_SYSTEM)
+        raw = repository.load()
+        if raw is None:
+            raise FileNotFoundError(repository.path)
+        if (
+            str(raw.get("storyId") or "") != runtime.program.story_id
+            or int(raw.get("storyVersion") or -1) != runtime.program.story_version
+            or str(raw.get("programSourceHash") or "") != runtime.program.source_hash
+        ):
+            raise StoryProgramMismatchError(
+                "saved story session does not match the compiled StoryProgram"
+            )
+        progress = global_store.load(runtime.program)
+        session = cls(
+            runtime,
+            flags,
+            global_progress=progress,
+            repository=repository,
+            global_store=global_store,
+            failure_injector=failure_injector,
+        )
+        session.active_branch_id = str(raw.get("activeBranchId") or "")
+        branches_raw = raw.get("branches")
+        outbox_raw = raw.get("globalEffectOutbox", ())
+        if not isinstance(branches_raw, Mapping) or not isinstance(outbox_raw, list):
+            raise StoryPersistenceError("invalid story session document")
+        session.branches = {
+            str(branch_id): session._branch_from_payload(branch_raw)
+            for branch_id, branch_raw in branches_raw.items()
+            if isinstance(branch_raw, Mapping)
+        }
+        if session.active_branch_id not in session.branches:
+            raise StoryPersistenceError("active story branch does not exist")
+        session.outbox = [
+            GlobalEffectOutboxEntry.from_payload(item)
+            for item in outbox_raw
+            if isinstance(item, Mapping)
+        ]
+        session._validate_all_branches()
+        session.flush_global_outbox()
+        return session
+
+    @property
+    def active_branch(self) -> StoryBranch:
+        self._require_enabled()
+        return self.branches[self.active_branch_id]
+
+    def execute(
+        self,
+        command: RuntimeCommand,
+        *,
+        history_entries: Sequence[Mapping[str, Any]] | None = None,
+    ) -> StorySessionAck:
+        self._require_enabled()
+        branch = self.active_branch
+        duplicate = branch.idempotency.lookup(command)
+        if duplicate is not None:
+            return StorySessionAck.from_payload(duplicate.ack, duplicate=True)
+        result = self.runtime.execute(
+            branch.state,
+            command,
+            global_variables=self.global_progress.variables,
+        )
+        if history_entries is not None:
+            branch.history_entries = _history_entries(history_entries)
+        return self._commit_result(
+            branch,
+            command,
+            result.events,
+            result.global_effects,
+            state=result.state,
+        )
+
+    def fork(self, branch_id: str, *, generation: int | None = None) -> StoryBranch:
+        self._require_enabled()
+        branch_id = _branch_id(branch_id)
+        if branch_id in self.branches:
+            raise ValueError(f"story branch {branch_id!r} already exists")
+        source = self.active_branch
+        checkpoint = self._checkpoint(
+            source,
+            source.generation if generation is None else generation,
+        )
+        forked = StoryBranch(
+            id=branch_id,
+            parent_id=source.id,
+            generation=checkpoint.generation,
+            state=checkpoint.state,
+            head_event_id=checkpoint.head_event_id,
+            events=list(source.events[: checkpoint.event_count]),
+            checkpoints=[
+                item
+                for item in source.checkpoints
+                if item.generation <= checkpoint.generation
+            ],
+            idempotency=StoryCommandIdempotencyIndex.from_payload(
+                list(checkpoint.idempotency_payload)
+            ),
+            history_entries=checkpoint.history_entries,
+        )
+        self.branches[branch_id] = forked
+        self.active_branch_id = branch_id
+        self._save()
+        return forked
+
+    def restore_generation(self, generation: int) -> StoryBranch:
+        self._require_enabled()
+        branch = self.active_branch
+        checkpoint = self._checkpoint(branch, generation)
+        branch.generation = checkpoint.generation
+        branch.state = checkpoint.state
+        branch.head_event_id = checkpoint.head_event_id
+        del branch.events[checkpoint.event_count :]
+        branch.checkpoints = [
+            item for item in branch.checkpoints if item.generation <= generation
+        ]
+        branch.idempotency = StoryCommandIdempotencyIndex.from_payload(
+            list(checkpoint.idempotency_payload)
+        )
+        branch.history_entries = checkpoint.history_entries
+        self._save()
+        return branch
+
+    def switch_branch(self, branch_id: str) -> StoryBranch:
+        self._require_enabled()
+        if branch_id not in self.branches:
+            raise KeyError(f"story branch {branch_id!r} does not exist")
+        self.active_branch_id = branch_id
+        self._save()
+        return self.active_branch
+
+    def chat_snapshot(self) -> dict[str, Any]:
+        self._require_enabled()
+        view = story_state_view(
+            self.runtime.program,
+            self.active_branch.state,
+            self.global_progress,
+        )
+        return story_chat_snapshot(view)
+
+    def to_payload(self) -> dict[str, Any]:
+        self._require_enabled()
+        return {
+            "activeBranchId": self.active_branch_id,
+            "storyId": self.runtime.program.story_id,
+            "storyVersion": self.runtime.program.story_version,
+            "programSourceHash": self.runtime.program.source_hash,
+            "branches": {
+                branch_id: branch.to_payload()
+                for branch_id, branch in sorted(self.branches.items())
+            },
+            "globalEffectOutbox": [item.to_payload() for item in self.outbox],
+        }
+
+    def flush_global_outbox(self) -> None:
+        self._require_enabled()
+        changed = False
+        for entry in self.outbox:
+            if entry.applied:
+                continue
+            if entry.id not in self.global_progress.applied_outbox_ids:
+                self._apply_global_entry(entry)
+                if self.global_store is not None:
+                    self.global_store.save(self.global_progress)
+                self.failure_injector("after_global_apply")
+            entry.applied = True
+            changed = True
+            self._save()
+        if changed:
+            self.outbox = [item for item in self.outbox if not item.applied][-256:]
+            self._save()
+
+    def _commit_result(
+        self,
+        branch: StoryBranch,
+        command: StartStory | RuntimeCommand,
+        events: tuple[StoryEvent, ...],
+        global_effects: tuple[EffectSpec, ...],
+        *,
+        state: StoryState | None = None,
+    ) -> StorySessionAck:
+        if state is not None:
+            branch.state = state
+        parent = branch.head_event_id
+        causal_events = []
+        for event in events:
+            causal_id = f"{branch.id}:{event.id}"
+            causal = CausalStoryEvent(causal_id, parent, event)
+            causal_events.append(causal)
+            parent = causal_id
+        branch.events.extend(causal_events)
+        branch.head_event_id = parent
+        branch.generation += 1
+
+        ending_ids = tuple(
+            str(event.payload.get("nodeId") or "")
+            for event in events
+            if event.type == StoryEventType.ENDING_REACHED
+        )
+        if global_effects or ending_ids:
+            branch_command_id = str(getattr(command, "command_id"))
+            self.outbox.append(
+                GlobalEffectOutboxEntry(
+                    id=(
+                        f"{self.runtime.program.story_id}:{branch.id}:"
+                        f"{branch_command_id}"
+                    ),
+                    source_branch_id=branch.id,
+                    source_command_id=branch_command_id,
+                    effects=global_effects,
+                    ending_ids=ending_ids,
+                )
+            )
+
+        view = story_state_view(
+            self.runtime.program,
+            branch.state,
+            self.global_progress,
+        )
+        ack = StorySessionAck(
+            command_id=str(getattr(command, "command_id")),
+            branch_id=branch.id,
+            generation=branch.generation,
+            revision=branch.state.revision,
+            event_ids=tuple(item.id for item in causal_events),
+            head_event_id=branch.head_event_id,
+            duplicate=False,
+            story=MappingProxyType(view),
+            presentation_events=tuple(
+                MappingProxyType(item) for item in story_event_messages(events)
+            ),
+        )
+        branch.idempotency.record(
+            command,
+            accepted=True,
+            resulting_revision=branch.state.revision,
+            event_ids=ack.event_ids,
+            ack=ack.to_payload(),
+        )
+        branch.checkpoints.append(
+            StoryCheckpoint(
+                generation=branch.generation,
+                message_count=len(branch.history_entries),
+                state=branch.state,
+                head_event_id=branch.head_event_id,
+                event_count=len(branch.events),
+                history_entries=branch.history_entries,
+                idempotency_payload=tuple(
+                    MappingProxyType(item) for item in branch.idempotency.to_payload()
+                ),
+            )
+        )
+        branch.checkpoints = branch.checkpoints[-128:]
+        self._save()
+        self.failure_injector("after_session_commit")
+        self.flush_global_outbox()
+        return ack
+
+    def _apply_global_entry(self, entry: GlobalEffectOutboxEntry) -> None:
+        variables = self.global_progress.variables
+        definitions = {
+            definition.id: definition
+            for definition in self.runtime.program.variables
+            if definition.scope == VariableScope.GLOBAL
+        }
+        for effect in entry.effects:
+            if effect.op not in {"set", "increment", "add-set", "remove-set"}:
+                raise StoryPersistenceError(f"unsupported global effect {effect.op!r}")
+            variable_id = str(effect.args[0])
+            definition = definitions.get(variable_id)
+            if definition is None:
+                raise StoryPersistenceError(
+                    f"outbox targets non-global variable {variable_id!r}"
+                )
+            previous = variables[variable_id]
+            operand = effect.args[1]
+            if effect.op == "set":
+                current = (
+                    frozenset(str(item) for item in operand)
+                    if definition.type
+                    in {VariableType.STRING_SET, VariableType.NODE_SET}
+                    else freeze_value(operand)
+                )
+            elif effect.op == "increment":
+                current = int(previous) + int(operand)
+                if definition.minimum is not None:
+                    current = max(definition.minimum, current)
+                if definition.maximum is not None:
+                    current = min(definition.maximum, current)
+            else:
+                items = set(previous)
+                if effect.op == "add-set":
+                    items.add(str(operand))
+                else:
+                    items.discard(str(operand))
+                current = frozenset(items)
+            if not variable_value_is_valid(definition, current):
+                raise StoryPersistenceError(
+                    f"outbox produced invalid value for {variable_id!r}"
+                )
+            variables[variable_id] = current
+        self.global_progress.unlocked_ending_ids.update(entry.ending_ids)
+        self.global_progress.applied_outbox_ids.add(entry.id)
+        self.global_progress.revision += 1
+
+    def _branch_from_payload(self, raw: Mapping[str, Any]) -> StoryBranch:
+        state_raw = raw.get("state")
+        if not isinstance(state_raw, Mapping):
+            raise StoryPersistenceError("story branch state must be an object")
+        events_raw = raw.get("events", ())
+        checkpoints_raw = raw.get("checkpoints", ())
+        if not isinstance(events_raw, list) or not isinstance(checkpoints_raw, list):
+            raise StoryPersistenceError("story branch logs must be lists")
+        events = []
+        for item in events_raw:
+            if not isinstance(item, Mapping) or not isinstance(
+                item.get("event"), Mapping
+            ):
+                raise StoryPersistenceError("causal story event is invalid")
+            events.append(
+                CausalStoryEvent(
+                    id=str(item.get("id") or ""),
+                    parent_event_id=_optional_text(item.get("parentEventId")),
+                    event=story_event_from_payload(item["event"]),
+                )
+            )
+        checkpoints = [
+            self._checkpoint_from_payload(item)
+            for item in checkpoints_raw
+            if isinstance(item, Mapping)
+        ]
+        return StoryBranch(
+            id=str(raw.get("id") or ""),
+            parent_id=_optional_text(raw.get("parentId")),
+            generation=int(raw.get("generation") or 0),
+            state=story_state_from_payload(state_raw, program=self.runtime.program),
+            head_event_id=_optional_text(raw.get("headEventId")),
+            events=events,
+            checkpoints=checkpoints,
+            idempotency=StoryCommandIdempotencyIndex.from_payload(
+                raw.get("idempotency", [])
+            ),
+            history_entries=_history_entries(raw.get("historyEntries", ())),
+        )
+
+    def _checkpoint_from_payload(self, raw: Mapping[str, Any]) -> StoryCheckpoint:
+        state_raw = raw.get("state")
+        if not isinstance(state_raw, Mapping):
+            raise StoryPersistenceError("checkpoint state must be an object")
+        idempotency = raw.get("idempotency", ())
+        if not isinstance(idempotency, list):
+            raise StoryPersistenceError("checkpoint idempotency must be a list")
+        return StoryCheckpoint(
+            generation=int(raw.get("generation") or 0),
+            message_count=int(raw.get("messageCount") or 0),
+            state=story_state_from_payload(state_raw, program=self.runtime.program),
+            head_event_id=_optional_text(raw.get("headEventId")),
+            event_count=int(raw.get("eventCount") or 0),
+            history_entries=_history_entries(raw.get("historyEntries", ())),
+            idempotency_payload=tuple(
+                MappingProxyType(dict(item))
+                for item in idempotency
+                if isinstance(item, Mapping)
+            ),
+        )
+
+    def _validate_all_branches(self) -> None:
+        initial = self.runtime.initial_state()
+        for branch_id, branch in self.branches.items():
+            if branch.id != branch_id or not branch.checkpoints:
+                raise StoryPersistenceError("invalid story branch identity")
+            parent = None
+            for causal in branch.events:
+                if causal.parent_event_id != parent:
+                    raise StoryPersistenceError("broken causal story event chain")
+                if not causal.id or ":" not in causal.id:
+                    raise StoryPersistenceError("invalid causal story event id")
+                parent = causal.id
+            if parent != branch.head_event_id:
+                raise StoryPersistenceError(
+                    "story branch head does not match event chain"
+                )
+            replayed = StoryEventReplayer().replay(
+                initial,
+                tuple(item.event for item in branch.events),
+                program=self.runtime.program,
+            )
+            if replayed != branch.state:
+                raise StoryPersistenceError(
+                    f"story branch {branch.id!r} does not match event replay"
+                )
+
+    def _checkpoint(self, branch: StoryBranch, generation: int) -> StoryCheckpoint:
+        for checkpoint in reversed(branch.checkpoints):
+            if checkpoint.generation == generation:
+                return checkpoint
+        raise KeyError(f"generation {generation} has no checkpoint")
+
+    def _save(self) -> None:
+        if self.repository is not None:
+            self.repository.save(self.to_payload())
+
+    def _require_enabled(self) -> None:
+        self.flags.require(FeatureFlag.STORY_SYSTEM)
+
+
+def _initial_global_progress(program: StoryProgram) -> GlobalStoryProgress:
+    return GlobalStoryProgress(
+        story_id=program.story_id,
+        story_version=program.story_version,
+        program_source_hash=program.source_hash,
+        variables={
+            definition.id: freeze_value(definition.initial)
+            for definition in program.variables
+            if definition.scope == VariableScope.GLOBAL
+        },
+    )
+
+
+def _history_entries(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise StoryPersistenceError("history entries must be a list")
+    return tuple(
+        MappingProxyType(dict(item)) for item in value if isinstance(item, Mapping)
+    )
+
+
+def _branch_id(value: str) -> str:
+    candidate = str(value or "").strip()
+    if not candidate or len(candidate) > 80:
+        raise ValueError("branch id must contain 1-80 characters")
+    if any(
+        character
+        not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
+        for character in candidate
+    ):
+        raise ValueError("branch id contains unsupported characters")
+    return candidate
+
+
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None

--- a/core/sprite/chat_branch_storage.py
+++ b/core/sprite/chat_branch_storage.py
@@ -8,6 +8,7 @@ from typing import Any
 
 ACTIVE_HISTORY_FILENAME = "active.json"
 BRANCH_TREE_FILENAME = "branches.json"
+STORY_SESSION_FILENAME = "story-v2.json"
 BRANCH_TREE_VERSION = 1
 
 
@@ -63,13 +64,15 @@ def remove_chat_history_storage(path: str | Path) -> None:
         directory_targets = [chat_history_session_dir(candidate)]
 
     # A history directory is not an ownership boundary. Remove only files
-    # created by chat storage, then remove the directory if it is empty.
-    # Never recursively delete unrelated content from an external directory.
+    # created by chat and story session storage, then remove the directory
+    # if it is empty. Never recursively delete unrelated content from an
+    # external directory.
     for directory in directory_targets:
         for name in (
             BRANCH_TREE_FILENAME,
             f"{ACTIVE_HISTORY_FILENAME}.tmp",
             ACTIVE_HISTORY_FILENAME,
+            STORY_SESSION_FILENAME,
         ):
             target = directory / name
             target.unlink(missing_ok=True)

--- a/frontend/src/features/chat-stage/ChatStagePage.tsx
+++ b/frontend/src/features/chat-stage/ChatStagePage.tsx
@@ -6,7 +6,7 @@ import { closeChatSurface } from "../../shared/desktop/chatWindow";
 import { sendChatCommand, uploadChatAttachments } from "../../entities/chat/repository";
 import { useI18n } from "../../shared/i18n";
 import type { PluginPageTarget } from "../../shared/plugin/PluginSlot";
-import type { ChatAttachmentInput, ChatSendPayload, ChatTurnOptions } from "../../shared/platform/types";
+import type { ChatAttachmentInput, ChatOption, ChatSendPayload, ChatTurnOptions } from "../../shared/platform/types";
 import { normalizeThemeColor } from "../../shared/theme/appTheme";
 import { DEFAULT_TYPEWRITER_CPS } from "../../shared/theme/chatTheme";
 import { AlertDialog, useToast } from "../../shared/ui";
@@ -33,6 +33,7 @@ import {
   ToolConfirmationLayer,
 } from "./components/StageLayers";
 import { TopStageTools } from "./components/TopStageTools";
+import { StoryDebugPanel } from "./components/StoryDebugPanel";
 import "./chat-stage.css";
 import { buildChatStageViewModel, chatStageReducer, emptyChatState } from "./chatState";
 import { isRemoteMobileAccessPage, layerClassName } from "./chatStageUtils";
@@ -412,15 +413,30 @@ export function ChatStagePage() {
     void handleDropFiles(files);
   };
 
-  const submitOption = (option: string) => {
+  const submitOption = (option: ChatOption) => {
+    const label = typeof option === "string" ? option : option.label;
+    if (typeof option !== "string" && !option.enabled) {
+      return;
+    }
     showDialogImmediately();
     dispatch({
       queued: state.turnOptions.batchEnabled,
       source: "submit-option",
-      text: option,
+      text: label,
       type: "submitUserMessage",
     });
-    void sendCommand({ payload: option, type: "submit-option" });
+    void sendCommand({
+      payload:
+        typeof option === "string"
+          ? option
+          : {
+              choiceId: option.id,
+              expectedNodeId: option.expectedNodeId,
+              expectedRevision: option.expectedRevision,
+              kind: "story-choice",
+            },
+      type: "submit-option",
+    });
   };
 
   const resolveToolConfirmation = (action: "confirm" | "cancel") => {
@@ -692,6 +708,7 @@ export function ChatStagePage() {
           sprites={stageSprites}
         />
         <StatLayer stats={viewModel.stats} />
+        <StoryDebugPanel story={viewModel.story} />
         <TokenUsageLayer hidden={!tokenUsageVisible} text={viewModel.tokenUsageText} />
         <BusyLayer hidden={!viewModel.layers.busy} text={viewModel.busyText} />
         <NotificationLayer

--- a/frontend/src/features/chat-stage/chat-stage.css
+++ b/frontend/src/features/chat-stage/chat-stage.css
@@ -8,6 +8,7 @@
 @import "./styles/status-overlays.css";
 @import "./styles/history-dialog.css";
 @import "./styles/branch-dialog.css";
+@import "./styles/story-debug.css";
 @import "./styles/modal-shell.css";
 @import "./styles/responsive.css";
 @import "./styles/animations.css";

--- a/frontend/src/features/chat-stage/components/StageLayers.tsx
+++ b/frontend/src/features/chat-stage/components/StageLayers.tsx
@@ -13,7 +13,7 @@ import { Clock, Coins, Gauge, Heart, Shield, Sparkles, Star, Target, Zap, type L
 import { startDesktopWindowResize, type DesktopResizeDirection } from "../../../shared/desktop/desktopApi";
 import { useI18n } from "../../../shared/i18n";
 import { PluginSlot, type PluginPageTarget } from "../../../shared/plugin/PluginSlot";
-import type { ChatStat, ChatToolConfirmation } from "../../../shared/platform/types";
+import type { ChatOption, ChatStat, ChatToolConfirmation } from "../../../shared/platform/types";
 import { Button, ThemeFrame } from "../../../shared/ui";
 import type { ChatStageSprite } from "../chatState";
 import { classNames, hideBrokenStageAsset, layerClassName, stageAssetUrl } from "../chatStageUtils";
@@ -280,8 +280,8 @@ export function OptionsLayer({
   options,
 }: {
   hidden: boolean;
-  onSelect: (option: string) => void;
-  options: string[];
+  onSelect: (option: ChatOption) => void;
+  options: ChatOption[];
 }) {
   const { t } = useI18n();
   if (hidden || !options.length) {
@@ -295,26 +295,32 @@ export function OptionsLayer({
       hidden={hidden}
     >
       <div aria-label={t("chat.options.label")} className="options-layer__scroll" role="list">
-        {options.map((option, index) => (
-          <div className="options-layer__item" key={option} role="listitem">
-            <ThemeFrame prefix="chat-option" />
-            <Button
-              autoFocus={index === 0}
-              className="options-layer__button"
-              onClick={() => onSelect(option)}
-              onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
-                if (event.key !== "Enter" || event.nativeEvent.isComposing) {
-                  return;
-                }
-                event.preventDefault();
-                event.stopPropagation();
-                onSelect(option);
-              }}
-            >
-              {option}
-            </Button>
-          </div>
-        ))}
+        {options.map((option, index) => {
+          const label = typeof option === "string" ? option : option.label;
+          const disabled = typeof option !== "string" && !option.enabled;
+          const key = typeof option === "string" ? option : `${option.expectedRevision}:${option.id}`;
+          return (
+            <div className="options-layer__item" key={key} role="listitem">
+              <ThemeFrame prefix="chat-option" />
+              <Button
+                autoFocus={index === 0}
+                className="options-layer__button"
+                disabled={disabled}
+                onClick={() => onSelect(option)}
+                onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
+                  if (event.key !== "Enter" || event.nativeEvent.isComposing) {
+                    return;
+                  }
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onSelect(option);
+                }}
+              >
+                {label}
+              </Button>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/features/chat-stage/components/StoryDebugPanel.tsx
+++ b/frontend/src/features/chat-stage/components/StoryDebugPanel.tsx
@@ -1,0 +1,26 @@
+import type { ChatStoryState } from "../../../shared/platform/types";
+
+export function StoryDebugPanel({ story }: { story?: ChatStoryState }) {
+  if (!story) {
+    return null;
+  }
+  return (
+    <details className="story-debug-panel" data-chat-stage-hitbox="true">
+      <summary>Story · {story.currentNodeTitle}</summary>
+      <dl>
+        <div>
+          <dt>Node</dt>
+          <dd>{story.currentNodeId}</dd>
+        </div>
+        <div>
+          <dt>Revision</dt>
+          <dd>{story.revision}</dd>
+        </div>
+        <div>
+          <dt>Cast</dt>
+          <dd>{story.activeCast.map((character) => character.id).join(", ") || "—"}</dd>
+        </div>
+      </dl>
+    </details>
+  );
+}

--- a/frontend/src/features/chat-stage/state/events.ts
+++ b/frontend/src/features/chat-stage/state/events.ts
@@ -182,6 +182,31 @@ export function applyStageEvent(state: ChatStageState, event: ChatStageEvent): C
         eventSeq: Math.max(state.eventSeq, event.seq),
         options: [],
       });
+    case "story.state.replace":
+      return withResolvedLayers({
+        ...state,
+        eventSeq: Math.max(state.eventSeq, event.seq),
+        options: event.story.options,
+        story: event.story,
+      });
+    case "story.node.entered":
+    case "story.node.unlocked":
+    case "story.cast.replace":
+    case "story.ending.reached":
+      return withResolvedLayers({
+        ...state,
+        eventSeq: Math.max(state.eventSeq, event.seq),
+        story: state.story
+          ? {
+              ...state.story,
+              lastEvent: {
+                payload: event.payload,
+                revision: event.revision,
+                type: event.type,
+              },
+            }
+          : undefined,
+      });
     case "tool.confirmation.show":
       return withResolvedLayers({
         ...clearTransientNotificationState(state),

--- a/frontend/src/features/chat-stage/state/reducer.ts
+++ b/frontend/src/features/chat-stage/state/reducer.ts
@@ -34,6 +34,14 @@ function snapshotReplacesOptimisticPresentation(
   if (snapshot.sessionClosedReason || snapshot.options.length > 0) {
     return true;
   }
+  if (
+    snapshot.story &&
+    (snapshot.story.ending ||
+      snapshot.story.revision !== state.story?.revision ||
+      snapshot.story.currentNodeId !== state.story?.currentNodeId)
+  ) {
+    return true;
+  }
   if (authoritativeEventSeq <= optimistic.eventSeq) {
     return false;
   }
@@ -143,7 +151,7 @@ export function chatStageReducer(state: ChatStageState, action: ChatStageAction)
           ? { ...next, optimisticSubmission: undefined }
           : preserveOptimisticPresentation(state, next);
       }
-      if (["dialog.end", "options.show", "session.closed"].includes(action.event.type)) {
+      if (["dialog.end", "options.show", "session.closed", "story.state.replace"].includes(action.event.type)) {
         return { ...next, optimisticSubmission: undefined };
       }
       return next;

--- a/frontend/src/features/chat-stage/state/types.ts
+++ b/frontend/src/features/chat-stage/state/types.ts
@@ -1,11 +1,13 @@
 import type {
   ChatAttachmentInput,
   ChatHistoryEntry,
+  ChatOption,
   ChatRuntimeStatus,
   ChatSnapshot,
   ChatSprite,
   ChatStat,
   ChatStageEvent,
+  ChatStoryState,
   ChatToolConfirmation,
   ChatTurnOptions,
   ChatTurnState,
@@ -62,7 +64,7 @@ export interface ChatStageState extends Omit<ChatSnapshot, "sprites"> {
       inputDraft: string;
       inputAttachments: ChatAttachmentInput[];
       notificationText?: string;
-      options: string[];
+      options: ChatOption[];
       sessionClosedReason?: string;
       status: ChatRuntimeStatus;
       statusMessage?: string;
@@ -96,8 +98,9 @@ export interface ChatStageViewModel {
   inputDraft: string;
   layers: ChatStageLayers;
   notificationText?: string;
-  options: string[];
+  options: ChatOption[];
   sprites: ChatStageSprite[];
+  story?: ChatStoryState;
   stats: ChatStat[];
   status: ChatRuntimeStatus;
   statusText: string;

--- a/frontend/src/features/chat-stage/state/viewModel.ts
+++ b/frontend/src/features/chat-stage/state/viewModel.ts
@@ -52,6 +52,7 @@ export function buildChatStageViewModel(state: ChatStageState): ChatStageViewMod
     options: state.options,
     sprites: state.sprites,
     stats: state.stats ?? [],
+    story: state.story,
     status: state.status,
     statusText: state.status,
     tokenUsageText,

--- a/frontend/src/features/chat-stage/styles/story-debug.css
+++ b/frontend/src/features/chat-stage/styles/story-debug.css
@@ -1,0 +1,44 @@
+.story-debug-panel {
+  position: absolute;
+  z-index: 72;
+  top: max(56px, calc(env(safe-area-inset-top) + 44px));
+  right: max(12px, env(safe-area-inset-right));
+  width: min(280px, calc(100vw - 24px));
+  padding: 8px 12px;
+  border: 1px solid color-mix(in srgb, var(--color-border) 78%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+  color: var(--color-text);
+  font-size: 0.78rem;
+  pointer-events: auto;
+  backdrop-filter: blur(12px);
+}
+
+.story-debug-panel summary {
+  cursor: pointer;
+  font-weight: 650;
+}
+
+.story-debug-panel dl,
+.story-debug-panel dl div {
+  display: grid;
+  gap: 4px 10px;
+}
+
+.story-debug-panel dl {
+  margin: 10px 0 2px;
+}
+
+.story-debug-panel dl div {
+  grid-template-columns: 64px 1fr;
+}
+
+.story-debug-panel dt,
+.story-debug-panel dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.story-debug-panel dt {
+  opacity: 0.68;
+}

--- a/frontend/src/shared/platform/sampleData.ts
+++ b/frontend/src/shared/platform/sampleData.ts
@@ -169,6 +169,7 @@ export const sampleConfig: AppConfig = {
     chat_ui_runtime_mode: "react",
     react_chat_fork_experimental_enabled: false,
     react_chat_flowchart_experimental_enabled: false,
+    story_system_enabled: false,
     mirror_auto_detect_china: true,
     mirror_region: "auto",
     huggingface_mirror_url: "",

--- a/frontend/src/shared/platform/types.ts
+++ b/frontend/src/shared/platform/types.ts
@@ -108,6 +108,7 @@ export interface SystemConfig {
   chat_ui_runtime_mode: "react";
   react_chat_fork_experimental_enabled: boolean;
   react_chat_flowchart_experimental_enabled: boolean;
+  story_system_enabled: boolean;
   mirror_auto_detect_china: boolean;
   mirror_region: string;
   huggingface_mirror_url: string;
@@ -885,6 +886,40 @@ export interface PluginPagePresentation {
   presentationId: string;
 }
 
+export interface ChatStoryOption {
+  enabled: boolean;
+  expectedNodeId: string;
+  expectedRevision: number;
+  id: string;
+  label: string;
+  lockedReason?: string | null;
+  source: "story";
+}
+
+export type ChatOption = string | ChatStoryOption;
+
+export interface ChatStoryState {
+  activeCast: Array<{ id: string; roles: string[] }>;
+  castRevision: number;
+  currentNodeId: string;
+  currentNodeTitle: string;
+  ending?: { id: string; title: string } | null;
+  lastEvent?: { payload: Record<string, unknown>; revision?: number; type: string };
+  objectives: unknown[];
+  options: ChatStoryOption[];
+  revision: number;
+  storyId: string;
+  storyVersion: number;
+  unlockedNotifications: Array<{ id: string; kind: string }>;
+  visibleVariables: Array<{
+    id: string;
+    maximum?: number | null;
+    minimum?: number | null;
+    type: string;
+    value: unknown;
+  }>;
+}
+
 export interface ChatSnapshot {
   activePlayback?: {
     characterName: string;
@@ -923,13 +958,15 @@ export interface ChatSnapshot {
   mobileAccess?: MobileAccessInfo;
   numericInfo?: string;
   notificationText?: string;
-  options: string[];
+  options: ChatOption[];
   pluginPagePresentations?: PluginPagePresentation[];
   runtimeDependencyError?: RuntimeDependencyError;
   runtimeMode?: "native" | "react";
   sessionClosedReason?: string;
   sessionId?: string;
   sprites: ChatSprite[];
+  story?: ChatStoryState;
+  storyAck?: Record<string, unknown>;
   stats?: ChatStat[];
   status: ChatRuntimeStatus;
   statusMessage?: string;
@@ -1056,8 +1093,14 @@ export type ChatStageEvent =
   | (ChatEventBase & { type: "bgm.change"; url: string })
   | (ChatEventBase & { type: "cg.show"; url: string })
   | (ChatEventBase & { type: "cg.hide" })
-  | (ChatEventBase & { type: "options.show"; options: string[] })
+  | (ChatEventBase & { type: "options.show"; options: ChatOption[] })
   | (ChatEventBase & { type: "options.clear" })
+  | (ChatEventBase & { type: "story.state.replace"; story: ChatStoryState })
+  | (ChatEventBase & {
+      type: "story.node.entered" | "story.node.unlocked" | "story.cast.replace" | "story.ending.reached";
+      payload: Record<string, unknown>;
+      revision: number;
+    })
   | (ChatEventBase & {
       type: "tool.confirmation.show";
       confirmationId: string;

--- a/frontend/src/test/features/chat-stage/chatState.test.ts
+++ b/frontend/src/test/features/chat-stage/chatState.test.ts
@@ -195,6 +195,133 @@ describe("chatStageReducer", () => {
     expect(restored.optimisticSubmission).toBeUndefined();
   });
 
+  it("clears an optimistic story choice when the next story state is published", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Mio",
+        dialogText: "Choose",
+        eventSeq: 3,
+        options: [
+          {
+            enabled: true,
+            expectedNodeId: "gate",
+            expectedRevision: 1,
+            id: "go",
+            label: "Go",
+            source: "story",
+          },
+        ],
+        story: {
+          activeCast: [],
+          castRevision: 1,
+          currentNodeId: "gate",
+          currentNodeTitle: "Gate",
+          objectives: [],
+          options: [],
+          revision: 1,
+          storyId: "campus",
+          storyVersion: 1,
+          unlockedNotifications: [],
+          visibleVariables: [],
+        },
+      },
+      { source: "submit-option", text: "Go", type: "submitUserMessage" },
+    );
+
+    const replaced = chatStageReducer(submitted, {
+      event: {
+        seq: 4,
+        story: {
+          activeCast: [],
+          castRevision: 1,
+          currentNodeId: "ending",
+          currentNodeTitle: "Rain",
+          ending: { id: "ending", title: "Rain" },
+          objectives: [],
+          options: [],
+          revision: 2,
+          storyId: "campus",
+          storyVersion: 1,
+          unlockedNotifications: [],
+          visibleVariables: [],
+        },
+        ts: 4,
+        type: "story.state.replace",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(replaced.optimisticSubmission).toBeUndefined();
+    expect(replaced.story?.currentNodeId).toBe("ending");
+    expect(replaced.options).toEqual([]);
+  });
+
+  it("replaces optimistic story presentation when a polled snapshot reaches an ending", () => {
+    const submitted = chatStageReducer(
+      {
+        ...emptyChatState,
+        characterName: "Aoi",
+        dialogText: "Go",
+        eventSeq: 3,
+        options: [],
+        status: "generating",
+        story: {
+          activeCast: [],
+          castRevision: 1,
+          currentNodeId: "gate",
+          currentNodeTitle: "Gate",
+          objectives: [],
+          options: [],
+          revision: 1,
+          storyId: "campus",
+          storyVersion: 1,
+          unlockedNotifications: [],
+          visibleVariables: [],
+        },
+        userDisplayName: "Aoi",
+      },
+      { source: "submit-option", text: "Go", type: "submitUserMessage" },
+    );
+
+    const polled = chatStageReducer(submitted, {
+      event: {
+        seq: 4,
+        snapshot: {
+          characterName: "Aoi",
+          dialogText: "Go",
+          eventSeq: 4,
+          inputDraft: "",
+          options: [],
+          sprites: [],
+          status: "idle",
+          story: {
+            activeCast: [],
+            castRevision: 1,
+            currentNodeId: "ending",
+            currentNodeTitle: "Rain",
+            ending: { id: "ending", title: "Rain" },
+            objectives: [],
+            options: [],
+            revision: 2,
+            storyId: "campus",
+            storyVersion: 1,
+            unlockedNotifications: [],
+            visibleVariables: [],
+          },
+        },
+        ts: 4,
+        type: "snapshot",
+        v: 1,
+      },
+      type: "event",
+    });
+
+    expect(polled.optimisticSubmission).toBeUndefined();
+    expect(polled.story?.ending).toEqual({ id: "ending", title: "Rain" });
+  });
+
   it("preserves a new draft when an earlier submission fails late", () => {
     const submitted = chatStageReducer(
       {

--- a/frontend_bridge_core/routes/api.py
+++ b/frontend_bridge_core/routes/api.py
@@ -170,6 +170,7 @@ from sdk.path_utils import (
     safe_project_path,
 )
 from application.runtime.state import BridgeState, _jsonify, plugin_load_snapshot
+from application.story.coordinator import start_or_recover_story_session
 from frontend_bridge_core.static import _frontend_dist_root
 from application.runtime.tasks import (
     _create_task,
@@ -1295,6 +1296,18 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                 self._send_json(_close_chat(self.state))
             elif method == "POST" and path == "/api/chat/command":
                 self._send_json(_handle_chat_command(self.state, body))
+            elif method == "POST" and path == "/api/story/start":
+                story_path = str(body.get("storyPath") or "").strip()
+                if not story_path:
+                    raise ValueError("storyPath is required")
+                session = start_or_recover_story_session(
+                    self.state,
+                    story_path,
+                    command_id=str(body.get("commandId") or new_log_id()),
+                )
+                self._send_json(
+                    _chat_snapshot(self.state, "idle", extra=session.chat_snapshot())
+                )
             elif method == "POST" and path == "/api/chat/themes/active":
                 self._send_json(set_active_chat_theme(self.state, body))
             elif method == "POST" and path == "/api/chat/themes/save":

--- a/frontend_bridge_core/routes/api.py
+++ b/frontend_bridge_core/routes/api.py
@@ -170,7 +170,12 @@ from sdk.path_utils import (
     safe_project_path,
 )
 from application.runtime.state import BridgeState, _jsonify, plugin_load_snapshot
-from application.story.coordinator import start_or_recover_story_session
+from application.story.coordinator import (
+    clear_story_session,
+    publish_story_transition,
+    release_unbound_story_session,
+    start_or_recover_story_session,
+)
 from frontend_bridge_core.static import _frontend_dist_root
 from application.runtime.tasks import (
     _create_task,
@@ -1305,8 +1310,10 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
                     story_path,
                     command_id=str(body.get("commandId") or new_log_id()),
                 )
+                patch = session.chat_snapshot()
+                publish_story_transition(self.state, patch)
                 self._send_json(
-                    _chat_snapshot(self.state, "idle", extra=session.chat_snapshot())
+                    _chat_snapshot(self.state, "idle", extra=patch)
                 )
             elif method == "POST" and path == "/api/chat/themes/active":
                 self._send_json(set_active_chat_theme(self.state, body))
@@ -1435,6 +1442,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
         )
         reset_history = bool(body.get("resetHistory"))
         if reset_history:
+            clear_story_session(self.state)
             for item in {history_path, default_history_path}:
                 remove_chat_history_storage(item)
         user_scenario = _scenario_from_template_like(row)
@@ -1455,6 +1463,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             "voiceLanguage": str(self.state.config_manager.config.system_config.voice_language or "ja"),
             "workflowPath": str(body.get("workflowPath") or ""),
         }
+        release_unbound_story_session(self.state, session_base["historyPath"])
         if _chat_process_running():
             self.state.chat_session = {**self.state.chat_session, **session_base}
             configure_mobile_access(
@@ -1599,6 +1608,7 @@ class FrontendBridgeHandler(BaseHTTPRequestHandler):
             "voiceLanguage": str(session.get("voiceLanguage") or self.state.config_manager.config.system_config.voice_language or "ja"),
             "workflowPath": str(session.get("workflowPath") or ""),
         }
+        release_unbound_story_session(self.state, session_base["historyPath"])
         if _chat_process_running():
             self.state.chat_session = {**self.state.chat_session, **session_base}
             configure_mobile_access(

--- a/main.py
+++ b/main.py
@@ -957,7 +957,7 @@ def main():
                         return body.strip()
             return text.strip()
 
-        def _fork_history_branch(user_index: int) -> None:
+        def _fork_history_branch(user_index: int, branch_id: str = "") -> None:
             if user_index < 0:
                 raise ValueError("分支索引无效。")
             user_pos = _user_history_position(user_index)
@@ -976,21 +976,33 @@ def main():
             _save_active_branch()
             prefix_history = list(chat_history[:user_pos])
             prefix_messages = _messages_before_user(user_index)
-            branch_state["counter"] = int(branch_state.get("counter") or 1) + 1
-            branch_id = f"branch-{branch_state['counter']}"
+            requested_id = str(branch_id or "").strip()
+            if requested_id:
+                if requested_id in _branches():
+                    raise ValueError("对话分支已存在。")
+                suffix = requested_id[7:] if requested_id.startswith("branch-") else ""
+                if suffix.isdigit():
+                    branch_state["counter"] = max(
+                        int(branch_state.get("counter") or 1),
+                        int(suffix),
+                    )
+                next_id = requested_id
+            else:
+                branch_state["counter"] = int(branch_state.get("counter") or 1) + 1
+                next_id = f"branch-{branch_state['counter']}"
             now = int(time.time() * 1000)
-            _branches()[branch_id] = {
+            _branches()[next_id] = {
                 "createdAt": now,
                 "forkedFromEntryId": f"history-{user_pos}",
                 "forkedFromText": user_text,
                 "history": list(prefix_history),
-                "id": branch_id,
+                "id": next_id,
                 "label": f"Branch {branch_state['counter']}",
                 "messages": copy.deepcopy(prefix_messages),
                 "parentId": _active_branch_id(),
                 "updatedAt": now,
             }
-            branch_state["active"] = branch_id
+            branch_state["active"] = next_id
             chat_history[:] = prefix_history
             llm_manager.set_messages(copy.deepcopy(prefix_messages))
             stream_sink.emit({"type": "options.clear"})
@@ -1274,8 +1286,11 @@ def main():
                     emit_ack(ok=True)
                     return
                 if command_type == "fork-history":
-                    raw_index = payload.get("userIndex") if isinstance(payload, dict) else payload
-                    _fork_history_branch(int(raw_index))
+                    raw_payload = payload if isinstance(payload, dict) else {"userIndex": payload}
+                    _fork_history_branch(
+                        int(raw_payload.get("userIndex")),
+                        branch_id=str(raw_payload.get("branchId") or "").strip(),
+                    )
                     emit_ack(ok=True)
                     return
                 if command_type == "switch-branch":

--- a/test/unit/application/story/test_chat_integration.py
+++ b/test/unit/application/story/test_chat_integration.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from application.chat.runtime_process import _handle_chat_command
 from application.story import StorySession
+from application.story.coordinator import (
+    bound_story_session,
+    clear_story_session,
+    discard_story_session_storage,
+    story_snapshot_patch,
+)
 from config.feature_flags import FeatureFlag, FeatureFlagConfigManager
 from config.schema import ApiConfig
 from core.story import StoryCompiler, StoryRuntime, parse_story_project
@@ -14,8 +21,11 @@ from test.unit.core.story.story_fixtures import campus_mystery_source
 
 class _ChatStream:
     def __init__(self) -> None:
+        self.published: list[dict] = []
+        self.command = None
         self.snapshot = {
             "dialogText": "Choose",
+            "eventSeq": 0,
             "historyEntries": [],
             "inputDraft": "",
             "options": [],
@@ -30,8 +40,29 @@ class _ChatStream:
     def update_session_snapshot(self, _session_id: str, patch: dict) -> None:
         self.snapshot.update(patch)
 
+    def publish_event(self, _session_id: str, event: dict) -> bool:
+        payload = dict(event)
+        seq = int(self.snapshot.get("eventSeq") or 0) + 1
+        payload["seq"] = seq
+        self.snapshot["eventSeq"] = seq
+        event_type = str(payload.get("type") or "")
+        if event_type == "history.replace":
+            self.snapshot["historyEntries"] = list(payload.get("entries") or [])
+        elif event_type == "story.state.replace":
+            story = dict(payload.get("story") or {})
+            self.snapshot["story"] = story
+            self.snapshot["options"] = list(story.get("options") or [])
+        elif event_type == "options.show":
+            self.snapshot["options"] = list(payload.get("options") or [])
+        self.published.append(payload)
+        return True
 
-def _state(*, enabled: bool) -> SimpleNamespace:
+    def send_command(self, session_id: str, command: dict) -> bool:
+        self.command = (session_id, dict(command))
+        return True
+
+
+def _state(*, enabled: bool, fork: bool = False, flowchart: bool = False) -> SimpleNamespace:
     flags = FeatureFlagConfigManager(
         environ={},
         overrides={FeatureFlag.STORY_SYSTEM: enabled},
@@ -40,8 +71,8 @@ def _state(*, enabled: bool) -> SimpleNamespace:
         config=SimpleNamespace(
             api_config=ApiConfig(),
             system_config=SimpleNamespace(
-                react_chat_flowchart_experimental_enabled=False,
-                react_chat_fork_experimental_enabled=False,
+                react_chat_flowchart_experimental_enabled=flowchart,
+                react_chat_fork_experimental_enabled=fork,
                 voice_language="ja",
             ),
         ),
@@ -85,6 +116,14 @@ def test_structured_story_choice_uses_deterministic_session() -> None:
     assert snapshot["story"]["currentNodeId"] == "old-school-gate"
     assert snapshot["storyAck"]["commandId"] == "choice-1"
     assert state.chat_stream.snapshot["story"]["revision"] == 2
+    assert snapshot["historyEntries"][-1]["role"] == "user"
+    assert "和绫约定调查旧校舍" in snapshot["historyEntries"][-1]["text"]
+    published_types = [event["type"] for event in state.chat_stream.published]
+    assert "history.replace" in published_types
+    assert "story.state.replace" in published_types
+    assert "options.show" in published_types
+    assert snapshot["eventSeq"] >= 1
+    assert state.story_session.active_branch.history_entries[-1]["role"] == "user"
 
 
 def test_structured_story_choice_keeps_legacy_error_when_flag_is_off() -> None:
@@ -98,3 +137,60 @@ def test_structured_story_choice_keeps_legacy_error_when_flag_is_off() -> None:
                 "type": "submit-option",
             },
         )
+
+
+def test_story_snapshot_is_not_projected_onto_another_history(tmp_path) -> None:
+    state = _state(enabled=True)
+    session = _story_session(state.config_manager.feature_flags)
+    session.owner_history_path = str((tmp_path / "one").resolve())
+    state.story_session = session
+    state.chat_session["historyPath"] = str((tmp_path / "two").resolve())
+
+    assert bound_story_session(state) is None
+    assert story_snapshot_patch(state) == {}
+
+
+def test_clearing_story_session_drops_memory_and_document(tmp_path) -> None:
+    history_path = tmp_path / "session"
+    history_path.mkdir()
+    story_path = history_path / "story-v2.json"
+    story_path.write_text("{}", encoding="utf-8")
+    state = _state(enabled=True)
+    state.chat_session["historyPath"] = str(history_path)
+    state.story_session = _story_session(state.config_manager.feature_flags)
+
+    discard_story_session_storage(history_path)
+    clear_story_session(state)
+
+    assert state.story_session is None
+    assert not story_path.exists()
+
+
+def test_fork_history_creates_a_matching_story_branch() -> None:
+    state = _state(enabled=True, fork=True)
+    session = _story_session(state.config_manager.feature_flags)
+    state.story_session = session
+    _handle_chat_command(
+        state,
+        {
+            "cmdId": "choice-1",
+            "payload": {
+                "choiceId": "prepare-investigation",
+                "expectedNodeId": "transfer-day",
+                "expectedRevision": 1,
+                "kind": "story-choice",
+            },
+            "type": "submit-option",
+        },
+    )
+
+    snapshot = _handle_chat_command(
+        state,
+        {"payload": {"userIndex": 0}, "type": "fork-history"},
+    )
+
+    assert snapshot["status"] == "generating"
+    assert "branch-2" in session.branches
+    assert session.active_branch_id == "branch-2"
+    assert session.active_branch.state.current_node_id == "transfer-day"
+    assert state.chat_stream.command[1]["payload"]["branchId"] == "branch-2"

--- a/test/unit/application/story/test_chat_integration.py
+++ b/test/unit/application/story/test_chat_integration.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from application.chat.runtime_process import _handle_chat_command
+from application.story import StorySession
+from config.feature_flags import FeatureFlag, FeatureFlagConfigManager
+from config.schema import ApiConfig
+from core.story import StoryCompiler, StoryRuntime, parse_story_project
+from test.unit.core.story.story_fixtures import campus_mystery_source
+
+
+class _ChatStream:
+    def __init__(self) -> None:
+        self.snapshot = {
+            "dialogText": "Choose",
+            "historyEntries": [],
+            "inputDraft": "",
+            "options": [],
+            "sessionId": "session-1",
+            "sprites": [],
+            "status": "idle",
+        }
+
+    def get_snapshot(self, _session_id: str) -> dict:
+        return dict(self.snapshot)
+
+    def update_session_snapshot(self, _session_id: str, patch: dict) -> None:
+        self.snapshot.update(patch)
+
+
+def _state(*, enabled: bool) -> SimpleNamespace:
+    flags = FeatureFlagConfigManager(
+        environ={},
+        overrides={FeatureFlag.STORY_SYSTEM: enabled},
+    )
+    manager = SimpleNamespace(
+        config=SimpleNamespace(
+            api_config=ApiConfig(),
+            system_config=SimpleNamespace(
+                react_chat_flowchart_experimental_enabled=False,
+                react_chat_fork_experimental_enabled=False,
+                voice_language="ja",
+            ),
+        ),
+        feature_flags=flags,
+    )
+    return SimpleNamespace(
+        chat_session={"sessionId": "session-1"},
+        chat_stream=_ChatStream(),
+        config_manager=manager,
+        story_session=None,
+    )
+
+
+def _story_session(flags: FeatureFlagConfigManager) -> StorySession:
+    program = StoryCompiler().compile(parse_story_project(campus_mystery_source()))
+    return StorySession.create(
+        StoryRuntime(program),
+        flags,
+        command_id="start-1",
+    )
+
+
+def test_structured_story_choice_uses_deterministic_session() -> None:
+    state = _state(enabled=True)
+    state.story_session = _story_session(state.config_manager.feature_flags)
+
+    snapshot = _handle_chat_command(
+        state,
+        {
+            "cmdId": "choice-1",
+            "payload": {
+                "choiceId": "prepare-investigation",
+                "expectedNodeId": "transfer-day",
+                "expectedRevision": 1,
+                "kind": "story-choice",
+            },
+            "type": "submit-option",
+        },
+    )
+
+    assert snapshot["story"]["currentNodeId"] == "old-school-gate"
+    assert snapshot["storyAck"]["commandId"] == "choice-1"
+    assert state.chat_stream.snapshot["story"]["revision"] == 2
+
+
+def test_structured_story_choice_keeps_legacy_error_when_flag_is_off() -> None:
+    state = _state(enabled=False)
+
+    with pytest.raises(ValueError, match="must be a string"):
+        _handle_chat_command(
+            state,
+            {
+                "payload": {"kind": "story-choice"},
+                "type": "submit-option",
+            },
+        )

--- a/test/unit/application/story/test_session.py
+++ b/test/unit/application/story/test_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 import json
 
@@ -11,12 +12,19 @@ from application.story import (
     StoryProgramMismatchError,
     StorySession,
 )
+from application.story.persistence import global_progress_filename
 from config.feature_flags import (
     FeatureDisabledError,
     FeatureFlag,
     FeatureFlagConfigManager,
 )
-from core.story import SelectChoice, StoryCompiler, StoryRuntime, parse_story_project
+from core.story import (
+    SelectChoice,
+    StoryCompiler,
+    StoryRuntime,
+    StoryRuntimeError,
+    parse_story_project,
+)
 from test.unit.core.story.story_fixtures import campus_mystery_source
 
 
@@ -51,6 +59,16 @@ def _choice(session: StorySession, command_id: str = "choice-1") -> SelectChoice
         expected_revision=state.revision,
         choice_id="prepare-investigation",
         expected_node_id="transfer-day",
+    )
+
+
+def _enter_with_key(session: StorySession, command_id: str = "choice-2") -> SelectChoice:
+    state = session.active_branch.state
+    return SelectChoice(
+        command_id=command_id,
+        expected_revision=state.revision,
+        choice_id="enter-with-key",
+        expected_node_id="old-school-gate",
     )
 
 
@@ -249,3 +267,82 @@ def test_causal_chain_tampering_is_rejected(tmp_path) -> None:
             repository=repository,
             global_store=global_store,
         )
+
+
+def test_concurrent_choices_do_not_duplicate_event_groups(tmp_path) -> None:
+    runtime = _runtime()
+    repository = JsonStorySessionRepository(tmp_path / "session")
+    global_store = JsonGlobalStoryProgressStore(tmp_path / "global")
+    session = StorySession.create(
+        runtime,
+        _flags(),
+        command_id="start-1",
+        repository=repository,
+        global_store=global_store,
+    )
+    revision = session.active_branch.state.revision
+
+    def attempt(index: int) -> object:
+        return session.execute(
+            SelectChoice(
+                command_id=f"choice-{index}",
+                expected_revision=revision,
+                choice_id="prepare-investigation",
+                expected_node_id="transfer-day",
+            )
+        )
+
+    accepted = []
+    errors = []
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(attempt, index) for index in range(8)]
+        for future in as_completed(futures):
+            try:
+                accepted.append(future.result())
+            except StoryRuntimeError as error:
+                errors.append(error)
+
+    assert len(accepted) == 1
+    assert len(errors) == 7
+    recovered = StorySession.recover(
+        runtime,
+        _flags(),
+        repository=repository,
+        global_store=global_store,
+    )
+    assert recovered.active_branch.state == session.active_branch.state
+    assert recovered.active_branch.state.revision == accepted[0].revision
+
+
+def test_set_variable_effects_round_trip_through_recovery(tmp_path) -> None:
+    runtime = _runtime()
+    repository = JsonStorySessionRepository(tmp_path / "session")
+    global_store = JsonGlobalStoryProgressStore(tmp_path / "global")
+    session = StorySession.create(
+        runtime,
+        _flags(),
+        command_id="start-1",
+        repository=repository,
+        global_store=global_store,
+    )
+    session.execute(_choice(session))
+    session.execute(_enter_with_key(session))
+
+    recovered = StorySession.recover(
+        runtime,
+        _flags(),
+        repository=repository,
+        global_store=global_store,
+    )
+
+    assert recovered.active_branch.state == session.active_branch.state
+    assert recovered.active_branch.state.variables["inventory"] == frozenset()
+
+
+def test_long_story_ids_keep_distinct_global_progress_files() -> None:
+    prefix = "a" * 100
+    first = prefix + "left-branch-id"
+    second = prefix + "right-branch-id"
+    assert len(first) <= 128
+    assert first[:100] == second[:100]
+    assert global_progress_filename(first) != global_progress_filename(second)

--- a/test/unit/application/story/test_session.py
+++ b/test/unit/application/story/test_session.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+import pytest
+
+from application.story import (
+    JsonGlobalStoryProgressStore,
+    JsonStorySessionRepository,
+    StoryProgramMismatchError,
+    StorySession,
+)
+from config.feature_flags import (
+    FeatureDisabledError,
+    FeatureFlag,
+    FeatureFlagConfigManager,
+)
+from core.story import SelectChoice, StoryCompiler, StoryRuntime, parse_story_project
+from test.unit.core.story.story_fixtures import campus_mystery_source
+
+
+def _flags(enabled: bool = True) -> FeatureFlagConfigManager:
+    return FeatureFlagConfigManager(
+        environ={}, overrides={FeatureFlag.STORY_SYSTEM: enabled}
+    )
+
+
+def _runtime(*, global_progress: bool = False) -> StoryRuntime:
+    source = campus_mystery_source()
+    if global_progress:
+        source["variables"]["world.progress"] = {
+            "type": "integer",
+            "scope": "global",
+            "initial": 0,
+            "min": 0,
+            "max": 100,
+            "visible": True,
+        }
+        source["narrativeGraph"]["nodes"][0]["choices"][0]["effects"].append(
+            {"increment": ["world.progress", 1]}
+        )
+    program = StoryCompiler().compile(parse_story_project(source))
+    return StoryRuntime(program)
+
+
+def _choice(session: StorySession, command_id: str = "choice-1") -> SelectChoice:
+    state = session.active_branch.state
+    return SelectChoice(
+        command_id=command_id,
+        expected_revision=state.revision,
+        choice_id="prepare-investigation",
+        expected_node_id="transfer-day",
+    )
+
+
+def test_disabled_flag_prevents_session_creation_and_storage(tmp_path) -> None:
+    repository = JsonStorySessionRepository(tmp_path / "session")
+
+    with pytest.raises(FeatureDisabledError):
+        StorySession.create(
+            _runtime(),
+            _flags(False),
+            command_id="start-1",
+            repository=repository,
+        )
+
+    assert not repository.path.exists()
+
+
+def test_duplicate_command_returns_original_ack_without_advancing_revision() -> None:
+    session = StorySession.create(_runtime(), _flags(), command_id="start-1")
+    command = _choice(session)
+
+    accepted = session.execute(command)
+    duplicate = session.execute(command)
+
+    assert duplicate.duplicate is True
+    assert duplicate.event_ids == accepted.event_ids
+    assert duplicate.revision == accepted.revision
+    assert session.active_branch.state.revision == accepted.revision
+    assert session.active_branch.generation == accepted.generation
+
+
+def test_fork_restore_and_switch_preserve_branch_local_cast() -> None:
+    session = StorySession.create(_runtime(), _flags(), command_id="start-1")
+    session.execute(_choice(session))
+    main_cast = session.active_branch.state.cast_state.active_character_ids
+
+    fork = session.fork("alternate", generation=1)
+    assert fork.state.current_node_id == "transfer-day"
+    assert fork.state.cast_state.active_character_ids == ("ling",)
+
+    session.switch_branch("main")
+    assert session.active_branch.state.cast_state.active_character_ids == main_cast
+    session.restore_generation(1)
+    assert session.active_branch.state.current_node_id == "transfer-day"
+    assert session.active_branch.state.cast_state.active_character_ids == ("ling",)
+
+
+def test_session_round_trip_replays_identical_state_and_history(tmp_path) -> None:
+    runtime = _runtime()
+    repository = JsonStorySessionRepository(tmp_path / "session")
+    global_store = JsonGlobalStoryProgressStore(tmp_path / "global")
+    session = StorySession.create(
+        runtime,
+        _flags(),
+        command_id="start-1",
+        repository=repository,
+        global_store=global_store,
+        history_entries=({"role": "user", "content": "开始"},),
+    )
+    session.execute(
+        _choice(session),
+        history_entries=(
+            {"role": "user", "content": "开始"},
+            {"role": "assistant", "content": "你来到校门口。"},
+        ),
+    )
+
+    recovered = StorySession.recover(
+        runtime,
+        _flags(),
+        repository=repository,
+        global_store=global_store,
+    )
+
+    assert recovered.active_branch.state == session.active_branch.state
+    assert (
+        recovered.active_branch.history_entries == session.active_branch.history_entries
+    )
+    assert recovered.chat_snapshot() == session.chat_snapshot()
+
+
+def test_recovery_rejects_program_source_hash_mismatch(tmp_path) -> None:
+    repository = JsonStorySessionRepository(tmp_path / "session")
+    global_store = JsonGlobalStoryProgressStore(tmp_path / "global")
+    runtime = _runtime()
+    StorySession.create(
+        runtime,
+        _flags(),
+        command_id="start-1",
+        repository=repository,
+        global_store=global_store,
+    )
+    with repository.path.open(encoding="utf-8") as file:
+        payload = json.load(file)
+    payload["branches"]["main"]["state"]["programSourceHash"] = "sha256:other"
+    repository.save(payload)
+
+    with pytest.raises(StoryProgramMismatchError):
+        StorySession.recover(
+            runtime,
+            _flags(),
+            repository=repository,
+            global_store=global_store,
+        )
+
+
+def test_recovery_applies_pending_global_outbox_once(tmp_path) -> None:
+    runtime = _runtime(global_progress=True)
+    repository = JsonStorySessionRepository(tmp_path / "session")
+    global_store = JsonGlobalStoryProgressStore(tmp_path / "global")
+    session = StorySession.create(
+        runtime,
+        _flags(),
+        command_id="start-1",
+        repository=repository,
+        global_store=global_store,
+    )
+    session.failure_injector = lambda point: (
+        (_ for _ in ()).throw(RuntimeError("simulated crash"))
+        if point == "after_session_commit"
+        else None
+    )
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        session.execute(_choice(session))
+    assert global_store.load(runtime.program).variables["world.progress"] == 0
+
+    recovered = StorySession.recover(
+        runtime,
+        _flags(),
+        repository=repository,
+        global_store=global_store,
+    )
+    recovered_again = StorySession.recover(
+        runtime,
+        _flags(),
+        repository=repository,
+        global_store=global_store,
+    )
+
+    assert recovered.global_progress.variables["world.progress"] == 1
+    assert recovered_again.global_progress.variables["world.progress"] == 1
+
+
+def test_recovery_does_not_repeat_globally_applied_outbox(tmp_path) -> None:
+    runtime = _runtime(global_progress=True)
+    repository = JsonStorySessionRepository(tmp_path / "session")
+    global_store = JsonGlobalStoryProgressStore(tmp_path / "global")
+    session = StorySession.create(
+        runtime,
+        _flags(),
+        command_id="start-1",
+        repository=repository,
+        global_store=global_store,
+    )
+    session.failure_injector = lambda point: (
+        (_ for _ in ()).throw(RuntimeError("simulated crash"))
+        if point == "after_global_apply"
+        else None
+    )
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        session.execute(_choice(session))
+    assert global_store.load(runtime.program).variables["world.progress"] == 1
+
+    recovered = StorySession.recover(
+        runtime,
+        _flags(),
+        repository=repository,
+        global_store=global_store,
+    )
+
+    assert recovered.global_progress.variables["world.progress"] == 1
+
+
+def test_causal_chain_tampering_is_rejected(tmp_path) -> None:
+    runtime = _runtime()
+    repository = JsonStorySessionRepository(tmp_path / "session")
+    global_store = JsonGlobalStoryProgressStore(tmp_path / "global")
+    StorySession.create(
+        runtime,
+        _flags(),
+        command_id="start-1",
+        repository=repository,
+        global_store=global_store,
+    )
+    payload = deepcopy(repository.load())
+    assert payload is not None
+    payload["branches"]["main"]["events"][1]["parentEventId"] = "wrong"
+    repository.save(payload)
+
+    with pytest.raises(ValueError, match="causal"):
+        StorySession.recover(
+            runtime,
+            _flags(),
+            repository=repository,
+            global_store=global_store,
+        )

--- a/test/unit/application/test_event_sink.py
+++ b/test/unit/application/test_event_sink.py
@@ -615,5 +615,31 @@ class EventSinkSnapshotTests(unittest.TestCase):
         self.assertEqual(dismissed["pluginPagePresentations"], [])
 
 
+class StoryEventSinkTests(unittest.TestCase):
+    def test_structured_options_and_story_state_survive_snapshot_folding(self):
+        option = {
+            "enabled": True,
+            "expectedNodeId": "gate",
+            "expectedRevision": 3,
+            "id": "enter",
+            "label": "Enter",
+            "source": "story",
+        }
+        snapshot = fold_event_into_snapshot(
+            make_empty_chat_snapshot(),
+            {"type": "options.show", "options": ["Wait", option]},
+        )
+        snapshot = fold_event_into_snapshot(
+            snapshot,
+            {
+                "type": "story.state.replace",
+                "story": {"currentNodeId": "gate", "options": [option]},
+            },
+        )
+
+        self.assertEqual(snapshot["options"], [option])
+        self.assertEqual(snapshot["story"]["currentNodeId"], "gate")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/core/test_chat_branch_storage.py
+++ b/test/unit/core/test_chat_branch_storage.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from core.sprite.chat_branch_storage import (
     ACTIVE_HISTORY_FILENAME,
     BRANCH_TREE_FILENAME,
+    STORY_SESSION_FILENAME,
     chat_history_active_path,
     chat_history_branch_tree_path,
     load_branch_state,
@@ -215,6 +216,20 @@ class ChatBranchStorageTests(unittest.TestCase):
             self.assertEqual(_chat_history_path(state, {"historyPath": legacy_path.as_posix()}, template), legacy_path.resolve())
         finally:
             remove_chat_history_storage(root)
+
+    def test_clear_removes_story_session_document(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "session"
+            root.mkdir()
+            (root / ACTIVE_HISTORY_FILENAME).write_text("[]", encoding="utf-8")
+            (root / BRANCH_TREE_FILENAME).write_text("{}", encoding="utf-8")
+            story = root / STORY_SESSION_FILENAME
+            story.write_text("{}", encoding="utf-8")
+
+            remove_chat_history_storage(root)
+
+            self.assertFalse(root.exists())
+            self.assertFalse(story.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a feature-gated `StorySession` with branch generations, causal event heads, checkpoints, persisted command idempotency, and atomic v2 storage
- separate branch-local state from monotonic global progress and use an idempotent outbox across both crash windows
- integrate structured story choices and story snapshots into the existing chat bridge while preserving legacy behavior when `story_system` is disabled
- add typed React story options and a minimal story debug panel

## Feature flag

All new behavior requires the centralized `story_system` flag introduced by the parent PR. The flag defaults to off. Existing string options, chat history, event snapshots, and runtime commands retain their previous behavior when it is disabled.

## Verification

- `python -m pytest test/unit/core/story test/unit/application/story test/unit/application/test_event_sink.py test/unit/frontend_bridge_core/test_chat_stream_commands.py -q` (147 passed)
- `pnpm lint:types`
- `pnpm exec vitest run src/test/features/chat-stage/chatState.test.ts src/test/features/chat-stage/ChatStagePage.test.tsx` (112 passed)
- `git diff --check`

## Stack

- Base: `story/feature-flags` (#311)
- This PR: Phase 3 session protocol and chat integration

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次核对的重点轻轻收拢，方便继续查看。

此 PR 为受 `story_system` 控制的剧情会话新增了持久化与 chat-stage 结构化选项，但实时发布、会话/聊天分支一致性、并发命令和集合变量恢复仍有可达缺陷。

### New Features

- 新增 `StorySession`、分支检查点、命令幂等性以及 v2 会话和全局进度存储。
- 聊天舞台新增结构化剧情选项、协议类型与剧情调试面板。

### Tests

- 新增 StorySession 恢复/幂等性和结构化剧情选项桥接测试。

<details>
<summary>Original summary in English</summary>

This PR adds persistence and chat-stage structured options for feature-gated story sessions, but reachable defects remain in live publication, session/chat-branch consistency, concurrent commands, and set-valued-variable recovery.

### New Features

- Adds `StorySession`, branch checkpoints, command idempotency, and v2 session/global-progress storage.
- Adds structured story options, protocol types, and a story debug panel to the chat stage.

### Tests

- Adds tests for StorySession recovery/idempotency and structured story-option bridge handling.

</details>

<!-- astrbot-review:end:summary -->