### PR TITLE
docs(template): add contract-first prompt compiler design

### DIFF
--- a/ai/llm/TEMPLATE_GENERATOR_DESIGN.md
+++ b/ai/llm/TEMPLATE_GENERATOR_DESIGN.md
@@ -1,65 +1,86 @@
-# Template Generator 注册式 Prompt 编译器设计
+# Contract-first Prompt Specification Compiler 设计
 
 ## 1. 摘要
 
-当前 `template_generator.py` 实际上不是调用 LLM 生成模板，而是把角色、背景、功能开关、工具、插件补丁和本地化文案组合成运行时 system prompt。本文建议将其重构为一个注册式 Prompt Compiler：
+当前 `template_generator.py` 并不是调用 LLM 生成模板，而是把角色、背景、功能开关、工具、插件补丁和本地化文案编译成运行时 system prompt。本文建议将它重构为 Contract-first Prompt Specification Compiler。
 
-- Prompt Generator 只处理一个明确的 Prompt 片段。
-- 每个 Generator 只接收自己的窄输入 DTO，不读取完整编译上下文。
-- Registry 保存 Generator 的 ID、阶段、优先级、适用 Profile 和输入投影器。
-- Compiler 是唯一能够访问完整编译上下文并协调所有 Generator 的组件。
-- Generator 返回结构化 `PromptContribution`，不直接修改其他 Generator 的文本。
-- 继续使用现有 `OutputFieldSpec`、`RequirementSpec`、`OutputContractPatch` 和插件接口，不修改现有 Output Contract 公共契约。
-- 自由聊天和剧情模式共享同一个 Output Contract 构造与渲染流程，只注册不同的 Prompt Generator。
+该设计把 Prompt 看作确定性编译产物：
 
-该设计的核心模式是：
+1. API 请求只表达用户选择的原始事实。
+2. Resolver 解析资源并建立满足不变量的 Capability。
+3. 内置能力和插件通过同一种 Contribution 机制参与编译。
+4. Contribution 可以原子化贡献上下文 Section 和 `OutputContractPatch`。
+5. Reducer 从唯一的基础 Output Contract 开始应用 Patch，得到唯一的结构化输出契约。
+6. Assembler 生成完整 `PromptSpecification`。
+7. Validator 校验输出契约、运行时能力和文档结构。
+8. 纯 Renderer 将 Specification 渲染为最终 system prompt。
 
-- Registry：注册可用的 Prompt Generator。
-- Ordered Contributor Pipeline：按阶段和优先级执行贡献者。
-- Builder/Assembler：把多个结构化贡献组装成 Prompt Document。
-- Strategy/Profile：表达自由聊天和剧情模式的差异。
-- Adapter：将 Generator 产生的 Contract 贡献适配到现有 `OutputContractPatch`。
-- Dependency Injection + Interface Segregation：Generator 只依赖自己的输入和必要服务。
+Output Contract 是“模型必须输出什么”的唯一事实源；完整 Prompt 的唯一事实源是 `PromptSpecification`。角色设定、背景资料和工具描述属于输入上下文，不被错误地塞入 Output Contract，但可以与相关 Contract Patch 由同一个 Contribution 原子化提供。
+
+现有 `OutputFieldSpec`、`RequirementSpec`、`OutputContractPatch`、`ChatOutputContract` 和插件注册 API 保持兼容。现有 `TemplateGenerator.generate_chat_template()` 在迁移期间作为薄 Facade 保留。
 
 ## 2. 背景与现状
 
 当前实现主要存在以下问题：
 
-1. `TemplateGenerator.generate_chat_template()` 同时负责角色解析、字段定义、规则定义、背景资料、立绘资料、工具描述、插件补丁、本地化和最终字符串拼接。
-2. `generate_chat_template()` 与 `render_dialog_reply_contract()` 重复维护大量 Output Contract 字段及 Requirement 逻辑。
-3. `use_effect`、`use_cg`、`use_choice`、`use_stat` 等布尔参数不断增加，使方法签名和条件分支持续膨胀。
-4. 前端收到模板后，通过搜索“可用音效”“可调用工具”等自然语言锚点修改 system prompt，容易受语言和文案变化影响。
+1. `TemplateGenerator.generate_chat_template()` 同时负责资源解析、字段定义、规则定义、背景资料、立绘资料、工具描述、插件补丁、本地化和最终字符串拼接。
+2. `generate_chat_template()` 与 `render_dialog_reply_contract()` 重复维护 Output Contract 字段及 Requirement 逻辑。
+3. `use_effect`、`use_cg`、`use_choice`、`use_stat` 等布尔参数与对应资源分别传递，可以表达矛盾状态。
+4. 前端通过搜索“可用音效”“可调用工具”等自然语言锚点修改 system prompt。
 5. `effectNames` 已作为结构化参数发送到后端，但模板生成入口没有完整消费它。
-6. 模板生成依赖全局 `config_manager`，并可能在生成过程中保存语音语言配置，使确定性编译混入全局状态修改。
-7. 普通 Prompt 内容、Output Contract、插件扩展和运行时字段处理之间的边界不清晰。
+6. 模板生成依赖全局 `config_manager` 和全局语言状态，并可能在生成过程中保存配置。
+7. Prompt 文本、Output Contract、插件扩展和运行时字段处理没有共享唯一的结构化事实源。
+8. 插件 Patch 只按 `priority` 排序；相同优先级的冲突可能依赖插件加载顺序。
 
-## 3. 目标
+## 3. 第一性原则与不变量
 
-### 3.1 功能目标
+### 3.1 编译链路
 
-- 可以独立注册角色、背景、音效、工具、输出要求等 Generator。
-- 每个 Generator 只接收与自身相关的数据。
-- Generator 可以贡献普通 Prompt Section，也可以通过现有 `OutputContractPatch` 贡献 JSON 字段或 Requirement。
-- 支持稳定、可预测、可测试的执行顺序。
-- 自由聊天和剧情模式复用同一套 Contract 构造逻辑。
-- 插件继续使用现有 Output Contract 扩展 API。
-- 最终 Prompt 在迁移期间保持向后兼容。
+```text
+TemplateGenerateRequest
+    -> CompilationSourceResolver
+    -> PromptCompilationSource
+    -> Registered Contributions
+    -> ResolvedOutputContract + Structured Sections
+    -> PromptSpecification
+    -> Validation
+    -> Localized Renderer
+    -> System Prompt
+```
 
-### 3.2 质量目标
+每一层只做一次语义转换。上游保留事实，下游消费已经验证的模型，不重新猜测上游意图。
 
-- 同一输入产生稳定输出。
-- 单个 Generator 可以独立单元测试。
-- Generator 的异常能够定位到稳定 ID。
-- 不允许通过字符串搜索修改其他 Generator 的输出。
-- 新增功能时不需要修改一个巨大的 `generate_chat_template()`。
+### 3.2 必须成立的不变量
 
-## 4. 非目标
+- Profile 只有一个来源。
+- 同一能力不同时使用“启用开关”和“可用资源”作为两个事实源。
+- 基础 Contract 只包含运行时不可取消的字段和要求。
+- JSON 示例、字段说明和 Requirement 从同一个 `ResolvedOutputContract` 渲染。
+- 内置能力与插件都不能直接修改最终字符串。
+- 同一输入、同一 Registry 快照和同一本地化目录产生字节级稳定输出。
+- Registry 在插件加载结束后冻结，单次编译期间不可变。
+- 编译过程不读取或修改全局配置。
+- Prompt 声明的内置运行时字段必须由运行时支持。
 
-- 本次设计不修改 LLM 对话 JSON 的运行时解析协议。
-- 不修改 `OutputFieldSpec`、`RequirementSpec`、`OutputContractPatch` 或 `ChatOutputContract` 的公共定义。
-- 不自动赋予自定义 JSON 字段运行时语义。字段的解析和执行仍由对应运行时处理器负责。
-- 不在第一阶段移除现有 `TemplateGenerator.generate_chat_template()` 公共入口；它将作为兼容 Facade 保留。
-- 不让插件直接获得或修改完整 Prompt Document。
+## 4. 目标与非目标
+
+### 4.1 目标
+
+- 内置能力与插件使用同一种 Contribution/Patch 机制。
+- 新增普通能力时只需新增 Resolver、Contributor 和注册项，不修改 Compiler。
+- Output Contract 成为输出格式和 Requirement 的唯一事实源。
+- 相关上下文、输出字段和 Requirement 原子化出现或消失。
+- 自由聊天和剧情模式共享 Contract Reducer、Validator 和 Renderer。
+- 保持插件 Output Contract Patch API 兼容。
+- 支持稳定排序、冲突检测、结构化错误和请求级本地化。
+
+### 4.2 非目标
+
+- 不修改 LLM 对话 JSON 的运行时解析协议。
+- 不在第一阶段删除 `TemplateGenerator.generate_chat_template()` 公共入口。
+- 不允许插件直接访问或修改最终 Prompt 字符串。
+- 不把角色资料、世界观或工具说明伪装成 Output Contract 字段。
+- 不自动为插件自定义字段创造运行时语义；插件需要声明它是 Prompt-only 数据或注册运行时能力。
 
 ## 5. 总体架构
 
@@ -68,86 +89,146 @@ flowchart TD
     A["TemplateGenerateRequest"] --> B["CompilationSourceResolver"]
     B --> C["PromptCompilationSource"]
     C --> D["PromptCompiler"]
-    D --> E["PromptGeneratorRegistry"]
+    D --> E["Frozen Contribution Registry"]
     E --> F["Input Projector"]
-    F --> G["Narrow Generator Input"]
-    G --> H["Prompt Generator"]
+    F --> G["Narrow Contributor Input"]
+    G --> H["Built-in / Plugin Contributor"]
     H --> I["PromptContribution"]
-    I --> J["PromptDocumentAssembler"]
-    J --> K["Existing OutputContractPatch Pipeline"]
-    K --> L["Contract Validator"]
-    L --> M["Localized Prompt Renderer"]
-    M --> N["System Prompt"]
+    I --> J["Contract Reducer"]
+    I --> K["Section Assembler"]
+    J --> L["ResolvedOutputContract"]
+    K --> M["PromptSpecification"]
+    L --> M
+    M --> N["Specification Validator"]
+    N --> O["Localized Prompt Renderer"]
+    O --> P["System Prompt"]
 ```
 
-只有 `CompilationSourceResolver` 和 `PromptCompiler` 知道完整上下文。Prompt Generator 只看到注册时投影出的窄输入 DTO。
+Compiler 只负责编排，不认识 Effect、CG、Choice、Translation 等业务能力。所有业务差异通过已注册 Contribution 表达。
 
-## 6. 核心领域模型
+## 6. 请求事实与解析后的 Capability
 
-### 6.1 完整编译源
+### 6.1 原始请求
 
-完整编译源是 Compiler 内部模型，不暴露给 Generator：
+```python
+@dataclass(frozen=True)
+class TemplateGenerateRequest:
+    profile: PromptProfileId
+    character_names: tuple[str, ...]
+    background_name: str | None
+    effect_names: tuple[str, ...]
+    enabled_features: frozenset[FeatureId]
+    ui_language: str
+    voice_language: str
+    limits: PromptLimits
+```
+
+请求 DTO 不直接传给 Contributor。Resolver 负责规范化名称、读取 Repository、处理缺失资源和建立 Capability。
+
+### 6.2 解析后的编译源
 
 ```python
 @dataclass(frozen=True)
 class PromptCompilationSource:
-    profile: str
+    profile: PromptProfile
     language: str
     voice_language: str
-    characters: tuple[CharacterConfig, ...]
-    background: BackgroundConfig | None
-    effects: tuple[EffectConfig, ...]
-    tools: tuple[ToolDescription, ...]
-    features: PromptFeatures
+    characters: CharacterCapability
+    background: BackgroundCapability | None
+    effects: EffectCapability | None
+    translation: TranslationCapability | None
+    choice: ChoiceCapability | None
+    narration: NarrationCapability | None
+    stat: StatCapability | None
+    cg: CgCapability | None
+    cot: CotCapability | None
+    tools: ToolCapability | None
     limits: PromptLimits
-    output_contract_patches: tuple[OutputContractPatch, ...]
+    plugin_contract_patches: tuple[OutputContractPatch, ...]
 ```
 
-该类型只用于解析和协调，不传给具体 Generator。
-
-### 6.2 窄输入 DTO
-
-每个 Generator 定义自己的输入：
+Capability 的存在表示该能力已启用且数据满足最低不变量：
 
 ```python
 @dataclass(frozen=True)
-class CharacterPromptInput:
-    characters: tuple[CharacterConfig, ...]
-    language: str
-
-
-@dataclass(frozen=True)
-class EffectPromptInput:
-    enabled: bool
+class EffectCapability:
     effects: tuple[EffectConfig, ...]
-    language: str
+    allow_unlisted: bool = False
 
-
-@dataclass(frozen=True)
-class BackgroundPromptInput:
-    background: BackgroundConfig | None
-    include_bgm: bool
-    language: str
+    def __post_init__(self) -> None:
+        if not self.effects and not self.allow_unlisted:
+            raise ValueError("Effect capability requires effects or allow_unlisted")
 ```
 
-如果 Generator 后续确实需要新数据，应显式扩展自己的 DTO，而不是改为接收完整 Context。
+Resolver 必须明确区分：
 
-### 6.3 Prompt Section
+- 用户没有启用能力：Capability 为 `None`。
+- 部分资源名称失效：记录结构化警告并使用剩余资源。
+- 所有资源失效：根据 API 策略报错或显式降级，不能静默生成空能力。
 
-普通 Prompt 文本使用结构化 Section 表达：
+Profile 只保存在 `PromptCompilationSource`，`compiler.compile(source)` 不再接收第二个 Profile 参数。
+
+## 7. Prompt Specification
+
+### 7.1 结构化 Section
 
 ```python
+class PromptSectionKind(StrEnum):
+    CAST_CONTEXT = "cast_context"
+    WORLD_CONTEXT = "world_context"
+    CAPABILITY = "capability"
+    TOOL = "tool"
+    CLOSING = "closing"
+
+
 @dataclass(frozen=True)
 class PromptSection:
     id: str
-    content: str
+    kind: PromptSectionKind
+    title_key: str | None
+    body: PromptBody
 ```
 
-Section 的阶段和优先级属于注册信息，不属于文本本身。
+`PromptBody` 可以是已转义文本，也可以是 Renderer 支持的结构化列表、键值表或资源列表。标题、本地化、空行和文档级格式由 Renderer 负责，Contributor 不把自然语言标题烘焙进大字符串。
 
-### 6.4 Prompt Contribution
+### 7.2 内部唯一 Output Contract
 
-Generator 可以同时贡献普通文本和现有 Contract Patch：
+公共 `ChatOutputContract` 不包含可 Patch 的 Requirement ID，因此编译过程使用内部结构化模型，并在边界适配回现有公共类型：
+
+```python
+@dataclass(frozen=True)
+class ResolvedOutputContract:
+    id: str
+    fields: tuple[OutputFieldSpec, ...]
+    requirements: tuple[RequirementSpec, ...]
+    stream_mode: Literal["json_object", "json_lines", "json_array"]
+    target_export: str
+    protected_fields: frozenset[str]
+```
+
+它是以下内容的唯一来源：
+
+- JSON 输出示例。
+- Output field notes。
+- Requirement 列表。
+- JSON Schema。
+- `ChatOutputContract` 适配结果。
+- 运行时兼容性校验输入。
+
+### 7.3 完整 Specification
+
+```python
+@dataclass(frozen=True)
+class PromptSpecification:
+    profile: PromptProfile
+    sections: tuple[PromptSection, ...]
+    output_contract: ResolvedOutputContract
+    policies: PromptPolicies
+```
+
+Renderer 只消费 `PromptSpecification` 和请求级 Translator，不读取 Registry、Repository 或全局配置。
+
+## 8. Contribution 模型
 
 ```python
 @dataclass(frozen=True)
@@ -156,43 +237,121 @@ class PromptContribution:
     contract_patch: OutputContractPatch | None = None
 ```
 
-普通 Generator 不获得可变 Prompt Builder，也不能直接删除或修改其他 Generator 的 Section。
+一个能力可以原子化贡献“模型需要知道什么”和“模型必须输出什么”。例如 Effect Contribution 同时提供可用 Effect 列表、`effect` 字段和 `r_effect` Requirement。Contribution 要么完整加入，要么不加入，避免三者漂移。
 
-## 7. Generator 接口
+现有插件仍注册 `OutputContractPatch`。`PluginOutputContractPatchAdapter` 在编译边界将它包装成不包含 Section、`layer=PLUGIN` 的 Contribution，因此不要求插件迁移到新的内部 Registry API。
+
+### 8.1 窄输入 Contributor
 
 ```python
 InputT = TypeVar("InputT")
 
 
-class PromptGenerator(Protocol[InputT]):
-    def generate(self, data: InputT) -> PromptContribution | None:
+class PromptContributor(Protocol[InputT]):
+    def contribute(self, data: InputT) -> PromptContribution | None:
         ...
 ```
 
-Generator 应尽量是纯函数：
+Contributor 应是纯函数：
 
 - 不读取全局 `config_manager`。
 - 不保存系统配置。
-- 不访问 Registry。
-- 不读取其他 Generator 的输出。
-- 不依赖最终 Prompt 中的自然语言标题或文本位置。
+- 不访问 Registry 或其他 Contribution。
+- 不依赖最终 Prompt 的自然语言位置。
+- 不直接渲染文档标题和全局空行。
 
-翻译器、日志器等稳定服务通过构造函数注入：
+## 9. 基础 Contract 与内置 Contribution
+
+### 9.1 最小基础 Contract
+
+基础 Contract 只包含运行时不可取消的不变量：
 
 ```python
-class EffectPromptGenerator:
-    def __init__(self, translator: TemplateTranslator) -> None:
-        self._translator = translator
-
-    def generate(self, data: EffectPromptInput) -> PromptContribution | None:
-        ...
+BASE_DIALOG_CONTRACT_SPEC = BaseOutputContractSpec(
+    id=DEFAULT_DIALOG_CONTRACT_ID,
+    field_specs=(CHARACTER_NAME_FIELD, SPRITE_FIELD, SPEECH_FIELD),
+    requirement_specs=(
+        FORMAT_REQUIREMENT,
+        CHARACTER_NAME_REQUIREMENT,
+        SPRITE_REQUIREMENT,
+        SPEECH_REQUIREMENT,
+    ),
+    protected_fields=frozenset({"character_name", "sprite", "speech"}),
+    stream_mode="json_object",
+    target_export="llm.output",
+)
 ```
 
-## 8. 注册模型
+基础字段的形状是常量，但包含角色名称的文案不是全局常量。`BaseOutputContractFactory` 使用必需的 `CharacterCapability` 和请求级 Translator 将上述 Spec 实例化为初始 `ResolvedOutputContract`。它只填充基础不可变量，不包含 Effect、CG、Choice 等可选功能分支。
 
-### 8.1 阶段
+### 9.2 可选内置能力全部使用 Contribution
 
-仅依赖单个全局数字优先级容易产生隐式耦合，因此使用“阶段 + 阶段内优先级 + ID”的稳定顺序：
+以下能力不再作为 Contract Builder 中的 `if` 分支：
+
+```text
+core.translation
+core.effects
+core.choice
+core.narration
+core.stat
+core.cg
+core.scene
+core.bgm
+core.cot
+core.limits
+```
+
+以 Effect 为例：
+
+```python
+@dataclass(frozen=True)
+class EffectPromptInput:
+    capability: EffectCapability
+    language: str
+
+
+class EffectContributor:
+    def __init__(self, translator_catalog: TemplateTranslatorCatalog) -> None:
+        self._translator_catalog = translator_catalog
+
+    def contribute(self, data: EffectPromptInput) -> PromptContribution:
+        translator = self._translator_catalog.for_locale(data.language)
+        return PromptContribution(
+            sections=(
+                PromptSection(
+                    id="core.available_effects",
+                    kind=PromptSectionKind.CAPABILITY,
+                    title_key="available_effects",
+                    body=EffectListBody(data.capability.effects),
+                ),
+            ),
+            contract_patch=OutputContractPatch(
+                id="core.effects",
+                target_contract=DEFAULT_DIALOG_CONTRACT_ID,
+                priority=170,
+                add_fields=(
+                    OutputFieldSpec(
+                        key="effect",
+                        type="string",
+                        description=translator.text("template_gen.r_effect"),
+                    ),
+                ),
+                add_requirements=(
+                    RequirementSpec(
+                        id="r_effect",
+                        text=translator.text("template_gen.r_effect"),
+                        order=170,
+                    ),
+                ),
+            ),
+        )
+```
+
+内置 Contributor 通过显式语言选择请求级 Translator，`OutputFieldSpec` 和 `RequirementSpec` 中保存确定的最终文本。公共插件仍可以提交已经渲染的文本，以保持兼容。Translator Catalog 是只读稳定服务，不能依赖全局 `current_language()`。
+
+## 10. Registration、排序与 Profile
+
+### 10.1 阶段
 
 ```python
 class PromptPhase(IntEnum):
@@ -205,15 +364,35 @@ class PromptPhase(IntEnum):
     CLOSING = 900
 ```
 
-最终排序键：
+阶段是稳定扩展槽；普通新功能应复用已有阶段。只有出现新的全局语义边界时才增加阶段。
 
 ```python
-(registration.phase, registration.priority, registration.id)
+class ContributionLayer(IntEnum):
+    BUILTIN = 100
+    PLUGIN = 200
 ```
 
-ID 用于相同优先级下的确定性排序，同时用于错误报告和重复注册检测。
+### 10.2 Profile Selector
 
-### 8.2 注册信息
+共享 Contributor 默认适用于所有 Profile，不显式枚举 `free_chat`、`story`：
+
+```python
+@dataclass(frozen=True)
+class ProfileSelector:
+    include: frozenset[PromptProfileId] | None = None  # None means all
+    exclude: frozenset[PromptProfileId] = frozenset()
+```
+
+Profile 由 `ProfileRegistry` 验证并可声明父 Profile 或 Capability 标签。Profile 专属 Contributor 使用显式 `include`。
+
+### 10.3 失败策略
+
+```python
+class FailurePolicy(StrEnum):
+    FAIL_FAST = "fail_fast"
+    SKIP_WITH_WARNING = "skip_with_warning"
+    USE_FALLBACK = "use_fallback"
+```
 
 ```python
 @dataclass(frozen=True)
@@ -221,434 +400,326 @@ class PromptRegistration(Generic[InputT]):
     id: str
     phase: PromptPhase
     priority: int
-    profiles: frozenset[str]
+    profiles: ProfileSelector
     select_input: Callable[[PromptCompilationSource], InputT | None]
-    generator: PromptGenerator[InputT]
-    required: bool = False
+    contributor: PromptContributor[InputT]
+    failure_policy: FailurePolicy = FailurePolicy.FAIL_FAST
+    fallback: PromptContribution | None = None
+    layer: ContributionLayer = ContributionLayer.BUILTIN
 ```
 
-优先级和 Profile 属于“如何参与编译流程”，因此放在 Registration，而不是 Generator 内部。
+`select_input` 是 Composition Root 中的适配边界，只有它和 Compiler 可以看见完整 Source。Contributor 始终只接收窄输入。
 
-### 8.3 类型擦除边界
+Registration Validator 要求 `USE_FALLBACK` 必须提供 fallback，其他失败策略不得携带 fallback，避免再次产生组合状态歧义。
 
-Registry 内需要保存不同输入类型的 Generator。泛型类型检查在 `register()` 时完成，Registry 内部保存已经绑定的执行函数：
+### 10.4 确定性排序和冻结
+
+Registration 按以下键排序：
 
 ```python
-class PromptGeneratorRegistry:
-    def register(
-        self,
-        *,
-        id: str,
-        phase: PromptPhase,
-        priority: int,
-        profiles: frozenset[str],
-        select_input: Callable[[PromptCompilationSource], InputT | None],
-        generator: PromptGenerator[InputT],
-        required: bool = False,
-    ) -> None:
-        def contribute(source: PromptCompilationSource) -> PromptContribution | None:
-            data = select_input(source)
-            if data is None:
-                return None
-            return generator.generate(data)
-
-        self._store_erased_registration(
-            id=id,
-            phase=phase,
-            priority=priority,
-            profiles=profiles,
-            contribute=contribute,
-            required=required,
-        )
+(registration.layer, registration.phase, registration.priority, registration.id)
 ```
 
-Generator 本身仍保持完整的窄输入类型信息。
+同一 ID 重复注册立即失败。Registry 在插件加载完成后冻结；Compiler 每次使用不可变 Registry 快照。
 
-## 9. 注册示例
+Built-in 和 Plugin 使用相同 Contribution、Reducer 和 Validator，但权限不同：
 
-### 9.1 Character Generator
+- Plugin Contribution 在 Built-in 之后应用，以保留插件覆盖核心描述的现有语义。
+- Plugin 不能删除受保护字段。
+- 新增重复字段必须报错；修改字段必须使用 `field_patches`。
+
+## 11. Contract Reducer 与冲突规则
+
+Reducer 从 `BaseOutputContractFactory` 创建的初始 Contract 开始：
+
+1. 应用 Built-in Contribution Patch。
+2. 应用 Plugin Patch。
+3. 验证字段、Requirement 和运行时能力。
+4. 生成不可变 `ResolvedOutputContract`。
+
+Plugin Patch 也必须按稳定键排序：
 
 ```python
-registry.register(
-    id="core.characters",
-    phase=PromptPhase.CAST_CONTEXT,
-    priority=100,
-    profiles=frozenset({"free_chat", "story"}),
-    select_input=lambda source: CharacterPromptInput(
-        characters=source.characters,
-        language=source.language,
-    ),
-    generator=CharacterPromptGenerator(translator),
-    required=True,
-)
+(patch.priority, patch.id)
 ```
 
-### 9.2 Effect Generator
+冲突规则：
 
-```python
-registry.register(
-    id="core.effects",
-    phase=PromptPhase.CAPABILITIES,
-    priority=200,
-    profiles=frozenset({"free_chat", "story"}),
-    select_input=lambda source: EffectPromptInput(
-        enabled=source.features.use_effect,
-        effects=source.effects,
-        language=source.language,
-    ),
-    generator=EffectPromptGenerator(translator),
-)
-```
-
-Effect Generator 不知道角色、背景、CG、Choice 或完整 Output Contract。
-
-## 10. Output Contract 兼容设计
-
-### 10.1 保留现有公共类型
-
-以下现有类型和接口保持不变：
-
-- `DEFAULT_DIALOG_CONTRACT_ID`
-- `OutputFieldSpec`
-- `RequirementSpec`
-- `FieldPatch`
-- `RequirementPatch`
-- `OutputContractPatch`
-- `ChatOutputContract`
-- 插件 Output Contract Patch 注册接口
-
-新增 Pipeline 只负责生产和收集现有 `OutputContractPatch`。
-
-### 10.2 基础 Contract
-
-基础 Contract 仍由核心代码拥有，包含受保护字段：
-
-- `character_name`
-- `sprite`
-- `speech`
-
-这些字段不能被普通 Generator 或插件删除。现有保护行为必须保留。
-
-### 10.3 Generator 贡献 Contract Patch
-
-例如 Effect Generator：
-
-```python
-class EffectPromptGenerator:
-    def generate(self, data: EffectPromptInput) -> PromptContribution | None:
-        if not data.enabled:
-            return None
-
-        return PromptContribution(
-            sections=(
-                PromptSection(
-                    id="available_effects",
-                    content=render_available_effects(data.effects),
-                ),
-            ),
-            contract_patch=OutputContractPatch(
-                id="core.prompt.effects",
-                target_contract=DEFAULT_DIALOG_CONTRACT_ID,
-                priority=170,
-                add_fields=(
-                    OutputFieldSpec(
-                        key="effect",
-                        type="string",
-                        description=translate("r_effect"),
-                        required=False,
-                    ),
-                ),
-                add_requirements=(
-                    RequirementSpec(
-                        id="r_effect",
-                        text=translate("r_effect"),
-                        order=170,
-                    ),
-                ),
-            ),
-        )
-```
-
-### 10.4 Patch 应用顺序
-
-为保持插件覆盖核心行为的现有语义，Patch 分两层应用：
-
-1. 从基础 Contract 开始。
-2. 应用内置 Prompt Generator 产生的 Patch。
-3. 按现有 `priority` 规则应用插件 Patch。
-4. 执行 Contract 校验。
-5. 使用唯一 Renderer 输出格式说明和 Requirement 文本。
-
-内置 Generator 的注册优先级决定其执行和 Section 顺序；插件 Patch 的 `priority` 只在插件 Patch 层内排序。
-
-### 10.5 冲突规则
-
-- Registration ID 必须唯一，重复注册立即报错。
-- Prompt Section ID 在同一 Profile 的最终文档中必须唯一。
-- 内置 Generator 添加重复字段 key 时立即报错，不静默覆盖。
-- 内置 Generator 添加重复 Requirement ID 时立即报错。
-- 插件修改仍使用现有 `field_patches` 和 `requirement_patches` 语义。
-- 插件不能删除受保护字段。
-- `field_patches` 指向不存在字段时记录结构化警告。
-- `requirement_patches` 指向不存在 Requirement 时记录结构化警告。
+- Registration ID、Patch ID 和最终 Section ID 必须唯一。
+- `target_contract` 不存在时产生结构化警告并跳过。
+- `add_fields` 添加已有 key 时失败；覆盖必须使用 `field_patches`。
+- `add_requirements` 添加已有 ID 时失败；覆盖必须使用 `requirement_patches`。
+- Patch 指向不存在字段或 Requirement 时记录结构化警告。
+- 插件不能删除 `protected_fields`。
+- 最终字段保持基础字段顺序，再按 Contribution 排序追加。
 - 最终 Requirement 按 `(order, id)` 排序。
-- 最终 Contract 必须经过必需字段、重复 ID 和字段类型校验。
+- 相同优先级 Patch 通过 ID 获得稳定顺序，不能依赖插件加载顺序。
+- 字段类型、必需字段、Schema 和流模式必须经过校验。
 
-### 10.6 Contract 与运行时行为
+## 12. 运行时契约适配与校验
 
-`OutputContractPatch` 只描述 LLM 输出格式和要求，不自动注册运行时行为。例如添加 `emotion` 字段不会自动切换立绘；需要由独立运行时字段处理器解释它。
+Prompt Contract 只声明输出格式，不自动创造运行时行为。但内置字段必须和运行时事实一致。
 
-## 11. Prompt Document 组装
+为避免破坏公共 `OutputFieldSpec`，运行时绑定保存在独立内部 Manifest：
 
 ```python
 @dataclass(frozen=True)
-class PromptDocument:
-    sections: tuple[PromptSection, ...]
-    format_block: str
-    requirements_block: str
+class RuntimeFieldCapability:
+    field_key: str
+    accepted_types: frozenset[str]
+    handler_id: str | None
+    passthrough_allowed: bool = False
 ```
 
-Assembler 负责：
+Validator 至少检查：
 
-- 收集非空 Contribution。
-- 验证 Section ID。
-- 收集内置 Contract Patch。
-- 调用统一 Output Contract 构造器。
-- 生成结构化 Prompt Document。
+- `character_name`、`sprite`、`speech` 与 `LLMDialogMessage` 一致。
+- 内置 `effect`、`translate` 等字段具有对应运行时能力。
+- `stream_mode` 与实际 Parser 支持范围一致。
+- Plugin 自定义字段可以通过新增的可选 companion API 注册 Runtime capability；未注册的现有插件字段按 Prompt-only passthrough 处理，以保持兼容并记录诊断信息。
+
+最终 `ResolvedOutputContract` 通过 Adapter 转换成现有 `ChatOutputContract`，不修改现有公共 SDK 类型。可选 Runtime capability 注册是增量 API，不改变现有 `OutputContractPatch` 的构造和注册方式。
+
+## 13. Assembler 与 Renderer
+
+Assembler 收集 Contribution、验证 Section ID、调用 Contract Reducer，并生成 `PromptSpecification`。
 
 Renderer 负责：
 
-- 按已排序 Section 输出文本。
-- 统一空行和标题格式。
+- 按已排序 Section 输出本地化标题和内容。
+- 从 `ResolvedOutputContract` 生成 JSON 示例、字段说明和 Requirement。
+- 统一空行、列表和转义规则。
 - 保证 JSON 格式提醒位于结尾。
 - 保证相同输入产生字节级稳定输出。
 
-普通 Generator 不负责全局空行、最终结束提醒或文档级格式。
-
-## 12. Profile 与模式差异
-
-自由聊天和剧情模式使用相同 Registry 和 Compiler，但选择不同 Profile：
+Translator 必须是请求级、locale-bound 的不可变对象：
 
 ```python
-free_prompt = compiler.compile(source, profile="free_chat")
-story_prompt = compiler.compile(source, profile="story")
+renderer = PromptRenderer(translator_catalog.for_locale(source.language))
 ```
 
-可通过以下方式表达差异：
+禁止 Renderer 或 Contributor 调用全局 `current_language()` 决定请求语言。
 
-- Registration 的 `profiles` 属性。
-- 不同 Profile 使用不同输入投影器。
-- Profile 自己提供少量专属 Generator，例如剧情阶段上下文或隐藏目标。
-
-禁止重新实现一套独立的 Output Contract Builder。自由聊天和剧情模式必须共享：
-
-- 基础字段定义。
-- Requirement 构造。
-- Contract Patch 应用。
-- Contract 校验。
-- Contract Renderer。
-
-## 13. 前后端边界
+## 14. 前后端边界
 
 前端只发送结构化生成请求：
 
 ```json
 {
+  "profile": "free_chat",
   "characters": ["Mio", "Aoi"],
   "backgroundName": "Classroom",
   "effectNames": ["Rain", "Door"],
-  "useEffect": true,
-  "useChoice": true,
+  "enabledFeatures": ["effect", "choice"],
+  "uiLanguage": "zh_CN",
   "voiceLanguage": "ja"
 }
 ```
 
-后端负责解析资源并生成完整 system prompt。前端不再：
+后端生成完整 system prompt。前端不再搜索、删除或插入自然语言 Prompt 段落。
 
-- 搜索“可用音效”字符串。
-- 搜索“可调用工具”字符串。
-- 删除旧 Prompt 段落。
-- 把新段落插入某个自然语言标题前。
+模板编辑器仍可允许用户手动修改生成后的 Prompt，但结构化参数变化后重新生成时，以后端输出为准。产品层应提示重新生成会覆盖手动编辑，或将手动内容保存为独立 User Override Section。
 
-模板编辑器仍可允许用户手动修改生成后的 system prompt，但结构化参数变化后重新生成时，以后端 Compiler 输出为准。
+## 15. 错误处理与可观测性
 
-## 14. 错误处理与可观测性
-
-建议使用稳定错误信息：
+稳定错误码至少包括：
 
 ```text
-prompt.generator.duplicate_id
-prompt.generator.input_failed
-prompt.generator.generate_failed
+prompt.profile.unknown
+prompt.capability.invalid
+prompt.registry.frozen
+prompt.contributor.duplicate_id
+prompt.contributor.input_failed
+prompt.contributor.contribute_failed
 prompt.section.duplicate_id
+prompt.contract.patch_duplicate_id
+prompt.contract.patch_target_missing
 prompt.contract.duplicate_field
 prompt.contract.duplicate_requirement
-prompt.contract.patch_target_missing
 prompt.contract.protected_field
+prompt.contract.runtime_unsupported
 prompt.contract.validation_failed
 ```
 
-日志至少包含：
+日志至少包含 `profile`、`contributor_id`、`layer`、`phase`、`priority`、`contract_patch_id`、`failure_policy` 和 `duration_ms`。
 
-- `profile`
-- `generator_id`
-- `phase`
-- `priority`
-- `contract_patch_id`
-- `duration_ms`
+不得记录完整角色隐私内容或完整 system prompt，除非明确处于开发调试模式。任何失败都不能被静默吞掉。
 
-不得记录完整角色隐私内容或完整 system prompt，除非明确处于开发调试模式。
-
-Required Generator 失败时终止编译；Optional Generator 失败是否降级必须由注册策略明确指定，不能静默吞掉异常。
-
-## 15. 建议代码布局
+## 16. 建议代码布局
 
 ```text
 ai/llm/
-├── template_generator.py          # 兼容 Facade，迁移完成后保持薄层
+├── template_generator.py          # 兼容 Facade
 ├── TEMPLATE_GENERATOR_DESIGN.md
 └── prompt_compiler/
-    ├── __init__.py
-    ├── models.py                  # Source、Section、Contribution、Profile
-    ├── registry.py                # Registration 与排序
-    ├── compiler.py                # 编译流程
-    ├── contract.py                # 现有 Contract Patch 的统一应用与校验
-    ├── renderer.py                # 本地化 Prompt 渲染
-    ├── resolvers.py               # 角色、背景、音效、工具解析
-    └── generators/
+    ├── request.py                 # API 请求事实
+    ├── capabilities.py            # 满足不变量的 Capability
+    ├── models.py                  # Section、Contribution、Specification
+    ├── profiles.py                # Profile Registry 与 Selector
+    ├── registry.py                # Registration、排序与冻结
+    ├── compiler.py                # 纯编排
+    ├── contract.py                # Base Contract、Reducer、Adapter
+    ├── runtime_contract.py        # 运行时能力 Manifest 与校验
+    ├── renderer.py                # 请求级本地化渲染
+    ├── resolvers.py               # Repository -> Capability
+    └── contributors/
         ├── characters.py
         ├── sprites.py
         ├── background.py
         ├── effects.py
+        ├── translation.py
         ├── tools.py
-        ├── requirements.py
+        ├── choices.py
+        ├── stats.py
         └── closing.py
 ```
 
-## 16. 渐进迁移方案
+## 17. 渐进迁移方案
 
-### 阶段 0：锁定现有输出
+### 阶段 0：锁定完整行为
 
-- 为典型自由聊天组合增加 golden/snapshot 测试。
-- 覆盖透明背景、真实背景、多角色、Effect、CG、Choice、Stat、Translation、CoT 和限制参数。
-- 覆盖插件字段与 Requirement Patch。
-- 锁定剧情模式 Contract 输出。
+- 为自由聊天和剧情模式增加 golden/snapshot 测试。
+- 覆盖背景、多角色、Effect、CG、Choice、Stat、Translation、CoT、限制参数和缺失资源。
+- 覆盖插件字段、Requirement Patch、相同优先级和冲突场景。
+- Golden 测试覆盖后端输出及当前前端字符串注入后的最终 Prompt。
 
-### 阶段 1：提取统一 Contract 构造器
+### 阶段 1：建立唯一 ResolvedOutputContract
 
-- 把 `generate_chat_template()` 与 `render_dialog_reply_contract()` 重复的字段、Requirement 和 Patch 逻辑提取到唯一内部函数。
-- 保持函数签名和最终输出不变。
-- 现有 `TemplateGenerator` 继续作为调用入口。
+- 提取基础 Contract、Reducer、Validator 和 Renderer。
+- 两个现有入口调用同一 Contract 流程。
+- JSON 示例、字段说明和 Requirement 全部从同一 Contract 渲染。
+- 保持公共函数签名和现有输出不变。
 
-### 阶段 2：引入 Registry 和 Prompt Document
+### 阶段 2：迁移内置可选能力
 
-- 新增模型、Registry、Compiler、Assembler 和 Renderer。
-- 先迁移 Character、Sprite、Background 和 Tools Section。
-- 旧入口把位置参数转换为 `PromptCompilationSource`，再调用 Compiler。
+- 将 Translation、Effect、CG、Choice、Narration、Stat、CoT 和限制改造成 Built-in Contribution。
+- 删除 Contract Builder 中对应的布尔条件分支。
+- 每迁移一个能力，同时迁移 Section、字段和 Requirement。
 
-### 阶段 3：迁移可选功能
+### 阶段 3：引入 Capability Resolver 和结构化 Section
 
-- 依次迁移 Translation、Effect、CG、Choice、Narration、Stat 和 CoT。
-- 每迁移一个功能，同时迁移其 Section 和现有 Contract Patch 贡献。
-- 每一步进行新旧 Prompt 字节级或语义级对比。
+- API 请求解析为满足不变量的 Capability。
+- 迁移 Character、Sprite、Background 和 Tools Section。
+- 标题、本地化和空行转移到 Renderer。
+- 旧入口把位置参数转换为 Request，再调用 Resolver 和 Compiler。
 
-### 阶段 4：移除前端字符串注入
+### 阶段 4：统一插件 Patch Reducer
 
-- 后端根据 `effectNames` 生成音效 Section。
-- 删除前端对“可用音效”和“可调用工具”的字符串搜索及插入。
-- 保留前端结构化选项和手动 Prompt 编辑能力。
+- 插件与内置能力共享 Reducer、Validator 和稳定排序。
+- 增加 Patch ID 唯一性和 `(priority, id)` 排序。
+- 对依赖旧加载顺序的插件冲突提供诊断和迁移说明。
 
-### 阶段 5：统一剧情模式
+### 阶段 5：移除前端字符串注入
 
-- 剧情模式改用同一 Compiler 和 Contract 构造器。
-- 剧情专属场景、进度、工具和工作流由 Profile 专属 Generator 贡献。
-- 删除重复 Contract 渲染代码。
+- 后端根据 `effectNames` 解析 `EffectCapability`。
+- 删除前端对自然语言锚点的搜索及插入。
+- 手动编辑改为显式 User Override Section 或清晰的覆盖提示。
 
-### 阶段 6：清理全局依赖
+### 阶段 6：统一剧情 Profile
 
-- Resolver 显式注入 Config Repository、Tool Registry 和 Translator。
+- 剧情模式使用同一个 Compiler、Contract Reducer 和 Renderer。
+- 剧情专属内容由 Profile 专属 Contributor 提供。
+- 共享 Contributor 默认适用于所有 Profile。
+
+### 阶段 7：清理全局依赖
+
+- Resolver 显式注入 Config Repository、Tool Registry 和 Translator Catalog。
 - 编译过程不保存 `voice_language` 或其他全局配置。
-- API 层决定是否单独保存用户配置，Compiler 只消费请求值。
+- API 层决定是否保存用户配置，Compiler 只消费请求快照。
 
-## 17. 测试策略
+## 18. 测试策略
 
-### 17.1 Generator 单元测试
+### 18.1 Resolver 与 Capability
 
-- 每个 Generator 只构造自己的窄输入 DTO。
-- 验证启用、禁用和空输入。
-- 验证只产生声明的 Section 和 Contract Patch。
-- 验证 Generator 不依赖其他功能数据。
+- 部分、全部资源名称失效时的行为。
+- 不允许构造矛盾 Capability。
+- Profile 只从一个来源解析。
 
-### 17.2 Registry 测试
+### 18.2 Contributor
 
-- 阶段排序。
-- 同阶段优先级排序。
-- 相同优先级按 ID 确定性排序。
-- 重复 ID 报错。
-- Profile 过滤。
-- Input Projector 返回 `None` 时跳过。
+- Contributor 只使用窄输入。
+- 相关 Section、字段和 Requirement 原子化出现。
+- 不依赖全局配置或全局语言。
 
-### 17.3 Contract 测试
+### 18.3 Registry
 
-- 基础字段始终存在。
-- 内置 Generator Patch 在插件 Patch 前应用。
-- 插件字段修改和 Requirement 操作保持现有行为。
-- 受保护字段不能删除。
-- 重复字段和 Requirement 可诊断。
-- Patch target 不存在时产生明确警告。
+- Layer、阶段、优先级和 ID 排序。
+- 重复 ID、Registry 冻结和 Profile Selector。
+- 每一种 FailurePolicy。
 
-### 17.4 集成与兼容测试
+### 18.4 Contract
+
+- 基础受保护字段始终存在。
+- Built-in Patch 在 Plugin Patch 前应用。
+- Plugin Patch 按 `(priority, id)` 排序。
+- 重复字段、Requirement 和未知目标诊断。
+- JSON 示例、字段说明、Schema 和 Requirement 来自同一 Contract。
+- Runtime Manifest 与内置字段一致。
+
+### 18.5 集成与兼容
 
 - 旧入口和新 Compiler 对相同输入生成相同 Prompt。
-- 前端 `effectNames` 能在后端生成稳定音效 Section。
-- 自由聊天和剧情模式共享相同 Contract 内容。
-- Prompt 结尾始终包含本地化 JSON 格式提醒。
-- 不同语言下不依赖自然语言字符串定位 Section。
+- `effectNames` 生成稳定 Effect Capability 和 Section。
+- 自由聊天和剧情模式共享基础 Contract。
+- 不同语言不依赖自然语言字符串定位 Section。
+- 并发编译不同语言时互不影响。
+- 相同输入、Registry 快照和语言目录产生字节级相同结果。
 
-## 18. 验收标准
+## 19. 验收标准
 
-- `generate_chat_template()` 成为薄 Facade，不再直接拼接所有 Section。
-- `render_dialog_reply_contract()` 与自由聊天不再重复维护 Contract 规则。
-- 每个核心 Generator 只接收自己的 DTO。
-- 所有 Generator 均通过 Registry 注册，并按稳定规则排序。
-- Output Contract 公共类型和插件 API 不发生破坏性变化。
-- Effect Prompt 完全由后端结构化生成，前端不再修改生成文本。
-- 自由聊天与剧情模式共享唯一 Contract 构造、Patch、校验和渲染逻辑。
-- 编译过程不修改全局配置。
-- 迁移前后的既有模板生成测试全部通过。
+- `generate_chat_template()` 成为薄 Facade。
+- 系统中只有一个 `ResolvedOutputContract` 构造、Patch、校验和渲染流程。
+- JSON 示例、字段说明和 Requirement 不再重复维护。
+- 基础 Contract 只包含不可取消字段和要求。
+- 所有可选内置功能都通过 Built-in Contribution 注册。
+- 内置和插件使用相同 Contribution、Reducer 和 Validator。
+- Compiler 不包含 Effect、CG、Choice、Translation 等业务条件分支。
+- 相关 Section、字段和 Requirement 原子化出现或消失。
+- Contributor 只接收窄 DTO。
+- Plugin Patch 具有稳定顺序和冲突诊断。
+- 新增 Profile 不需要修改所有共享 Contributor。
+- 公共类型和插件 API 不发生破坏性变化。
+- Effect Prompt 完全由后端结构化生成。
+- 编译过程不读写全局配置或全局 locale。
+- 内置 Contract 字段通过运行时兼容性校验。
+- 迁移前后的模板生成测试全部通过。
 
-## 19. 被否决的方案
+## 20. 被否决的方案
 
-### 19.1 大量链式 Setter
+### 20.1 所有内容都塞入 OutputContract
 
-```python
-builder.set_characters(...).set_background(...).set_use_effect(...).build()
-```
+角色资料、背景和工具是模型输入上下文，不是输出 Schema。最终设计使用 `PromptSpecification` 统一承载两者，但保持 Section 与 Output Contract 正交。
 
-该方案只把长参数列表转换为 Setter，仍然存在布尔参数膨胀、默认值遗漏和职责集中问题。
+### 20.2 内置功能继续由 Builder 特判
 
-### 19.2 所有 Generator 接收完整 Context
+如果内置能力仍由 Builder 中的 `if` 生成，而只有插件使用 Patch，新增能力仍需修改核心 Builder。所有可选内置能力必须使用 Built-in Contribution。
 
-这会让 Generator 逐渐读取无关数据，形成隐式依赖，降低可测试性，也使后续上下文修改影响所有 Generator。
+### 20.3 所有 Contributor 接收完整 Source
 
-### 19.3 Generator 直接修改共享字符串
+完整 Source 只暴露给 Composition Root 中的 Input Projector；Contributor 接收窄输入 Capability。
 
-该方案会产生顺序依赖、自然语言锚点依赖和不可诊断的相互覆盖，与当前前端音效注入问题相同。
+### 20.4 Contributor 直接修改共享字符串
 
-### 19.4 重做 Output Contract
+这会产生顺序和自然语言锚点依赖，与当前前端字符串注入问题相同。
 
-现有 `OutputContractPatch` 已支持字段新增、字段修改、非核心字段删除、Requirement 新增及 append/prepend/replace/remove。重新设计会破坏插件兼容性，收益不足。
+### 20.5 重新设计插件公共 API
 
-## 20. 最终决策
+现有 `OutputContractPatch` 已支持字段和 Requirement 扩展，因此使用内部 `ResolvedOutputContract` 和 Adapter，不修改公共 API。
 
-采用注册式 Prompt Contributor Pipeline：
+## 21. 最终决策
 
-1. Compiler 持有完整编译源。
-2. Registration 通过 Input Projector 为 Generator 构造窄输入 DTO。
-3. Generator 返回结构化 Prompt Section 和可选的现有 `OutputContractPatch`。
-4. Registry 通过 Phase、Priority 和 ID 提供稳定顺序。
-5. Assembler 合并贡献，统一 Contract 构造器应用内置和插件 Patch。
-6. Validator 保护核心字段并检测冲突。
-7. Renderer 统一输出最终本地化 system prompt。
-8. 现有 `TemplateGenerator` 在迁移期间作为兼容 Facade 保留。
+采用 Contract-first Prompt Specification Compiler：
 
+1. Request 只表达原始事实。
+2. Resolver 将事实解析为满足不变量的 Capability。
+3. 基础 Output Contract 只包含运行时不可取消字段。
+4. 所有可选内置能力和插件都通过 Contribution 参与编译。
+5. Contribution 原子化贡献 Context Section 和 `OutputContractPatch`。
+6. Registry 通过 Layer、Phase、Priority 和 ID 提供稳定顺序，并在编译前冻结。
+7. Contract Reducer 生成唯一 `ResolvedOutputContract`。
+8. Validator 检查冲突、保护字段、Schema、流模式和运行时兼容性。
+9. Assembler 生成唯一 `PromptSpecification`。
+10. 请求级 Renderer 从 Specification 生成最终本地化 system prompt。
+11. 现有公共类型、插件 Patch API 和 `TemplateGenerator` 入口通过 Adapter/Facade 保持兼容。
+
+该结构使 Compiler 对新增普通能力关闭修改、对 Contribution 扩展开启，同时避免把 Output Contract 扩张成新的上帝对象。

--- a/ai/llm/TEMPLATE_GENERATOR_DESIGN.md
+++ b/ai/llm/TEMPLATE_GENERATOR_DESIGN.md
@@ -1,0 +1,654 @@
+# Template Generator 注册式 Prompt 编译器设计
+
+## 1. 摘要
+
+当前 `template_generator.py` 实际上不是调用 LLM 生成模板，而是把角色、背景、功能开关、工具、插件补丁和本地化文案组合成运行时 system prompt。本文建议将其重构为一个注册式 Prompt Compiler：
+
+- Prompt Generator 只处理一个明确的 Prompt 片段。
+- 每个 Generator 只接收自己的窄输入 DTO，不读取完整编译上下文。
+- Registry 保存 Generator 的 ID、阶段、优先级、适用 Profile 和输入投影器。
+- Compiler 是唯一能够访问完整编译上下文并协调所有 Generator 的组件。
+- Generator 返回结构化 `PromptContribution`，不直接修改其他 Generator 的文本。
+- 继续使用现有 `OutputFieldSpec`、`RequirementSpec`、`OutputContractPatch` 和插件接口，不修改现有 Output Contract 公共契约。
+- 自由聊天和剧情模式共享同一个 Output Contract 构造与渲染流程，只注册不同的 Prompt Generator。
+
+该设计的核心模式是：
+
+- Registry：注册可用的 Prompt Generator。
+- Ordered Contributor Pipeline：按阶段和优先级执行贡献者。
+- Builder/Assembler：把多个结构化贡献组装成 Prompt Document。
+- Strategy/Profile：表达自由聊天和剧情模式的差异。
+- Adapter：将 Generator 产生的 Contract 贡献适配到现有 `OutputContractPatch`。
+- Dependency Injection + Interface Segregation：Generator 只依赖自己的输入和必要服务。
+
+## 2. 背景与现状
+
+当前实现主要存在以下问题：
+
+1. `TemplateGenerator.generate_chat_template()` 同时负责角色解析、字段定义、规则定义、背景资料、立绘资料、工具描述、插件补丁、本地化和最终字符串拼接。
+2. `generate_chat_template()` 与 `render_dialog_reply_contract()` 重复维护大量 Output Contract 字段及 Requirement 逻辑。
+3. `use_effect`、`use_cg`、`use_choice`、`use_stat` 等布尔参数不断增加，使方法签名和条件分支持续膨胀。
+4. 前端收到模板后，通过搜索“可用音效”“可调用工具”等自然语言锚点修改 system prompt，容易受语言和文案变化影响。
+5. `effectNames` 已作为结构化参数发送到后端，但模板生成入口没有完整消费它。
+6. 模板生成依赖全局 `config_manager`，并可能在生成过程中保存语音语言配置，使确定性编译混入全局状态修改。
+7. 普通 Prompt 内容、Output Contract、插件扩展和运行时字段处理之间的边界不清晰。
+
+## 3. 目标
+
+### 3.1 功能目标
+
+- 可以独立注册角色、背景、音效、工具、输出要求等 Generator。
+- 每个 Generator 只接收与自身相关的数据。
+- Generator 可以贡献普通 Prompt Section，也可以通过现有 `OutputContractPatch` 贡献 JSON 字段或 Requirement。
+- 支持稳定、可预测、可测试的执行顺序。
+- 自由聊天和剧情模式复用同一套 Contract 构造逻辑。
+- 插件继续使用现有 Output Contract 扩展 API。
+- 最终 Prompt 在迁移期间保持向后兼容。
+
+### 3.2 质量目标
+
+- 同一输入产生稳定输出。
+- 单个 Generator 可以独立单元测试。
+- Generator 的异常能够定位到稳定 ID。
+- 不允许通过字符串搜索修改其他 Generator 的输出。
+- 新增功能时不需要修改一个巨大的 `generate_chat_template()`。
+
+## 4. 非目标
+
+- 本次设计不修改 LLM 对话 JSON 的运行时解析协议。
+- 不修改 `OutputFieldSpec`、`RequirementSpec`、`OutputContractPatch` 或 `ChatOutputContract` 的公共定义。
+- 不自动赋予自定义 JSON 字段运行时语义。字段的解析和执行仍由对应运行时处理器负责。
+- 不在第一阶段移除现有 `TemplateGenerator.generate_chat_template()` 公共入口；它将作为兼容 Facade 保留。
+- 不让插件直接获得或修改完整 Prompt Document。
+
+## 5. 总体架构
+
+```mermaid
+flowchart TD
+    A["TemplateGenerateRequest"] --> B["CompilationSourceResolver"]
+    B --> C["PromptCompilationSource"]
+    C --> D["PromptCompiler"]
+    D --> E["PromptGeneratorRegistry"]
+    E --> F["Input Projector"]
+    F --> G["Narrow Generator Input"]
+    G --> H["Prompt Generator"]
+    H --> I["PromptContribution"]
+    I --> J["PromptDocumentAssembler"]
+    J --> K["Existing OutputContractPatch Pipeline"]
+    K --> L["Contract Validator"]
+    L --> M["Localized Prompt Renderer"]
+    M --> N["System Prompt"]
+```
+
+只有 `CompilationSourceResolver` 和 `PromptCompiler` 知道完整上下文。Prompt Generator 只看到注册时投影出的窄输入 DTO。
+
+## 6. 核心领域模型
+
+### 6.1 完整编译源
+
+完整编译源是 Compiler 内部模型，不暴露给 Generator：
+
+```python
+@dataclass(frozen=True)
+class PromptCompilationSource:
+    profile: str
+    language: str
+    voice_language: str
+    characters: tuple[CharacterConfig, ...]
+    background: BackgroundConfig | None
+    effects: tuple[EffectConfig, ...]
+    tools: tuple[ToolDescription, ...]
+    features: PromptFeatures
+    limits: PromptLimits
+    output_contract_patches: tuple[OutputContractPatch, ...]
+```
+
+该类型只用于解析和协调，不传给具体 Generator。
+
+### 6.2 窄输入 DTO
+
+每个 Generator 定义自己的输入：
+
+```python
+@dataclass(frozen=True)
+class CharacterPromptInput:
+    characters: tuple[CharacterConfig, ...]
+    language: str
+
+
+@dataclass(frozen=True)
+class EffectPromptInput:
+    enabled: bool
+    effects: tuple[EffectConfig, ...]
+    language: str
+
+
+@dataclass(frozen=True)
+class BackgroundPromptInput:
+    background: BackgroundConfig | None
+    include_bgm: bool
+    language: str
+```
+
+如果 Generator 后续确实需要新数据，应显式扩展自己的 DTO，而不是改为接收完整 Context。
+
+### 6.3 Prompt Section
+
+普通 Prompt 文本使用结构化 Section 表达：
+
+```python
+@dataclass(frozen=True)
+class PromptSection:
+    id: str
+    content: str
+```
+
+Section 的阶段和优先级属于注册信息，不属于文本本身。
+
+### 6.4 Prompt Contribution
+
+Generator 可以同时贡献普通文本和现有 Contract Patch：
+
+```python
+@dataclass(frozen=True)
+class PromptContribution:
+    sections: tuple[PromptSection, ...] = ()
+    contract_patch: OutputContractPatch | None = None
+```
+
+普通 Generator 不获得可变 Prompt Builder，也不能直接删除或修改其他 Generator 的 Section。
+
+## 7. Generator 接口
+
+```python
+InputT = TypeVar("InputT")
+
+
+class PromptGenerator(Protocol[InputT]):
+    def generate(self, data: InputT) -> PromptContribution | None:
+        ...
+```
+
+Generator 应尽量是纯函数：
+
+- 不读取全局 `config_manager`。
+- 不保存系统配置。
+- 不访问 Registry。
+- 不读取其他 Generator 的输出。
+- 不依赖最终 Prompt 中的自然语言标题或文本位置。
+
+翻译器、日志器等稳定服务通过构造函数注入：
+
+```python
+class EffectPromptGenerator:
+    def __init__(self, translator: TemplateTranslator) -> None:
+        self._translator = translator
+
+    def generate(self, data: EffectPromptInput) -> PromptContribution | None:
+        ...
+```
+
+## 8. 注册模型
+
+### 8.1 阶段
+
+仅依赖单个全局数字优先级容易产生隐式耦合，因此使用“阶段 + 阶段内优先级 + ID”的稳定顺序：
+
+```python
+class PromptPhase(IntEnum):
+    OUTPUT_FORMAT = 100
+    CAST_CONTEXT = 200
+    WORLD_CONTEXT = 300
+    CAPABILITIES = 400
+    TOOLS = 500
+    REQUIREMENTS = 600
+    CLOSING = 900
+```
+
+最终排序键：
+
+```python
+(registration.phase, registration.priority, registration.id)
+```
+
+ID 用于相同优先级下的确定性排序，同时用于错误报告和重复注册检测。
+
+### 8.2 注册信息
+
+```python
+@dataclass(frozen=True)
+class PromptRegistration(Generic[InputT]):
+    id: str
+    phase: PromptPhase
+    priority: int
+    profiles: frozenset[str]
+    select_input: Callable[[PromptCompilationSource], InputT | None]
+    generator: PromptGenerator[InputT]
+    required: bool = False
+```
+
+优先级和 Profile 属于“如何参与编译流程”，因此放在 Registration，而不是 Generator 内部。
+
+### 8.3 类型擦除边界
+
+Registry 内需要保存不同输入类型的 Generator。泛型类型检查在 `register()` 时完成，Registry 内部保存已经绑定的执行函数：
+
+```python
+class PromptGeneratorRegistry:
+    def register(
+        self,
+        *,
+        id: str,
+        phase: PromptPhase,
+        priority: int,
+        profiles: frozenset[str],
+        select_input: Callable[[PromptCompilationSource], InputT | None],
+        generator: PromptGenerator[InputT],
+        required: bool = False,
+    ) -> None:
+        def contribute(source: PromptCompilationSource) -> PromptContribution | None:
+            data = select_input(source)
+            if data is None:
+                return None
+            return generator.generate(data)
+
+        self._store_erased_registration(
+            id=id,
+            phase=phase,
+            priority=priority,
+            profiles=profiles,
+            contribute=contribute,
+            required=required,
+        )
+```
+
+Generator 本身仍保持完整的窄输入类型信息。
+
+## 9. 注册示例
+
+### 9.1 Character Generator
+
+```python
+registry.register(
+    id="core.characters",
+    phase=PromptPhase.CAST_CONTEXT,
+    priority=100,
+    profiles=frozenset({"free_chat", "story"}),
+    select_input=lambda source: CharacterPromptInput(
+        characters=source.characters,
+        language=source.language,
+    ),
+    generator=CharacterPromptGenerator(translator),
+    required=True,
+)
+```
+
+### 9.2 Effect Generator
+
+```python
+registry.register(
+    id="core.effects",
+    phase=PromptPhase.CAPABILITIES,
+    priority=200,
+    profiles=frozenset({"free_chat", "story"}),
+    select_input=lambda source: EffectPromptInput(
+        enabled=source.features.use_effect,
+        effects=source.effects,
+        language=source.language,
+    ),
+    generator=EffectPromptGenerator(translator),
+)
+```
+
+Effect Generator 不知道角色、背景、CG、Choice 或完整 Output Contract。
+
+## 10. Output Contract 兼容设计
+
+### 10.1 保留现有公共类型
+
+以下现有类型和接口保持不变：
+
+- `DEFAULT_DIALOG_CONTRACT_ID`
+- `OutputFieldSpec`
+- `RequirementSpec`
+- `FieldPatch`
+- `RequirementPatch`
+- `OutputContractPatch`
+- `ChatOutputContract`
+- 插件 Output Contract Patch 注册接口
+
+新增 Pipeline 只负责生产和收集现有 `OutputContractPatch`。
+
+### 10.2 基础 Contract
+
+基础 Contract 仍由核心代码拥有，包含受保护字段：
+
+- `character_name`
+- `sprite`
+- `speech`
+
+这些字段不能被普通 Generator 或插件删除。现有保护行为必须保留。
+
+### 10.3 Generator 贡献 Contract Patch
+
+例如 Effect Generator：
+
+```python
+class EffectPromptGenerator:
+    def generate(self, data: EffectPromptInput) -> PromptContribution | None:
+        if not data.enabled:
+            return None
+
+        return PromptContribution(
+            sections=(
+                PromptSection(
+                    id="available_effects",
+                    content=render_available_effects(data.effects),
+                ),
+            ),
+            contract_patch=OutputContractPatch(
+                id="core.prompt.effects",
+                target_contract=DEFAULT_DIALOG_CONTRACT_ID,
+                priority=170,
+                add_fields=(
+                    OutputFieldSpec(
+                        key="effect",
+                        type="string",
+                        description=translate("r_effect"),
+                        required=False,
+                    ),
+                ),
+                add_requirements=(
+                    RequirementSpec(
+                        id="r_effect",
+                        text=translate("r_effect"),
+                        order=170,
+                    ),
+                ),
+            ),
+        )
+```
+
+### 10.4 Patch 应用顺序
+
+为保持插件覆盖核心行为的现有语义，Patch 分两层应用：
+
+1. 从基础 Contract 开始。
+2. 应用内置 Prompt Generator 产生的 Patch。
+3. 按现有 `priority` 规则应用插件 Patch。
+4. 执行 Contract 校验。
+5. 使用唯一 Renderer 输出格式说明和 Requirement 文本。
+
+内置 Generator 的注册优先级决定其执行和 Section 顺序；插件 Patch 的 `priority` 只在插件 Patch 层内排序。
+
+### 10.5 冲突规则
+
+- Registration ID 必须唯一，重复注册立即报错。
+- Prompt Section ID 在同一 Profile 的最终文档中必须唯一。
+- 内置 Generator 添加重复字段 key 时立即报错，不静默覆盖。
+- 内置 Generator 添加重复 Requirement ID 时立即报错。
+- 插件修改仍使用现有 `field_patches` 和 `requirement_patches` 语义。
+- 插件不能删除受保护字段。
+- `field_patches` 指向不存在字段时记录结构化警告。
+- `requirement_patches` 指向不存在 Requirement 时记录结构化警告。
+- 最终 Requirement 按 `(order, id)` 排序。
+- 最终 Contract 必须经过必需字段、重复 ID 和字段类型校验。
+
+### 10.6 Contract 与运行时行为
+
+`OutputContractPatch` 只描述 LLM 输出格式和要求，不自动注册运行时行为。例如添加 `emotion` 字段不会自动切换立绘；需要由独立运行时字段处理器解释它。
+
+## 11. Prompt Document 组装
+
+```python
+@dataclass(frozen=True)
+class PromptDocument:
+    sections: tuple[PromptSection, ...]
+    format_block: str
+    requirements_block: str
+```
+
+Assembler 负责：
+
+- 收集非空 Contribution。
+- 验证 Section ID。
+- 收集内置 Contract Patch。
+- 调用统一 Output Contract 构造器。
+- 生成结构化 Prompt Document。
+
+Renderer 负责：
+
+- 按已排序 Section 输出文本。
+- 统一空行和标题格式。
+- 保证 JSON 格式提醒位于结尾。
+- 保证相同输入产生字节级稳定输出。
+
+普通 Generator 不负责全局空行、最终结束提醒或文档级格式。
+
+## 12. Profile 与模式差异
+
+自由聊天和剧情模式使用相同 Registry 和 Compiler，但选择不同 Profile：
+
+```python
+free_prompt = compiler.compile(source, profile="free_chat")
+story_prompt = compiler.compile(source, profile="story")
+```
+
+可通过以下方式表达差异：
+
+- Registration 的 `profiles` 属性。
+- 不同 Profile 使用不同输入投影器。
+- Profile 自己提供少量专属 Generator，例如剧情阶段上下文或隐藏目标。
+
+禁止重新实现一套独立的 Output Contract Builder。自由聊天和剧情模式必须共享：
+
+- 基础字段定义。
+- Requirement 构造。
+- Contract Patch 应用。
+- Contract 校验。
+- Contract Renderer。
+
+## 13. 前后端边界
+
+前端只发送结构化生成请求：
+
+```json
+{
+  "characters": ["Mio", "Aoi"],
+  "backgroundName": "Classroom",
+  "effectNames": ["Rain", "Door"],
+  "useEffect": true,
+  "useChoice": true,
+  "voiceLanguage": "ja"
+}
+```
+
+后端负责解析资源并生成完整 system prompt。前端不再：
+
+- 搜索“可用音效”字符串。
+- 搜索“可调用工具”字符串。
+- 删除旧 Prompt 段落。
+- 把新段落插入某个自然语言标题前。
+
+模板编辑器仍可允许用户手动修改生成后的 system prompt，但结构化参数变化后重新生成时，以后端 Compiler 输出为准。
+
+## 14. 错误处理与可观测性
+
+建议使用稳定错误信息：
+
+```text
+prompt.generator.duplicate_id
+prompt.generator.input_failed
+prompt.generator.generate_failed
+prompt.section.duplicate_id
+prompt.contract.duplicate_field
+prompt.contract.duplicate_requirement
+prompt.contract.patch_target_missing
+prompt.contract.protected_field
+prompt.contract.validation_failed
+```
+
+日志至少包含：
+
+- `profile`
+- `generator_id`
+- `phase`
+- `priority`
+- `contract_patch_id`
+- `duration_ms`
+
+不得记录完整角色隐私内容或完整 system prompt，除非明确处于开发调试模式。
+
+Required Generator 失败时终止编译；Optional Generator 失败是否降级必须由注册策略明确指定，不能静默吞掉异常。
+
+## 15. 建议代码布局
+
+```text
+ai/llm/
+├── template_generator.py          # 兼容 Facade，迁移完成后保持薄层
+├── TEMPLATE_GENERATOR_DESIGN.md
+└── prompt_compiler/
+    ├── __init__.py
+    ├── models.py                  # Source、Section、Contribution、Profile
+    ├── registry.py                # Registration 与排序
+    ├── compiler.py                # 编译流程
+    ├── contract.py                # 现有 Contract Patch 的统一应用与校验
+    ├── renderer.py                # 本地化 Prompt 渲染
+    ├── resolvers.py               # 角色、背景、音效、工具解析
+    └── generators/
+        ├── characters.py
+        ├── sprites.py
+        ├── background.py
+        ├── effects.py
+        ├── tools.py
+        ├── requirements.py
+        └── closing.py
+```
+
+## 16. 渐进迁移方案
+
+### 阶段 0：锁定现有输出
+
+- 为典型自由聊天组合增加 golden/snapshot 测试。
+- 覆盖透明背景、真实背景、多角色、Effect、CG、Choice、Stat、Translation、CoT 和限制参数。
+- 覆盖插件字段与 Requirement Patch。
+- 锁定剧情模式 Contract 输出。
+
+### 阶段 1：提取统一 Contract 构造器
+
+- 把 `generate_chat_template()` 与 `render_dialog_reply_contract()` 重复的字段、Requirement 和 Patch 逻辑提取到唯一内部函数。
+- 保持函数签名和最终输出不变。
+- 现有 `TemplateGenerator` 继续作为调用入口。
+
+### 阶段 2：引入 Registry 和 Prompt Document
+
+- 新增模型、Registry、Compiler、Assembler 和 Renderer。
+- 先迁移 Character、Sprite、Background 和 Tools Section。
+- 旧入口把位置参数转换为 `PromptCompilationSource`，再调用 Compiler。
+
+### 阶段 3：迁移可选功能
+
+- 依次迁移 Translation、Effect、CG、Choice、Narration、Stat 和 CoT。
+- 每迁移一个功能，同时迁移其 Section 和现有 Contract Patch 贡献。
+- 每一步进行新旧 Prompt 字节级或语义级对比。
+
+### 阶段 4：移除前端字符串注入
+
+- 后端根据 `effectNames` 生成音效 Section。
+- 删除前端对“可用音效”和“可调用工具”的字符串搜索及插入。
+- 保留前端结构化选项和手动 Prompt 编辑能力。
+
+### 阶段 5：统一剧情模式
+
+- 剧情模式改用同一 Compiler 和 Contract 构造器。
+- 剧情专属场景、进度、工具和工作流由 Profile 专属 Generator 贡献。
+- 删除重复 Contract 渲染代码。
+
+### 阶段 6：清理全局依赖
+
+- Resolver 显式注入 Config Repository、Tool Registry 和 Translator。
+- 编译过程不保存 `voice_language` 或其他全局配置。
+- API 层决定是否单独保存用户配置，Compiler 只消费请求值。
+
+## 17. 测试策略
+
+### 17.1 Generator 单元测试
+
+- 每个 Generator 只构造自己的窄输入 DTO。
+- 验证启用、禁用和空输入。
+- 验证只产生声明的 Section 和 Contract Patch。
+- 验证 Generator 不依赖其他功能数据。
+
+### 17.2 Registry 测试
+
+- 阶段排序。
+- 同阶段优先级排序。
+- 相同优先级按 ID 确定性排序。
+- 重复 ID 报错。
+- Profile 过滤。
+- Input Projector 返回 `None` 时跳过。
+
+### 17.3 Contract 测试
+
+- 基础字段始终存在。
+- 内置 Generator Patch 在插件 Patch 前应用。
+- 插件字段修改和 Requirement 操作保持现有行为。
+- 受保护字段不能删除。
+- 重复字段和 Requirement 可诊断。
+- Patch target 不存在时产生明确警告。
+
+### 17.4 集成与兼容测试
+
+- 旧入口和新 Compiler 对相同输入生成相同 Prompt。
+- 前端 `effectNames` 能在后端生成稳定音效 Section。
+- 自由聊天和剧情模式共享相同 Contract 内容。
+- Prompt 结尾始终包含本地化 JSON 格式提醒。
+- 不同语言下不依赖自然语言字符串定位 Section。
+
+## 18. 验收标准
+
+- `generate_chat_template()` 成为薄 Facade，不再直接拼接所有 Section。
+- `render_dialog_reply_contract()` 与自由聊天不再重复维护 Contract 规则。
+- 每个核心 Generator 只接收自己的 DTO。
+- 所有 Generator 均通过 Registry 注册，并按稳定规则排序。
+- Output Contract 公共类型和插件 API 不发生破坏性变化。
+- Effect Prompt 完全由后端结构化生成，前端不再修改生成文本。
+- 自由聊天与剧情模式共享唯一 Contract 构造、Patch、校验和渲染逻辑。
+- 编译过程不修改全局配置。
+- 迁移前后的既有模板生成测试全部通过。
+
+## 19. 被否决的方案
+
+### 19.1 大量链式 Setter
+
+```python
+builder.set_characters(...).set_background(...).set_use_effect(...).build()
+```
+
+该方案只把长参数列表转换为 Setter，仍然存在布尔参数膨胀、默认值遗漏和职责集中问题。
+
+### 19.2 所有 Generator 接收完整 Context
+
+这会让 Generator 逐渐读取无关数据，形成隐式依赖，降低可测试性，也使后续上下文修改影响所有 Generator。
+
+### 19.3 Generator 直接修改共享字符串
+
+该方案会产生顺序依赖、自然语言锚点依赖和不可诊断的相互覆盖，与当前前端音效注入问题相同。
+
+### 19.4 重做 Output Contract
+
+现有 `OutputContractPatch` 已支持字段新增、字段修改、非核心字段删除、Requirement 新增及 append/prepend/replace/remove。重新设计会破坏插件兼容性，收益不足。
+
+## 20. 最终决策
+
+采用注册式 Prompt Contributor Pipeline：
+
+1. Compiler 持有完整编译源。
+2. Registration 通过 Input Projector 为 Generator 构造窄输入 DTO。
+3. Generator 返回结构化 Prompt Section 和可选的现有 `OutputContractPatch`。
+4. Registry 通过 Phase、Priority 和 ID 提供稳定顺序。
+5. Assembler 合并贡献，统一 Contract 构造器应用内置和插件 Patch。
+6. Validator 保护核心字段并检测冲突。
+7. Renderer 统一输出最终本地化 system prompt。
+8. 现有 `TemplateGenerator` 在迁移期间作为兼容 Facade 保留。
+


### PR DESCRIPTION
## Summary

- redesign Template Generator as a contract-first Prompt Specification Compiler
- make built-in capabilities and plugins use the same Contribution/Patch reduction path
- keep context Sections separate from the Output Contract while allowing one capability to contribute both atomically
- define a single ResolvedOutputContract as the source for JSON examples, field notes, requirements, schema, and runtime compatibility checks
- add validated capabilities, deterministic patch ordering, frozen registries, explicit failure policies, extensible profiles, and request-scoped localization
- preserve the existing OutputContractPatch, ChatOutputContract, plugin registration, and TemplateGenerator public APIs through adapters and a facade

## Testing

- documentation-only change
- `git diff --check` passed
- verified balanced Markdown fences and unique section headings

## Scope

This PR remains based directly on main and changes only `ai/llm/TEMPLATE_GENERATOR_DESIGN.md`.

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次核对的重点收拢一下，方便继续确认。

本 PR 仅新增 `ai/llm/TEMPLATE_GENERATOR_DESIGN.md`，为现有 `TemplateGenerator` 提出 contract-first 编译器重构方案；未修改运行时代码。方案与现有对话 JSON 外层协议、插件兼容性、注册表冻结及受支持 Python 版本之间仍存在具体不一致。

### Enhancements

- 定义了 Request → Capability → Contribution → Contract → Renderer 的目标编译链路。
- 规划了内置能力与插件 Patch 的统一注册、确定性排序和请求级本地化。

### Chores

- 新增模板生成器重构设计、渐进迁移步骤和后续测试策略。

<details>
<summary>Original summary in English</summary>

This PR only adds `ai/llm/TEMPLATE_GENERATOR_DESIGN.md`, proposing a contract-first compiler refactor for the existing `TemplateGenerator`; it does not modify runtime code. The design still has concrete mismatches with the current dialogue JSON envelope, plugin compatibility, registry freezing, and the supported Python version.

### Enhancements

- Defines the target Request → Capability → Contribution → Contract → Renderer compilation pipeline.
- Plans unified registration, deterministic ordering, and request-scoped localization for built-in capabilities and plugin patches.

### Chores

- Adds the template-generator refactor design, phased migration plan, and follow-up test strategy.

</details>

<!-- astrbot-review:end:summary -->