### PR TITLE
refactor(chat): separate application orchestration from core capabilities

### DIFF
--- a/application/chat/effects.py
+++ b/application/chat/effects.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import Any
 
+from core.media.effect_audio import parse_effect_audio_bindings
 from i18n import tr as tr_i18n
-
-
-_LABEL_SEPARATOR_RE = re.compile(r"[,，]")
 
 
 @dataclass(frozen=True)
@@ -40,26 +37,6 @@ def _selected_name_keys(selected_names: Any) -> set[str]:
     return {value.casefold() for item in values if (value := str(item or "").strip())}
 
 
-def _effect_labels(tag_line: Any) -> tuple[str, ...]:
-    raw = str(tag_line or "").strip()
-    if not raw:
-        return ()
-    if "：" in raw:
-        raw = raw.split("：", 1)[-1]
-    elif ":" in raw:
-        raw = raw.split(":", 1)[-1]
-
-    labels: list[str] = []
-    seen: set[str] = set()
-    for part in _LABEL_SEPARATOR_RE.split(raw):
-        label = part.strip()
-        key = label.casefold()
-        if label and key not in seen:
-            seen.add(key)
-            labels.append(label)
-    return tuple(labels)
-
-
 def build_selected_effect_context(
     config_manager: Any,
     selected_names: Any,
@@ -86,19 +63,16 @@ def build_selected_effect_context(
             continue
         canonical_names.append(effect_name)
 
-        tag_lines = str(getattr(effect, "audio_tags", "") or "").splitlines()
-        audio_list = getattr(effect, "audio_list", []) or []
-        for index, audio_path in enumerate(audio_list):
-            path = str(audio_path or "").strip()
-            tag_line = tag_lines[index] if index < len(tag_lines) else ""
-            if not path:
-                continue
-            for label in _effect_labels(tag_line):
-                keyword_map[label] = path
-                label_key = label.casefold()
-                if label_key not in seen_labels:
-                    seen_labels.add(label_key)
-                    labels.append(label)
+        bindings = parse_effect_audio_bindings(
+            getattr(effect, "audio_tags", ""),
+            getattr(effect, "audio_list", []) or [],
+        )
+        for binding in bindings:
+            keyword_map[binding.keyword] = binding.audio_path
+            label_key = binding.keyword.casefold()
+            if label_key not in seen_labels:
+                seen_labels.add(label_key)
+                labels.append(binding.keyword)
 
     prompt_catalog = ""
     if labels:

--- a/application/chat/initial_sprite.py
+++ b/application/chat/initial_sprite.py
@@ -1,0 +1,75 @@
+"""Initial-sprite selection and presentation use cases."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.sprite.selection import (
+    find_character_sprite_by_path as find_sprite_in_characters,
+    resolve_initial_sprite_path,
+    resolve_runtime_path,
+    sprite_entry_path,
+)
+
+
+def _characters(config: Any) -> list[object]:
+    return list(getattr(getattr(config, "config", None), "characters", None) or [])
+
+
+def find_character_sprite_by_path(
+    config: Any,
+    raw_path: str,
+) -> tuple[str, int] | None:
+    return find_sprite_in_characters(_characters(config), raw_path)
+
+
+def initial_sprite_path_for_characters(
+    config: Any,
+    raw_path: str,
+    character_names: list[str] | None,
+) -> str:
+    selected_names = [
+        name.strip()
+        for name in (character_names or [])
+        if isinstance(name, str) and name.strip()
+    ]
+    default_path = ""
+    if selected_names:
+        character = config.get_character_by_name(selected_names[0])
+        sprites = getattr(character, "sprites", None) if character else None
+        if isinstance(character, dict):
+            sprites = character.get("sprites")
+        if isinstance(sprites, (list, tuple)) and sprites:
+            default_path = sprite_entry_path(sprites[0])
+
+    return resolve_initial_sprite_path(
+        _characters(config),
+        raw_path,
+        selected_names,
+        default_path=default_path,
+    )
+
+
+def display_initial_sprite(
+    raw_path: str,
+    *,
+    config: Any,
+    ui_updates: Any,
+) -> bool:
+    if not raw_path:
+        return False
+    matched = find_character_sprite_by_path(config, raw_path)
+    if matched is not None:
+        character_name, sprite_index = matched
+        ui_updates.update_sprite(character_name, sprite_index)
+        return True
+
+    resolved = resolve_runtime_path(raw_path)
+    character_name = resolved.stem or "initial"
+    return bool(
+        ui_updates.update_sprite_from_path(
+            str(resolved),
+            character_name=character_name,
+            scale=1.0,
+        )
+    )

--- a/application/chat/templates.py
+++ b/application/chat/templates.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from config.config_manager import character_name_key
 from core.sprite.chat_branch_storage import ACTIVE_HISTORY_FILENAME, BRANCH_TREE_FILENAME
-from core.sprite.initial_sprite import initial_sprite_path_for_characters
+from application.chat.initial_sprite import initial_sprite_path_for_characters
 from ai.llm.template_generator import (
     NoValidCharactersError,
     json_format_reminder,

--- a/application/chat/turn_wiring.py
+++ b/application/chat/turn_wiring.py
@@ -1,4 +1,4 @@
-"""Host-runtime composition for the framework-neutral chat turn service."""
+"""Application composition for the framework-neutral chat turn service."""
 
 from __future__ import annotations
 

--- a/core/media/effect_audio.py
+++ b/core/media/effect_audio.py
@@ -1,0 +1,52 @@
+"""Framework-neutral parsing for effect-audio keyword bindings."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+import re
+
+
+_KEYWORD_SEPARATOR_RE = re.compile(r"[,，]")
+
+
+@dataclass(frozen=True, slots=True)
+class EffectAudioBinding:
+    keyword: str
+    audio_path: str
+
+
+def parse_effect_audio_bindings(
+    audio_tags: object,
+    audio_paths: Sequence[object] | None,
+) -> tuple[EffectAudioBinding, ...]:
+    """Pair configured audio paths with comma-separated trigger keywords.
+
+    Blank tag lines retain their index so each line stays aligned with the
+    corresponding audio path.
+    """
+
+    paths = tuple(audio_paths or ())
+    bindings: list[EffectAudioBinding] = []
+    for index, raw_line in enumerate(str(audio_tags or "").splitlines()):
+        line = raw_line.strip()
+        if not line or index >= len(paths) or not paths[index]:
+            continue
+        if "：" in line:
+            keyword_block = line.split("：", 1)[-1].strip()
+        elif ":" in line:
+            keyword_block = line.split(":", 1)[-1].strip()
+        else:
+            keyword_block = line
+        audio_path = str(paths[index])
+        seen_keywords: set[str] = set()
+        for part in _KEYWORD_SEPARATOR_RE.split(keyword_block):
+            keyword = part.strip()
+            key = keyword.casefold()
+            if not keyword or key in seen_keywords:
+                continue
+            seen_keywords.add(key)
+            bindings.append(
+                EffectAudioBinding(keyword=keyword, audio_path=audio_path)
+            )
+    return tuple(bindings)

--- a/core/sprite/selection.py
+++ b/core/sprite/selection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 import os
 from pathlib import Path
 from typing import Any
@@ -20,7 +21,11 @@ def _character_name(character: object) -> str:
 
 
 def _character_sprites(character: object) -> list[Any]:
-    sprites = character.get("sprites") if isinstance(character, dict) else getattr(character, "sprites", None)
+    sprites = (
+        character.get("sprites")
+        if isinstance(character, dict)
+        else getattr(character, "sprites", None)
+    )
     return list(sprites) if isinstance(sprites, (list, tuple)) else []
 
 
@@ -34,13 +39,13 @@ def _sprite_path_key(raw_path: str) -> str:
 
 
 def find_character_sprite_by_path(
-    config: Any,
+    characters: Iterable[object],
     raw_path: str,
 ) -> tuple[str, int] | None:
     if not raw_path:
         return None
     target_key = _sprite_path_key(raw_path)
-    for character in getattr(config.config, "characters", None) or []:
+    for character in characters:
         for index, sprite in enumerate(_character_sprites(character)):
             sprite_path = sprite_entry_path(sprite)
             if not sprite_path:
@@ -51,48 +56,23 @@ def find_character_sprite_by_path(
     return None
 
 
-def initial_sprite_path_for_characters(
-    config: Any,
+def resolve_initial_sprite_path(
+    characters: Iterable[object],
     raw_path: str,
-    character_names: list[str] | None,
+    character_names: Iterable[object] | None,
+    *,
+    default_path: str = "",
 ) -> str:
-    selected_names = [name.strip() for name in (character_names or []) if isinstance(name, str) and name.strip()]
-    default_path = ""
-    if selected_names:
-        character = config.get_character_by_name(selected_names[0])
-        sprites = _character_sprites(character) if character else []
-        if sprites:
-            default_path = sprite_entry_path(sprites[0])
+    selected_names = [
+        name.strip()
+        for name in (character_names or [])
+        if isinstance(name, str) and name.strip()
+    ]
 
     requested_path = str(raw_path or "").strip()
     if not requested_path:
         return default_path
-    matched = find_character_sprite_by_path(config, requested_path)
+    matched = find_character_sprite_by_path(characters, requested_path)
     if matched is not None and matched[0] not in selected_names:
         return default_path
     return requested_path
-
-
-def display_initial_sprite(
-    raw_path: str,
-    *,
-    config: Any,
-    ui_updates: Any,
-) -> bool:
-    if not raw_path:
-        return False
-    matched = find_character_sprite_by_path(config, raw_path)
-    if matched is not None:
-        character_name, sprite_index = matched
-        ui_updates.update_sprite(character_name, sprite_index)
-        return True
-
-    resolved = resolve_runtime_path(raw_path)
-    character_name = resolved.stem or "initial"
-    return bool(
-        ui_updates.update_sprite_from_path(
-            str(resolved),
-            character_name=character_name,
-            scale=1.0,
-        )
-    )

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -204,6 +204,9 @@ application 可以组合多个能力域，但不实现具体 HTTP 或 UI 控件�
 application 是 `AppRuntime`、应用级 task、当前会话和 concrete manager 装配的唯一
 所有者；这些对象不能下沉到 `core/`。application 可以把结果投影为稳定的 SDK event
 或调用注入的 port，但不能直接构造 HTTP response、WebSocket frame 或 React DTO。
+聊天 turn service 的 manager/queue 装配、初始立绘呈现、特效方案选择和 LLM 特效
+用法提示都属于 `application/chat/`；`core/` 只保留对应的 admission policy、路径匹配
+和标签解析能力。
 AI、插件等下层能力需要通知宿主时，必须通过 `sdk/` 契约和 application
 注入的 adapter 回调，不得反向导入 `application/`。
 `application/story/` 负责把确定性剧情事务与聊天分支、持久化 generation、
@@ -246,12 +249,12 @@ ai/tools/     向 LLM 暴露能力的薄 tool wrapper
 
 ```text
 core/app_update/    主程序版本检查、release 和更新包处理
-core/media/         文件、附件、媒体资源和安全格式处理
-core/messaging/     消息模型、流解析和对话协议
+core/media/         文件、附件、媒体资源、安全格式和标签解析
+core/messaging/     消息模型、流解析、对话协议和框架无关的 turn policy
 core/model_assets/  模型下载、缓存、来源和进度
 core/runtime_env/   Python、pip、依赖检测和运行环境诊断
 core/security/      归档、下载来源等宿主安全校验及旧路径兼容入口
-core/sprite/        聊天记录、立绘和分支存储
+core/sprite/        立绘路径归一化/匹配、聊天记录和分支存储
 core/story/         剧本 Schema、确定性规则、编译、事件、校验和路径模拟
 ```
 

--- a/docs/PROJECT_STRUCTURE_MIGRATION.md
+++ b/docs/PROJECT_STRUCTURE_MIGRATION.md
@@ -5,7 +5,8 @@
 > 稳定结构约定：见 [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md)
 
 本文记录阶段性状态、兼容路径、PR 边界和可量化 OKR。O1 → O5 完成首次目录迁移；
-O6 在不搬迁主体业务的前提下，进一步锁定 `core/` 与 `application/` 的语义边界。
+O6 锁定 `core/` 与 `application/` 的语义边界，O7 按该边界迁移现存的高置信度
+流程编排。
 
 ## 1. 基线状态
 
@@ -169,6 +170,29 @@ PR 范围：
 - 架构 allowlist 继续为空；
 - 不迁移 O7 计划中的 chat wiring、演出编排等主体业务。
 
+### O7：迁移 chat wiring 与演出编排
+
+状态：本分支实现。
+
+PR 范围：
+
+- 将 chat turn service 的 config、queue、LLM/UI manager 装配从
+  `core/messaging/chat_turn_wiring.py` 迁到 `application/chat/turn_wiring.py`；
+- 将初始立绘的配置选择和 UI 更新迁到 `application/chat/initial_sprite.py`，
+  `core/sprite/selection.py` 只保留值输入的路径匹配；
+- 将特效方案选择、运行期 keyword map 和 LLM prompt catalog 迁到
+  `application/chat/effects.py`；
+- 将重复的音频标签解析收敛到 `core/media/effect_audio.py`，main 与 bridge
+  不再各自维护一份解析循环；
+- 将对应单测按职责归位，并禁止 core 再接收 LLM/UI manager 或新增 wiring 模块。
+
+完成条件：
+
+- `core/` 中不再出现 chat manager/queue composition 或 UI 演出调用；
+- main、bridge 只调用 application use case，不复制特效解析逻辑；
+- 纯路径匹配、turn policy 和标签解析可脱离 application 独立测试；
+- 架构 allowlist 保持为空，既有聊天行为和协议不变。
+
 ## 4. 迁移映射
 
 | 当前路径 | 目标位置 | Objective | 说明 |
@@ -197,6 +221,9 @@ PR 范围：
 | `frontend_bridge_core/model_assets.py`、`tts.py` | `application/model_assets/` | O3 | bridge 只创建 task 并转发结果 |
 | `frontend_bridge_core/logs.py` | `application/diagnostics/` | O3 | 诊断归档不在传输层实现 |
 | `core/media/auto_annotation.py` | `application/media/` | O3/O6 | AI 能力由 application 编排；O6 删除残留兼容入口并归位单测 |
+| `core/messaging/chat_turn_wiring.py` | `application/chat/turn_wiring.py` | O7 | manager、queue 与消息 port 装配属于 application |
+| `core/sprite/initial_sprite.py` | `core/sprite/selection.py` + `application/chat/initial_sprite.py` | O7 | core 只做路径匹配，配置选择和 UI 呈现由 application 负责 |
+| main/bridge 特效标签解析 | `core/media/effect_audio.py` + `application/chat/effects.py` | O7 | 单一解析能力，application 负责方案选择与 prompt/runtime 投影 |
 
 ## 5. 通用退出条件
 

--- a/frontend/scripts/verify-tauri-resources.mjs
+++ b/frontend/scripts/verify-tauri-resources.mjs
@@ -25,6 +25,9 @@ await assertExists(path.join(resourcesDir, "main.py"));
 await assertExists(path.join(resourcesDir, "frontend_bridge.py"));
 await assertExists(path.join(resourcesDir, "application", "chat", "mobile_access.py"));
 await assertExists(path.join(resourcesDir, "application", "chat", "runtime_process.py"));
+await assertExists(path.join(resourcesDir, "application", "chat", "effects.py"));
+await assertExists(path.join(resourcesDir, "application", "chat", "initial_sprite.py"));
+await assertExists(path.join(resourcesDir, "application", "chat", "turn_wiring.py"));
 await assertExists(path.join(resourcesDir, "application", "runtime", "dependencies.py"));
 await assertExists(path.join(resourcesDir, "frontend_bridge_core", "transport", "mobile_access.py"));
 await assertExists(path.join(resourcesDir, "ai", "llm", "llm_manager.py"));
@@ -51,6 +54,8 @@ for (const retiredPath of [
   path.join("core", "runtime"),
   path.join("core", "plugins"),
   path.join("core", "mobile_access"),
+  path.join("core", "messaging", "chat_turn_wiring.py"),
+  path.join("core", "sprite", "initial_sprite.py"),
   path.join("frontend_bridge_core", "handler.py"),
 ]) {
   await assertMissing(path.join(resourcesDir, retiredPath));

--- a/frontend_bridge_core/routes/api.py
+++ b/frontend_bridge_core/routes/api.py
@@ -190,6 +190,7 @@ from application.runtime.tasks import (
     _run_background_task,
     _update_task,
 )
+from application.chat.initial_sprite import initial_sprite_path_for_characters
 from application.chat.templates import (
     NoValidCharactersError,
     _compose_for_llm,
@@ -203,7 +204,6 @@ from application.chat.templates import (
     _save_template_summary,
     _generate_template_summary,
     _load_template_session_payload,
-    initial_sprite_path_for_characters,
 )
 from application.media.attachments import stage_uploaded_chat_attachments
 from frontend_bridge_core.tools import (

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ import ai.tools.story_tools
 from ai.llm.template_generator import is_transparent_background
 from ai.llm.llm_manager import LLMAdapterFactory, LLMManager
 from ai.llm.text_processor import TextProcessor
-from core.messaging.chat_turn_wiring import create_chat_turn_service
+from application.chat.turn_wiring import create_chat_turn_service
 from core.messaging.queue import ClearableQueue
 from application.runtime.context import (
     AppRuntime,
@@ -147,7 +147,10 @@ from application.chat.history_state import (
     save_chat_history,
 )
 from application.chat.session_restore import restore_session_presentation
-from core.sprite.initial_sprite import display_initial_sprite, find_character_sprite_by_path
+from application.chat.initial_sprite import (
+    display_initial_sprite,
+    find_character_sprite_by_path,
+)
 from core.sprite.sprite_cli import parse_sprite_args
 logger.info(
     "Chat startup imports completed",

--- a/test/unit/application/test_chat_turn_wiring.py
+++ b/test/unit/application/test_chat_turn_wiring.py
@@ -4,7 +4,7 @@ from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from core.messaging.chat_turn_wiring import create_chat_turn_service
+from application.chat.turn_wiring import create_chat_turn_service
 from core.messaging.queue import ClearableQueue
 
 

--- a/test/unit/application/test_initial_sprite.py
+++ b/test/unit/application/test_initial_sprite.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from application.chat import session_restore
-from core.sprite.initial_sprite import (
+from application.chat.initial_sprite import (
     display_initial_sprite,
     find_character_sprite_by_path,
     initial_sprite_path_for_characters,

--- a/test/unit/architecture/test_import_boundaries.py
+++ b/test/unit/architecture/test_import_boundaries.py
@@ -122,6 +122,16 @@ CORE_FORBIDDEN_APPLICATION_RUNTIME_NAMES = frozenset(
     }
 )
 
+CORE_FORBIDDEN_APPLICATION_MANAGER_NAMES = frozenset(
+    {
+        "llm_manager",
+        "ui_playback",
+        "ui_update_manager",
+        "ui_updates",
+        "ui_worker",
+    }
+)
+
 
 @dataclass(frozen=True, order=True)
 class ImportViolation:
@@ -322,6 +332,14 @@ def _dynamic_imported_roots(source: Path) -> set[str]:
     return _literal_dynamic_imported_roots(tree)
 
 
+def _referenced_names(tree: ast.AST) -> set[str]:
+    names = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+    names.update(
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    )
+    return names
+
+
 def _violations() -> frozenset[ImportViolation]:
     violations: set[ImportViolation] = set()
     for source in _python_sources():
@@ -404,14 +422,7 @@ def test_core_does_not_reference_application_runtime_owners() -> None:
         tree = ast.parse(
             source.read_text(encoding="utf-8"), filename=str(source)
         )
-        referenced_names = {
-            node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
-        }
-        referenced_names.update(
-            node.attr
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Attribute)
-        )
+        referenced_names = _referenced_names(tree)
         for name in sorted(
             referenced_names & CORE_FORBIDDEN_APPLICATION_RUNTIME_NAMES
         ):
@@ -420,6 +431,43 @@ def test_core_does_not_reference_application_runtime_owners() -> None:
     assert not unexpected, (
         "Application runtime/session ownership must not move into core; pass a "
         f"narrow protocol, callback, or value instead: {unexpected}"
+    )
+
+
+def test_core_does_not_receive_application_managers() -> None:
+    unexpected: list[str] = []
+    core_root = REPO_ROOT / "core"
+    for source in sorted(core_root.rglob("*.py")):
+        relative = source.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(
+            source.read_text(encoding="utf-8"), filename=str(source)
+        )
+        for name in sorted(
+            _referenced_names(tree) & CORE_FORBIDDEN_APPLICATION_MANAGER_NAMES
+        ):
+            unexpected.append(f"{relative}: {name}")
+
+    assert not unexpected, (
+        "Core capabilities must receive narrow callbacks/protocols instead of "
+        f"application managers: {unexpected}"
+    )
+
+
+def test_application_owns_chat_composition_and_presentation() -> None:
+    expected_application_modules = (
+        REPO_ROOT / "application" / "chat" / "effects.py",
+        REPO_ROOT / "application" / "chat" / "initial_sprite.py",
+        REPO_ROOT / "application" / "chat" / "turn_wiring.py",
+    )
+    retired_core_modules = (
+        REPO_ROOT / "core" / "messaging" / "chat_turn_wiring.py",
+        REPO_ROOT / "core" / "sprite" / "initial_sprite.py",
+    )
+
+    assert all(path.is_file() for path in expected_application_modules)
+    assert not any(path.exists() for path in retired_core_modules)
+    assert not list((REPO_ROOT / "core").rglob("*wiring.py")), (
+        "Composition roots and manager wiring belong to application."
     )
 
 

--- a/test/unit/core/media/test_effect_audio.py
+++ b/test/unit/core/media/test_effect_audio.py
@@ -1,0 +1,33 @@
+from core.media.effect_audio import EffectAudioBinding, parse_effect_audio_bindings
+
+
+def test_parse_effect_audio_bindings_preserves_line_alignment() -> None:
+    bindings = parse_effect_audio_bindings(
+        "特效 1：吓到\n\nEffect 3: 提示\n",
+        ["one.wav", "unused.wav", "three.wav"],
+    )
+
+    assert bindings == (
+        EffectAudioBinding("吓到", "one.wav"),
+        EffectAudioBinding("提示", "three.wav"),
+    )
+
+
+def test_parse_effect_audio_bindings_expands_multiple_keywords() -> None:
+    bindings = parse_effect_audio_bindings(
+        "晕掉, 晕过去，晕倒,眩晕,晕掉",
+        ["faint.wav"],
+    )
+
+    assert [binding.keyword for binding in bindings] == [
+        "晕掉",
+        "晕过去",
+        "晕倒",
+        "眩晕",
+    ]
+    assert {binding.audio_path for binding in bindings} == {"faint.wav"}
+
+
+def test_parse_effect_audio_bindings_ignores_unpaired_values() -> None:
+    assert parse_effect_audio_bindings("特效 1：\n特效 2：爆炸", ["one.wav"]) == ()
+    assert parse_effect_audio_bindings("特效 1：爆炸", []) == ()

--- a/test/unit/core/sprite/test_selection.py
+++ b/test/unit/core/sprite/test_selection.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from core.sprite.selection import (
+    find_character_sprite_by_path,
+    resolve_initial_sprite_path,
+)
+
+
+def test_find_character_sprite_by_path_accepts_character_values(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    characters = [
+        SimpleNamespace(
+            name="Nanami",
+            sprites=[SimpleNamespace(path="data/sprite/nanami/idle.webp")],
+        )
+    ]
+
+    assert find_character_sprite_by_path(
+        characters,
+        (tmp_path / "data/sprite/nanami/idle.webp").as_posix(),
+    ) == ("Nanami", 0)
+
+
+def test_resolve_initial_sprite_path_rejects_another_character_sprite() -> None:
+    characters = [
+        {"name": "Nanami", "sprites": [{"path": "sprites/nanami.png"}]},
+        {"name": "Junko", "sprites": [{"path": "sprites/junko.png"}]},
+    ]
+
+    assert (
+        resolve_initial_sprite_path(
+            characters,
+            "sprites/junko.png",
+            ["Nanami"],
+            default_path="sprites/nanami.png",
+        )
+        == "sprites/nanami.png"
+    )
+    assert (
+        resolve_initial_sprite_path(
+            characters,
+            "custom/portrait.png",
+            ["Nanami"],
+            default_path="sprites/nanami.png",
+        )
+        == "custom/portrait.png"
+    )

--- a/test/unit/frontend_bridge_core/test_effects_comprehensive.py
+++ b/test/unit/frontend_bridge_core/test_effects_comprehensive.py
@@ -5,9 +5,7 @@ Tests all bugs that were fixed:
 2. Audio tag index mismatch (empty lines preserved)
 3. Rename failure fallback (OSError handled)
 4. Missing prompt word detection (pinpoint)
-5. Effect usage guide generation
 """
-import os
 import shutil
 import tempfile
 import zipfile
@@ -122,8 +120,6 @@ def test_rename_multiple_collisions():
 
 def test_rename_to_same_name():
     """Renaming to the same name (no-op rename): no change."""
-    effect_list = [make_effect("闪光")]
-
     old_dir = Path("data/effects/闪光")
     new_dir = Path("data/effects/闪光")
     assert old_dir == new_dir


### PR DESCRIPTION
## Summary

- define the core Host Capability and application Use Case boundary, including executable import and runtime-ownership guards
- move chat turn wiring, initial-sprite presentation, and effect scheme orchestration into application/chat
- keep framework-neutral sprite selection and effect-audio parsing in core, removing duplicated parsing from main and the bridge
- align tests and Tauri resource verification with the canonical module paths

## Validation

- Python: 1871 passed, 7 skipped, 7 subtests passed
- Frontend: 115 files passed, 766 tests passed
- Prettier and TypeScript checks passed
- Tauri resource preparation and verification passed

<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次内容的要点收拢，方便继续查看。

本 PR 将聊天启动中的特效方案、初始立绘和 turn 装配迁至 `application/chat`，并将音频标签解析与立绘路径匹配保留为 `core` 能力；已核对 `main.py`、bridge 的启动/恢复调用链及 Tauri 资源暂存，未发现可定位的生产回归。

### Enhancements

- 将特效关键词映射与提示词生成收敛到 `application/chat/effects.py`，复用 `core/media/effect_audio.py` 的标签解析。
- 将初始立绘的配置选择和 UI 呈现移至 `application/chat/initial_sprite.py`，保留 `core/sprite/selection.py` 的路径归一化与归属匹配。

### Tests

- 新增特效音频解析、特效方案投影和立绘选择的单元测试，并将 turn wiring 与自动标注测试归位。

### Chores

- 更新架构边界文档、导入边界守卫及 Tauri 资源验证。

<details>
<summary>Original summary in English</summary>

This PR moves chat-startup effect handling, initial-sprite presentation, and turn wiring into `application/chat`, while retaining audio-tag parsing and sprite-path matching as `core` capabilities. The `main.py`, bridge launch/resume call chains, and Tauri staging were inspected; no actionable production regression was found.

### Enhancements

- Consolidates effect keyword mapping and prompt-guide generation in `application/chat/effects.py`, reusing tag parsing from `core/media/effect_audio.py`.
- Moves initial-sprite configuration selection and UI presentation to `application/chat/initial_sprite.py`, retaining path normalization and ownership matching in `core/sprite/selection.py`.

### Tests

- Adds unit coverage for effect-audio parsing, effect-scheme projections, and sprite selection, and relocates turn-wiring and auto-annotation tests.

### Chores

- Updates architecture-boundary documentation, import-boundary guards, and Tauri resource verification.

</details>

<!-- astrbot-review:end:summary -->