### PR TITLE
feat(tauri): add native file picker with in-app fallback

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.80.0",
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-dialog": "^2.4.0",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.4.0
+        version: 2.7.3
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@18.3.1)
@@ -606,6 +609,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.3':
+    resolution: {integrity: sha512-CRgE+7TP4tvq9MjBU6f04NLTFIqVMLKHk3hAqlhil00ngK9ACTrXPH3oHpKMProxILodd3YjBoKbMwSI4IEcfA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1843,6 +1849,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-dialog@2.7.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2637,7 +2637,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2842,6 +2842,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3305,6 +3329,7 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-updater",
  "tauri-runtime",
  "zip 5.1.1",
@@ -3716,6 +3741,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0.150"
 sha2 = "0.10.9"
 tar = "0.4.45"
 tauri = { version = "2.11.2", features = ["macos-private-api"] }
+tauri-plugin-dialog = "2"
 tauri-runtime = "2.11.2"
 zip = "5.0.0"
 

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Default permissions for Shinsekai desktop windows.",
   "windows": ["main"],
-  "permissions": ["core:default", "updater:default"]
+  "permissions": ["core:default", "dialog:default", "updater:default"]
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -453,6 +453,7 @@ pub fn run() {
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
                 app.manage(DesktopUpdateState::new());
             }
+            app.handle().plugin(tauri_plugin_dialog::init())?;
 
             let source_root = resolve_source_root(app)?;
             let app_root = resolve_app_root(app, &source_root)?;

--- a/frontend/src/shared/desktop/desktopApi.ts
+++ b/frontend/src/shared/desktop/desktopApi.ts
@@ -186,6 +186,43 @@ export function browseDesktopFiles(options?: { path?: string; showHidden?: boole
   return invokeDesktop<FileBrowserSnapshot>("desktop_files_browse", options ?? {});
 }
 
+export interface DesktopNativePickOptions {
+  defaultPath?: string;
+  extensions?: string[];
+  mode?: "file" | "path" | "directory";
+  multiple?: boolean;
+  title?: string;
+}
+
+export async function pickDesktopNativePath(options: DesktopNativePickOptions = {}): Promise<string[] | null> {
+  const { open } = await import("@tauri-apps/plugin-dialog");
+  const directory = options.mode === "directory";
+  const extensions = (options.extensions ?? [])
+    .map((item) => item.trim().replace(/^\.+/, ""))
+    .filter(Boolean);
+  const rawDefaultPath = options.defaultPath?.trim() || "";
+  // The native dialog requires an existing absolute path; project-relative
+  // initial paths (e.g. "plugins") are simply left to the dialog's own
+  // starting location.
+  const defaultPath =
+    rawDefaultPath.startsWith("/") ||
+    rawDefaultPath.startsWith("~") ||
+    /^[A-Za-z]:[\\/]/.test(rawDefaultPath)
+      ? rawDefaultPath
+      : undefined;
+  const result = await open({
+    defaultPath,
+    directory,
+    filters: extensions.length ? [{ extensions, name: extensions.join(", ") }] : undefined,
+    multiple: Boolean(options.multiple) && !directory,
+    title: options.title || undefined,
+  });
+  if (result === null) {
+    return null;
+  }
+  return Array.isArray(result) ? result : [result];
+}
+
 export function checkDesktopUpdate() {
   return invokeDesktop<DesktopUpdate | null>("desktop_update_check");
 }

--- a/frontend/src/shared/desktop/desktopApi.ts
+++ b/frontend/src/shared/desktop/desktopApi.ts
@@ -197,17 +197,13 @@ export interface DesktopNativePickOptions {
 export async function pickDesktopNativePath(options: DesktopNativePickOptions = {}): Promise<string[] | null> {
   const { open } = await import("@tauri-apps/plugin-dialog");
   const directory = options.mode === "directory";
-  const extensions = (options.extensions ?? [])
-    .map((item) => item.trim().replace(/^\.+/, ""))
-    .filter(Boolean);
+  const extensions = (options.extensions ?? []).map((item) => item.trim().replace(/^\.+/, "")).filter(Boolean);
   const rawDefaultPath = options.defaultPath?.trim() || "";
   // The native dialog requires an existing absolute path; project-relative
   // initial paths (e.g. "plugins") are simply left to the dialog's own
   // starting location.
   const defaultPath =
-    rawDefaultPath.startsWith("/") ||
-    rawDefaultPath.startsWith("~") ||
-    /^[A-Za-z]:[\\/]/.test(rawDefaultPath)
+    rawDefaultPath.startsWith("/") || rawDefaultPath.startsWith("~") || /^[A-Za-z]:[\\/]/.test(rawDefaultPath)
       ? rawDefaultPath
       : undefined;
   const result = await open({

--- a/frontend/src/shared/ui/PathPickerDialog.tsx
+++ b/frontend/src/shared/ui/PathPickerDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Check } from "lucide-react";
 
 import type { PathPickerMode } from "../platform/types";
+import { isTauriDesktop, pickDesktopNativePath } from "../desktop/desktopApi";
 import { useI18n } from "../i18n";
 import "./PathPickerDialog.css";
 import { Button } from "./Button";
@@ -45,12 +46,55 @@ export function PathPickerDialog({
 }: PathPickerDialogProps) {
   const { t } = useI18n();
   const [confirmPaths, setConfirmPaths] = useState<string[]>([]);
+  const [nativeDialogFailed, setNativeDialogFailed] = useState(false);
 
   useEffect(() => {
     if (!open) {
       setConfirmPaths([]);
+      setNativeDialogFailed(false);
     }
   }, [open]);
+
+  // On the Tauri desktop the OS-native dialog replaces the in-app browser.
+  useEffect(() => {
+    if (!open || !isTauriDesktop()) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const paths = await pickDesktopNativePath({
+          defaultPath: value,
+          extensions: acceptedExtensions,
+          mode,
+          multiple,
+          title,
+        });
+        if (cancelled) {
+          return;
+        }
+        if (paths === null) {
+          onClose();
+          return;
+        }
+        if (multiple && mode === "file" && onSelectMany) {
+          onSelectMany(paths);
+        } else if (paths[0]) {
+          onSelect(paths[0]);
+        }
+        onClose();
+      } catch {
+        // The dialog plugin may be unavailable (e.g. older desktop shell);
+        // fall back to the in-app browser instead of failing the pick.
+        if (!cancelled) {
+          setNativeDialogFailed(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [acceptedExtensions, mode, multiple, onClose, onSelect, onSelectMany, open, title, value]);
 
   const handleConfirm = () => {
     if (!confirmPaths.length) {
@@ -77,6 +121,10 @@ export function PathPickerDialog({
   }, []);
 
   if (!open) {
+    return null;
+  }
+  if (isTauriDesktop() && !nativeDialogFailed) {
+    // The native dialog owns the whole flow; render nothing behind it.
     return null;
   }
 

--- a/frontend/src/test/shared/ui/dialog.test.tsx
+++ b/frontend/src/test/shared/ui/dialog.test.tsx
@@ -191,9 +191,7 @@ describe("FilePicker on the Tauri desktop", () => {
     await waitFor(() => {
       expect(onPathChange).toHaveBeenCalledWith("C:/assets/mio.png");
     });
-    expect(openMock).toHaveBeenCalledWith(
-      expect.objectContaining({ directory: false, multiple: false }),
-    );
+    expect(openMock).toHaveBeenCalledWith(expect.objectContaining({ directory: false, multiple: false }));
     expect(browseFiles).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog", { name: "选择素材" })).not.toBeInTheDocument();
   });
@@ -211,9 +209,7 @@ describe("FilePicker on the Tauri desktop", () => {
     await waitFor(() => {
       expect(onPathChange).toHaveBeenCalledWith("D:/models/asr");
     });
-    expect(openMock).toHaveBeenCalledWith(
-      expect.objectContaining({ directory: true, multiple: false }),
-    );
+    expect(openMock).toHaveBeenCalledWith(expect.objectContaining({ directory: true, multiple: false }));
   });
 
   it("keeps the value unchanged when the native dialog is cancelled", async () => {

--- a/frontend/src/test/shared/ui/dialog.test.tsx
+++ b/frontend/src/test/shared/ui/dialog.test.tsx
@@ -7,6 +7,23 @@ import { AlertDialog, FileBrowserProvider, FilePicker } from "../../../shared/ui
 
 const browseFiles = vi.fn();
 
+const { isTauriMock, openMock } = vi.hoisted(() => ({
+  isTauriMock: vi.fn(() => false),
+  openMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: openMock,
+}));
+
+vi.mock("../../../shared/desktop/desktopApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../shared/desktop/desktopApi")>();
+  return {
+    ...actual,
+    isTauriDesktop: isTauriMock,
+  };
+});
+
 function renderWithFileBrowser(children: ReactNode) {
   return render(
     <I18nProvider language="zh_CN">
@@ -47,6 +64,7 @@ describe("AlertDialog", () => {
 
 describe("FilePicker", () => {
   beforeEach(() => {
+    isTauriMock.mockReturnValue(false);
     browseFiles.mockResolvedValue({
       cwd: "/tmp",
       entries: [
@@ -144,5 +162,83 @@ describe("FilePicker", () => {
       expect((input as HTMLInputElement).selectionStart).toBe(0);
       expect((input as HTMLInputElement).selectionEnd).toBe(cwd.length);
     });
+  });
+});
+
+describe("FilePicker on the Tauri desktop", () => {
+  beforeEach(() => {
+    isTauriMock.mockReturnValue(true);
+    browseFiles.mockResolvedValue({
+      cwd: "/tmp",
+      entries: [],
+      parent: "/",
+      roots: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens the OS-native file dialog and reports the picked path", async () => {
+    const onPathChange = vi.fn();
+    openMock.mockResolvedValueOnce("C:/assets/mio.png");
+
+    renderWithFileBrowser(<FilePicker onPathChange={onPathChange} pickLabel="选择素材" value="" />);
+
+    fireEvent.click(screen.getByLabelText("选择素材"));
+
+    await waitFor(() => {
+      expect(onPathChange).toHaveBeenCalledWith("C:/assets/mio.png");
+    });
+    expect(openMock).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: false, multiple: false }),
+    );
+    expect(browseFiles).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: "选择素材" })).not.toBeInTheDocument();
+  });
+
+  it("opens a directory dialog for directory mode", async () => {
+    const onPathChange = vi.fn();
+    openMock.mockResolvedValueOnce("D:/models/asr");
+
+    renderWithFileBrowser(
+      <FilePicker onPathChange={onPathChange} pickLabel="选择目录" pickerMode="directory" value="" />,
+    );
+
+    fireEvent.click(screen.getByLabelText("选择目录"));
+
+    await waitFor(() => {
+      expect(onPathChange).toHaveBeenCalledWith("D:/models/asr");
+    });
+    expect(openMock).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: true, multiple: false }),
+    );
+  });
+
+  it("keeps the value unchanged when the native dialog is cancelled", async () => {
+    const onPathChange = vi.fn();
+    openMock.mockResolvedValueOnce(null);
+
+    renderWithFileBrowser(<FilePicker onPathChange={onPathChange} pickLabel="选择素材" value="" />);
+
+    fireEvent.click(screen.getByLabelText("选择素材"));
+
+    await waitFor(() => {
+      expect(openMock).toHaveBeenCalledTimes(1);
+    });
+    expect(onPathChange).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the in-app browser when the native dialog fails", async () => {
+    const onPathChange = vi.fn();
+    openMock.mockRejectedValueOnce(new Error("plugin unavailable"));
+
+    renderWithFileBrowser(<FilePicker onPathChange={onPathChange} pickLabel="选择素材" value="" />);
+
+    fireEvent.click(screen.getByLabelText("选择素材"));
+
+    expect(await screen.findByRole("dialog", { name: "选择素材" })).toBeInTheDocument();
+    expect(onPathChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend_bridge_core/tools.py
+++ b/frontend_bridge_core/tools.py
@@ -19,7 +19,13 @@ MAX_FILE_BROWSER_ENTRIES = 2000
 
 
 def _local_file_access_roots(state: BridgeState) -> tuple[Path, ...]:
-    """Roots exposed to authenticated local-file tool operations."""
+    """Roots exposed to authenticated local-file tool operations.
+
+    The roots must cover everything the file-browser sidebar advertises
+    (project, app, home, downloads, and the local drive roots), otherwise
+    navigating the picker to a listed root — and saving paths picked there —
+    fails with "outside the allowed roots".
+    """
 
     root_raw = os.environ.get("EASYAI_PROJECT_ROOT") or str(Path.cwd())
     project_root = _resolve_path(Path(root_raw).expanduser())
@@ -28,6 +34,15 @@ def _local_file_access_roots(state: BridgeState) -> tuple[Path, ...]:
     downloads_dir = _user_downloads_dir()
     if downloads_dir is not None:
         roots.append(downloads_dir)
+    if os.name == "nt":
+        for code in range(ord("A"), ord("Z") + 1):
+            drive = Path(f"{chr(code)}:/")
+            if drive.exists():
+                roots.append(drive)
+    else:
+        anchor = Path("/")
+        if anchor.exists():
+            roots.append(anchor)
     return tuple(dict.fromkeys(_resolve_path(root) for root in roots))
 
 

--- a/sdk/ui/validators.py
+++ b/sdk/ui/validators.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import tempfile
 from pathlib import Path
@@ -16,11 +17,28 @@ from sdk.path_utils import reject_control_chars, safe_existing_path
 
 
 def _local_input_roots() -> tuple[Path, ...]:
+    """Trusted roots for form fields that reference local files.
+
+    Cover the whole local machine like the file picker does (all existing
+    drives on Windows, the filesystem anchor elsewhere), otherwise saving a
+    form whose paths live outside cwd/temp/home fails with "outside the
+    allowed roots".
+    """
+
     roots = [Path.cwd(), Path(tempfile.gettempdir())]
     try:
         roots.append(Path.home())
     except RuntimeError:
         pass
+    if os.name == "nt":
+        for code in range(ord("A"), ord("Z") + 1):
+            drive = Path(f"{chr(code)}:/")
+            if drive.exists():
+                roots.append(drive)
+    else:
+        anchor = Path("/")
+        if anchor.exists():
+            roots.append(anchor)
     return tuple(dict.fromkeys(roots))
 
 

--- a/test/unit/frontend_bridge_core/test_file_browser_paths.py
+++ b/test/unit/frontend_bridge_core/test_file_browser_paths.py
@@ -97,7 +97,7 @@ def test_file_browser_relative_paths_still_resolve_from_project_root(tmp_path, m
     assert snapshot["cwd"] == _display_path(target)
 
 
-def test_file_browser_rejects_paths_outside_local_access_roots(tmp_path, monkeypatch):
+def test_file_browser_allows_paths_outside_project_root(tmp_path, monkeypatch):
     project_root = tmp_path / "project"
     app_root = tmp_path / "Shinsekai"
     home = tmp_path / "home"
@@ -109,24 +109,32 @@ def test_file_browser_rejects_paths_outside_local_access_roots(tmp_path, monkeyp
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
 
-    if os.name == "nt":
-        # Every existing local drive is a root (matching the sidebar), so only
-        # network/UNC locations remain outside the allowed roots.
-        outside_path = "\\\\server\\share\\folder"
-    else:
-        outside_path = str(outside)
+    snapshot = _browse_local_files(
+        SimpleNamespace(app_root_dir=str(app_root)),
+        {"path": str(outside)},
+    )
+
+    assert snapshot["cwd"] == _display_path(outside)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="UNC paths are Windows-specific")
+def test_file_browser_rejects_unc_paths(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    app_root = tmp_path / "Shinsekai"
+    project_root.mkdir()
+    app_root.mkdir()
+
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(project_root))
 
     with pytest.raises(PermissionError, match="outside the allowed roots"):
         _browse_local_files(
             SimpleNamespace(app_root_dir=str(app_root)),
-            {"path": outside_path},
+            {"path": "\\\\server\\share\\folder"},
         )
 
 
+@pytest.mark.skipif(os.name != "nt", reason="drive roots are Windows-specific")
 def test_local_file_access_roots_include_existing_drives(tmp_path, monkeypatch):
-    if os.name != "nt":
-        return
-
     project_root = tmp_path / "project"
     app_root = tmp_path / "Shinsekai"
     project_root.mkdir()
@@ -139,3 +147,16 @@ def test_local_file_access_roots_include_existing_drives(tmp_path, monkeypatch):
         drive = Path(f"{chr(code)}:/")
         if drive.exists():
             assert drive.resolve(strict=False) in roots
+
+
+@pytest.mark.skipif(os.name == "nt", reason="filesystem anchor is POSIX-specific")
+def test_local_file_access_roots_include_posix_anchor(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    app_root = tmp_path / "Shinsekai"
+    project_root.mkdir()
+    app_root.mkdir()
+
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(project_root))
+    roots = _local_file_access_roots(SimpleNamespace(app_root_dir=str(app_root)))
+
+    assert Path("/").resolve(strict=False) in roots

--- a/test/unit/frontend_bridge_core/test_file_browser_paths.py
+++ b/test/unit/frontend_bridge_core/test_file_browser_paths.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -8,6 +9,7 @@ from frontend_bridge_core.tools import (
     _display_path,
     _file_browser_root_key,
     _file_browser_root_label,
+    _local_file_access_roots,
     _strip_windows_verbatim_prefix,
 )
 
@@ -107,8 +109,33 @@ def test_file_browser_rejects_paths_outside_local_access_roots(tmp_path, monkeyp
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
 
+    if os.name == "nt":
+        # Every existing local drive is a root (matching the sidebar), so only
+        # network/UNC locations remain outside the allowed roots.
+        outside_path = "\\\\server\\share\\folder"
+    else:
+        outside_path = str(outside)
+
     with pytest.raises(PermissionError, match="outside the allowed roots"):
         _browse_local_files(
             SimpleNamespace(app_root_dir=str(app_root)),
-            {"path": str(outside)},
+            {"path": outside_path},
         )
+
+
+def test_local_file_access_roots_include_existing_drives(tmp_path, monkeypatch):
+    if os.name != "nt":
+        return
+
+    project_root = tmp_path / "project"
+    app_root = tmp_path / "Shinsekai"
+    project_root.mkdir()
+    app_root.mkdir()
+
+    monkeypatch.setenv("EASYAI_PROJECT_ROOT", str(project_root))
+    roots = _local_file_access_roots(SimpleNamespace(app_root_dir=str(app_root)))
+
+    for code in range(ord("A"), ord("Z") + 1):
+        drive = Path(f"{chr(code)}:/")
+        if drive.exists():
+            assert drive.resolve(strict=False) in roots


### PR DESCRIPTION
<!-- astrbot-review:start:summary -->

## Summary by Ameath

小爱先把这次核对的重点轻轻收拢，方便你快速浏览。

本 PR 为 Tauri 主窗口接入系统原生文件/目录选择器，并在插件不可用时回退到内置浏览器；同时扩展本地路径访问范围。发现 POSIX 文件浏览测试未与新根范围同步，常规 Python 测试会失败。

### New Features

- Tauri 主窗口可调用系统原生文件或目录选择器。

### Enhancements

- 原生插件不可用时自动回退至现有 `FileManager`；本地文件浏览与路径校验覆盖现有本机卷或文件系统根。

### Tests

- 增加原生选择文件、目录、取消和插件失败回退的前端测试。

<details>
<summary>Original summary in English</summary>

This PR adds OS-native file and directory picking to the Tauri main window, falls back to the in-app browser when the plugin is unavailable, and expands local-path access. One POSIX file-browser test was not updated for the new root scope, so the normal Python test suite will fail.

### New Features

- The Tauri main window can invoke the OS-native file or directory picker.

### Enhancements

- The existing `FileManager` is used as a fallback when the native plugin is unavailable; local file browsing and path validation now cover existing local volumes or the filesystem root.

### Tests

- Adds frontend coverage for native file selection, directory selection, cancellation, and plugin-failure fallback.

</details>

<!-- astrbot-review:end:summary -->